### PR TITLE
Add configurable embedding model via AUTOMEM_MODEL env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ claude-code-transcripts/
 .fastembed_cache/
 .codex/
 .claude/settings.local.json
-.claude/skills/automem-search/
+.claude/skills/memex-search/
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,33 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "automem"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "crossbeam-channel",
- "directories",
- "fastembed",
- "indicatif",
- "memchr",
- "memmap2",
- "once_cell",
- "ort",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "simd-json",
- "tantivy",
- "tempfile",
- "toml",
- "usearch",
- "walkdir",
-]
-
-[[package]]
 name = "av-scenechange"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1825,33 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memex"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossbeam-channel",
+ "directories",
+ "fastembed",
+ "indicatif",
+ "memchr",
+ "memmap2",
+ "once_cell",
+ "ort",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "simd-json",
+ "tantivy",
+ "tempfile",
+ "toml",
+ "usearch",
+ "walkdir",
+]
 
 [[package]]
 name = "memmap2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "automem"
+name = "memex"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ cargo build
 
 Binary:
 ```
-./target/debug/automem
+./target/debug/memex
 ```
 
 ## Quickstart
 
 Index (incremental):
 ```
-./target/debug/automem index
+./target/debug/memex index
 ```
 
 Search (JSONL default):
 ```
-./target/debug/automem search "your query" --limit 20
+./target/debug/memex search "your query" --limit 20
 ```
 
 Notes:
@@ -31,17 +31,17 @@ Notes:
 
 Full transcript:
 ```
-./target/debug/automem session <session_id>
+./target/debug/memex session <session_id>
 ```
 
 Single record:
 ```
-./target/debug/automem show <doc_id>
+./target/debug/memex show <doc_id>
 ```
 
 Human output:
 ```
-./target/debug/automem search "your query" -v
+./target/debug/memex search "your query" -v
 ```
 
 ## Search modes
@@ -72,16 +72,34 @@ Human output:
 
 Disable:
 ```
-./target/debug/automem index --no-embeddings
+./target/debug/memex index --no-embeddings
+```
+
+## Embedding model
+
+Select via `--model` flag or `MEMEX_MODEL` env var:
+
+| Model | Dims | Speed | Quality |
+|-------|------|-------|---------|
+| minilm | 384 | Fastest | Good |
+| bge | 384 | Fast | Better |
+| nomic | 768 | Moderate | Good |
+| gemma | 768 | Slowest | Best (default) |
+
+```
+./target/debug/memex index --model minilm
+# or
+MEMEX_MODEL=minilm ./target/debug/memex index
 ```
 
 ## Config (optional)
 
-Create `~/.automem/config.toml` (or `<root>/config.toml` if you use `--root`):
+Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 
 ```toml
 embeddings = true
 auto_index_on_search = true
+model = "gemma"  # minilm, bge, nomic, gemma
 ```
 
 SKILL.md is included as an example.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,35 +1,36 @@
 ---
-name: automem-search
-description: Search, filter, and retrieve Claude/Codex history indexed by the automem CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
+name: memex-search
+description: Search, filter, and retrieve Claude/Codex history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
 ---
 
-# Automem Search
+# Memex Search
 
 Use this skill to index local history and retrieve results in a structured, LLM-friendly way.
 
 ## Indexing
 
 - Build or update the index (incremental):
-  - `./target/debug/automem index`
+  - `./target/debug/memex index`
 - Full rebuild (clears index):
-  - `./target/debug/automem reindex`
+  - `./target/debug/memex reindex`
 - Embeddings are on by default.
 - Disable embeddings:
-  - `./target/debug/automem index --no-embeddings`
+  - `./target/debug/memex index --no-embeddings`
 - Backfill embeddings only:
-  - `./target/debug/automem embed`
+  - `./target/debug/memex embed`
 - Common flags:
   - `--source <path>` for Claude logs
   - `--include-agents` to include agent transcripts
   - `--codex/--no-codex` to include or skip Codex logs
-  - `--root <path>` to change data root (default: `~/.automem`)
+  - `--model <minilm|bge|nomic|gemma>` to select embedding model
+  - `--root <path>` to change data root (default: `~/.memex`)
 
 ## Search (LLM default JSON)
 
 Run a search; output is JSON lines by default.
 
 ```
-./target/debug/automem search "query" --limit 20
+./target/debug/memex search "query" --limit 20
 ```
 
 Each JSON line includes:
@@ -76,7 +77,7 @@ Each JSON line includes:
 1) Global search with `--limit`
 2) Reduce with `--project` and `--since/--until`
 3) Optionally `--top-n-per-session` or `--unique-session`
