### PR TITLE
Add index service commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Select via `--model` flag or `MEMEX_MODEL` env var:
 | minilm | 384 | Fastest | Good |
 | bge | 384 | Fast | Better |
 | nomic | 768 | Moderate | Good |
-| gemma | 768 | Slowest | Best (default) |
-| potion | 256 | Fastest (tiny) | Lowest |
+| gemma | 768 | Slowest | Best |
+| potion | 256 | Fastest (tiny) | Lowest (default) |
 
 ```
 ./target/debug/memex index --model minilm
@@ -139,7 +139,7 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
-model = "gemma"  # minilm, bge, nomic, gemma, potion
+model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ embeddings = true
 auto_index_on_search = true
 model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
-index_service_continuous = false  # true = continuous background watch
-index_service_interval = 3600  # seconds (ignored when continuous = true)
+index_service_mode = "interval"  # interval or continuous
+index_service_interval = 3600  # seconds (ignored when mode = "continuous")
 index_service_poll_interval = 30  # seconds
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Index (incremental):
 ./target/debug/memex index
 ```
 
+Continuous index (polling):
+```
+./target/debug/memex index --watch --watch-interval 30
+```
+
 Search (JSONL default):
 ```
 ./target/debug/memex search "your query" --limit 20
@@ -85,12 +90,29 @@ Human output:
 - `--fields score,ts,doc_id,session_id,snippet`
 - `--json-array`
 
+## Background index service (macOS launchd)
+
+Enable the launchd service that runs indexing on a timer:
+
+```
+./target/debug/memex index-service enable --interval 3600 --label com.memex.index.example --stdout ~/Library/Logs/memex-index.log
+```
+
+Disable it:
+```
+./target/debug/memex index-service disable --label com.memex.index.example
+```
+
 ## Embeddings
 
 Disable:
 ```
 ./target/debug/memex index --no-embeddings
 ```
+
+Recommended when embeddings are on (especially non-`potion` models): run the background
+index service or `index --watch`, and consider setting `auto_index_on_search = false`
+to keep searches fast.
 
 ## Embedding model
 
@@ -118,6 +140,9 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 embeddings = true
 auto_index_on_search = true
 model = "gemma"  # minilm, bge, nomic, gemma, potion
+scan_cache_ttl = 3600  # seconds (default 1 hour)
 ```
+
+`scan_cache_ttl` controls how long auto-indexing considers scans fresh.
 
 The skill definition is bundled in `skills/memex-search/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Index (incremental):
 ./target/debug/memex index
 ```
 
-Continuous index (polling):
+Continuous index (foreground):
 ```
 ./target/debug/memex index --watch --watch-interval 30
 ```
@@ -92,16 +92,17 @@ Human output:
 
 ## Background index service (macOS launchd)
 
-Enable the launchd service that runs indexing on a timer:
+Enable:
+```
+./target/debug/memex index-service enable
+```
 
+Disable:
 ```
-./target/debug/memex index-service enable --interval 3600 --label com.memex.index.example --stdout ~/Library/Logs/memex-index.log
+./target/debug/memex index-service disable
 ```
 
-Disable it:
-```
-./target/debug/memex index-service disable --label com.memex.index.example
-```
+`index-service` reads config defaults (mode, interval, label, log paths). Flags override.
 
 ## Embeddings
 
@@ -141,6 +142,13 @@ embeddings = true
 auto_index_on_search = true
 model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
+index_service_watch = false  # true = continuous background watch
+index_service_interval = 3600  # seconds (ignored when watch = true)
+index_service_watch_interval = 30  # seconds
+index_service_label = "com.memex.index"
+index_service_stdout = "/path/to/memex-index.log"
+index_service_stderr = "/path/to/memex-index.err.log"
+index_service_plist = "/path/to/com.memex.index.plist"
 ```
 
 `scan_cache_ttl` controls how long auto-indexing considers scans fresh.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ Index (incremental):
 ./target/debug/memex index
 ```
 
-Continuous index (foreground):
-```
-./target/debug/memex index --watch --watch-interval 30
-```
-
 Search (JSONL default):
 ```
 ./target/debug/memex search "your query" --limit 20
@@ -95,6 +90,7 @@ Human output:
 Enable:
 ```
 ./target/debug/memex index-service enable
