### PR TITLE
Replace vector search with USearch HNSW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,9 @@ dependencies = [
  "serde_json",
  "simd-json",
  "tantivy",
+ "tempfile",
  "toml",
+ "usearch",
  "walkdir",
 ]
 
@@ -285,6 +287,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +385,68 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cxx"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbda285ba6e5866529faf76352bdf73801d9b44a6308d7cd58ca2379f378e994"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash 0.2.0",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9efde466c5d532d57efd92f861da3bdb7f61e369128ce8b4c3fe0c9de4fa4d"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3efb93799095bccd4f763ca07997dc39a69e5e61ab52d2c407d4988d21ce144d"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3092010228026e143b32a4463ed9fa8f86dca266af4bf5f3b2a26e113dbe4e45"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d72ebfcd351ae404fb00ff378dfc9571827a00722c9e735c9181aec320ba0a"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "darling"
@@ -604,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +767,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1042,6 +1123,15 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1694,6 +1784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2347,16 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usearch"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa6dc1b7f3062021396be66cbea6061948592d5025ff2b0f2594352d52ad518"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simd-json = { version = "0.13", features = ["serde"] }
 tantivy = "0.22"
+usearch = "2"
 toml = "0.8"
 walkdir = "2.5"
 indicatif = "0.17"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -251,10 +251,9 @@ fn run_index(
         no_embeddings,
         "embeddings",
     )?;
-    if reindex
-        && paths.root.exists() {
-            std::fs::remove_dir_all(&paths.root)?;
-        }
+    if reindex && paths.root.exists() {
+        std::fs::remove_dir_all(&paths.root)?;
+    }
     paths.ensure_dirs()?;
     let index = SearchIndex::open_or_create(&paths.index)?;
     let vector_exists = paths.vectors.join("meta.json").exists()
@@ -460,7 +459,8 @@ fn run_semantic_search(
     let vector = VectorIndex::open(&paths.vectors)?;
     let mut embedder = EmbedderHandle::new()?;
     let embeddings = embedder.embed_texts(&[options.query.as_str()])?;
-    let embedding = embeddings.first()
+    let embedding = embeddings
+        .first()
         .ok_or_else(|| anyhow!("embedding missing"))?;
     let mut results = Vec::new();
     let now_ms = chrono::Utc::now().timestamp_millis() as u64;
@@ -505,7 +505,8 @@ fn run_hybrid_search(
     })?;
 
     let embeddings = embedder.embed_texts(&[options.query.as_str()])?;
