### PR TITLE
fix: show live embed progress while queue is filling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -559,6 +559,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
 
         for ((doc_id, _, source), vec) in batch.iter().zip(embeddings.iter()) {
             vector.add(*doc_id, vec)?;
+            progress.sub_embed_pending(*source, 1);
             progress.add_embedded(*source, 1);
             embedded_counts[source.idx()] += 1;
             *embedded_total += 1;
@@ -577,6 +578,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
         let text = truncate_for_embedding(record.text);
         if !text.is_empty() {
             progress.add_embed_total(record.source, 1);
+            progress.add_embed_pending(record.source, 1);
             batch.push((record.doc_id, text, record.source));
 
             if batch.len() >= BATCH_SIZE {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1337,6 +1337,7 @@ fn flush_embeddings(
     let mut count = 0;
     for ((doc_id, _, source), vec) in items.iter().zip(embeddings.iter()) {
         vindex.add(*doc_id, vec)?;
+        progress.sub_embed_pending(*source, 1);
         progress.add_embedded(*source, 1);
         count += 1;
     }


### PR DESCRIPTION
## Summary
- update embed progress messaging to include discovered total and queued work
- track pending items in `memex embed` so progress updates before the first batch flush
- decrement pending count when embedding batches are flushed (both `embed` and ingest path)

<img width="220" height="249" alt="image" src="https://github.com/user-attachments/assets/ad1eec40-726b-4ae3-8c54-faf6be5eacff" />

## Why
`memex embed` could sit at `embedded 0 ready` for a long time even while records were queued, which looked stalled with default models.

## Validation
- cargo fmt -- --check
- cargo build
- cargo test
- cargo clippy --all-targets -- -D warnings