### PR TITLE
Perf: batch embeddings and add CoreML acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "once_cell",
+ "ort",
  "rayon",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "5.0"
 fastembed = "5"
+ort = "2.0.0-rc.10"
 crossbeam-channel = "0.5"
 once_cell = "1.19"
 memchr = "2.7"

--- a/examples/embed_smoke.rs
+++ b/examples/embed_smoke.rs
@@ -3,7 +3,7 @@ use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 fn main() -> Result<()> {
     let mut model = TextEmbedding::try_new(
-        InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(true),
+        InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false),
     )?;
     let input = vec!["hello world", "small embedding smoke test"];
     let embeddings = model.embed(input, None)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -288,6 +288,8 @@ fn run_index(
 }
 
 fn run_embed(root: Option<PathBuf>) -> Result<()> {
+    const BATCH_SIZE: usize = 256;
+
     let paths = Paths::new(root)?;
     let index = SearchIndex::open_or_create(&paths.index)?;
     let mut embedder = EmbedderHandle::new()?;
@@ -298,6 +300,30 @@ fn run_embed(root: Option<PathBuf>) -> Result<()> {
 
     let mut embedded_counts = [0u64; 3];
     let mut embedded_total = 0u64;
+    let mut batch: Vec<(u64, String, crate::types::SourceKind)> = Vec::with_capacity(BATCH_SIZE);
+
+    let flush_batch =
+        |batch: &mut Vec<(u64, String, crate::types::SourceKind)>,
+         embedder: &mut EmbedderHandle,
+         vector: &mut VectorIndex,
+         progress: &crate::progress::Progress,
+         embedded_counts: &mut [u64; 3],
+         embedded_total: &mut u64| {
+            if batch.is_empty() {
+                return Ok(());
+            }
+            let texts: Vec<&str> = batch.iter().map(|(_, text, _)| text.as_str()).collect();
+            let embeddings = embedder.embed_texts(&texts)?;
+
+            for ((doc_id, _, source), vec) in batch.iter().zip(embeddings.iter()) {
+                vector.add(*doc_id, vec)?;
+                progress.add_embedded(*source, 1);
+                embedded_counts[source.idx()] += 1;
+                *embedded_total += 1;
+            }
+            batch.clear();
+            Ok::<_, anyhow::Error>(())
+        };
 
     index.for_each_record(|record| {
         if record.text.is_empty() || !is_embedding_role(&record.role) {
@@ -306,19 +332,34 @@ fn run_embed(root: Option<PathBuf>) -> Result<()> {
         if vector.contains(record.doc_id) {
             return Ok(());
         }
-        progress.add_embed_total(record.source, 1);
-        progress.add_embed_pending(record.source, 1);
         let text = truncate_for_embedding(record.text);
-        let embeddings = embedder.embed_texts(&[text.as_str()])?;
-        if let Some(vec) = embeddings.first() {
-            vector.add(record.doc_id, vec)?;
-            progress.add_embedded(record.source, 1);
-            embedded_counts[record.source.idx()] += 1;
-            embedded_total += 1;
+        if !text.is_empty() {
+            progress.add_embed_total(record.source, 1);
+            batch.push((record.doc_id, text, record.source));
+
+            if batch.len() >= BATCH_SIZE {
+                flush_batch(
+                    &mut batch,
+                    &mut embedder,
+                    &mut vector,
+                    &progress,
+                    &mut embedded_counts,
+                    &mut embedded_total,
+                )?;
+            }
         }
-        progress.sub_embed_pending(record.source, 1);
         Ok(())
     })?;
+
+    // Flush remaining
+    flush_batch(
+        &mut batch,
+        &mut embedder,
+        &mut vector,
+        &progress,
+        &mut embedded_counts,
+        &mut embedded_total,
+    )?;
 
     vector.save()?;
     progress.finish();

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -8,8 +8,8 @@ pub struct EmbedderHandle {
 
 impl EmbedderHandle {
     pub fn new() -> Result<Self> {
-        let mut opts = InitOptions::new(EmbeddingModel::EmbeddingGemma300M)
-            .with_show_download_progress(false);
+        let mut opts =
+            InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false);
 
         // Use CoreML on macOS for hardware acceleration
         #[cfg(target_os = "macos")]

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -8,15 +8,17 @@ pub struct EmbedderHandle {
 
 impl EmbedderHandle {
     pub fn new() -> Result<Self> {
-        let mut opts =
-            InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false);
-
-        // Use CoreML on macOS for hardware acceleration
         #[cfg(target_os = "macos")]
-        {
+        let opts = {
             use ort::execution_providers::CoreMLExecutionProvider;
-            opts = opts.with_execution_providers(vec![CoreMLExecutionProvider::default().build()]);
-        }
+            InitOptions::new(EmbeddingModel::EmbeddingGemma300M)
+                .with_show_download_progress(false)
+                .with_execution_providers(vec![CoreMLExecutionProvider::default().build()])
+        };
+
+        #[cfg(not(target_os = "macos"))]
+        let opts = InitOptions::new(EmbeddingModel::EmbeddingGemma300M)
+            .with_show_download_progress(false);
 
         let model = TextEmbedding::try_new(opts)?;
         // EmbeddingGemma outputs 768-dim embeddings

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -17,8 +17,8 @@ impl EmbedderHandle {
         };
 
         #[cfg(not(target_os = "macos"))]
-        let opts = InitOptions::new(EmbeddingModel::EmbeddingGemma300M)
-            .with_show_download_progress(false);
+        let opts =
+            InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false);
 
         let model = TextEmbedding::try_new(opts)?;
         // EmbeddingGemma outputs 768-dim embeddings

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -238,6 +238,7 @@ impl Progress {
         self.update_embed_message(source);
     }
 
+    #[allow(dead_code)]
     pub fn sub_embed_pending(&self, source: SourceKind, count: u64) {
         self.embed_pending[source.idx()].fetch_sub(count, Ordering::Relaxed);
         self.update_embed_message(source);


### PR DESCRIPTION
## Summary
- Disable download progress bar for cleaner output
- Add CoreML execution provider on macOS for hardware acceleration
- Batch embeddings in chunks of 256 instead of one-at-a-time for major throughput improvement

## Changes
- `src/embed.rs`: Use CoreML on macOS via `#[cfg(target_os = "macos")]`
- `src/cli.rs`: Progressive batching in `run_embed` (flush every 256 records)
- `src/ingest.rs`: Batch all texts in `flush_embeddings` before calling model
- Added `ort = "2.0.0-rc.10"` dependency for CoreML support