### PR TITLE
Fix index progress counter steps

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -21,7 +21,7 @@ use walkdir::WalkDir;
 
 const EMBED_BATCH_SIZE: usize = 64;
 const EMBED_MAX_CHARS: usize = 8192;
-const INDEX_PROGRESS_BATCH: u64 = 100;
+const INDEX_PROGRESS_BATCH: u64 = 1;
 
 #[derive(Debug, Clone)]
 pub struct IngestOptions {


### PR DESCRIPTION
Set index progress batching to 1 so the index counter increments per record.\n\nTests: cargo test.