### PR TITLE
Add potion embedding option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,9 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "exr"
@@ -870,10 +873,10 @@ dependencies = [
  "anyhow",
  "hf-hub",
  "image",
- "ndarray",
+ "ndarray 0.16.1",
  "ort",
  "serde_json",
- "tokenizers",
+ "tokenizers 0.22.2",
 ]
 
 [[package]]
@@ -1839,6 +1842,7 @@ dependencies = [
  "indicatif",
  "memchr",
  "memmap2",
+ "model2vec-rs",
  "once_cell",
  "ort",
  "rayon",
@@ -1896,6 +1900,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "model2vec-rs"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23693c16304bc11674c991f47aa33794e641204e67547e0cef31c794c38ea00f"
+dependencies = [
+ "anyhow",
+ "clap",
+ "half",
+ "hf-hub",
+ "ndarray 0.15.6",
+ "safetensors",
+ "serde_json",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1968,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2174,7 +2207,7 @@ version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
 dependencies = [
- "ndarray",
+ "ndarray 0.16.1",
  "ort-sys",
  "smallvec 2.0.0-alpha.10",
  "tracing",
@@ -2755,6 +2788,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "safetensors"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3365,41 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "hf-hub",
+ "indicatif",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.17",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "5.0"
 fastembed = "5"
+model2vec-rs = "0.1.4"
 ort = "2.0.0-rc.10"
 crossbeam-channel = "0.5"
 once_cell = "1.19"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Select via `--model` flag or `MEMEX_MODEL` env var:
 | bge | 384 | Fast | Better |
 | nomic | 768 | Moderate | Good |
 | gemma | 768 | Slowest | Best (default) |
+| potion | 256 | Fastest (tiny) | Lowest |
 
 ```
 ./target/debug/memex index --model minilm
@@ -116,7 +117,7 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
-model = "gemma"  # minilm, bge, nomic, gemma
+model = "gemma"  # minilm, bge, nomic, gemma, potion
 ```
 
 The skill definition is bundled in `skills/memex-search/SKILL.md`.

--- a/examples/embed_smoke.rs
+++ b/examples/embed_smoke.rs
@@ -1,28 +1,14 @@
 use anyhow::Result;
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use memex::embed::EmbedderHandle;
 
 fn main() -> Result<()> {
-    // Respect MEMEX_MODEL env var
-    let (model_type, dims) = match std::env::var("MEMEX_MODEL")
-        .ok()
-        .as_deref()
-        .map(str::to_lowercase)
-        .as_deref()
-    {
-        Some("minilm" | "mini" | "fast") => (EmbeddingModel::AllMiniLML6V2, 384),
-        Some("bge" | "bge-small" | "bgesmall") => (EmbeddingModel::BGESmallENV15, 384),
-        Some("nomic") => (EmbeddingModel::NomicEmbedTextV15, 768),
-        _ => (EmbeddingModel::EmbeddingGemma300M, 768),
-    };
-
-    let mut model =
-        TextEmbedding::try_new(InitOptions::new(model_type).with_show_download_progress(false))?;
     let input = vec!["hello world", "small embedding smoke test"];
-    let embeddings = model.embed(input, None)?;
+    let mut embedder = EmbedderHandle::new()?;
+    let embeddings = embedder.embed_texts(&input)?;
     if embeddings.is_empty() {
         anyhow::bail!("no embeddings returned");
     }
-    println!("embeddings: {} vectors, dims {}", embeddings.len(), dims);
+    println!("embeddings: {} vectors, dims {}", embeddings.len(), embedder.dims);
     if let Some(first) = embeddings.first() {
         let preview: Vec<String> = first.iter().take(8).map(|v| format!("{v:.4}")).collect();
         println!("first: [{}]", preview.join(", "));

--- a/examples/embed_smoke.rs
+++ b/examples/embed_smoke.rs
@@ -8,7 +8,11 @@ fn main() -> Result<()> {
     if embeddings.is_empty() {
         anyhow::bail!("no embeddings returned");
     }
-    println!("embeddings: {} vectors, dims {}", embeddings.len(), embedder.dims);
+    println!(
+        "embeddings: {} vectors, dims {}",
+        embeddings.len(),
+        embedder.dims
+    );
     if let Some(first) = embeddings.first() {
         let preview: Vec<String> = first.iter().take(8).map(|v| format!("{v:.4}")).collect();
         println!("first: [{}]", preview.join(", "));

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -23,7 +23,7 @@ Use this skill to index local history and retrieve results in a structured, LLM-
   - `--source <path>` for Claude logs
   - `--include-agents` to include agent transcripts
   - `--codex/--no-codex` to include or skip Codex logs
-  - `--model <minilm|bge|nomic|gemma>` to select embedding model
+  - `--model <minilm|bge|nomic|gemma|potion>` to select embedding model
   - `--root <path>` to change data root (default: `~/.memex`)
 
 ## Search (LLM default JSON)
@@ -96,7 +96,7 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
-model = "gemma"  # minilm, bge, nomic, gemma
+model = "gemma"  # minilm, bge, nomic, gemma, potion
 ```
 
 `auto_index_on_search` runs an incremental index update before each search.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ enum Commands {
         embeddings: bool,
         #[arg(long)]
         no_embeddings: bool,
-        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality)
+        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
         #[arg(long)]
         model: Option<String>,
         #[arg(long)]
@@ -57,14 +57,14 @@ enum Commands {
         embeddings: bool,
         #[arg(long)]
         no_embeddings: bool,
-        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality)
+        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
         #[arg(long)]
         model: Option<String>,
         #[arg(long)]
         root: Option<PathBuf>,
     },
     Embed {
-        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality)
+        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
         #[arg(long)]
         model: Option<String>,
         #[arg(long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ impl Paths {
 pub struct UserConfig {
     pub embeddings: Option<bool>,
     pub auto_index_on_search: Option<bool>,
-    /// Embedding model: minilm, bge, nomic, gemma (default)
+    /// Embedding model: minilm, bge, nomic, gemma (default), potion
     pub model: Option<String>,
 }
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,7 +1,8 @@
 use anyhow::{Result, anyhow};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use model2vec_rs::model::StaticModel;
 
-/// Supported embedding models with their dimensions
+/// Supported embedding models
 #[derive(Debug, Clone, Copy, Default)]
 pub enum ModelChoice {
     /// AllMiniLML6V2 - 22M params, 384 dims, very fast
@@ -13,24 +14,18 @@ pub enum ModelChoice {
     /// EmbeddingGemma300M - 300M params, 768 dims, highest quality but slowest
     #[default]
     Gemma,
+    /// PotionBase8M - 8M params, model2vec backend, tiny and fast
+    Potion,
 }
 
 impl ModelChoice {
-    fn to_fastembed(self) -> EmbeddingModel {
+    fn fastembed_config(self) -> Option<(EmbeddingModel, usize)> {
         match self {
-            ModelChoice::MiniLM => EmbeddingModel::AllMiniLML6V2,
-            ModelChoice::BGESmall => EmbeddingModel::BGESmallENV15,
-            ModelChoice::Nomic => EmbeddingModel::NomicEmbedTextV15,
-            ModelChoice::Gemma => EmbeddingModel::EmbeddingGemma300M,
-        }
-    }
-
-    fn dims(self) -> usize {
-        match self {
-            ModelChoice::MiniLM => 384,
-            ModelChoice::BGESmall => 384,
-            ModelChoice::Nomic => 768,
-            ModelChoice::Gemma => 768,
+            ModelChoice::MiniLM => Some((EmbeddingModel::AllMiniLML6V2, 384)),
+            ModelChoice::BGESmall => Some((EmbeddingModel::BGESmallENV15, 384)),
+            ModelChoice::Nomic => Some((EmbeddingModel::NomicEmbedTextV15, 768)),
+            ModelChoice::Gemma => Some((EmbeddingModel::EmbeddingGemma300M, 768)),
+            ModelChoice::Potion => None,
         }
     }
 
@@ -41,15 +36,25 @@ impl ModelChoice {
             "bge" | "bge-small" | "bgesmall" => Ok(ModelChoice::BGESmall),
             "nomic" => Ok(ModelChoice::Nomic),
             "gemma" | "embeddinggemma" | "default" => Ok(ModelChoice::Gemma),
+            "potion"
+            | "potion8m"
+            | "potion-8m"
+            | "potion-base-8m"
+            | "model2vec" => Ok(ModelChoice::Potion),
             _ => Err(anyhow!(
-                "unknown model '{s}', options: minilm, bge, nomic, gemma"
+                "unknown model '{s}', options: minilm, bge, nomic, gemma, potion"
             )),
         }
     }
 }
 
+enum EmbedBackend {
+    Fastembed(TextEmbedding),
+    Model2Vec(StaticModel),
+}
+
 pub struct EmbedderHandle {
-    model: TextEmbedding,
+    backend: EmbedBackend,
     pub dims: usize,
 }
 
@@ -66,67 +71,117 @@ impl EmbedderHandle {
     }
 
     pub fn with_model(choice: ModelChoice) -> Result<Self> {
-        let model_type = choice.to_fastembed();
-        let dims = choice.dims();
+        if let Some((model_type, dims)) = choice.fastembed_config() {
+            // Set thread count for ONNX Runtime to use all cores
+            let num_cpus = std::thread::available_parallelism()
+                .map(|p| p.get())
+                .unwrap_or(8);
+            unsafe {
+                std::env::set_var("OMP_NUM_THREADS", num_cpus.to_string());
+                std::env::set_var("ORT_NUM_THREADS", num_cpus.to_string());
+            }
 
-        // Set thread count for ONNX Runtime to use all cores
-        let num_cpus = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or(8);
-        unsafe {
-            std::env::set_var("OMP_NUM_THREADS", num_cpus.to_string());
-            std::env::set_var("ORT_NUM_THREADS", num_cpus.to_string());
+            #[cfg(target_os = "macos")]
+            let opts = {
+                use ort::execution_providers::coreml::{
+                    CoreMLComputeUnits, CoreMLExecutionProvider,
+                };
+                let compute_units = std::env::var("MEMEX_COMPUTE_UNITS")
+                    .ok()
+                    .map(|v| match v.to_lowercase().as_str() {
+                        "ane" | "neural" | "neuralengine" => {
+                            CoreMLComputeUnits::CPUAndNeuralEngine
+                        }
+                        "gpu" => CoreMLComputeUnits::CPUAndGPU,
+                        "cpu" => CoreMLComputeUnits::CPUOnly,
+                        _ => CoreMLComputeUnits::All,
+                    })
+                    .unwrap_or(CoreMLComputeUnits::All);
+                let provider = CoreMLExecutionProvider::default()
+                    .with_subgraphs(true)
+                    .with_compute_units(compute_units);
+                InitOptions::new(model_type)
+                    .with_show_download_progress(false)
+                    .with_execution_providers(vec![provider.build()])
+            };
+
+            #[cfg(not(target_os = "macos"))]
+            let opts = InitOptions::new(model_type).with_show_download_progress(false);
+
+            let model = TextEmbedding::try_new(opts)?;
+            Ok(Self {
+                backend: EmbedBackend::Fastembed(model),
+                dims,
+            })
+        } else {
+            let model = StaticModel::from_pretrained(
+                "minishlab/potion-base-8M",
+                None,
+                None,
+                None,
+            )?;
+            let dims = model
+                .encode(&[String::from("dimension_check")])
+                .first()
+                .map(|vec| vec.len())
+                .ok_or_else(|| anyhow!("no embedding returned"))?;
+            Ok(Self {
+                backend: EmbedBackend::Model2Vec(model),
+                dims,
+            })
         }
-
-        #[cfg(target_os = "macos")]
-        let opts = {
-            use ort::execution_providers::coreml::{CoreMLComputeUnits, CoreMLExecutionProvider};
-            let compute_units = std::env::var("MEMEX_COMPUTE_UNITS")
-                .ok()
-                .map(|v| match v.to_lowercase().as_str() {
-                    "ane" | "neural" | "neuralengine" => CoreMLComputeUnits::CPUAndNeuralEngine,
-                    "gpu" => CoreMLComputeUnits::CPUAndGPU,
-                    "cpu" => CoreMLComputeUnits::CPUOnly,
-                    _ => CoreMLComputeUnits::All,
-                })
-                .unwrap_or(CoreMLComputeUnits::All);
-            let provider = CoreMLExecutionProvider::default()
-                .with_subgraphs(true)
-                .with_compute_units(compute_units);
-            InitOptions::new(model_type)
-                .with_show_download_progress(false)
-                .with_execution_providers(vec![provider.build()])
-        };
-
-        #[cfg(not(target_os = "macos"))]
-        let opts = InitOptions::new(model_type).with_show_download_progress(false);
-
-        let model = TextEmbedding::try_new(opts)?;
-        Ok(Self { model, dims })
     }
 
     pub fn embed_texts(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
-        let embeddings = self.model.embed(texts, None)?;
-        Ok(embeddings)
+        match &mut self.backend {
+            EmbedBackend::Fastembed(model) => Ok(model.embed(texts, None)?),
+            EmbedBackend::Model2Vec(model) => {
+                let input: Vec<String> = texts.iter().map(|t| t.to_string()).collect();
+                Ok(model.encode_with_args(&input, Some(512), 64))
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn fastembed_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().expect("lock fastembed")
+    }
 
     #[test]
     fn test_embedder_init() {
+        let _guard = fastembed_test_lock();
+        let env_model = std::env::var("MEMEX_MODEL")
+            .ok()
+            .map(|s| s.to_lowercase());
         let embedder = EmbedderHandle::new().expect("failed to init embedder");
         // Default is Gemma with 768 dims, but env var could change it
-        assert!(embedder.dims == 384 || embedder.dims == 768);
+        let is_potion = matches!(
+            env_model.as_deref(),
+            Some("potion")
+                | Some("potion8m")
+                | Some("potion-8m")
+                | Some("potion-base-8m")
+                | Some("model2vec")
+        );
+        if is_potion {
+            assert!(embedder.dims > 0);
+        } else {
+            assert!(embedder.dims == 384 || embedder.dims == 768);
+        }
     }
 
     #[test]
     fn test_embed_single_text() {
+        let _guard = fastembed_test_lock();
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts = vec!["Hello world"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -136,6 +191,7 @@ mod tests {
 
     #[test]
     fn test_embed_multiple_texts() {
+        let _guard = fastembed_test_lock();
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts = vec!["Hello world", "How are you?", "Rust is great"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -147,6 +203,7 @@ mod tests {
 
     #[test]
     fn test_embed_empty() {
+        let _guard = fastembed_test_lock();
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts: Vec<&str> = vec![];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -155,6 +212,7 @@ mod tests {
 
     #[test]
     fn test_embeddings_are_different() {
+        let _guard = fastembed_test_lock();
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts = vec!["cats are cute", "dogs are loyal"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -163,6 +221,7 @@ mod tests {
 
     #[test]
     fn test_similar_texts_have_similar_embeddings() {
+        let _guard = fastembed_test_lock();
         let mut embedder = EmbedderHandle::new().expect("failed to init embedder");
         let texts = vec!["the cat sat on the mat", "a cat is sitting on a mat"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -180,5 +239,26 @@ mod tests {
             cosine_sim > 0.8,
             "expected high similarity, got {cosine_sim}"
         );
+    }
+
+    #[test]
+    fn test_parse_potion_model() {
+        let choice = ModelChoice::parse("potion").expect("parse potion");
+        assert!(matches!(choice, ModelChoice::Potion));
+        let choice = ModelChoice::parse("potion-base-8m").expect("parse potion-base-8m");
+        assert!(matches!(choice, ModelChoice::Potion));
+        let choice = ModelChoice::parse("model2vec").expect("parse model2vec");
+        assert!(matches!(choice, ModelChoice::Potion));
+    }
+
+    #[test]
+    fn test_potion_embedding() {
+        let _guard = fastembed_test_lock();
+        let mut embedder =
+            EmbedderHandle::with_model(ModelChoice::Potion).expect("init potion embedder");
+        let texts = vec!["potion model smoke test", "another short sentence"];
+        let embeddings = embedder.embed_texts(&texts).expect("embed with potion");
+        assert_eq!(embeddings.len(), 2);
+        assert_eq!(embeddings[0].len(), embedder.dims);
     }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -36,11 +36,9 @@ impl ModelChoice {
             "bge" | "bge-small" | "bgesmall" => Ok(ModelChoice::BGESmall),
             "nomic" => Ok(ModelChoice::Nomic),
             "gemma" | "embeddinggemma" | "default" => Ok(ModelChoice::Gemma),
-            "potion"
-            | "potion8m"
-            | "potion-8m"
-            | "potion-base-8m"
-            | "model2vec" => Ok(ModelChoice::Potion),
+            "potion" | "potion8m" | "potion-8m" | "potion-base-8m" | "model2vec" => {
+                Ok(ModelChoice::Potion)
+            }
             _ => Err(anyhow!(
                 "unknown model '{s}', options: minilm, bge, nomic, gemma, potion"
             )),
@@ -89,9 +87,7 @@ impl EmbedderHandle {
                 let compute_units = std::env::var("MEMEX_COMPUTE_UNITS")
                     .ok()
                     .map(|v| match v.to_lowercase().as_str() {
-                        "ane" | "neural" | "neuralengine" => {
-                            CoreMLComputeUnits::CPUAndNeuralEngine
-                        }
+                        "ane" | "neural" | "neuralengine" => CoreMLComputeUnits::CPUAndNeuralEngine,
                         "gpu" => CoreMLComputeUnits::CPUAndGPU,
                         "cpu" => CoreMLComputeUnits::CPUOnly,
                         _ => CoreMLComputeUnits::All,
@@ -114,12 +110,7 @@ impl EmbedderHandle {
                 dims,
             })
         } else {
-            let model = StaticModel::from_pretrained(
-                "minishlab/potion-base-8M",
-                None,
-                None,
-                None,
-            )?;
+            let model = StaticModel::from_pretrained("minishlab/potion-base-8M", None, None, None)?;
             let dims = model
                 .encode(&[String::from("dimension_check")])
                 .first()
@@ -153,15 +144,15 @@ mod tests {
 
     fn fastembed_test_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().expect("lock fastembed")
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("lock fastembed")
     }
 
     #[test]
     fn test_embedder_init() {
         let _guard = fastembed_test_lock();
-        let env_model = std::env::var("MEMEX_MODEL")
-            .ok()
-            .map(|s| s.to_lowercase());
+        let env_model = std::env::var("MEMEX_MODEL").ok().map(|s| s.to_lowercase());
         let embedder = EmbedderHandle::new().expect("failed to init embedder");
         // Default is Gemma with 768 dims, but env var could change it
         let is_potion = matches!(


### PR DESCRIPTION
Adds the legacy potion (model2vec) embedding backend as an option and updates CLI/docs/examples. Serializes embedder tests to avoid fastembed cache lock contention. Tests: cargo test.