+./target/debug/memex index-service enable --continuous
 ```
 
 Disable:
@@ -102,7 +98,7 @@ Disable:
 ./target/debug/memex index-service disable
 ```
 
-`index-service` reads config defaults (mode, interval, label, log paths). Flags override.
+`index-service` reads config defaults (mode, interval, log paths). Flags override.
 
 ## Embeddings
 
@@ -142,14 +138,12 @@ embeddings = true
 auto_index_on_search = true
 model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
-index_service_watch = false  # true = continuous background watch
-index_service_interval = 3600  # seconds (ignored when watch = true)
-index_service_watch_interval = 30  # seconds
-index_service_label = "com.memex.index"
-index_service_stdout = "/path/to/memex-index.log"
-index_service_stderr = "/path/to/memex-index.err.log"
-index_service_plist = "/path/to/com.memex.index.plist"
+index_service_continuous = false  # true = continuous background watch
+index_service_interval = 3600  # seconds (ignored when continuous = true)
+index_service_poll_interval = 30  # seconds
 ```
+
+Service logs and the plist live under `~/.memex` by default.
 
 `scan_cache_ttl` controls how long auto-indexing considers scans fresh.
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -12,8 +12,8 @@ Use this skill to index local history and retrieve results in a structured, LLM-
 
 - Build or update the index (incremental):
   - `memex index`
-- Continuous index (polling):
-  - `memex index --watch --watch-interval 30`
+- Continuous index:
+  - `memex index-service enable --continuous`
 - Full rebuild (clears index):
   - `memex reindex`
 - Embeddings are on by default.
@@ -79,6 +79,7 @@ Each JSON line includes:
 
 ```
 memex index-service enable
+memex index-service enable --continuous
 memex index-service disable
 ```
 
@@ -107,18 +108,15 @@ embeddings = true
 auto_index_on_search = true
 model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
-index_service_watch = false  # true = continuous background watch
-index_service_interval = 3600  # seconds (ignored when watch = true)
-index_service_watch_interval = 30  # seconds
-index_service_label = "com.memex.index"
-index_service_stdout = "/path/to/memex-index.log"
-index_service_stderr = "/path/to/memex-index.err.log"
-index_service_plist = "/path/to/com.memex.index.plist"
+index_service_continuous = false  # true = continuous background watch
+index_service_interval = 3600  # seconds (ignored when continuous = true)
+index_service_poll_interval = 30  # seconds
 ```
 
 `auto_index_on_search` runs an incremental index update before each search.
 `scan_cache_ttl` sets the maximum scan staleness for auto-indexing.
-`index-service` reads config defaults (mode, interval, label, log paths). Flags override.
+`index-service` reads config defaults (mode, interval, log paths). Flags override.
+Service logs and the plist live under `~/.memex` by default.
 
 Recommended when embeddings are on (especially non-`potion` models): run the
 background index service or `index --watch`, and consider setting

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -12,6 +12,8 @@ Use this skill to index local history and retrieve results in a structured, LLM-
 
 - Build or update the index (incremental):
   - `memex index`
+- Continuous index (polling):
+  - `memex index --watch --watch-interval 30`
 - Full rebuild (clears index):
   - `memex reindex`
 - Embeddings are on by default.
@@ -73,6 +75,13 @@ Each JSON line includes:
 - `--fields score,ts,doc_id,session_id,snippet` to reduce output
 - `-v/--verbose` for human output
 
+### Background index service (macOS launchd)
+
+```
+memex index-service enable --interval 3600 --label com.memex.index.example --stdout ~/Library/Logs/memex-index.log
+memex index-service disable --label com.memex.index.example
+```
+
 ### Narrow first (fastest reducers)
 
 1) Global search with `--limit`
@@ -97,9 +106,15 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 embeddings = true
 auto_index_on_search = true
 model = "gemma"  # minilm, bge, nomic, gemma, potion