-    let embedding = embeddings.first()
+    let embedding = embeddings
+        .first()
         .ok_or_else(|| anyhow!("embedding missing"))?;
     let vector_results = vector.search(embedding, vector_k)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,18 +465,18 @@ fn run_semantic_search(
     let mut results = Vec::new();
     let now_ms = chrono::Utc::now().timestamp_millis() as u64;
     for (doc_id, distance) in vector.search(embedding, limit)? {
-        if let Some(record) = index.get_by_doc_id(doc_id)? {
-            if matches_filters(&record, options) {
-                let base = score_from_distance(distance);
-                let score = apply_recency(
-                    base,
-                    record.ts,
-                    now_ms,
-                    recency_weight,
-                    recency_half_life_days,
-                );
-                results.push((score, record));
-            }
+        if let Some(record) = index.get_by_doc_id(doc_id)?
+            && matches_filters(&record, options)
+        {
+            let base = score_from_distance(distance);
+            let score = apply_recency(
+                base,
+                record.ts,
+                now_ms,
+                recency_weight,
+                recency_half_life_days,
+            );
+            results.push((score, record));
         }
     }
     let results = apply_post_processing(results, render);
@@ -572,40 +572,40 @@ fn apply_recency(score: f32, ts: u64, now_ms: u64, weight: f32, half_life_days: 
 }
 
 fn matches_filters(record: &crate::types::Record, options: &QueryOptions) -> bool {
-    if let Some(project) = &options.project {
-        if &record.project != project {
-            return false;
-        }
+    if let Some(project) = &options.project
+        && &record.project != project
+    {
+        return false;
     }
-    if let Some(role) = &options.role {
-        if &record.role != role {
-            return false;
-        }
+    if let Some(role) = &options.role
+        && &record.role != role
+    {
+        return false;
     }
-    if let Some(tool) = &options.tool {
-        if record.tool_name.as_deref() != Some(tool.as_str()) {
-            return false;
-        }
+    if let Some(tool) = &options.tool
+        && record.tool_name.as_deref() != Some(tool.as_str())
+    {
+        return false;
     }
-    if let Some(source) = options.source {
-        if !source.matches(record.source) {
-            return false;
-        }
+    if let Some(source) = options.source
+        && !source.matches(record.source)
+    {
+        return false;
     }
-    if let Some(session_id) = &options.session_id {
-        if &record.session_id != session_id {
-            return false;
-        }
+    if let Some(session_id) = &options.session_id
+        && &record.session_id != session_id
+    {
+        return false;
     }
-    if let Some(since) = options.since {
-        if record.ts < since {
-            return false;
-        }
+    if let Some(since) = options.since
+        && record.ts < since
+    {
+        return false;
     }
-    if let Some(until) = options.until {
-        if record.ts > until {
-            return false;
-        }
+    if let Some(until) = options.until
+        && record.ts > until
+    {
+        return false;
     }
     true
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -251,14 +251,14 @@ fn build_query(
         ));
     }
 
-    if let Some(source) = options.source {
-        if let Some(field) = fields.source {
-            let term = Term::from_field_text(field, source.as_str());
-            clauses.push((
-                Occur::Must,
-                Box::new(TermQuery::new(term, IndexRecordOption::Basic)),
-            ));
-        }
+    if let Some(source) = options.source
+        && let Some(field) = fields.source
+    {
+        let term = Term::from_field_text(field, source.as_str());
+        clauses.push((
+            Occur::Must,
+            Box::new(TermQuery::new(term, IndexRecordOption::Basic)),
+        ));
     }
 
     if let Some(session_id) = &options.session_id {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -325,15 +325,15 @@ fn writer_loop(
                 progress.add_embed_pending(record.source, 1);
                 embed_buffer.push((record.doc_id, text, record.source));
             }
-            if let Some(emb) = embedder.as_mut() {
-                if embed_buffer.len() >= EMBED_BATCH_SIZE {
-                    embedded_count += flush_embeddings(
-                        &mut embed_buffer,
-                        emb,
-                        vector_index.as_mut().unwrap(),
-                        &progress,
-                    )?;
-                }
+            if let Some(emb) = embedder.as_mut()
+                && embed_buffer.len() >= EMBED_BATCH_SIZE
+            {
+                embedded_count += flush_embeddings(
+                    &mut embed_buffer,
+                    emb,
+                    vector_index.as_mut().unwrap(),
+                    &progress,
+                )?;
             }
         }
         count += 1;

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -580,10 +580,10 @@ fn parse_claude_file(
                         if block_obj.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
                             let tool_output = block_obj.get("content").map(|v| v.to_string());
                             let mut text = extract_text_from_tool_result(block).unwrap_or_default();
-                            if text.is_empty() {
-                                if let Some(content) = block_obj.get("content") {
-                                    text = content.to_string();
-                                }
+                            if text.is_empty()
+                                && let Some(content) = block_obj.get("content")
+                            {
+                                text = content.to_string();
                             }
                             let tool_name = block_obj
                                 .get("tool_use_id")
@@ -731,10 +731,10 @@ fn parse_codex_session(
                     text_parts.push(text);
                 } else if let Some(arr) = content.as_array() {
                     for block in arr {
-                        if let Some(block_obj) = block.as_object() {
-                            if let Some(text) = block_obj.get("text").and_then(|v| v.as_str()) {
-                                text_parts.push(text);
-                            }
+                        if let Some(block_obj) = block.as_object()
+                            && let Some(text) = block_obj.get("text").and_then(|v| v.as_str())
+                        {
+                            text_parts.push(text);
                         }
                     }
                 }
@@ -772,10 +772,10 @@ fn parse_codex_session(
                 .get("arguments")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            if let Some(call_id) = payload.get("call_id").and_then(|v| v.as_str()) {
-                if let Some(name) = tool_name.clone() {
-                    call_id_to_name.insert(call_id.to_string(), name);
-                }
+            if let Some(call_id) = payload.get("call_id").and_then(|v| v.as_str())
+                && let Some(name) = tool_name.clone()
+            {
+                call_id_to_name.insert(call_id.to_string(), name);
             }
             let text = tool_input.clone().unwrap_or_default();
             let record = Record {
@@ -1014,12 +1014,11 @@ fn extract_text_from_tool_result(block: &simd_json::BorrowedValue) -> Option<Str
     if let Some(arr) = content.as_array() {
         let mut parts = Vec::new();
         for item in arr {
-            if let Some(obj) = item.as_object() {
-                if obj.get("type").and_then(|v| v.as_str()) == Some("text") {
-                    if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
-                        parts.push(text);
-                    }
-                }
+            if let Some(obj) = item.as_object()
+                && obj.get("type").and_then(|v| v.as_str()) == Some("text")
+                && let Some(text) = obj.get("text").and_then(|v| v.as_str())
+            {
+                parts.push(text);
             }
         }
         if !parts.is_empty() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,7 @@
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SourceKind {
     #[default]
     Claude,
@@ -36,7 +35,6 @@ impl SourceKind {
         }
     }
 }
-
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,9 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum SourceKind {
+    #[default]
     Claude,
     CodexSession,
     CodexHistory,
@@ -35,11 +37,6 @@ impl SourceKind {
     }
 }
 
-impl Default for SourceKind {
-    fn default() -> Self {
-        SourceKind::Claude
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -117,11 +117,7 @@ impl VectorIndex {
         }
 
         let results = self.index.search(embedding, limit)?;
-        Ok(results
-            .keys
-            .into_iter()
-            .zip(results.distances)
-            .collect())
+        Ok(results.keys.into_iter().zip(results.distances).collect())
     }
 
     pub fn save(&self) -> Result<()> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -28,10 +28,12 @@ impl VectorIndex {
             }
         }
 
-        let mut options = IndexOptions::default();
-        options.dimensions = dimensions;
-        options.metric = MetricKind::Cos;
-        options.quantization = ScalarKind::F32;
+        let options = IndexOptions {
+            dimensions,
+            metric: MetricKind::Cos,
+            quantization: ScalarKind::F32,
+            ..IndexOptions::default()
+        };
 
         let index = Index::new(&options)?;
 
@@ -118,7 +120,7 @@ impl VectorIndex {
         Ok(results
             .keys
             .into_iter()
-            .zip(results.distances.into_iter())
+            .zip(results.distances)
             .collect())
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,98 +1,81 @@
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
 pub struct VectorIndex {
     dims: usize,
     path: PathBuf,
-    vectors: Vec<f32>,
-    doc_ids: Vec<u64>,
+    index: Index,
     doc_id_set: HashSet<u64>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct VectorMeta {
-    dimensions: usize,
 }
 
 impl VectorIndex {
     pub fn open_or_create(dir: &Path, dimensions: usize) -> Result<Self> {
         fs::create_dir_all(dir)?;
-        let meta_path = dir.join("meta.json");
-        let vectors_path = dir.join("vectors.f32");
-        let ids_path = dir.join("doc_ids.u64");
+        let index_path = dir.join("usearch.index");
+        let ids_path = dir.join("doc_ids.bin");
 
-        let mut reset = false;
-        if meta_path.exists() {
-            let data = fs::read_to_string(&meta_path)?;
-            let meta: VectorMeta = serde_json::from_str(&data)?;
-            if meta.dimensions != dimensions {
-                reset = true;
+        // Check if existing index has different dimensions
+        if index_path.exists() {
+            let existing = Index::new(&IndexOptions::default())?;
+            existing.load(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
+            if existing.dimensions() != dimensions {
+                // Dimension mismatch, remove old files
+                let _ = fs::remove_file(&index_path);
+                let _ = fs::remove_file(&ids_path);
             }
         }
 
-        if reset {
-            let _ = fs::remove_file(&meta_path);
-            let _ = fs::remove_file(&vectors_path);
-            let _ = fs::remove_file(&ids_path);
-        }
+        let mut options = IndexOptions::default();
+        options.dimensions = dimensions;
+        options.metric = MetricKind::Cos;
+        options.quantization = ScalarKind::F32;
 
-        if !meta_path.exists() {
-            let meta = VectorMeta { dimensions };
-            fs::write(&meta_path, serde_json::to_string_pretty(&meta)?)?;
-        }
+        let index = Index::new(&options)?;
 
-        let (doc_ids, vectors) = if vectors_path.exists() && ids_path.exists() {
-            let ids_bytes = fs::read(&ids_path)?;
-            let vec_bytes = fs::read(&vectors_path)?;
-            let doc_ids = bytes_to_u64(&ids_bytes);
-            let vectors = bytes_to_f32(&vec_bytes);
-            if doc_ids.len() * dimensions != vectors.len() {
-                return Err(anyhow!("vector index corrupt"));
+        let doc_id_set = if index_path.exists() {
+            index.load(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
+            if ids_path.exists() {
+                load_doc_ids(&ids_path)?
+            } else {
+                HashSet::new()
             }
-            (doc_ids, vectors)
         } else {
-            (Vec::new(), Vec::new())
+            index.reserve(10000)?;
+            HashSet::new()
         };
-
-        let doc_id_set = doc_ids.iter().copied().collect();
 
         Ok(Self {
             dims: dimensions,
             path: dir.to_path_buf(),
-            vectors,
-            doc_ids,
+            index,
             doc_id_set,
         })
     }
 
     pub fn open(dir: &Path) -> Result<Self> {
-        let meta_path = dir.join("meta.json");
-        let vectors_path = dir.join("vectors.f32");
-        let ids_path = dir.join("doc_ids.u64");
-        if !meta_path.exists() || !vectors_path.exists() || !ids_path.exists() {
+        let index_path = dir.join("usearch.index");
+        let ids_path = dir.join("doc_ids.bin");
+
+        if !index_path.exists() {
             return Err(anyhow!("vector index not found"));
         }
-        let data = fs::read_to_string(&meta_path)?;
-        let meta: VectorMeta = serde_json::from_str(&data)?;
 
-        let ids_bytes = fs::read(&ids_path)?;
-        let vec_bytes = fs::read(&vectors_path)?;
-        let doc_ids = bytes_to_u64(&ids_bytes);
-        let vectors = bytes_to_f32(&vec_bytes);
-        if doc_ids.len() * meta.dimensions != vectors.len() {
-            return Err(anyhow!("vector index corrupt"));
-        }
-        let doc_id_set = doc_ids.iter().copied().collect();
+        let index = Index::new(&IndexOptions::default())?;
+        index.load(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
+
+        let doc_id_set = if ids_path.exists() {
+            load_doc_ids(&ids_path)?
+        } else {
+            HashSet::new()
+        };
 
         Ok(Self {
-            dims: meta.dimensions,
+            dims: index.dimensions(),
             path: dir.to_path_buf(),
-            vectors,
-            doc_ids,
+            index,
             doc_id_set,
         })
     }
@@ -108,10 +91,14 @@ impl VectorIndex {
         if !self.doc_id_set.insert(doc_id) {
             return Ok(());
         }
-        let mut vec = embedding.to_vec();
-        normalize(&mut vec);
-        self.doc_ids.push(doc_id);
-        self.vectors.extend_from_slice(&vec);
+
+        // Expand capacity if needed
+        if self.index.size() >= self.index.capacity() {
+            let new_capacity = (self.index.capacity() * 2).max(10000);
+            self.index.reserve(new_capacity)?;
+        }
+
+        self.index.add(doc_id, embedding)?;
         Ok(())
     }
 
@@ -123,45 +110,29 @@ impl VectorIndex {
                 embedding.len()
             ));
         }
-        if self.doc_ids.is_empty() {
+        if self.index.size() == 0 {
             return Ok(Vec::new());
         }
-        let mut query = embedding.to_vec();
-        normalize(&mut query);
 
-        let mut heap: Vec<(u64, f32)> = Vec::new();
-        for (idx, doc_id) in self.doc_ids.iter().copied().enumerate() {
-            let start = idx * self.dims;
-            let end = start + self.dims;
-            let vec = &self.vectors[start..end];
-            let dot = dot_product(&query, vec);
-            let distance = 1.0 - dot;
-            if heap.len() < limit {
-                heap.push((doc_id, distance));
-                if heap.len() == limit {
-                    heap.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
-                }
-            } else if let Some(top) = heap.first_mut() {
-                if distance < top.1 {
-                    *top = (doc_id, distance);
-                    heap.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
-                }
-            }
-        }
-
-        heap.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
-        Ok(heap)
+        let results = self.index.search(embedding, limit)?;
+        Ok(results
+            .keys
+            .into_iter()
+            .zip(results.distances.into_iter())
+            .collect())
     }
 
     pub fn save(&self) -> Result<()> {
-        let vectors_path = self.path.join("vectors.f32");
-        let ids_path = self.path.join("doc_ids.u64");
-        let tmp_vectors = self.path.join("vectors.f32.tmp");
-        let tmp_ids = self.path.join("doc_ids.u64.tmp");
-        fs::write(&tmp_vectors, f32_to_bytes(&self.vectors))?;
-        fs::write(&tmp_ids, u64_to_bytes(&self.doc_ids))?;
-        fs::rename(&tmp_vectors, &vectors_path)?;
-        fs::rename(&tmp_ids, &ids_path)?;
+        let index_path = self.path.join("usearch.index");
+        let ids_path = self.path.join("doc_ids.bin");
+
+        // Save index
+        self.index
+            .save(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
+
+        // Save doc_ids
+        save_doc_ids(&ids_path, &self.doc_id_set)?;
+
         Ok(())
     }
 
@@ -175,54 +146,169 @@ impl VectorIndex {
     }
 }
 
-fn normalize(vec: &mut [f32]) {
-    let mut sum = 0.0f32;
-    for v in vec.iter() {
-        sum += v * v;
-    }
-    if sum <= 0.0 {
-        return;
-    }
-    let inv = sum.sqrt().recip();
-    for v in vec.iter_mut() {
-        *v *= inv;
-    }
-}
-
-fn dot_product(a: &[f32], b: &[f32]) -> f32 {
-    let mut sum = 0.0f32;
-    for (x, y) in a.iter().zip(b.iter()) {
-        sum += x * y;
-    }
-    sum
-}
-
-fn bytes_to_u64(bytes: &[u8]) -> Vec<u64> {
-    bytes
+fn load_doc_ids(path: &Path) -> Result<HashSet<u64>> {
+    let bytes = fs::read(path)?;
+    let ids: Vec<u64> = bytes
         .chunks_exact(8)
         .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
-        .collect()
+        .collect();
+    Ok(ids.into_iter().collect())
 }
 
-fn bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
-        .collect()
-}
-
-fn u64_to_bytes(values: &[u64]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 8);
-    for v in values {
-        out.extend_from_slice(&v.to_le_bytes());
+fn save_doc_ids(path: &Path, ids: &HashSet<u64>) -> Result<()> {
+    let mut bytes = Vec::with_capacity(ids.len() * 8);
+    for id in ids {
+        bytes.extend_from_slice(&id.to_le_bytes());
     }
-    out
+    let tmp = path.with_extension("bin.tmp");
+    fs::write(&tmp, &bytes)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
 }
 
-fn f32_to_bytes(values: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 4);
-    for v in values {
-        out.extend_from_slice(&v.to_le_bytes());
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_vector(dims: usize, seed: f32) -> Vec<f32> {
+        (0..dims).map(|i| (i as f32 + seed).sin()).collect()
     }
-    out
+
+    #[test]
+    fn test_create_and_add() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        let v1 = make_vector(64, 1.0);
+        idx.add(1, &v1).unwrap();
+
+        assert!(idx.contains(1));
+        assert!(!idx.contains(2));
+        assert_eq!(idx.dimensions(), 64);
+    }
+
+    #[test]
+    fn test_duplicate_add_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        let v1 = make_vector(64, 1.0);
+        idx.add(1, &v1).unwrap();
+        idx.add(1, &v1).unwrap(); // duplicate
+
+        assert!(idx.contains(1));
+    }
+
+    #[test]
+    fn test_dimension_mismatch_error() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        let wrong_dims = make_vector(32, 1.0);
+        let result = idx.add(1, &wrong_dims);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_search_empty_index() {
+        let tmp = TempDir::new().unwrap();
+        let idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        let query = make_vector(64, 1.0);
+        let results = idx.search(&query, 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_returns_nearest() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        let v1 = make_vector(64, 1.0);
+        let v2 = make_vector(64, 2.0);
+        let v3 = make_vector(64, 3.0);
+
+        idx.add(1, &v1).unwrap();
+        idx.add(2, &v2).unwrap();
+        idx.add(3, &v3).unwrap();
+
+        // Search with v1 as query, should return v1 first (distance ~0)
+        let results = idx.search(&v1, 3).unwrap();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].0, 1); // v1 should be first match
+        assert!(results[0].1 < 0.01); // distance should be near zero
+    }
+
+    #[test]
+    fn test_save_and_reload() {
+        let tmp = TempDir::new().unwrap();
+
+        // Create and populate index
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+            let v1 = make_vector(64, 1.0);
+            let v2 = make_vector(64, 2.0);
+            idx.add(100, &v1).unwrap();
+            idx.add(200, &v2).unwrap();
+            idx.save().unwrap();
+        }
+
+        // Reload and verify
+        {
+            let idx = VectorIndex::open(tmp.path()).unwrap();
+            assert!(idx.contains(100));
+            assert!(idx.contains(200));
+            assert!(!idx.contains(300));
+            assert_eq!(idx.dimensions(), 64);
+
+            // Verify search still works
+            let query = make_vector(64, 1.0);
+            let results = idx.search(&query, 2).unwrap();
+            assert_eq!(results.len(), 2);
+            assert_eq!(results[0].0, 100);
+        }
+    }
+
+    #[test]
+    fn test_open_nonexistent_fails() {
+        let tmp = TempDir::new().unwrap();
+        let result = VectorIndex::open(tmp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dimension_change_resets_index() {
+        let tmp = TempDir::new().unwrap();
+
+        // Create index with 64 dims
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+            let v = make_vector(64, 1.0);
+            idx.add(1, &v).unwrap();
+            idx.save().unwrap();
+        }
+
+        // Reopen with different dims, should reset
+        {
+            let idx = VectorIndex::open_or_create(tmp.path(), 128).unwrap();
+            assert!(!idx.contains(1)); // old data should be gone
+            assert_eq!(idx.dimensions(), 128);
+        }
+    }
+
+    #[test]
+    fn test_search_with_limit() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+
+        for i in 0..10 {
+            let v = make_vector(64, i as f32);
+            idx.add(i, &v).unwrap();
+        }
+
+        let query = make_vector(64, 0.0);
+        let results = idx.search(&query, 3).unwrap();
+        assert_eq!(results.len(), 3);
+    }
 }


### PR DESCRIPTION
Migrated vector search from custom brute-force implementation (O(n) complexity) to USearch's HNSW algorithm (O(log n) approximate search). Replaced flat binary storage with USearch's native persistence format. Updated dependencies with usearch and tempfile. Added 9 comprehensive tests covering index creation, persistence, search correctness, and edge cases. All tests pass.