### PR TITLE
feat: add opencode skill and fix ingest ordering

### DIFF
--- a/skills/opencode.md
+++ b/skills/opencode.md
@@ -1,0 +1,58 @@
+---
+name: opencode
+description: Search, filter, and retrieve Opencode history via memex CLI. Use for context resumption, finding past code/decisions, and self-correction based on history.
+allowed-tools: Bash(memex:*)
+---
+
+# Memex for Opencode
+
+`memex` is the primary memory retrieval tool. Use it to access historical sessions and indexed code interactions.
+
+## Usage Patterns
+
+- **Context Retrieval:** "What did we discuss in the last session regarding the API?"
+  - `memex search "API discussion" --sort ts --limit 10`
+- **Code Discovery:** "Find the specific function implementation from last week."
+  - `memex search "function implementation" --hybrid`
+- **Session Identification:** "Which session covered the database migration?"
+  - `memex search "database migration" --unique-session`
+
+## Search Modes
+
+### Semantic vs Exact
+
+| Need                     | Flag         | Example                                 |
+| ------------------------ | ------------ | --------------------------------------- |
+| Exact terms, IDs, errors | (default)    | `memex search "Error: 500"`             |
+| Concepts, intent         | `--semantic` | `memex search "auth flow" --semantic`   |
+| Mixed specific + fuzzy   | `--hybrid`   | `memex search "user_id logic" --hybrid` |
+
+## Session Context
+
+Use `--session {session_id}` to isolate a specific interaction thread.
+
+1. **Find Session ID:**
+   - `memex search "topic" --unique-session`
+2. **Narrow Search:**
+   - `memex search "detail" --session <session_id>`
+3. **Fetch Transcript:**
+   - `memex session <session_id>`
+
+## Output Parsing
+
+Output is JSONL (JSON Lines). Each line is a valid JSON object.
+
+**Schema:**
+
+- `doc_id`: Unique record ID.
+- `session_id`: Conversation thread ID.
+- `ts`: ISO 8601 timestamp.
+- `role`: `user`, `assistant`, `system`.
+- `text`: Content payload.
+- `score`: Search relevance (float).
+
+**Interpretation:**
+
+- **Filtering:** Discard results below a relevance threshold (e.g., `score < 0.5`) unless specific.
+- **Ordering:** Sort by `ts` for timeline reconstruction.
+- **Grouping:** Aggregate by `session_id` to view conversation turns.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,9 @@ struct IndexArgs {
     /// Index Codex sessions from ~/.codex [default: true]
     #[arg(long, default_value_t = true)]
     codex: bool,
+    /// Index Opencode sessions from ~/.local/share/opencode [default: true]
+    #[arg(long, default_value_t = true)]
+    opencode: bool,
     /// Generate embeddings for semantic search during indexing
     #[arg(long)]
     embeddings: bool,
@@ -439,6 +442,7 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
         index.source.clone(),
         index.include_agents,
         index.codex,
+        index.opencode,
         index.embeddings,
         index.no_embeddings,
         index.model.clone(),
@@ -452,6 +456,7 @@ fn run_index(
     source: Option<PathBuf>,
     include_agents: bool,
     codex: bool,
+    opencode: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
     model: Option<String>,
@@ -483,6 +488,7 @@ fn run_index(
         claude_source: source.unwrap_or_else(default_claude_source),
         include_agents,
         include_codex: codex,
+        include_opencode: opencode,
         embeddings,
         backfill_embeddings,
         model: model_choice,
@@ -519,10 +525,10 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     let mut embedder = EmbedderHandle::with_model(model_choice)?;
     let mut vector = VectorIndex::open_or_create(&paths.vectors, embedder.dims)?;
 
-    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 3], [0; 3], true));
+    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 4], [0; 4], true));
     progress.set_embed_ready();
 
-    let mut embedded_counts = [0u64; 3];
+    let mut embedded_counts = [0u64; 4];
     let mut embedded_total = 0u64;
     let mut batch: Vec<(u64, String, crate::types::SourceKind)> = Vec::with_capacity(BATCH_SIZE);
 
@@ -530,7 +536,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
                        embedder: &mut EmbedderHandle,
                        vector: &mut VectorIndex,
                        progress: &crate::progress::Progress,