-4) `./target/debug/automem session <id>` for full context
+4) `./target/debug/memex session <id>` for full context
 
 ### Practical narrowing tips
 
@@ -89,11 +90,12 @@ Each JSON line includes:
 
 ## Config
 
-Create `~/.automem/config.toml` (or `<root>/config.toml` if you use `--root`):
+Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 
 ```toml
 embeddings = true
 auto_index_on_search = true
+model = "gemma"  # minilm, bge, nomic, gemma
 ```
 
 `auto_index_on_search` runs an incremental index update before each search.
@@ -109,9 +111,9 @@ auto_index_on_search = true
 ## Fetch Full Context
 
 - One record:
-  - `./target/debug/automem show <doc_id>`
+  - `./target/debug/memex show <doc_id>`
 - Full transcript:
-  - `./target/debug/automem session <session_id>`
+  - `./target/debug/memex session <session_id>`
 
 Both commands return JSON by default.
 
@@ -119,13 +121,13 @@ Both commands return JSON by default.
 
 Use `-v/--verbose` for human-readable output:
 
-- `./target/debug/automem search "query" -v`
-- `./target/debug/automem show <doc_id> -v`
-- `./target/debug/automem session <session_id> -v`
+- `./target/debug/memex search "query" -v`
+- `./target/debug/memex show <doc_id> -v`
+- `./target/debug/memex session <session_id> -v`
 
 ## Recommended LLM Flow
 
-1) `./target/debug/automem search "query" --limit 20`
+1) `./target/debug/memex search "query" --limit 20`
 2) Pick hits using `matches` or `snippet`
-3) `./target/debug/automem show <doc_id>` or `./target/debug/automem session <session_id>`
+3) `./target/debug/memex show <doc_id>` or `./target/debug/memex session <session_id>`
 4) Refine with `--session`, `--role`, or time filters

