### PR TITLE
Add Ctrl+C and Ctrl+D support to quit TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agents
+
+## Before committing
+
+Always run these checks before committing. Do not commit if either fails.
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+```
+
+If `cargo fmt --check` fails, run `cargo fmt` and include the formatting fix in your commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -868,7 +868,12 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
         return Ok(false);
     }
 
-    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('q')) {
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(
+            key.code,
+            KeyCode::Char('q') | KeyCode::Char('c') | KeyCode::Char('d')
+        )
+    {
         return Ok(true);
     }
 


### PR DESCRIPTION
Add standard keyboard signal support to exit the memex TUI application. Users can now quit with Ctrl+C and Ctrl+D in addition to the existing Ctrl+Q. This handles the most common terminal exit patterns that users expect.