### PR TITLE
feat: support embedding compute units in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Configure memex declaratively (generates `~/.memex/config.toml`):
           settings = {
             embeddings = true;
             model = "minilm";
+            compute_units = "ane"; # macOS: ane, gpu, cpu, all
             auto_index_on_search = true;
             index_service_interval = 3600;
           };
@@ -224,7 +225,7 @@ Select via `--model` flag or `MEMEX_MODEL` env var:
 | bge | 384 | Fast | Better |
 | nomic | 768 | Moderate | Good |
 | gemma | 768 | Slowest | Best |
-| potion | 256 | Fastest (tiny) | Lowest (default) |
+| potion | 256 | Fastest (tiny) | Lowest |
 
 ```
 memex index --model minilm
@@ -239,7 +240,8 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
-model = "potion"  # minilm, bge, nomic, gemma, potion
+model = "minilm"  # minilm, bge, nomic, gemma, potion
+compute_units = "ane"  # macOS only: ane, gpu, cpu, all
 scan_cache_ttl = 3600  # seconds (default 1 hour)
 index_service_mode = "interval"  # interval or continuous
 index_service_interval = 3600  # seconds (ignored when mode = "continuous")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -478,6 +478,7 @@ fn run_index(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+    config.apply_embed_runtime_env();
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
@@ -505,6 +506,7 @@ fn run_index(
         embeddings,
         backfill_embeddings,
         model: model_choice,
+        compute_units: config.resolve_compute_units(),
     };
 
     let report = ingest_all(&paths, &index, &opts)?;
@@ -530,6 +532,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
 
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+    config.apply_embed_runtime_env();
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
@@ -644,6 +647,7 @@ fn run_search(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+    config.apply_embed_runtime_env();
     let model_choice = config.resolve_model(None)?;
     let auto_index_on_search = config.auto_index_on_search_default();
     let embeddings_default = config.embeddings_default();
@@ -663,6 +667,7 @@ fn run_search(
             embeddings: embeddings_default,
             backfill_embeddings,
             model: model_choice,
+            compute_units: config.resolve_compute_units(),
         };
         // Skip indexing if we recently scanned (within TTL)
         let _ = ingest_if_stale(&paths, &index, &opts, scan_cache_ttl)?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -442,6 +442,7 @@ impl App {
                     embeddings: embeddings_default,
                     backfill_embeddings,
                     model: model_choice,
+                    compute_units: config.resolve_compute_units(),
                 };
                 ingest_if_stale(&paths, &index, &opts, config.scan_cache_ttl())
             })();


### PR DESCRIPTION
## Summary
- add `compute_units` to config (`config.toml`) so macOS embedding runtime selection is not env-only
- keep backward compatibility via `MEMEX_COMPUTE_UNITS` env fallback
- apply compute-unit resolution consistently in index/embed/search and ingest/tui indexing paths
- add unit tests for compute-unit precedence and fallback behavior

## Why
Users currently need environment variables to tune embedding runtime on macOS. This change makes that configurable alongside other memex settings.

## Validation
- cargo fmt -- --check
- cargo build
- cargo test
- cargo clippy --all-targets -- -D warnings
