### PR TITLE
Add Linux builds to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,45 @@ jobs:
           files: |
             memex-*.tar.gz
             memex-*.sha256
+
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          arch="${{ matrix.arch }}"
+          artifact="memex-${version}-linux-${arch}.tar.gz"
+          tar -C target/${{ matrix.target }}/release -czf "${artifact}" memex
+          sha256sum "${artifact}" > "${artifact}.sha256"
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            memex-*.tar.gz
+            memex-*.sha256


### PR DESCRIPTION
## Summary
- Add `build-linux` job to release workflow producing x86_64 and arm64 Linux binaries
- Install cross-compilation toolchain for arm64 Linux builds
- Use `sha256sum` instead of `shasum` for Linux artifact checksums