### PR TITLE
Add skill-install CLI command for Claude/Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Binary:
 ./target/debug/memex
 ```
 
+## Install Skill
+
+Install the memex-search skill so Claude/Codex can use it automatically:
+
+```bash
+# Install for Claude Code only (default)
+./target/debug/memex skill-install
+
+# Install for both Claude and Codex
+./target/debug/memex skill-install --codex
+
+# Install for Codex only
+./target/debug/memex skill-install --no-claude --codex
+```
+
+Restart Claude/Codex to load the skill.
+
 ## Quickstart
 
 Index (incremental):
@@ -102,4 +119,4 @@ auto_index_on_search = true
 model = "gemma"  # minilm, bge, nomic, gemma
 ```
 
-SKILL.md is included as an example.
+The skill definition is bundled in `skills/memex-search/SKILL.md`.

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: memex-search
 description: Search, filter, and retrieve Claude/Codex history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
+allowed-tools: Bash(memex:*)
 ---
 
 # Memex Search
@@ -10,14 +11,14 @@ Use this skill to index local history and retrieve results in a structured, LLM-
 ## Indexing
 
 - Build or update the index (incremental):
-  - `./target/debug/memex index`
+  - `memex index`
 - Full rebuild (clears index):
-  - `./target/debug/memex reindex`
+  - `memex reindex`
 - Embeddings are on by default.
 - Disable embeddings:
-  - `./target/debug/memex index --no-embeddings`
+  - `memex index --no-embeddings`
 - Backfill embeddings only:
-  - `./target/debug/memex embed`
+  - `memex embed`
 - Common flags:
   - `--source <path>` for Claude logs
   - `--include-agents` to include agent transcripts
@@ -30,7 +31,7 @@ Use this skill to index local history and retrieve results in a structured, LLM-
 Run a search; output is JSON lines by default.
 
 ```
-./target/debug/memex search "query" --limit 20
+memex search "query" --limit 20
 ```
 
 Each JSON line includes:
@@ -62,7 +63,7 @@ Each JSON line includes:
 ### Grouping / dedupe
 
 - `--top-n-per-session <n>` (top n per session)
-- `--unique-session` (same as top‑k per session = 1)
+- `--unique-session` (same as top-k per session = 1)
 - `--sort score|ts` (default score)
 
 ### Output shape
@@ -77,12 +78,12 @@ Each JSON line includes:
 1) Global search with `--limit`
 2) Reduce with `--project` and `--since/--until`
 3) Optionally `--top-n-per-session` or `--unique-session`
-4) `./target/debug/memex session <id>` for full context
+4) `memex session <id>` for full context
 
 ### Practical narrowing tips
 
 - Start with exact terms (quoted) before hybrid if results are noisy.
-- Use `--unique-session` to collapse PR‑link spam fast.
+- Use `--unique-session` to collapse PR-link spam fast.
 - Use `--min-score` to prune low-signal hits.
 - Use `--sort ts` when you want a timeline view.
 - Use `--role assistant` for narrative outcomes; `--role tool_result` for command errors.
@@ -111,9 +112,9 @@ model = "gemma"  # minilm, bge, nomic, gemma
 ## Fetch Full Context
 
 - One record:
-  - `./target/debug/memex show <doc_id>`
+  - `memex show <doc_id>`
 - Full transcript:
-  - `./target/debug/memex session <session_id>`
+  - `memex session <session_id>`
 
 Both commands return JSON by default.
 
@@ -121,13 +122,13 @@ Both commands return JSON by default.
 
 Use `-v/--verbose` for human-readable output:
 
-- `./target/debug/memex search "query" -v`
-- `./target/debug/memex show <doc_id> -v`
-- `./target/debug/memex session <session_id> -v`
+- `memex search "query" -v`
+- `memex show <doc_id> -v`
+- `memex session <session_id> -v`
 
 ## Recommended LLM Flow
 
-1) `./target/debug/memex search "query" --limit 20`
+1) `memex search "query" --limit 20`
 2) Pick hits using `matches` or `snippet`
-3) `./target/debug/memex show <doc_id>` or `./target/debug/memex session <session_id>`
+3) `memex show <doc_id>` or `memex session <session_id>`
 4) Refine with `--session`, `--role`, or time filters


### PR DESCRIPTION
## Summary

- Adds `memex skill-install` command to install the memex-search skill to `~/.claude/skills/` and/or `~/.codex/skills/`
- Skill is bundled at compile time, so installation works from a built binary
- Moved SKILL.md to `skills/memex-search/` and added `allowed-tools: Bash(memex:*)` to restrict tool access
- Updated skill to use `memex` instead of `./target/debug/memex` paths (assumes memex is in PATH)