--- a/examples/embed_bench.rs
+++ b/examples/embed_bench.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use std::time::Instant;
+
+fn generate_texts(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            format!(
+                "This is test sentence number {} for embedding benchmarks",
+                i
+            )
+        })
+        .collect()
+}
+
+fn bench_model(name: &str, model_type: EmbeddingModel, dims: usize) -> Result<()> {
+    println!("\n{} ({} dims)", name, dims);
+    println!("{}", "-".repeat(60));
+
+    let start = Instant::now();
+
+    #[cfg(target_os = "macos")]
+    let opts = {
+        use ort::execution_providers::CoreMLExecutionProvider;
+        InitOptions::new(model_type)
+            .with_show_download_progress(false)
+            .with_execution_providers(vec![CoreMLExecutionProvider::default().build()])
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let opts = InitOptions::new(model_type).with_show_download_progress(false);
+
+    let mut model = TextEmbedding::try_new(opts)?;
+    println!("  Init: {:>6}ms", start.elapsed().as_millis());
+
+    // Warmup
+    let _ = model.embed(vec!["warmup"], None)?;
+
+    // Test different batch sizes and internal batch_size param
+    let texts_500 = generate_texts(500);
+    let text_refs: Vec<&str> = texts_500.iter().map(|s| s.as_str()).collect();
+
+    // Test with different internal batch sizes
+    for internal_batch in [None, Some(32), Some(64), Some(128), Some(256)] {
+        let start = Instant::now();
+        let embeddings = model.embed(&text_refs, internal_batch)?;
+        let elapsed = start.elapsed();
+
+        let texts_per_sec = 500.0 / elapsed.as_secs_f64();
+        let batch_str = internal_batch
+            .map(|b| format!("{}", b))
+            .unwrap_or("default".to_string());
+
+        println!(
+            "  500 texts (batch_size={:>7}): {:>5}ms | {:>6.0} texts/sec | {} vecs",
+            batch_str,
+            elapsed.as_millis(),
+            texts_per_sec,
+            embeddings.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    println!("Embedding Model Benchmark - Internal Batch Size Test");
+    println!("=====================================================");
+    println!("CPU cores: {}", std::thread::available_parallelism()?.get());
+    #[cfg(target_os = "macos")]
+    println!("Backend: CoreML + ONNX Runtime");
+    #[cfg(not(target_os = "macos"))]
+    println!("Backend: ONNX Runtime (CPU)");
+
+    // Just test with MiniLM and Gemma for speed
+    let models = [
+        ("MiniLM", EmbeddingModel::AllMiniLML6V2, 384),
+        ("Gemma", EmbeddingModel::EmbeddingGemma300M, 768),
+    ];
+
+    for (name, model_type, dims) in models {
+        if let Err(e) = bench_model(name, model_type, dims) {
+            println!("{}: error - {}", name, e);
+        }
+    }
+
+    Ok(())
+}

--- a/examples/embed_smoke.rs
+++ b/examples/embed_smoke.rs
@@ -2,15 +2,26 @@ use anyhow::Result;
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 fn main() -> Result<()> {
-    let mut model = TextEmbedding::try_new(
-        InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false),
-    )?;
+    // Respect AUTOMEM_MODEL env var
+    let (model_type, dims) = match std::env::var("AUTOMEM_MODEL")
+        .ok()
+        .as_deref()
+        .map(str::to_lowercase)
+        .as_deref()
+    {
+        Some("minilm" | "mini" | "fast") => (EmbeddingModel::AllMiniLML6V2, 384),
+        Some("bge" | "bge-small" | "bgesmall") => (EmbeddingModel::BGESmallENV15, 384),
+        Some("nomic") => (EmbeddingModel::NomicEmbedTextV15, 768),
+        _ => (EmbeddingModel::EmbeddingGemma300M, 768),
+    };
+
+    let mut model =
+        TextEmbedding::try_new(InitOptions::new(model_type).with_show_download_progress(false))?;
     let input = vec!["hello world", "small embedding smoke test"];
     let embeddings = model.embed(input, None)?;
     if embeddings.is_empty() {
         anyhow::bail!("no embeddings returned");
     }
-    let dims = embeddings[0].len();
     println!("embeddings: {} vectors, dims {}", embeddings.len(), dims);
     if let Some(first) = embeddings.first() {
         let preview: Vec<String> = first.iter().take(8).map(|v| format!("{v:.4}")).collect();

--- a/examples/embed_smoke.rs
+++ b/examples/embed_smoke.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 fn main() -> Result<()> {
-    // Respect AUTOMEM_MODEL env var
-    let (model_type, dims) = match std::env::var("AUTOMEM_MODEL")
+    // Respect MEMEX_MODEL env var
+    let (model_type, dims) = match std::env::var("MEMEX_MODEL")
         .ok()
         .as_deref()
         .map(str::to_lowercase)

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ impl Paths {
             Some(path) => path,
             None => {
                 let base = BaseDirs::new().ok_or_else(|| anyhow!("missing home dir"))?;
-                base.home_dir().join(".automem")
+                base.home_dir().join(".memex")
             }
         };
 
@@ -41,6 +41,8 @@ impl Paths {
 pub struct UserConfig {
     pub embeddings: Option<bool>,
     pub auto_index_on_search: Option<bool>,
+    /// Embedding model: minilm, bge, nomic, gemma (default)
+    pub model: Option<String>,
 }
 
 impl UserConfig {
@@ -60,5 +62,9 @@ impl UserConfig {
 
     pub fn auto_index_on_search_default(&self) -> bool {
         self.auto_index_on_search.unwrap_or(true)
+    }
+
+    pub fn model(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,5 +1,52 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+
+/// Supported embedding models with their dimensions
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ModelChoice {
+    /// AllMiniLML6V2 - 22M params, 384 dims, very fast
+    MiniLM,
+    /// BGESmallENV15 - 33M params, 384 dims, good balance
+    BGESmall,
+    /// NomicEmbedTextV15 - 137M params, 768 dims, good quality
+    Nomic,
+    /// EmbeddingGemma300M - 300M params, 768 dims, highest quality but slowest
+    #[default]
+    Gemma,
+}
+
+impl ModelChoice {
+    fn to_fastembed(self) -> EmbeddingModel {
+        match self {
+            ModelChoice::MiniLM => EmbeddingModel::AllMiniLML6V2,
+            ModelChoice::BGESmall => EmbeddingModel::BGESmallENV15,
+            ModelChoice::Nomic => EmbeddingModel::NomicEmbedTextV15,
+            ModelChoice::Gemma => EmbeddingModel::EmbeddingGemma300M,
+        }
+    }
+
+    fn dims(self) -> usize {
+        match self {
+            ModelChoice::MiniLM => 384,
+            ModelChoice::BGESmall => 384,
+            ModelChoice::Nomic => 768,
+            ModelChoice::Gemma => 768,
+        }
+    }
+
+    /// Parse from string (env var or config)
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "minilm" | "mini" | "fast" => Ok(ModelChoice::MiniLM),
+            "bge" | "bge-small" | "bgesmall" => Ok(ModelChoice::BGESmall),
+            "nomic" => Ok(ModelChoice::Nomic),
+            "gemma" | "embeddinggemma" | "default" => Ok(ModelChoice::Gemma),
+            _ => Err(anyhow!(
+                "unknown model '{s}', options: minilm, bge, nomic, gemma"
+            )),
+        }
+    }
+}
 
 pub struct EmbedderHandle {
     model: TextEmbedding,
@@ -8,21 +55,32 @@ pub struct EmbedderHandle {
 
 impl EmbedderHandle {
     pub fn new() -> Result<Self> {
+        // Check AUTOMEM_MODEL env var, default to Gemma
+        let choice = std::env::var("AUTOMEM_MODEL")
+            .ok()
+            .map(|s| ModelChoice::from_str(&s))
+            .transpose()?
+            .unwrap_or_default();
+
+        Self::with_model(choice)
+    }
+
+    pub fn with_model(choice: ModelChoice) -> Result<Self> {
+        let model_type = choice.to_fastembed();
+        let dims = choice.dims();
+
         #[cfg(target_os = "macos")]
         let opts = {
             use ort::execution_providers::CoreMLExecutionProvider;
-            InitOptions::new(EmbeddingModel::EmbeddingGemma300M)
+            InitOptions::new(model_type)
                 .with_show_download_progress(false)
                 .with_execution_providers(vec![CoreMLExecutionProvider::default().build()])
         };
 
         #[cfg(not(target_os = "macos"))]
-        let opts =
-            InitOptions::new(EmbeddingModel::EmbeddingGemma300M).with_show_download_progress(false);
+        let opts = InitOptions::new(model_type).with_show_download_progress(false);
 
         let model = TextEmbedding::try_new(opts)?;
-        // EmbeddingGemma outputs 768-dim embeddings
-        let dims = 768;
         Ok(Self { model, dims })
     }
 
@@ -42,7 +100,8 @@ mod tests {
     #[test]
     fn test_embedder_init() {
         let embedder = EmbedderHandle::new().expect("failed to init embedder");
-        assert_eq!(embedder.dims, 768);
+        // Default is Gemma with 768 dims, but env var could change it
+        assert!(embedder.dims == 384 || embedder.dims == 768);
     }
 
     #[test]
@@ -51,7 +110,7 @@ mod tests {
         let texts = vec!["Hello world"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
         assert_eq!(embeddings.len(), 1);
-        assert_eq!(embeddings[0].len(), 768);
+        assert_eq!(embeddings[0].len(), embedder.dims);
     }
 
     #[test]
@@ -61,7 +120,7 @@ mod tests {
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
         assert_eq!(embeddings.len(), 3);
         for emb in &embeddings {
-            assert_eq!(emb.len(), 768);
+            assert_eq!(emb.len(), embedder.dims);
         }
     }
 
@@ -78,7 +137,6 @@ mod tests {
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts = vec!["cats are cute", "dogs are loyal"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
-        // Embeddings for different texts should be different
         assert_ne!(embeddings[0], embeddings[1]);
     }
 
@@ -88,7 +146,6 @@ mod tests {
         let texts = vec!["the cat sat on the mat", "a cat is sitting on a mat"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
 
-        // Compute cosine similarity
         let dot: f32 = embeddings[0]
             .iter()
             .zip(embeddings[1].iter())
@@ -98,7 +155,6 @@ mod tests {
         let norm1: f32 = embeddings[1].iter().map(|x| x * x).sum::<f32>().sqrt();
         let cosine_sim = dot / (norm0 * norm1);
 
-        // Similar sentences should have high cosine similarity (> 0.8)
         assert!(
             cosine_sim > 0.8,
             "expected high similarity, got {}",

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -55,8 +55,8 @@ pub struct EmbedderHandle {
 
 impl EmbedderHandle {
     pub fn new() -> Result<Self> {
-        // Check AUTOMEM_MODEL env var, default to Gemma
-        let choice = std::env::var("AUTOMEM_MODEL")
+        // Check MEMEX_MODEL env var, default to Gemma
+        let choice = std::env::var("MEMEX_MODEL")
             .ok()
             .map(|s| ModelChoice::from_str(&s))
             .transpose()?


### PR DESCRIPTION
## Summary
- Adds `ModelChoice` enum supporting 4 embedding models with different speed/quality tradeoffs
- Models can be selected via `AUTOMEM_MODEL` environment variable
- Updated smoke test example to also respect the env var

## Model Options
| Model | Params | Dims | Speed | Alias |
|-------|--------|------|-------|-------|
| MiniLM | 22M | 384 | Fastest | `minilm`, `mini`, `fast` |
| BGE-Small | 33M | 384 | Fast | `bge`, `bge-small` |
| Nomic | 137M | 768 | Moderate | `nomic` |
| Gemma (default) | 300M | 768 | Slowest | `gemma`, `default` |

## Usage
```bash
# Use fast model for development
AUTOMEM_MODEL=minilm automem embed

# Use default (Gemma) for production quality
automem embed
```