+scan_cache_ttl = 3600  # seconds (default 1 hour)
 ```
 
 `auto_index_on_search` runs an incremental index update before each search.
+`scan_cache_ttl` sets the maximum scan staleness for auto-indexing.
+
+Recommended when embeddings are on (especially non-`potion` models): run the
+background index service or `index --watch`, and consider setting
+`auto_index_on_search = false` to keep searches fast.
 
 ### Semantic and Hybrid
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -78,8 +78,8 @@ Each JSON line includes:
 ### Background index service (macOS launchd)
 
 ```
-memex index-service enable --interval 3600 --label com.memex.index.example --stdout ~/Library/Logs/memex-index.log
-memex index-service disable --label com.memex.index.example
+memex index-service enable
+memex index-service disable
 ```
 
 ### Narrow first (fastest reducers)
@@ -105,12 +105,20 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
-model = "gemma"  # minilm, bge, nomic, gemma, potion
+model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
+index_service_watch = false  # true = continuous background watch
+index_service_interval = 3600  # seconds (ignored when watch = true)
+index_service_watch_interval = 30  # seconds
+index_service_label = "com.memex.index"
+index_service_stdout = "/path/to/memex-index.log"
+index_service_stderr = "/path/to/memex-index.err.log"
+index_service_plist = "/path/to/com.memex.index.plist"
 ```
 
 `auto_index_on_search` runs an incremental index update before each search.
 `scan_cache_ttl` sets the maximum scan staleness for auto-indexing.
+`index-service` reads config defaults (mode, interval, label, log paths). Flags override.
 
 Recommended when embeddings are on (especially non-`potion` models): run the
 background index service or `index --watch`, and consider setting

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -108,8 +108,8 @@ embeddings = true
 auto_index_on_search = true
 model = "potion"  # minilm, bge, nomic, gemma, potion
 scan_cache_ttl = 3600  # seconds (default 1 hour)