-                       embedded_counts: &mut [u64; 3],
+                       embedded_counts: &mut [u64; 4],
                        embedded_total: &mut u64| {
         if batch.is_empty() {
             return Ok(());
@@ -587,11 +593,12 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {})",
+        "embedded {} vectors (claude {}, codex {}, history {}, opencode {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::CodexSession.idx()],
         embedded_counts[crate::types::SourceKind::CodexHistory.idx()],
+        embedded_counts[crate::types::SourceKind::Opencode.idx()],
     );
 
     std::io::stdout().flush().ok();
@@ -639,6 +646,7 @@ fn run_search(
             claude_source: default_claude_source(),
             include_agents: false,
             include_codex: true,
+            include_opencode: true,
             embeddings: embeddings_default,
             backfill_embeddings,
             model: model_choice,
@@ -1113,9 +1121,10 @@ fn run_setup(force: bool) -> Result<()> {
     // Detect installed tools
     let claude_path = find_in_path("claude");
     let codex_path = find_in_path("codex");
+    let opencode_path = find_in_path("opencode");
 
-    if claude_path.is_none() && codex_path.is_none() {
-        return Err(anyhow!("Neither claude nor codex found in PATH"));
+    if claude_path.is_none() && codex_path.is_none() && opencode_path.is_none() {
+        return Err(anyhow!("Neither claude, codex, nor opencode found in PATH"));
     }
 
     // Show what will be installed
@@ -1126,6 +1135,9 @@ fn run_setup(force: bool) -> Result<()> {
     }
     if codex_path.is_some() {
         println!("  Codex: automem-search prompt");
+    }
+    if opencode_path.is_some() {
+        println!("  Opencode: automem-search prompt");
     }
     if force {
         println!();
@@ -1143,6 +1155,10 @@ fn run_setup(force: bool) -> Result<()> {
     }
     if let Some(path) = &codex_path {
         items.push(("codex", format!("Codex ({})", path.display())));
+        defaults.push(true);
+    }
+    if let Some(path) = &opencode_path {
+        items.push(("opencode", format!("Opencode ({})", path.display())));
         defaults.push(true);
     }
 
@@ -1237,12 +1253,35 @@ fn run_setup(force: bool) -> Result<()> {
                     println!("{verb} Codex prompt at {}.", dest.display());
                 }
             }
+            "opencode" => {
+                let dest_dir = home
+                    .join(".local")
+                    .join("share")
+                    .join("opencode")
+                    .join("prompts");
+                let dest = dest_dir.join("automem-search.md");
+                if dest.exists() && !force {
+                    println!(
+                        "Skipping Opencode prompt (already installed at {}). Use --force to overwrite.",
+                        dest.display()
+                    );
+                } else {
+                    std::fs::create_dir_all(&dest_dir)?;
+                    std::fs::write(&dest, codex_prompt)?;
+                    let verb = if dest.exists() {
+                        "Updated"
+                    } else {
+                        "Installed"
+                    };
+                    println!("{verb} Opencode prompt at {}.", dest.display());
+                }
+            }
             _ => {}
         }
     }
 
     println!();
-    println!("Done! Restart Claude Code / Codex to pick up changes.");
+    println!("Done! Restart Claude Code / Codex / Opencode to pick up changes.");
 
     Ok(())
 }
@@ -1267,11 +1306,12 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
 
     // Get source info from first record
     let record = &records[0];
-    let source_path = &record.source_path;
     let tool = match record.source {
         crate::types::SourceKind::Claude => "claude",
         crate::types::SourceKind::CodexSession | crate::types::SourceKind::CodexHistory => "codex",
+        crate::types::SourceKind::Opencode => "opencode",
     };
+    let source_path = &record.source_path;
 
     // Build agentexport command
     let mut cmd = std::process::Command::new("agentexport");
