### PR TITLE
Improve CLI help text and argument documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memex"
-version = "0.1.0"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Add comprehensive help text and documentation to all CLI commands and arguments. Users can now run `memex --help` for quick start guidance and `memex <command> --help` for detailed argument descriptions including timestamp formats, available output fields, and usage examples.