-index_service_continuous = false  # true = continuous background watch
-index_service_interval = 3600  # seconds (ignored when continuous = true)
+index_service_mode = "interval"  # interval or continuous
+index_service_interval = 3600  # seconds (ignored when mode = "continuous")
 index_service_poll_interval = 30  # seconds
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,9 +259,7 @@ pub fn run() -> Result<()> {
                 stderr,
                 plist,
             } => {
-                run_index_service_enable(
-                    &index, label, interval, stdout, stderr, plist,
-                )?;
+                run_index_service_enable(&index, label, interval, stdout, stderr, plist)?;
             }
             IndexServiceCommand::Disable { label, plist } => {
                 run_index_service_disable(label, plist)?;
@@ -1028,7 +1026,9 @@ fn run_index_service_enable(
         return Err(anyhow!("launchd scheduling is only supported on macOS"));
     }
     if index.embeddings && index.no_embeddings {
-        return Err(anyhow!("--embeddings and --no-embeddings cannot be used together"));
+        return Err(anyhow!(
+            "--embeddings and --no-embeddings cannot be used together"
+        ));
     }
     let (label, plist_path) = resolve_service_paths(label, plist)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1056,12 +1056,22 @@ fn run_index_service_enable(
     let paths = Paths::new(index.root.clone())?;
     let config = UserConfig::load(&paths)?;
     let cli_continuous = continuous || poll_interval.is_some();
+    let config_continuous = match config.index_service_mode() {
+        Some("interval") => false,
+        Some("continuous") => true,
+        Some(other) => {
+            return Err(anyhow!(
+                "invalid index_service_mode: {other} (expected \"interval\" or \"continuous\")"
+            ));
+        }
+        None => config.index_service_continuous_default(),
+    };
     let continuous = if cli_continuous {
         true
     } else if interval.is_some() {
         false
     } else {
-        config.index_service_continuous_default()
+        config_continuous
     };
     let poll_interval = poll_interval.unwrap_or(config.index_service_poll_interval());
     let interval = interval.unwrap_or(config.index_service_interval());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1027,6 +1027,7 @@ fn run_skill_install(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_index_service_enable(
     index: &IndexArgs,
     label: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use crate::types::SourceFilter;
 use crate::vector::VectorIndex;
 use anyhow::{Result, anyhow};
 use chrono::SecondsFormat;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use regex::RegexBuilder;
 use serde::Serialize;
 use serde_json::Value;
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[derive(Parser)]
 #[command(
@@ -26,42 +27,43 @@ pub struct Cli {
     command: Commands,
 }
 
+#[derive(Args, Clone)]
+struct IndexArgs {
+    #[arg(long)]
+    source: Option<PathBuf>,
+    #[arg(long)]
+    include_agents: bool,
+    #[arg(long, default_value_t = true)]
+    codex: bool,
+    #[arg(long)]
+    embeddings: bool,
+    #[arg(long)]
+    no_embeddings: bool,
+    /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
+    #[arg(long)]
+    model: Option<String>,
+    #[arg(long)]
+    root: Option<PathBuf>,
+}
+
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
     Index {
+        #[command(flatten)]
+        index: IndexArgs,
         #[arg(long)]
-        source: Option<PathBuf>,
-        #[arg(long)]
-        include_agents: bool,
-        #[arg(long, default_value_t = true)]
-        codex: bool,
-        #[arg(long)]
-        embeddings: bool,
-        #[arg(long)]
-        no_embeddings: bool,
-        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
-        #[arg(long)]
-        model: Option<String>,
-        #[arg(long)]
-        root: Option<PathBuf>,
+        watch: bool,
+        #[arg(
+            long = "watch-interval",
+            default_value_t = 30,
+            value_parser = clap::value_parser!(u64).range(1..)
+        )]
+        watch_interval: u64,
     },
     Reindex {
-        #[arg(long)]
-        source: Option<PathBuf>,
-        #[arg(long)]
-        include_agents: bool,
-        #[arg(long, default_value_t = true)]
-        codex: bool,
-        #[arg(long)]
-        embeddings: bool,
-        #[arg(long)]
-        no_embeddings: bool,
-        /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
-        #[arg(long)]
-        model: Option<String>,
-        #[arg(long)]
-        root: Option<PathBuf>,
+        #[command(flatten)]
+        index: IndexArgs,
     },
     Embed {
         /// Embedding model: minilm (fast), bge, nomic, gemma (default, best quality), potion (tiny)
@@ -113,6 +115,11 @@ enum Commands {
         #[arg(long)]
         root: Option<PathBuf>,
     },
+    /// Run indexing as a background service via launchd (macOS only)
+    IndexService {
+        #[command(subcommand)]
+        action: IndexServiceCommand,
+    },
     Session {
         session_id: String,
         #[arg(short, long)]
@@ -148,48 +155,50 @@ enum Commands {
     },
 }
 
+#[derive(Subcommand)]
+enum IndexServiceCommand {
+    Enable {
+        #[command(flatten)]
+        index: IndexArgs,
+        #[arg(long)]
+        label: Option<String>,
+        #[arg(
+            long,
+            default_value_t = 3600,
+            value_parser = clap::value_parser!(u64).range(1..)
+        )]
+        interval: u64,
+        #[arg(long)]
+        stdout: Option<PathBuf>,
+        #[arg(long)]
+        stderr: Option<PathBuf>,
+        #[arg(long)]
+        plist: Option<PathBuf>,
+    },
+    Disable {
+        #[arg(long)]
+        label: Option<String>,
+        #[arg(long)]
+        plist: Option<PathBuf>,
+    },
+}
+
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Index {
-            source,
-            include_agents,
-            codex,
-            embeddings,
-            no_embeddings,
-            model,
-            root,
+            index,
+            watch,
+            watch_interval,
         } => {
-            run_index(
-                source,
-                include_agents,
-                codex,
-                embeddings,
-                no_embeddings,
-                model,
-                root,
-                false,
-            )?;
+            if watch {
+                run_index_loop(&index, watch_interval)?;
+            } else {
+                run_index_args(&index, false)?;
+            }
         }
-        Commands::Reindex {
-            source,
-            include_agents,
-            codex,
-            embeddings,
-            no_embeddings,
-            model,
-            root,
-        } => {
-            run_index(
-                source,
-                include_agents,
-                codex,
-                embeddings,
-                no_embeddings,
-                model,
-                root,
-                true,
-            )?;
+        Commands::Reindex { index } => {
+            run_index_args(&index, true)?;
         }
         Commands::Embed { model, root } => {
             run_embed(model, root)?;
@@ -241,6 +250,23 @@ pub fn run() -> Result<()> {
                 root,
             )?;
         }
+        Commands::IndexService { action } => match action {
+            IndexServiceCommand::Enable {
+                index,
+                label,
+                interval,
+                stdout,
+                stderr,
+                plist,
+            } => {
+                run_index_service_enable(
+                    &index, label, interval, stdout, stderr, plist,
+                )?;
+            }
+            IndexServiceCommand::Disable { label, plist } => {
+                run_index_service_disable(label, plist)?;
+            }
+        },
         Commands::Session {
             session_id,
             verbose,
@@ -268,6 +294,27 @@ pub fn run() -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn run_index_loop(index: &IndexArgs, interval_secs: u64) -> Result<()> {
+    loop {
+        run_index_args(index, false)?;
+        std::io::stdout().flush().ok();
+        std::thread::sleep(Duration::from_secs(interval_secs));
+    }
+}
+
+fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
+    run_index(
+        index.source.clone(),
+        index.include_agents,
+        index.codex,
+        index.embeddings,
+        index.no_embeddings,
+        index.model.clone(),
+        index.root.clone(),
+        reindex,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -967,6 +1014,210 @@ fn run_skill_install(
     }
 
     Ok(())
+}
+
+fn run_index_service_enable(
+    index: &IndexArgs,
+    label: Option<String>,
+    interval: u64,
+    stdout: Option<PathBuf>,
+    stderr: Option<PathBuf>,
+    plist: Option<PathBuf>,
+) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Err(anyhow!("launchd scheduling is only supported on macOS"));
+    }
+    if index.embeddings && index.no_embeddings {
+        return Err(anyhow!("--embeddings and --no-embeddings cannot be used together"));
+    }
+    let (label, plist_path) = resolve_service_paths(label, plist)?;
+
+    if let Some(parent) = plist_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let exe = std::env::current_exe()?;
+    let mut program_args = Vec::new();
+    program_args.push(exe.to_string_lossy().to_string());
+    program_args.extend(build_index_command_args(index));
+
+    let contents = build_launchd_plist(
+        &label,
+        &program_args,
+        interval,
+        stdout.as_ref(),
+        stderr.as_ref(),
+    );
+    std::fs::write(&plist_path, contents)?;
+
+    println!("wrote launchd plist: {}", plist_path.display());
+    let status = std::process::Command::new("launchctl")
+        .arg("load")
+        .arg("-w")
+        .arg(&plist_path)
+        .status()?;
+    if !status.success() {
+        return Err(anyhow!("launchctl load failed"));
+    }
+    println!("enabled launchd job: {label}");
+    Ok(())
+}
+
+fn run_index_service_disable(label: Option<String>, plist: Option<PathBuf>) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Err(anyhow!("launchd scheduling is only supported on macOS"));
+    }
+    let (label, plist_path) = resolve_service_paths(label, plist)?;
+    if !plist_path.exists() {
+        println!("no launchd plist found: {}", plist_path.display());
+        return Ok(());
+    }
+    let status = std::process::Command::new("launchctl")
+        .arg("unload")
+        .arg("-w")
+        .arg(&plist_path)
+        .status()?;
+    if !status.success() {
+        return Err(anyhow!("launchctl unload failed"));
+    }
+    std::fs::remove_file(&plist_path)?;
+    println!("disabled launchd job: {label}");
+    Ok(())
+}
+
+fn resolve_service_paths(
+    label: Option<String>,
+    plist: Option<PathBuf>,
+) -> Result<(String, PathBuf)> {
+    let label = match (label, plist.as_ref()) {
+        (Some(label), _) => label,
+        (None, Some(path)) => path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "com.memex.index".to_string()),
+        (None, None) => "com.memex.index".to_string(),
+    };
+    validate_launchd_label(&label)?;
+    let plist_path = match plist {
+        Some(path) => path,
+        None => default_launchd_plist_path(&label)?,
+    };
+    Ok((label, plist_path))
+}
+
+fn validate_launchd_label(label: &str) -> Result<()> {
+    if label.trim().is_empty() {
+        return Err(anyhow!("launchd label cannot be empty"));
+    }
+    if label.contains('/') || label.contains('\\') {
+        return Err(anyhow!("launchd label cannot contain path separators"));
+    }
+    Ok(())
+}
+
+fn build_index_command_args(index: &IndexArgs) -> Vec<String> {
+    let mut args = Vec::new();
+    args.push("index".to_string());
+
+    if let Some(source) = &index.source {
+        args.push("--source".to_string());
+        args.push(source.to_string_lossy().to_string());
+    }
+    if index.include_agents {
+        args.push("--include-agents".to_string());
+    }
+    args.push("--codex".to_string());
+    args.push(format!("{}", index.codex));
+    if index.embeddings {
+        args.push("--embeddings".to_string());
+    }
+    if index.no_embeddings {
+        args.push("--no-embeddings".to_string());
+    }
+    if let Some(model) = &index.model {
+        args.push("--model".to_string());
+        args.push(model.clone());
+    }
+    if let Some(root) = &index.root {
+        args.push("--root".to_string());
+        args.push(root.to_string_lossy().to_string());
+    }
+    args
+}
+
+fn build_launchd_plist(
+    label: &str,
+    program_args: &[String],
+    interval: u64,
+    stdout: Option<&PathBuf>,
+    stderr: Option<&PathBuf>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n",
+    );
+    out.push_str("<plist version=\"1.0\">\n");
+    out.push_str("<dict>\n");
+    out.push_str("  <key>Label</key>\n");
+    out.push_str(&format!("  <string>{}</string>\n", xml_escape(label)));
+    out.push_str("  <key>ProgramArguments</key>\n");
+    out.push_str("  <array>\n");
+    for arg in program_args {
+        out.push_str(&format!("    <string>{}</string>\n", xml_escape(arg)));
+    }
+    out.push_str("  </array>\n");
+    out.push_str("  <key>RunAtLoad</key>\n");
+    out.push_str("  <true/>\n");
+    out.push_str("  <key>StartInterval</key>\n");
+    out.push_str(&format!("  <integer>{interval}</integer>\n"));
+
+    if let Some(stdout) = stdout {
+        out.push_str("  <key>StandardOutPath</key>\n");
+        out.push_str(&format!(
+            "  <string>{}</string>\n",
+            xml_escape(&stdout.to_string_lossy())
+        ));
+    }
+    if let Some(stderr) = stderr {
+        out.push_str("  <key>StandardErrorPath</key>\n");
+        out.push_str(&format!(
+            "  <string>{}</string>\n",
+            xml_escape(&stderr.to_string_lossy())
+        ));
+    }
+
+    out.push_str("</dict>\n");
+    out.push_str("</plist>\n");
+    out
+}
+
+fn xml_escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn default_launchd_plist_path(label: &str) -> Result<PathBuf> {
+    let home = directories::BaseDirs::new()
+        .ok_or_else(|| anyhow!("cannot determine home directory"))?
+        .home_dir()
+        .to_path_buf();
+    Ok(home
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{label}.plist")))
 }
 
 fn default_claude_source() -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,20 @@ pub struct UserConfig {
     /// Scan cache TTL in seconds. If a scan was done within this time,
     /// skip re-scanning on search. Default: 3600 seconds (1 hour).
     pub scan_cache_ttl: Option<u64>,
+    /// Run background index service in watch mode (continuous).
+    pub index_service_watch: Option<bool>,
+    /// Background index service interval in seconds (ignored when watch is true).
+    pub index_service_interval: Option<u64>,
+    /// Background index service watch interval in seconds.
+    pub index_service_watch_interval: Option<u64>,
+    /// Background index service launchd label.
+    pub index_service_label: Option<String>,
+    /// Background index service stdout log path.
+    pub index_service_stdout: Option<PathBuf>,
+    /// Background index service stderr log path.
+    pub index_service_stderr: Option<PathBuf>,
+    /// Background index service plist path.
+    pub index_service_plist: Option<PathBuf>,
 }
 
 impl UserConfig {
@@ -73,5 +87,17 @@ impl UserConfig {
 
     pub fn scan_cache_ttl(&self) -> u64 {
         self.scan_cache_ttl.unwrap_or(3600)
+    }
+
+    pub fn index_service_watch_default(&self) -> bool {
+        self.index_service_watch.unwrap_or(false)
+    }
+
+    pub fn index_service_interval(&self) -> u64 {
+        self.index_service_interval.unwrap_or(3600)
+    }
+
+    pub fn index_service_watch_interval(&self) -> u64 {
+        self.index_service_watch_interval.unwrap_or(30)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub struct UserConfig {
     /// Embedding model: minilm, bge, nomic, gemma, potion (default)
     pub model: Option<String>,
     /// Scan cache TTL in seconds. If a scan was done within this time,
-    /// skip re-scanning on search. Default: 30 seconds.
+    /// skip re-scanning on search. Default: 3600 seconds (1 hour).
     pub scan_cache_ttl: Option<u64>,
 }
 
@@ -72,6 +72,6 @@ impl UserConfig {
     }
 
     pub fn scan_cache_ttl(&self) -> u64 {
-        self.scan_cache_ttl.unwrap_or(30)
+        self.scan_cache_ttl.unwrap_or(3600)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,9 @@ pub struct UserConfig {
     /// Scan cache TTL in seconds. If a scan was done within this time,
     /// skip re-scanning on search. Default: 3600 seconds (1 hour).
     pub scan_cache_ttl: Option<u64>,
-    /// Run background index service continuously.
+    /// Background index service mode: "interval" or "continuous".
+    pub index_service_mode: Option<String>,
+    /// Run background index service continuously (legacy).
     #[serde(alias = "index_service_watch")]
     pub index_service_continuous: Option<bool>,
     /// Background index service interval in seconds (ignored when continuous is true).
@@ -89,6 +91,10 @@ impl UserConfig {
 
     pub fn scan_cache_ttl(&self) -> u64 {
         self.scan_cache_ttl.unwrap_or(3600)
+    }
+
+    pub fn index_service_mode(&self) -> Option<&str> {
+        self.index_service_mode.as_deref()
     }
 
     pub fn index_service_continuous_default(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,12 +46,14 @@ pub struct UserConfig {
     /// Scan cache TTL in seconds. If a scan was done within this time,
     /// skip re-scanning on search. Default: 3600 seconds (1 hour).
     pub scan_cache_ttl: Option<u64>,
-    /// Run background index service in watch mode (continuous).
-    pub index_service_watch: Option<bool>,
-    /// Background index service interval in seconds (ignored when watch is true).
+    /// Run background index service continuously.
+    #[serde(alias = "index_service_watch")]
+    pub index_service_continuous: Option<bool>,
+    /// Background index service interval in seconds (ignored when continuous is true).
     pub index_service_interval: Option<u64>,
-    /// Background index service watch interval in seconds.
-    pub index_service_watch_interval: Option<u64>,
+    /// Background index service poll interval in seconds.
+    #[serde(alias = "index_service_watch_interval")]
+    pub index_service_poll_interval: Option<u64>,
     /// Background index service launchd label.
     pub index_service_label: Option<String>,
     /// Background index service stdout log path.
@@ -89,15 +91,15 @@ impl UserConfig {
         self.scan_cache_ttl.unwrap_or(3600)
     }
 
-    pub fn index_service_watch_default(&self) -> bool {
-        self.index_service_watch.unwrap_or(false)
+    pub fn index_service_continuous_default(&self) -> bool {
+        self.index_service_continuous.unwrap_or(false)
     }
 
     pub fn index_service_interval(&self) -> u64 {
         self.index_service_interval.unwrap_or(3600)
     }
 
-    pub fn index_service_watch_interval(&self) -> u64 {
-        self.index_service_watch_interval.unwrap_or(30)
+    pub fn index_service_poll_interval(&self) -> u64 {
+        self.index_service_poll_interval.unwrap_or(30)
     }
 }


### PR DESCRIPTION
Adds explicit index-service enable/disable commands and watch usage for continuous indexing. Sets scan cache TTL default to 1 hour and documents potion as the default model. Updates README and skill docs with recommended background indexing for embeddings. Tests: cargo test.