@@ -1487,6 +1527,9 @@ fn build_index_command_args(
     }
     if !index.codex {
         args.push("--no-codex".to_string());
+    }
+    if !index.opencode {
+        args.push("--no-opencode".to_string());
     }
     if index.embeddings {
         args.push("--embeddings".to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,8 @@ pub struct UserConfig {
     pub claude_resume_cmd: Option<String>,
     /// Resume command template for Codex sessions.
     pub codex_resume_cmd: Option<String>,
+    /// Resume command template for Opencode sessions.
+    pub opencode_resume_cmd: Option<String>,
 }
 
 impl UserConfig {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -101,6 +101,7 @@ enum SourceChoice {
     All,
     Claude,
     Codex,
+    Opencode,
 }
 
 impl SourceChoice {
@@ -108,7 +109,8 @@ impl SourceChoice {
         match self {
             SourceChoice::All => SourceChoice::Claude,
             SourceChoice::Claude => SourceChoice::Codex,
-            SourceChoice::Codex => SourceChoice::All,
+            SourceChoice::Codex => SourceChoice::Opencode,
+            SourceChoice::Opencode => SourceChoice::All,
         }
     }
 
@@ -117,6 +119,7 @@ impl SourceChoice {
             SourceChoice::All => None,
             SourceChoice::Claude => Some(SourceFilter::Claude),
             SourceChoice::Codex => Some(SourceFilter::Codex),
+            SourceChoice::Opencode => Some(SourceFilter::Opencode),
         }
     }
 
@@ -125,6 +128,7 @@ impl SourceChoice {
             SourceChoice::All => "all",
             SourceChoice::Claude => "claude",
             SourceChoice::Codex => "codex",
+            SourceChoice::Opencode => "opencode",
         }
     }
 }
@@ -434,6 +438,7 @@ impl App {
                     claude_source: default_claude_source(),
                     include_agents: false,
                     include_codex: true,
+                    include_opencode: true,
                     embeddings: embeddings_default,
                     backfill_embeddings,
                     model: model_choice,
@@ -688,6 +693,11 @@ impl App {
                 .codex_resume_cmd
                 .clone()
                 .or_else(|| default_resume_template("codex")),
+            SourceKind::Opencode => self
+                .config
+                .opencode_resume_cmd
+                .clone()
+                .or_else(|| default_resume_template("opencode")),
         };
         let Some(template) = template else {
             self.set_status("resume command not configured in config.toml");
@@ -719,6 +729,7 @@ impl App {
         let tool = match session.source {
             SourceKind::Claude => "claude",
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
+            SourceKind::Opencode => "opencode",
         };
         let source_path = session.source_path.clone();
 
@@ -1618,6 +1629,7 @@ fn default_resume_template(cmd: &str) -> Option<String> {
             find_in_path("claude").map(|_| "cd {cwd} && claude --resume {session_id}".to_string())
         }
         "codex" => find_in_path("codex").map(|_| "codex resume {session_id}".to_string()),
+        "opencode" => find_in_path("opencode").map(|_| "opencode resume {session_id}".to_string()),
         _ => None,
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@ pub enum SourceKind {
     Claude,
     CodexSession,
     CodexHistory,
+    Opencode,
 }
 
 impl SourceKind {
@@ -15,6 +16,7 @@ impl SourceKind {
             SourceKind::Claude => 0,
             SourceKind::CodexSession => 1,
             SourceKind::CodexHistory => 2,
+            SourceKind::Opencode => 3,
         }
     }
 
@@ -22,6 +24,7 @@ impl SourceKind {
         match self {
             SourceKind::Claude => "claude",
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
+            SourceKind::Opencode => "opencode",
         }
     }
 
@@ -30,6 +33,10 @@ impl SourceKind {
             SourceKind::CodexSession
         } else if path.contains(".codex/history.jsonl") || path.contains(".codex\\history.jsonl") {
             SourceKind::CodexHistory
+        } else if path.contains("opencode/storage/message")
+            || path.contains("opencode\\storage\\message")
+        {
+            SourceKind::Opencode
         } else {
             SourceKind::Claude
         }
@@ -41,6 +48,7 @@ impl SourceKind {
 pub enum SourceFilter {
     Claude,
     Codex,
+    Opencode,
 }
 
 impl SourceFilter {
@@ -50,6 +58,7 @@ impl SourceFilter {
             SourceFilter::Codex => {
                 source == SourceKind::CodexSession || source == SourceKind::CodexHistory
             }
+            SourceFilter::Opencode => source == SourceKind::Opencode,
         }
     }
 
@@ -57,6 +66,7 @@ impl SourceFilter {
         match self {
             SourceFilter::Claude => "claude",
             SourceFilter::Codex => "codex",
+            SourceFilter::Opencode => "opencode",
         }
     }
 }


### PR DESCRIPTION
What this PR do:

- Add skills/opencode.md for AI agent instructions on using memex.
- Fix nondeterministic message part ordering in ingest.rs.
- Ensure opencode message parts are sorted by filename before processing.

<img width="947" height="1064" alt="image" src="https://github.com/user-attachments/assets/6d4114d2-d461-449e-9ed8-d31f69012806" />
