### PR TITLE
Disable embeddings by default and fix model docs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ impl Paths {
 pub struct UserConfig {
     pub embeddings: Option<bool>,
     pub auto_index_on_search: Option<bool>,
-    /// Embedding model: minilm, bge, nomic, gemma, potion (default)
+    /// Embedding model: minilm, bge, nomic, gemma (default), potion
     pub model: Option<String>,
     /// Scan cache TTL in seconds. If a scan was done within this time,
     /// skip re-scanning on search. Default: 30 seconds.
@@ -60,7 +60,7 @@ impl UserConfig {
     }
 
     pub fn embeddings_default(&self) -> bool {
-        self.embeddings.unwrap_or(true)
+        self.embeddings.unwrap_or(false)
     }
 
     pub fn auto_index_on_search_default(&self) -> bool {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -71,14 +71,15 @@ impl Progress {
         claude_index.set_message("indexed 0 rec");
         claude_index.enable_steady_tick(Duration::from_millis(80));
 
-        let claude_embed = multi.add(ProgressBar::new_spinner());
-        claude_embed.set_style(spinner_style.clone());
-        if embeddings {
-            claude_embed.set_message("embedded 0");
+        let claude_embed = if embeddings {
+            let bar = multi.add(ProgressBar::new_spinner());
+            bar.set_style(spinner_style.clone());
+            bar.set_message("embedded 0");
+            bar.enable_steady_tick(Duration::from_millis(80));
+            bar
         } else {
-            claude_embed.set_message("embeddings off");
-        }
-        claude_embed.enable_steady_tick(Duration::from_millis(80));
+            ProgressBar::hidden()
+        };
 
         // Codex header
         let codex_header = multi.add(ProgressBar::new_spinner());
@@ -97,14 +98,15 @@ impl Progress {
         codex_index.set_message("indexed 0 rec");
         codex_index.enable_steady_tick(Duration::from_millis(80));
 
-        let codex_embed = multi.add(ProgressBar::new_spinner());
-        codex_embed.set_style(spinner_style);
-        if embeddings {
-            codex_embed.set_message("embedded 0");
+        let codex_embed = if embeddings {
+            let bar = multi.add(ProgressBar::new_spinner());
+            bar.set_style(spinner_style);
+            bar.set_message("embedded 0");
+            bar.enable_steady_tick(Duration::from_millis(80));
+            bar
         } else {
-            codex_embed.set_message("embeddings off");
-        }
-        codex_embed.enable_steady_tick(Duration::from_millis(80));
+            ProgressBar::hidden()
+        };
 
         Self {
             multi,


### PR DESCRIPTION
Disable embeddings by default for cleaner index output and fix incorrect model documentation.

Changes:
- Embeddings now default to false (users can enable via --embeddings flag or config)
- Fixed model comment: gemma is the default, not potion
- Hide embedding progress bars entirely when embeddings are disabled