### PR TITLE
feat: add nix flake and modules

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -74,6 +74,87 @@ Binary:
 ./target/release/memex
 ```
 
+## Nix
+
+### Quickstart
+
+Run memex directly from the flake:
+
+```bash
+nix run github:nicosuave/memex
+```
+
+### Development Environment
+
+Enter a reproducible development shell:
+
+```bash
+nix develop
+```
+
+> **Note**
+> No public binary cache is currently configured. The first run of `nix build` or `nix run` will build from source locally.
+
+### NixOS Service
+
+Enable the background indexing service using the provided module.
+
+<details>
+<summary>NixOS Module Configuration</summary>
+
+```nix
+{
+  inputs.memex.url = "github:nicosuave/memex";
+
+  outputs = { nixpkgs, memex, ... }: {
+    nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+      modules = [
+        memex.nixosModules.default
+        {
+          services.memex = {
+            enable = true;
+            continuous = true; # Run as a daemon (optional)
+          };
+        }
+      ];
+    };
+  };
+}
+```
+</details>
+
+### Home Manager
+
+Configure settings declaratively. This generates `~/.memex/config.toml`.
+
+<details>
+<summary>Home Manager Configuration</summary>
+
+```nix
+{
+  inputs.memex.url = "github:nicosuave/memex";
+
+  outputs = { memex, ... }: {
+    # Inside your Home Manager configuration
+    modules = [
+      memex.homeManagerModules.default
+      {
+        programs.memex = {
+          enable = true;
+          settings = {
+            embeddings = true;
+            model = "minilm";
+            auto_index_on_search = true;
+            index_service_interval = 3600;
+          };
+        };
+      }
+    ];
+  };
+}
+```
+</details>
+
 ## Setup (manual)
 
 If you built from source, run setup to install:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1768791178,
+        "narHash": "sha256-ZVqH14w7y40DEQOghli1c28NopVNFk1MNNRzEIwMa6M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3941028eccc4d981f75c933786e1fd95b71024f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,78 @@
+{
+  description = "memex - High-performance local search engine for LLM history";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    flake-utils,
+    ...
+  }: let
+    overlays = [
+      (import rust-overlay)
+      (final: prev: {
+        memex = final.callPackage ./nix/package.nix {
+          rustPlatform = final.makeRustPlatform {
+            cargo = final.rust-bin.stable.latest.default;
+            rustc = final.rust-bin.stable.latest.default;
+          };
+        };
+      })
+    ];
+  in
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = ["rust-src" "rust-analyzer" "clippy"];
+        };
+      in {
+        packages.default = pkgs.memex;
+        packages.memex = pkgs.memex;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = pkgs.memex;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs;
+            [
+              pkg-config
+              openssl
+              rustToolchain
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+
+          nativeBuildInputs = with pkgs; [pkg-config];
+
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.openssl];
+        };
+      }
+    )
+    // {
+      nixosModules.default = import ./nix/nixos-module.nix;
+      homeManagerModules.default = import ./nix/hm-module.nix;
+      overlays.default = final: prev: {
+        memex = final.callPackage ./nix/package.nix {
+          rustPlatform = final.makeRustPlatform {
+            cargo = final.rust-bin.stable.latest.default;
+            rustc = final.rust-bin.stable.latest.default;
+          };
+        };
+      };
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.memex;
+  tomlFormat = pkgs.formats.toml {};
+in {
+  options.programs.memex = {
+    enable = lib.mkEnableOption "memex";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.memex;
+      description = "The memex package to install.";
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = {};
+      description = ''
+        Configuration written to ~/.memex/config.toml.
+
+        Supported keys:
+        - embeddings (bool)
+        - auto_index_on_search (bool)
+        - model (string): "minilm", "bge", "nomic", "gemma", "potion"
+        - scan_cache_ttl (int): seconds
+        - index_service_mode (string): "interval" or "continuous"
+        - index_service_interval (int): seconds
+        - index_service_poll_interval (int): seconds
+        - claude_resume_cmd (string)
+        - codex_resume_cmd (string)
+      '';
+      example = {
+        embeddings = true;
+        model = "minilm";
+        auto_index_on_search = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    home.file.".memex/config.toml" = lib.mkIf (cfg.settings != {}) {
+      source = tomlFormat.generate "memex-config" cfg.settings;
+    };
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.memex;
+in {
+  options.services.memex = {
+    enable = lib.mkEnableOption "memex index service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.memex;
+      description = "The memex package to use.";
+    };
+
+    continuous = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Run in continuous mode (watch) instead of interval mode.";
+    };
+
+    interval = lib.mkOption {
+      type = lib.types.str;
+      default = "3600";
+      description = "Interval for indexing in seconds or systemd time span (if not continuous).";
+    };
+
+    watchInterval = lib.mkOption {
+      type = lib.types.int;
+      default = 30;
+      description = "Polling interval in seconds (if continuous).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.memex-index = {
+      description = "Memex Index Service";
+      wantedBy = ["default.target"];
+      path = [cfg.package];
+      serviceConfig = {
+        ExecStart =
+          if cfg.continuous
+          then "${cfg.package}/bin/memex index --watch --watch-interval ${toString cfg.watchInterval}"
+          else "${cfg.package}/bin/memex index";
+
+        Restart =
+          if cfg.continuous
+          then "always"
+          else "no";
+        RestartSec = 10;
+      };
+    };
+
+    systemd.user.timers.memex-index = lib.mkIf (!cfg.continuous) {
+      description = "Memex Index Timer";
+      wantedBy = ["timers.target"];
+      timerConfig = {
+        OnBootSec = "5m";
+        OnUnitActiveSec = cfg.interval;
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  stdenv,
+  darwin,
+}:
+rustPlatform.buildRustPackage {
+  pname = "memex";
+  version = (lib.importTOML ../Cargo.toml).package.version;
+
+  src = lib.cleanSource ../.;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+
+  # Tests require network access to download embedding models
+  doCheck = false;
+
+  meta = {
+    description = "Fast local history search for Claude and Codex logs";
+    homepage = "https://github.com/nicosuave/memex";
+    license = lib.licenses.mit;
+    mainProgram = "memex";
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
Add a Nix flake and modules for NixOS and Home Manager.

- Provide a development shell with all dependencies.
- Include a NixOS module for the background indexing service.
- Include a Home Manager module for declarative configuration.
- Add a new Nix section to the README with usage instructions.

<img width="947" height="1064" alt="image" src="https://github.com/user-attachments/assets/0ea13d82-0602-4f5f-b728-86b2bb45b5aa" />
