### PR TITLE
Add portable CUDA embedding runtime support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2001,7 @@ dependencies = [
  "fastembed",
  "indicatif",
  "libc",
+ "libloading",
  "memchr",
  "memmap2",
  "model2vec-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ description = "CLI tool for indexing and searching Claude Code conversation hist
 license = "MIT"
 repository = "https://github.com/nicosuave/memex"
 
+[features]
+default = []
+cuda = ["ort/cuda", "dep:libloading"]
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
@@ -33,5 +37,6 @@ ratatui = "0.28"
 crossterm = "0.27"
 tempfile = "3"
 libc = "0.2"
+libloading = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "memex"
 version = "0.3.1"
 edition = "2024"
+build = "build.rs"
 description = "CLI tool for indexing and searching Claude Code conversation history"
 license = "MIT"
 repository = "https://github.com/nicosuave/memex"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ Configure memex declaratively (generates `~/.memex/config.toml`):
           settings = {
             embeddings = true;
             model = "minilm";
-            compute_units = "ane"; # macOS: ane, gpu, cpu, all
+            execution_provider = "auto"; # coreml on macOS, cpu elsewhere
+            cuda_device_id = 0; # optional when execution_provider = "cuda"
+            cuda_library_paths = ["/usr/local/cuda/lib64"]; # optional override
+            cudnn_library_paths = ["/usr/lib/x86_64-linux-gnu"]; # optional override
+            compute_units = "ane"; # CoreML only: ane, gpu, cpu, all
             auto_index_on_search = true;
             index_service_interval = 3600;
           };
@@ -145,6 +149,12 @@ memex search "your query" -v
 
 ```
 cargo build --release
+```
+
+Linux with NVIDIA CUDA support:
+
+```
+cargo build --release --features cuda
 ```
 
 Binary:
@@ -233,6 +243,27 @@ memex index --model minilm
 MEMEX_MODEL=minilm memex index
 ```
 
+## Execution provider
+
+Select via `execution_provider` in config or `MEMEX_EXECUTION_PROVIDER`:
+
+| Provider | Platforms | Notes |
+|----------|-----------|-------|
+| auto | all | Default. Uses CoreML on macOS, CPU elsewhere |
+| cpu | all | Force CPU execution |
+| coreml | macOS | Uses CoreML; `compute_units` controls ane/gpu/cpu/all |
+| cuda | Linux/NVIDIA | Requires a binary built with `--features cuda` and CUDA 12/cuDNN runtime libraries |
+
+When `execution_provider = "cuda"`, you can optionally select a GPU with
+`cuda_device_id` or `MEMEX_CUDA_DEVICE_ID`.
+
+When loading CUDA, memex first tries the system loader paths, then any
+configured `cuda_library_paths` / `cudnn_library_paths`, then common CUDA install
+locations and active `venv` / `conda` `site-packages/nvidia/*/lib` directories.
+If your system keeps CUDA or cuDNN in a nonstandard location, set
+`MEMEX_CUDA_LIBRARY_PATHS` and `MEMEX_CUDNN_LIBRARY_PATHS` or the matching config
+keys.
+
 ## Config (optional)
 
 Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
@@ -241,7 +272,11 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 embeddings = true
 auto_index_on_search = true
 model = "minilm"  # minilm, bge, nomic, gemma, potion
-compute_units = "ane"  # macOS only: ane, gpu, cpu, all
+execution_provider = "auto"  # auto, cpu, coreml, cuda
+cuda_device_id = 0  # optional, when execution_provider = "cuda"
+cuda_library_paths = ["/usr/local/cuda/lib64"]  # optional list of CUDA library dirs
+cudnn_library_paths = ["/usr/lib/x86_64-linux-gnu"]  # optional list of cuDNN library dirs
+compute_units = "ane"  # CoreML only: ane, gpu, cpu, all
 scan_cache_ttl = 3600  # seconds (default 1 hour)
 index_service_mode = "interval"  # interval or continuous
 index_service_interval = 3600  # seconds (ignored when mode = "continuous")
@@ -255,6 +290,9 @@ codex_resume_cmd = "codex resume {session_id}"
 Service logs and the plist live under `~/.memex` by default (macOS). On Linux, systemd units are created in `~/.config/systemd/user/`.
 
 `scan_cache_ttl` controls how long auto-indexing considers scans fresh.
+`execution_provider` applies to ONNX-backed models; `potion` uses the model2vec backend.
+`cuda_library_paths` and `cudnn_library_paths` accept path lists and are only used
+when `execution_provider = "cuda"`.
 
 Resume command templates accept `{session_id}`, `{project}`, `{source}`, `{source_path}`, `{source_dir}`, `{cwd}`.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let cuda_enabled = std::env::var_os("CARGO_FEATURE_CUDA").is_some();
+
+    if target_os == "linux" && cuda_enabled {
+        println!("cargo:rustc-link-arg-bin=memex=-Wl,-rpath,$ORIGIN");
+        println!("cargo:rustc-link-arg-bin=memex=-Wl,-rpath,$ORIGIN/deps");
+    }
+}

--- a/examples/embed_bench.rs
+++ b/examples/embed_bench.rs
@@ -24,6 +24,11 @@ fn main() -> Result<()> {
 
     // Test 1: Baseline with MiniLM
     println!("\n--- Test 1: MiniLM (default settings) ---");
+    unsafe {
+        std::env::set_var("MEMEX_EXECUTION_PROVIDER", "cpu");
+        std::env::remove_var("MEMEX_COMPUTE_UNITS");
+        std::env::remove_var("MEMEX_CUDA_DEVICE_ID");
+    }
     {
         let start = Instant::now();
         let mut embedder = EmbedderHandle::with_model(ModelChoice::MiniLM)?;
@@ -43,11 +48,13 @@ fn main() -> Result<()> {
         );
     }
 
-    // Test 2: Different compute units
+    #[cfg(target_os = "macos")]
     for unit in ["all", "ane", "gpu", "cpu"] {
-        println!("\n--- Test 2: MEMEX_COMPUTE_UNITS={unit} ---");
+        println!("\n--- Test 2: MEMEX_EXECUTION_PROVIDER=coreml MEMEX_COMPUTE_UNITS={unit} ---");
         unsafe {
+            std::env::set_var("MEMEX_EXECUTION_PROVIDER", "coreml");
             std::env::set_var("MEMEX_COMPUTE_UNITS", unit);
+            std::env::remove_var("MEMEX_CUDA_DEVICE_ID");
         }
 
         let start = Instant::now();
@@ -73,10 +80,44 @@ fn main() -> Result<()> {
         let _ = results;
     }
 
+    #[cfg(all(not(target_os = "macos"), feature = "cuda"))]
+    {
+        println!("\n--- Test 2: MEMEX_EXECUTION_PROVIDER=cuda MEMEX_CUDA_DEVICE_ID=0 ---");
+        unsafe {
+            std::env::set_var("MEMEX_EXECUTION_PROVIDER", "cuda");
+            std::env::set_var("MEMEX_CUDA_DEVICE_ID", "0");
+            std::env::remove_var("MEMEX_COMPUTE_UNITS");
+        }
+
+        let start = Instant::now();
+        let mut embedder = match EmbedderHandle::with_model(ModelChoice::MiniLM) {
+            Ok(e) => e,
+            Err(e) => {
+                println!("  Failed to init: {e}");
+                return Ok(());
+            }
+        };
+        println!("  Model init: {}ms", start.elapsed().as_millis());
+
+        let _ = embedder.embed_texts(&["warmup"])?;
+
+        let start = Instant::now();
+        let results = embedder.embed_texts(&text_refs)?;
+        let elapsed = start.elapsed();
+        println!(
+            "  500 texts: {}ms ({:.0} texts/sec)",
+            elapsed.as_millis(),
+            500.0 / elapsed.as_secs_f64()
+        );
+        let _ = results;
+    }
+
     // Test 3: Gemma model (larger, higher quality)
-    println!("\n--- Test 3: Gemma model (larger, higher quality) ---");
+    println!("\n--- Test 3: Gemma model (larger, higher quality) on CPU ---");
     unsafe {
-        std::env::set_var("MEMEX_COMPUTE_UNITS", "all");
+        std::env::set_var("MEMEX_EXECUTION_PROVIDER", "cpu");
+        std::env::remove_var("MEMEX_COMPUTE_UNITS");
+        std::env::remove_var("MEMEX_CUDA_DEVICE_ID");
     }
     {
         let start = Instant::now();

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -26,6 +26,10 @@ in {
         - embeddings (bool)
         - auto_index_on_search (bool)
         - model (string): "minilm", "bge", "nomic", "gemma", "potion"
+        - execution_provider (string): "auto", "cpu", "coreml", "cuda"
+        - cuda_device_id (int): GPU index when using the CUDA execution provider
+        - cuda_library_paths (list of strings): optional CUDA library directories
+        - cudnn_library_paths (list of strings): optional cuDNN library directories
         - scan_cache_ttl (int): seconds
         - index_service_mode (string): "interval" or "continuous"
         - index_service_interval (int): seconds
@@ -41,6 +45,8 @@ in {
       example = {
         embeddings = true;
         model = "minilm";
+        execution_provider = "auto";
+        cuda_device_id = 0;
         auto_index_on_search = true;
       };
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::config::{Paths, UserConfig, default_claude_source};
-use crate::embed::{EmbedderHandle, ModelChoice};
+use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_all, ingest_if_stale};
 use crate::tui;
@@ -478,10 +478,10 @@ fn run_index(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    config.apply_embed_runtime_env();
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
+    let embed_runtime = config.resolve_embed_runtime()?;
     let embeddings = resolve_flag(
         config.embeddings_default(),
         embeddings_flag,
@@ -506,7 +506,7 @@ fn run_index(
         embeddings,
         backfill_embeddings,
         model: model_choice,
-        compute_units: config.resolve_compute_units(),
+        embed_runtime,
     };
 
     let report = ingest_all(&paths, &index, &opts)?;
@@ -532,13 +532,13 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
 
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    config.apply_embed_runtime_env();
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
+    let embed_runtime = config.resolve_embed_runtime()?;
 
     let index = SearchIndex::open_or_create(&paths.index)?;
-    let mut embedder = EmbedderHandle::with_model(model_choice)?;
+    let mut embedder = EmbedderHandle::with_model_and_runtime(model_choice, &embed_runtime)?;
     let mut vector = VectorIndex::open_or_create(&paths.vectors, embedder.dims)?;
 
     let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 4], [0; 4], true));
@@ -649,8 +649,8 @@ fn run_search(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    config.apply_embed_runtime_env();
     let model_choice = config.resolve_model(None)?;
+    let embed_runtime = config.resolve_embed_runtime()?;
     let auto_index_on_search = config.auto_index_on_search_default();
     let embeddings_default = config.embeddings_default();
     let scan_cache_ttl = config.scan_cache_ttl();
@@ -669,7 +669,7 @@ fn run_search(
             embeddings: embeddings_default,
             backfill_embeddings,
             model: model_choice,
-            compute_units: config.resolve_compute_units(),
+            embed_runtime: embed_runtime.clone(),
         };
         // Skip indexing if we recently scanned (within TTL)
         let _ = ingest_if_stale(&paths, &index, &opts, scan_cache_ttl)?;
@@ -720,6 +720,7 @@ fn run_search(
                 render: &render,
                 paths: &paths,
                 model_choice,
+                embed_runtime: &embed_runtime,
                 recency_weight,
                 recency_half_life_days,
             },
@@ -734,6 +735,7 @@ fn run_search(
                 render: &render,
                 paths: &paths,
                 model_choice,
+                embed_runtime: &embed_runtime,
                 recency_weight,
                 recency_half_life_days,
             },
@@ -753,6 +755,7 @@ struct SearchContext<'a> {
     render: &'a RenderOptions,
     paths: &'a Paths,
     model_choice: ModelChoice,
+    embed_runtime: &'a EmbedRuntimeConfig,
     recency_weight: f32,
     recency_half_life_days: f32,
 }
@@ -764,7 +767,7 @@ fn run_semantic_search(
     ctx: &SearchContext,
 ) -> Result<()> {
     let vector = VectorIndex::open(&ctx.paths.vectors)?;
-    let mut embedder = EmbedderHandle::with_model(ctx.model_choice)?;
+    let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
     let embeddings = embedder.embed_texts(&[options.query.as_str()])?;
     let embedding = embeddings
         .first()
@@ -798,7 +801,7 @@ fn run_hybrid_search(
     ctx: &SearchContext,
 ) -> Result<()> {
     let vector = VectorIndex::open(&ctx.paths.vectors)?;
-    let mut embedder = EmbedderHandle::with_model(ctx.model_choice)?;
+    let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
 
     let bm25_k = (limit * 5).clamp(50, 500);
     let vector_k = (limit * 5).clamp(50, 500);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::embed::ModelChoice;
+use crate::embed::{EmbedRuntimeConfig, ExecutionProviderChoice, ModelChoice};
 use anyhow::{Result, anyhow};
 use directories::BaseDirs;
 use serde::Deserialize;
@@ -51,6 +51,14 @@ pub struct UserConfig {
     pub auto_index_on_search: Option<bool>,
     /// Embedding model: minilm, bge, nomic, gemma (default), potion
     pub model: Option<String>,
+    /// Execution provider: auto, cpu, coreml, cuda
+    pub execution_provider: Option<String>,
+    /// CUDA device index when execution_provider is "cuda"
+    pub cuda_device_id: Option<i32>,
+    /// Additional search paths for CUDA runtime libraries
+    pub cuda_library_paths: Option<Vec<PathBuf>>,
+    /// Additional search paths for cuDNN runtime libraries
+    pub cudnn_library_paths: Option<Vec<PathBuf>>,
     /// Embedding runtime compute units on macOS: ane, gpu, cpu, all
     pub compute_units: Option<String>,
     /// Scan cache TTL in seconds. If a scan was done within this time,
@@ -116,6 +124,57 @@ impl UserConfig {
         Ok(ModelChoice::default())
     }
 
+    pub fn resolve_execution_provider(&self) -> Result<ExecutionProviderChoice> {
+        if let Some(provider) = self.execution_provider.as_deref() {
+            return ExecutionProviderChoice::parse(provider);
+        }
+        match std::env::var("MEMEX_EXECUTION_PROVIDER") {
+            Ok(provider) => ExecutionProviderChoice::parse(&provider),
+            Err(std::env::VarError::NotPresent) => Ok(ExecutionProviderChoice::Auto),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                Err(anyhow!("MEMEX_EXECUTION_PROVIDER is not valid unicode"))
+            }
+        }
+    }
+
+    pub fn resolve_cuda_device_id(&self) -> Result<Option<i32>> {
+        if let Some(device_id) = self.cuda_device_id {
+            return Ok(Some(device_id));
+        }
+        match std::env::var("MEMEX_CUDA_DEVICE_ID") {
+            Ok(device_id) => {
+                let parsed = device_id
+                    .parse::<i32>()
+                    .map_err(|err| anyhow!("MEMEX_CUDA_DEVICE_ID must be an integer: {err}"))?;
+                Ok(Some(parsed))
+            }
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                Err(anyhow!("MEMEX_CUDA_DEVICE_ID is not valid unicode"))
+            }
+        }
+    }
+
+    pub fn resolve_cuda_library_paths(&self) -> Result<Vec<PathBuf>> {
+        if let Some(paths) = &self.cuda_library_paths {
+            return Ok(paths.clone());
+        }
+        match std::env::var_os("MEMEX_CUDA_LIBRARY_PATHS") {
+            Some(paths) => Ok(std::env::split_paths(&paths).collect()),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub fn resolve_cudnn_library_paths(&self) -> Result<Vec<PathBuf>> {
+        if let Some(paths) = &self.cudnn_library_paths {
+            return Ok(paths.clone());
+        }
+        match std::env::var_os("MEMEX_CUDNN_LIBRARY_PATHS") {
+            Some(paths) => Ok(std::env::split_paths(&paths).collect()),
+            None => Ok(Vec::new()),
+        }
+    }
+
     pub fn resolve_compute_units(&self) -> Option<String> {
         if let Some(units) = self.compute_units.as_deref() {
             return Some(units.to_string());
@@ -123,12 +182,19 @@ impl UserConfig {
         std::env::var("MEMEX_COMPUTE_UNITS").ok()
     }
 
-    pub fn apply_embed_runtime_env(&self) {
-        if let Some(units) = self.resolve_compute_units() {
-            unsafe {
-                std::env::set_var("MEMEX_COMPUTE_UNITS", units);
-            }
-        }
+    pub fn resolve_embed_runtime(&self) -> Result<EmbedRuntimeConfig> {
+        Ok(EmbedRuntimeConfig {
+            execution_provider: self.resolve_execution_provider()?,
+            compute_units: self.resolve_compute_units(),
+            cuda_device_id: self.resolve_cuda_device_id()?,
+            cuda_library_paths: self.resolve_cuda_library_paths()?,
+            cudnn_library_paths: self.resolve_cudnn_library_paths()?,
+        })
+    }
+
+    pub fn apply_embed_runtime_env(&self) -> Result<()> {
+        self.resolve_embed_runtime()?.apply_env()?;
+        Ok(())
     }
 
     pub fn scan_cache_ttl(&self) -> u64 {
@@ -155,47 +221,12 @@ impl UserConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    struct EnvVarGuard {
-        prev: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(value: Option<&str>) -> Self {
-            let prev = std::env::var("MEMEX_COMPUTE_UNITS").ok();
-            unsafe {
-                match value {
-                    Some(v) => std::env::set_var("MEMEX_COMPUTE_UNITS", v),
-                    None => std::env::remove_var("MEMEX_COMPUTE_UNITS"),
-                }
-            }
-            Self { prev }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match self.prev.as_deref() {
-                    Some(v) => std::env::set_var("MEMEX_COMPUTE_UNITS", v),
-                    None => std::env::remove_var("MEMEX_COMPUTE_UNITS"),
-                }
-            }
-        }
-    }
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("lock MEMEX_COMPUTE_UNITS env")
-    }
+    use crate::test_support::{EnvVarGuard, env_lock};
 
     #[test]
     fn resolve_compute_units_prefers_config_over_env() {
         let _guard = env_lock();
-        let _env = EnvVarGuard::set(Some("gpu"));
+        let _env = EnvVarGuard::set(&[("MEMEX_COMPUTE_UNITS", Some("gpu"))]);
         let config = UserConfig {
             compute_units: Some("ane".to_string()),
             ..UserConfig::default()
@@ -206,7 +237,7 @@ mod tests {
     #[test]
     fn resolve_compute_units_uses_env_fallback() {
         let _guard = env_lock();
-        let _env = EnvVarGuard::set(Some("cpu"));
+        let _env = EnvVarGuard::set(&[("MEMEX_COMPUTE_UNITS", Some("cpu"))]);
         let config = UserConfig::default();
         assert_eq!(config.resolve_compute_units().as_deref(), Some("cpu"));
     }
@@ -214,8 +245,162 @@ mod tests {
     #[test]
     fn resolve_compute_units_none_when_unset() {
         let _guard = env_lock();
-        let _env = EnvVarGuard::set(None);
+        let _env = EnvVarGuard::set(&[("MEMEX_COMPUTE_UNITS", None)]);
         let config = UserConfig::default();
         assert_eq!(config.resolve_compute_units(), None);
+    }
+
+    #[test]
+    fn resolve_execution_provider_prefers_config_over_env() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_EXECUTION_PROVIDER", Some("cpu"))]);
+        let config = UserConfig {
+            execution_provider: Some("cuda".to_string()),
+            ..UserConfig::default()
+        };
+        assert_eq!(
+            config
+                .resolve_execution_provider()
+                .expect("resolve execution provider"),
+            ExecutionProviderChoice::Cuda
+        );
+    }
+
+    #[test]
+    fn resolve_execution_provider_uses_env_fallback() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_EXECUTION_PROVIDER", Some("coreml"))]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_execution_provider()
+                .expect("resolve execution provider"),
+            ExecutionProviderChoice::CoreML
+        );
+    }
+
+    #[test]
+    fn resolve_execution_provider_defaults_to_auto() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_EXECUTION_PROVIDER", None)]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_execution_provider()
+                .expect("resolve execution provider"),
+            ExecutionProviderChoice::Auto
+        );
+    }
+
+    #[test]
+    fn resolve_cuda_device_id_prefers_config_over_env() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_CUDA_DEVICE_ID", Some("1"))]);
+        let config = UserConfig {
+            cuda_device_id: Some(3),
+            ..UserConfig::default()
+        };
+        assert_eq!(
+            config
+                .resolve_cuda_device_id()
+                .expect("resolve cuda device id"),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn resolve_cuda_device_id_uses_env_fallback() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_CUDA_DEVICE_ID", Some("2"))]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_cuda_device_id()
+                .expect("resolve cuda device id"),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn resolve_cuda_device_id_none_when_unset() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("MEMEX_CUDA_DEVICE_ID", None)]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_cuda_device_id()
+                .expect("resolve cuda device id"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_cuda_library_paths_prefers_config_over_env() {
+        let _guard = env_lock();
+        let env_paths = std::env::join_paths(["/env/cuda/lib64"]).expect("join env paths");
+        let _env = EnvVarGuard::set_os(&[("MEMEX_CUDA_LIBRARY_PATHS", Some(&env_paths))]);
+        let config = UserConfig {
+            cuda_library_paths: Some(vec![PathBuf::from("/config/cuda/lib64")]),
+            ..UserConfig::default()
+        };
+        assert_eq!(
+            config
+                .resolve_cuda_library_paths()
+                .expect("resolve cuda library paths"),
+            vec![PathBuf::from("/config/cuda/lib64")]
+        );
+    }
+
+    #[test]
+    fn resolve_cuda_library_paths_uses_env_fallback() {
+        let _guard = env_lock();
+        let env_paths =
+            std::env::join_paths(["/env/cuda/lib64", "/env/cuda/extras"]).expect("join env paths");
+        let _env = EnvVarGuard::set_os(&[("MEMEX_CUDA_LIBRARY_PATHS", Some(&env_paths))]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_cuda_library_paths()
+                .expect("resolve cuda library paths"),
+            vec![
+                PathBuf::from("/env/cuda/lib64"),
+                PathBuf::from("/env/cuda/extras")
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_cudnn_library_paths_prefers_config_over_env() {
+        let _guard = env_lock();
+        let env_paths = std::env::join_paths(["/env/cudnn/lib64"]).expect("join env paths");
+        let _env = EnvVarGuard::set_os(&[("MEMEX_CUDNN_LIBRARY_PATHS", Some(&env_paths))]);
+        let config = UserConfig {
+            cudnn_library_paths: Some(vec![PathBuf::from("/config/cudnn/lib64")]),
+            ..UserConfig::default()
+        };
+        assert_eq!(
+            config
+                .resolve_cudnn_library_paths()
+                .expect("resolve cudnn library paths"),
+            vec![PathBuf::from("/config/cudnn/lib64")]
+        );
+    }
+
+    #[test]
+    fn resolve_cudnn_library_paths_uses_env_fallback() {
+        let _guard = env_lock();
+        let env_paths = std::env::join_paths(["/env/cudnn/lib64", "/env/cudnn/extras"])
+            .expect("join env paths");
+        let _env = EnvVarGuard::set_os(&[("MEMEX_CUDNN_LIBRARY_PATHS", Some(&env_paths))]);
+        let config = UserConfig::default();
+        assert_eq!(
+            config
+                .resolve_cudnn_library_paths()
+                .expect("resolve cudnn library paths"),
+            vec![
+                PathBuf::from("/env/cudnn/lib64"),
+                PathBuf::from("/env/cudnn/extras")
+            ]
+        );
     }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -249,6 +249,14 @@ fn resolve_library_paths_from_env(var: &str) -> Vec<PathBuf> {
 
 #[cfg(feature = "cuda")]
 fn preload_dylib(path: impl AsRef<std::ffi::OsStr>) -> std::result::Result<(), libloading::Error> {
+    #[cfg(unix)]
+    let library = unsafe {
+        libloading::os::unix::Library::open(
+            Some(path),
+            libloading::os::unix::RTLD_LAZY | libloading::os::unix::RTLD_GLOBAL,
+        )
+    }?;
+    #[cfg(not(unix))]
     let library = unsafe { libloading::Library::new(path) }?;
     mem::forget(library);
     Ok(())
@@ -270,13 +278,25 @@ fn preload_cuda_dependencies(runtime: &EmbedRuntimeConfig) -> Result<()> {
 fn try_preload_cuda_dependencies(runtime: &EmbedRuntimeConfig) -> Result<()> {
     let cuda_dirs = candidate_cuda_library_dirs(&runtime.cuda_library_paths);
     let cudnn_dirs = candidate_cudnn_library_dirs(&runtime.cudnn_library_paths);
-    preload_library_group("CUDA", CUDA_DYLIBS, &cuda_dirs)?;
-    preload_library_group("cuDNN", CUDNN_DYLIBS, &cudnn_dirs)?;
+    preload_library_group(
+        "CUDA",
+        CUDA_DYLIBS,
+        &cuda_dirs,
+        "You can set `cuda_library_paths` and `cudnn_library_paths` in config or via \
+         `MEMEX_CUDA_LIBRARY_PATHS` / `MEMEX_CUDNN_LIBRARY_PATHS`.",
+    )?;
+    preload_library_group(
+        "cuDNN",
+        CUDNN_DYLIBS,
+        &cudnn_dirs,
+        "You can set `cuda_library_paths` and `cudnn_library_paths` in config or via \
+         `MEMEX_CUDA_LIBRARY_PATHS` / `MEMEX_CUDNN_LIBRARY_PATHS`.",
+    )?;
     Ok(())
 }
 
 #[cfg(feature = "cuda")]
-fn preload_library_group(group: &str, dylibs: &[&str], dirs: &[PathBuf]) -> Result<()> {
+fn preload_library_group(group: &str, dylibs: &[&str], dirs: &[PathBuf], hint: &str) -> Result<()> {
     let mut missing = Vec::new();
 
     for dylib in dylibs {
@@ -309,14 +329,9 @@ fn preload_library_group(group: &str, dylibs: &[&str], dirs: &[PathBuf]) -> Resu
             .join(", ")
     };
     Err(anyhow!(
-        "missing {group} libraries: {}. Searched default loader paths and candidate directories: {}. \
-         You can set `{}` and `{}` in config or via `{}` / `{}`.",
+        "missing {group} libraries: {}. Searched default loader paths and candidate directories: {}. {hint}",
         missing.join(", "),
         searched,
-        "cuda_library_paths",
-        "cudnn_library_paths",
-        MEMEX_CUDA_LIBRARY_PATHS_ENV,
-        MEMEX_CUDNN_LIBRARY_PATHS_ENV
     ))
 }
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,6 +1,58 @@
 use anyhow::{Result, anyhow};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use model2vec_rs::model::StaticModel;
+use std::path::PathBuf;
+
+#[cfg(feature = "cuda")]
+use std::path::Path;
+#[cfg(feature = "cuda")]
+use std::{collections::HashSet, mem, sync::OnceLock};
+
+const MEMEX_EXECUTION_PROVIDER_ENV: &str = "MEMEX_EXECUTION_PROVIDER";
+const MEMEX_CUDA_DEVICE_ID_ENV: &str = "MEMEX_CUDA_DEVICE_ID";
+const MEMEX_COMPUTE_UNITS_ENV: &str = "MEMEX_COMPUTE_UNITS";
+const MEMEX_CUDA_LIBRARY_PATHS_ENV: &str = "MEMEX_CUDA_LIBRARY_PATHS";
+const MEMEX_CUDNN_LIBRARY_PATHS_ENV: &str = "MEMEX_CUDNN_LIBRARY_PATHS";
+
+#[cfg(all(feature = "cuda", windows))]
+const CUDA_DYLIBS: &[&str] = &[
+    "cublasLt64_12.dll",
+    "cublas64_12.dll",
+    "cufft64_11.dll",
+    "cudart64_12.dll",
+];
+
+#[cfg(all(feature = "cuda", not(windows)))]
+const CUDA_DYLIBS: &[&str] = &[
+    "libcublasLt.so.12",
+    "libcublas.so.12",
+    "libnvrtc.so.12",
+    "libcurand.so.10",
+    "libcufft.so.11",
+    "libcudart.so.12",
+];
+
+#[cfg(all(feature = "cuda", windows))]
+const CUDNN_DYLIBS: &[&str] = &[
+    "cudnn_engines_runtime_compiled64_9.dll",
+    "cudnn_engines_precompiled64_9.dll",
+    "cudnn_heuristic64_9.dll",
+    "cudnn_ops64_9.dll",
+    "cudnn_adv64_9.dll",
+    "cudnn_graph64_9.dll",
+    "cudnn64_9.dll",
+];
+
+#[cfg(all(feature = "cuda", not(windows)))]
+const CUDNN_DYLIBS: &[&str] = &[
+    "libcudnn_engines_runtime_compiled.so.9",
+    "libcudnn_engines_precompiled.so.9",
+    "libcudnn_heuristic.so.9",
+    "libcudnn_ops.so.9",
+    "libcudnn_adv.so.9",
+    "libcudnn_graph.so.9",
+    "libcudnn.so.9",
+];
 
 /// Supported embedding models
 #[derive(Debug, Clone, Copy, Default)]
@@ -46,6 +98,433 @@ impl ModelChoice {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ExecutionProviderChoice {
+    #[default]
+    Auto,
+    Cpu,
+    CoreML,
+    Cuda,
+}
+
+impl ExecutionProviderChoice {
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "auto" | "default" => Ok(Self::Auto),
+            "cpu" => Ok(Self::Cpu),
+            "coreml" | "core-ml" => Ok(Self::CoreML),
+            "cuda" => Ok(Self::Cuda),
+            _ => Err(anyhow!(
+                "unknown execution provider '{s}', options: auto, cpu, coreml, cuda"
+            )),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Cpu => "cpu",
+            Self::CoreML => "coreml",
+            Self::Cuda => "cuda",
+        }
+    }
+
+    fn effective(self) -> Self {
+        match self {
+            Self::Auto => Self::default_for_platform(),
+            other => other,
+        }
+    }
+
+    fn default_for_platform() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self::CoreML
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self::Cpu
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EmbedRuntimeConfig {
+    pub execution_provider: ExecutionProviderChoice,
+    pub compute_units: Option<String>,
+    pub cuda_device_id: Option<i32>,
+    pub cuda_library_paths: Vec<PathBuf>,
+    pub cudnn_library_paths: Vec<PathBuf>,
+}
+
+impl EmbedRuntimeConfig {
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            execution_provider: resolve_execution_provider_from_env()?,
+            compute_units: std::env::var(MEMEX_COMPUTE_UNITS_ENV).ok(),
+            cuda_device_id: resolve_cuda_device_id_from_env()?,
+            cuda_library_paths: resolve_library_paths_from_env(MEMEX_CUDA_LIBRARY_PATHS_ENV),
+            cudnn_library_paths: resolve_library_paths_from_env(MEMEX_CUDNN_LIBRARY_PATHS_ENV),
+        })
+    }
+
+    pub fn apply_env(&self) -> Result<()> {
+        apply_runtime_env(
+            self.execution_provider,
+            self.compute_units.as_deref(),
+            self.cuda_device_id,
+            &self.cuda_library_paths,
+            &self.cudnn_library_paths,
+        )
+    }
+}
+
+pub fn resolve_execution_provider_from_env() -> Result<ExecutionProviderChoice> {
+    match std::env::var(MEMEX_EXECUTION_PROVIDER_ENV) {
+        Ok(provider) => ExecutionProviderChoice::parse(&provider),
+        Err(std::env::VarError::NotPresent) => Ok(ExecutionProviderChoice::Auto),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow!(
+            "{MEMEX_EXECUTION_PROVIDER_ENV} is not valid unicode"
+        )),
+    }
+}
+
+pub fn resolve_cuda_device_id_from_env() -> Result<Option<i32>> {
+    match std::env::var(MEMEX_CUDA_DEVICE_ID_ENV) {
+        Ok(device_id) => {
+            let parsed = device_id
+                .parse::<i32>()
+                .map_err(|err| anyhow!("{MEMEX_CUDA_DEVICE_ID_ENV} must be an integer: {err}"))?;
+            Ok(Some(parsed))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(anyhow!("{MEMEX_CUDA_DEVICE_ID_ENV} is not valid unicode"))
+        }
+    }
+}
+
+pub fn apply_runtime_env(
+    execution_provider: ExecutionProviderChoice,
+    compute_units: Option<&str>,
+    cuda_device_id: Option<i32>,
+    cuda_library_paths: &[PathBuf],
+    cudnn_library_paths: &[PathBuf],
+) -> Result<()> {
+    unsafe {
+        std::env::set_var(MEMEX_EXECUTION_PROVIDER_ENV, execution_provider.as_str());
+        match compute_units {
+            Some(units) => std::env::set_var(MEMEX_COMPUTE_UNITS_ENV, units),
+            None => std::env::remove_var(MEMEX_COMPUTE_UNITS_ENV),
+        }
+        match cuda_device_id {
+            Some(device_id) => std::env::set_var(MEMEX_CUDA_DEVICE_ID_ENV, device_id.to_string()),
+            None => std::env::remove_var(MEMEX_CUDA_DEVICE_ID_ENV),
+        }
+        if cuda_library_paths.is_empty() {
+            std::env::remove_var(MEMEX_CUDA_LIBRARY_PATHS_ENV);
+        } else {
+            std::env::set_var(
+                MEMEX_CUDA_LIBRARY_PATHS_ENV,
+                std::env::join_paths(cuda_library_paths)?,
+            );
+        }
+        if cudnn_library_paths.is_empty() {
+            std::env::remove_var(MEMEX_CUDNN_LIBRARY_PATHS_ENV);
+        } else {
+            std::env::set_var(
+                MEMEX_CUDNN_LIBRARY_PATHS_ENV,
+                std::env::join_paths(cudnn_library_paths)?,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_library_paths_from_env(var: &str) -> Vec<PathBuf> {
+    std::env::var_os(var)
+        .map(|value| std::env::split_paths(&value).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "cuda")]
+fn preload_dylib(path: impl AsRef<std::ffi::OsStr>) -> std::result::Result<(), libloading::Error> {
+    let library = unsafe { libloading::Library::new(path) }?;
+    mem::forget(library);
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+fn preload_cuda_dependencies(runtime: &EmbedRuntimeConfig) -> Result<()> {
+    static PRELOADED: OnceLock<()> = OnceLock::new();
+    if PRELOADED.get().is_some() {
+        Ok(())
+    } else {
+        try_preload_cuda_dependencies(runtime)?;
+        let _ = PRELOADED.set(());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn try_preload_cuda_dependencies(runtime: &EmbedRuntimeConfig) -> Result<()> {
+    let cuda_dirs = candidate_cuda_library_dirs(&runtime.cuda_library_paths);
+    let cudnn_dirs = candidate_cudnn_library_dirs(&runtime.cudnn_library_paths);
+    preload_library_group("CUDA", CUDA_DYLIBS, &cuda_dirs)?;
+    preload_library_group("cuDNN", CUDNN_DYLIBS, &cudnn_dirs)?;
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+fn preload_library_group(group: &str, dylibs: &[&str], dirs: &[PathBuf]) -> Result<()> {
+    let mut missing = Vec::new();
+
+    for dylib in dylibs {
+        if preload_dylib(dylib).is_ok() {
+            continue;
+        }
+        let Some(path) = find_library_in_dirs(dylib, dirs) else {
+            missing.push(*dylib);
+            continue;
+        };
+        preload_dylib(&path).map_err(|err| {
+            anyhow!(
+                "failed to preload {group} library `{}` from `{}`: {err}",
+                dylib,
+                path.display()
+            )
+        })?;
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let searched = if dirs.is_empty() {
+        "default loader paths only".to_string()
+    } else {
+        dirs.iter()
+            .map(|dir| dir.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    Err(anyhow!(
+        "missing {group} libraries: {}. Searched default loader paths and candidate directories: {}. \
+         You can set `{}` and `{}` in config or via `{}` / `{}`.",
+        missing.join(", "),
+        searched,
+        "cuda_library_paths",
+        "cudnn_library_paths",
+        MEMEX_CUDA_LIBRARY_PATHS_ENV,
+        MEMEX_CUDNN_LIBRARY_PATHS_ENV
+    ))
+}
+
+#[cfg(feature = "cuda")]
+fn find_library_in_dirs(dylib: &str, dirs: &[PathBuf]) -> Option<PathBuf> {
+    dirs.iter()
+        .map(|dir| dir.join(dylib))
+        .find(|candidate| candidate.is_file())
+}
+
+#[cfg(feature = "cuda")]
+fn candidate_cuda_library_dirs(explicit_paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs = explicit_paths.to_vec();
+    append_common_cuda_dirs(&mut dirs);
+    append_active_python_nvidia_dirs(&mut dirs);
+    normalize_existing_dirs(dirs)
+}
+
+#[cfg(feature = "cuda")]
+fn candidate_cudnn_library_dirs(explicit_paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs = explicit_paths.to_vec();
+    append_common_cudnn_dirs(&mut dirs);
+    append_active_python_nvidia_dirs(&mut dirs);
+    normalize_existing_dirs(dirs)
+}
+
+#[cfg(feature = "cuda")]
+fn append_common_cuda_dirs(dirs: &mut Vec<PathBuf>) {
+    for var in ["CUDA_PATH", "CUDA_HOME", "CUDA_ROOT"] {
+        if let Some(root) = std::env::var_os(var).map(PathBuf::from) {
+            dirs.push(root.clone());
+            dirs.push(root.join("lib64"));
+            dirs.push(root.join("lib"));
+            dirs.push(root.join("targets/x86_64-linux/lib"));
+            dirs.push(root.join("bin"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    dirs.extend([
+        PathBuf::from("/usr/local/cuda/lib64"),
+        PathBuf::from("/usr/local/cuda/lib"),
+        PathBuf::from("/usr/local/cuda/targets/x86_64-linux/lib"),
+        PathBuf::from("/usr/lib/x86_64-linux-gnu"),
+        PathBuf::from("/usr/lib64"),
+        PathBuf::from("/usr/lib"),
+        PathBuf::from("/lib/x86_64-linux-gnu"),
+        PathBuf::from("/lib64"),
+    ]);
+}
+
+#[cfg(feature = "cuda")]
+fn append_common_cudnn_dirs(dirs: &mut Vec<PathBuf>) {
+    for var in ["CUDNN_HOME", "CUDNN_ROOT", "CUDNN_PATH"] {
+        if let Some(root) = std::env::var_os(var).map(PathBuf::from) {
+            dirs.push(root.clone());
+            dirs.push(root.join("lib64"));
+            dirs.push(root.join("lib"));
+            dirs.push(root.join("bin"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    dirs.extend([
+        PathBuf::from("/usr/lib/x86_64-linux-gnu"),
+        PathBuf::from("/usr/lib64"),
+        PathBuf::from("/usr/lib"),
+        PathBuf::from("/lib/x86_64-linux-gnu"),
+        PathBuf::from("/lib64"),
+    ]);
+}
+
+#[cfg(feature = "cuda")]
+fn append_active_python_nvidia_dirs(dirs: &mut Vec<PathBuf>) {
+    for var in ["VIRTUAL_ENV", "CONDA_PREFIX"] {
+        if let Some(root) = std::env::var_os(var).map(PathBuf::from) {
+            dirs.extend(python_nvidia_lib_dirs(&root));
+        }
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn python_nvidia_lib_dirs(root: &Path) -> Vec<PathBuf> {
+    let lib_root = root.join("lib");
+    let Ok(entries) = std::fs::read_dir(lib_root) else {
+        return Vec::new();
+    };
+
+    let mut dirs = Vec::new();
+    for entry in entries.filter_map(|entry| entry.ok()) {
+        let python_dir = entry.path();
+        let Some(name) = python_dir.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("python") {
+            continue;
+        }
+        let nvidia_dir = python_dir.join("site-packages/nvidia");
+        let Ok(packages) = std::fs::read_dir(nvidia_dir) else {
+            continue;
+        };
+        for package in packages.filter_map(|entry| entry.ok()) {
+            let lib_dir = package.path().join("lib");
+            if lib_dir.is_dir() {
+                dirs.push(lib_dir);
+            }
+        }
+    }
+    dirs
+}
+
+#[cfg(feature = "cuda")]
+fn normalize_existing_dirs(dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for dir in dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        let normalized = dir.canonicalize().unwrap_or(dir);
+        if seen.insert(normalized.clone()) {
+            out.push(normalized);
+        }
+    }
+    out
+}
+
+fn init_options_for_model(
+    model_type: EmbeddingModel,
+    runtime: &EmbedRuntimeConfig,
+) -> Result<InitOptions> {
+    let effective_provider = runtime.execution_provider.effective();
+    let opts = InitOptions::new(model_type).with_show_download_progress(false);
+
+    match effective_provider {
+        ExecutionProviderChoice::Auto => unreachable!("auto should resolve to a concrete provider"),
+        ExecutionProviderChoice::Cpu => Ok(opts),
+        ExecutionProviderChoice::CoreML => init_options_with_coreml(opts, runtime),
+        ExecutionProviderChoice::Cuda => init_options_with_cuda(opts, runtime),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn init_options_with_coreml(
+    opts: InitOptions,
+    runtime: &EmbedRuntimeConfig,
+) -> Result<InitOptions> {
+    use ort::execution_providers::coreml::{CoreMLComputeUnits, CoreMLExecutionProvider};
+
+    let compute_units = runtime
+        .compute_units
+        .as_deref()
+        .map(|v| match v.to_lowercase().as_str() {
+            "ane" | "neural" | "neuralengine" => CoreMLComputeUnits::CPUAndNeuralEngine,
+            "gpu" => CoreMLComputeUnits::CPUAndGPU,
+            "cpu" => CoreMLComputeUnits::CPUOnly,
+            _ => CoreMLComputeUnits::All,
+        })
+        .unwrap_or(CoreMLComputeUnits::All);
+    let provider = CoreMLExecutionProvider::default()
+        .with_subgraphs(true)
+        .with_compute_units(compute_units);
+    let dispatch = if matches!(runtime.execution_provider, ExecutionProviderChoice::CoreML) {
+        provider.build().error_on_failure()
+    } else {
+        provider.build()
+    };
+    Ok(opts.with_execution_providers(vec![dispatch]))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn init_options_with_coreml(
+    _opts: InitOptions,
+    _runtime: &EmbedRuntimeConfig,
+) -> Result<InitOptions> {
+    Err(anyhow!(
+        "execution_provider=coreml is only supported on macOS"
+    ))
+}
+
+#[cfg(feature = "cuda")]
+fn init_options_with_cuda(opts: InitOptions, runtime: &EmbedRuntimeConfig) -> Result<InitOptions> {
+    use ort::execution_providers::{CUDAExecutionProvider, ExecutionProvider};
+
+    preload_cuda_dependencies(runtime)?;
+    let mut provider = CUDAExecutionProvider::default();
+    if let Some(device_id) = runtime.cuda_device_id {
+        provider = provider.with_device_id(device_id);
+    }
+    if !provider.is_available()? {
+        return Err(anyhow!(
+            "CUDA execution provider is not available; ensure this binary was built with \
+             `--features cuda` and that the required CUDA 12/cuDNN runtime libraries are installed"
+        ));
+    }
+    Ok(opts.with_execution_providers(vec![provider.build().error_on_failure()]))
+}
+
+#[cfg(not(feature = "cuda"))]
+fn init_options_with_cuda(
+    _opts: InitOptions,
+    _runtime: &EmbedRuntimeConfig,
+) -> Result<InitOptions> {
+    Err(anyhow!(
+        "execution_provider=cuda requires a memex binary built with cargo feature `cuda`"
+    ))
+}
+
 enum EmbedBackend {
     Fastembed(TextEmbedding),
     Model2Vec(StaticModel),
@@ -58,42 +537,31 @@ pub struct EmbedderHandle {
 
 impl EmbedderHandle {
     pub fn with_model(choice: ModelChoice) -> Result<Self> {
+        let runtime = EmbedRuntimeConfig::from_env()?;
+        Self::with_model_and_runtime(choice, &runtime)
+    }
+
+    pub fn with_model_and_runtime(
+        choice: ModelChoice,
+        runtime: &EmbedRuntimeConfig,
+    ) -> Result<Self> {
         if let Some((model_type, dims)) = choice.fastembed_config() {
-            // Set thread count for ONNX Runtime to use all cores
-            let num_cpus = std::thread::available_parallelism()
-                .map(|p| p.get())
-                .unwrap_or(8);
-            unsafe {
-                std::env::set_var("OMP_NUM_THREADS", num_cpus.to_string());
-                std::env::set_var("ORT_NUM_THREADS", num_cpus.to_string());
-            }
-
-            #[cfg(target_os = "macos")]
-            let opts = {
-                use ort::execution_providers::coreml::{
-                    CoreMLComputeUnits, CoreMLExecutionProvider,
-                };
-                let compute_units = std::env::var("MEMEX_COMPUTE_UNITS")
-                    .ok()
-                    .map(|v| match v.to_lowercase().as_str() {
-                        "ane" | "neural" | "neuralengine" => CoreMLComputeUnits::CPUAndNeuralEngine,
-                        "gpu" => CoreMLComputeUnits::CPUAndGPU,
-                        "cpu" => CoreMLComputeUnits::CPUOnly,
-                        _ => CoreMLComputeUnits::All,
-                    })
-                    .unwrap_or(CoreMLComputeUnits::All);
-                let provider = CoreMLExecutionProvider::default()
-                    .with_subgraphs(true)
-                    .with_compute_units(compute_units);
-                InitOptions::new(model_type)
-                    .with_show_download_progress(false)
-                    .with_execution_providers(vec![provider.build()])
-            };
-
-            #[cfg(not(target_os = "macos"))]
-            let opts = InitOptions::new(model_type).with_show_download_progress(false);
-
-            let model = TextEmbedding::try_new(opts)?;
+            let requested_provider = runtime.execution_provider;
+            let effective_provider = requested_provider.effective();
+            let opts = init_options_for_model(model_type, runtime)?;
+            let model = TextEmbedding::try_new(opts).map_err(|err| match effective_provider {
+                ExecutionProviderChoice::Cuda => anyhow!(
+                    "failed to initialize CUDA execution provider: {err}. Ensure the binary was \
+                     built with `--features cuda` and the required CUDA 12/cuDNN libraries are \
+                     on the dynamic linker path (for example via LD_LIBRARY_PATH)"
+                ),
+                ExecutionProviderChoice::CoreML
+                    if matches!(requested_provider, ExecutionProviderChoice::CoreML) =>
+                {
+                    anyhow!("failed to initialize CoreML execution provider: {err}")
+                }
+                _ => err,
+            })?;
             Ok(Self {
                 backend: EmbedBackend::Fastembed(model),
                 dims,
@@ -129,14 +597,9 @@ impl EmbedderHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn fastembed_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("lock fastembed")
-    }
+    use crate::test_support::{EnvVarGuard, env_lock};
+    #[cfg(feature = "cuda")]
+    use tempfile::TempDir;
 
     fn test_embedder_from_env() -> EmbedderHandle {
         let choice = std::env::var("MEMEX_MODEL")
@@ -150,7 +613,12 @@ mod tests {
 
     #[test]
     fn test_embedder_init() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let env_model = std::env::var("MEMEX_MODEL").ok().map(|s| s.to_lowercase());
         let embedder = test_embedder_from_env();
         // Default is Gemma with 768 dims, but env var could change it
@@ -171,7 +639,12 @@ mod tests {
 
     #[test]
     fn test_embed_single_text() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder = test_embedder_from_env();
         let texts = vec!["Hello world"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -181,7 +654,12 @@ mod tests {
 
     #[test]
     fn test_embed_multiple_texts() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder = test_embedder_from_env();
         let texts = vec!["Hello world", "How are you?", "Rust is great"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -193,7 +671,12 @@ mod tests {
 
     #[test]
     fn test_embed_empty() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder = test_embedder_from_env();
         let texts: Vec<&str> = vec![];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -202,7 +685,12 @@ mod tests {
 
     #[test]
     fn test_embeddings_are_different() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder = test_embedder_from_env();
         let texts = vec!["cats are cute", "dogs are loyal"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -211,7 +699,12 @@ mod tests {
 
     #[test]
     fn test_similar_texts_have_similar_embeddings() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder = test_embedder_from_env();
         let texts = vec!["the cat sat on the mat", "a cat is sitting on a mat"];
         let embeddings = embedder.embed_texts(&texts).expect("failed to embed");
@@ -242,8 +735,167 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_execution_provider() {
+        assert_eq!(
+            ExecutionProviderChoice::parse("auto").expect("parse auto"),
+            ExecutionProviderChoice::Auto
+        );
+        assert_eq!(
+            ExecutionProviderChoice::parse("cpu").expect("parse cpu"),
+            ExecutionProviderChoice::Cpu
+        );
+        assert_eq!(
+            ExecutionProviderChoice::parse("coreml").expect("parse coreml"),
+            ExecutionProviderChoice::CoreML
+        );
+        assert_eq!(
+            ExecutionProviderChoice::parse("cuda").expect("parse cuda"),
+            ExecutionProviderChoice::Cuda
+        );
+    }
+
+    #[test]
+    fn test_apply_runtime_env_sets_expected_vars() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", None),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+            ("MEMEX_CUDA_LIBRARY_PATHS", None),
+            ("MEMEX_CUDNN_LIBRARY_PATHS", None),
+        ]);
+        apply_runtime_env(
+            ExecutionProviderChoice::Cuda,
+            Some("all"),
+            Some(2),
+            &[PathBuf::from("/opt/cuda/lib64")],
+            &[PathBuf::from("/opt/cudnn/lib64")],
+        )
+        .expect("apply runtime env");
+        assert_eq!(
+            std::env::var("MEMEX_EXECUTION_PROVIDER").ok().as_deref(),
+            Some("cuda")
+        );
+        assert_eq!(
+            std::env::var("MEMEX_COMPUTE_UNITS").ok().as_deref(),
+            Some("all")
+        );
+        assert_eq!(
+            std::env::var("MEMEX_CUDA_DEVICE_ID").ok().as_deref(),
+            Some("2")
+        );
+        assert_eq!(
+            std::env::var_os("MEMEX_CUDA_LIBRARY_PATHS")
+                .map(|value| std::env::split_paths(&value).collect::<Vec<_>>()),
+            Some(vec![PathBuf::from("/opt/cuda/lib64")])
+        );
+        assert_eq!(
+            std::env::var_os("MEMEX_CUDNN_LIBRARY_PATHS")
+                .map(|value| std::env::split_paths(&value).collect::<Vec<_>>()),
+            Some(vec![PathBuf::from("/opt/cudnn/lib64")])
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    fn temp_virtual_env(packages: &[&str]) -> TempDir {
+        let dir = TempDir::new().expect("create temp venv");
+        for package in packages {
+            std::fs::create_dir_all(
+                dir.path()
+                    .join("lib")
+                    .join("python3.11")
+                    .join("site-packages")
+                    .join("nvidia")
+                    .join(package)
+                    .join("lib"),
+            )
+            .expect("create package lib dir");
+        }
+        dir
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_python_nvidia_lib_dirs_detects_site_packages() {
+        let dir = temp_virtual_env(&["cublas", "cuda_runtime", "cudnn"]);
+        let libs = python_nvidia_lib_dirs(dir.path());
+        assert!(
+            libs.contains(
+                &dir.path()
+                    .join("lib/python3.11/site-packages/nvidia/cublas/lib")
+            )
+        );
+        assert!(
+            libs.contains(
+                &dir.path()
+                    .join("lib/python3.11/site-packages/nvidia/cuda_runtime/lib")
+            )
+        );
+        assert!(
+            libs.contains(
+                &dir.path()
+                    .join("lib/python3.11/site-packages/nvidia/cudnn/lib")
+            )
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_candidate_cuda_library_dirs_include_virtual_env_packages() {
+        let _guard = env_lock();
+        let dir = temp_virtual_env(&["cublas", "cuda_runtime"]);
+        let venv = dir.path().as_os_str();
+        let _env = EnvVarGuard::set_os(&[
+            ("VIRTUAL_ENV", Some(venv)),
+            ("CONDA_PREFIX", None),
+            ("MEMEX_CUDA_LIBRARY_PATHS", None),
+        ]);
+        let dirs = candidate_cuda_library_dirs(&[]);
+        assert!(
+            dirs.contains(
+                &dir.path()
+                    .join("lib/python3.11/site-packages/nvidia/cublas/lib")
+                    .canonicalize()
+                    .expect("canonical cublas dir")
+            )
+        );
+        assert!(
+            dirs.contains(
+                &dir.path()
+                    .join("lib/python3.11/site-packages/nvidia/cuda_runtime/lib")
+                    .canonicalize()
+                    .expect("canonical cuda runtime dir")
+            )
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_candidate_cudnn_library_dirs_include_explicit_env_paths() {
+        let _guard = env_lock();
+        let dir = TempDir::new().expect("create temp dir");
+        let cudnn_dir = dir.path().join("cudnn/lib");
+        std::fs::create_dir_all(&cudnn_dir).expect("create cudnn dir");
+        let joined = std::env::join_paths([&cudnn_dir]).expect("join cudnn paths");
+        let _env = EnvVarGuard::set_os(&[
+            ("MEMEX_CUDNN_LIBRARY_PATHS", Some(joined.as_os_str())),
+            ("VIRTUAL_ENV", None),
+            ("CONDA_PREFIX", None),
+        ]);
+        let dirs = candidate_cudnn_library_dirs(&resolve_library_paths_from_env(
+            MEMEX_CUDNN_LIBRARY_PATHS_ENV,
+        ));
+        assert!(dirs.contains(&cudnn_dir.canonicalize().expect("canonical cudnn dir")));
+    }
+
+    #[test]
     fn test_potion_embedding() {
-        let _guard = fastembed_test_lock();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[
+            ("MEMEX_EXECUTION_PROVIDER", Some("auto")),
+            ("MEMEX_CUDA_DEVICE_ID", None),
+            ("MEMEX_COMPUTE_UNITS", None),
+        ]);
         let mut embedder =
             EmbedderHandle::with_model(ModelChoice::Potion).expect("init potion embedder");
         let texts = vec!["potion model smoke test", "another short sentence"];

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,5 +1,5 @@
 use crate::config::Paths;
-use crate::embed::{EmbedderHandle, ModelChoice};
+use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::SearchIndex;
 use crate::progress::Progress;
 use crate::state::{FileState, IngestState, ScanCache};
@@ -32,7 +32,7 @@ pub struct IngestOptions {
     pub embeddings: bool,
     pub backfill_embeddings: bool,
     pub model: ModelChoice,
-    pub compute_units: Option<String>,
+    pub embed_runtime: EmbedRuntimeConfig,
 }
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ struct WriterContext {
     vector_dir: PathBuf,
     progress: Arc<Progress>,
     model: ModelChoice,
-    compute_units: Option<String>,
+    embed_runtime: EmbedRuntimeConfig,
 }
 
 /// Check if scan cache is fresh; if so, skip indexing entirely.
@@ -299,7 +299,7 @@ pub fn ingest_all(
         vector_dir: paths.vectors.clone(),
         progress: progress.clone(),
         model: options.model,
-        compute_units: options.compute_units.clone(),
+        embed_runtime: options.embed_runtime.clone(),
     };
     let writer_handle =
         std::thread::spawn(move || writer_loop(writer_index, rx_record, delete_paths, writer_ctx));
@@ -375,7 +375,7 @@ fn writer_loop(
         vector_dir,
         progress,
         model,
-        compute_units,
+        embed_runtime,
     } = ctx;
     let mut writer = index.writer()?;
     for path in delete_paths {
@@ -389,15 +389,7 @@ fn writer_loop(
     let mut embed_buffer: Vec<(u64, String, SourceKind)> = Vec::new();
     let mut index_pending: [u64; 4] = [0, 0, 0, 0];
     if embeddings {
-        if let Some(units) = compute_units.as_deref() {
-            unsafe {
-                std::env::set_var("MEMEX_COMPUTE_UNITS", units);
-            }
-        }
-        unsafe {
-            std::env::set_var("HF_HUB_DISABLE_PROGRESS_BARS", "1");
-        }
-        let handle = EmbedderHandle::with_model(model)?;
+        let handle = EmbedderHandle::with_model_and_runtime(model, &embed_runtime)?;
         let dims = handle.dims;
         vector_index = Some(crate::vector::VectorIndex::open_or_create(
             &vector_dir,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,6 @@ pub mod state;
 pub mod tui;
 pub mod types;
 pub mod vector;
+
+#[cfg(test)]
+pub mod test_support;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,3 @@
-mod cli;
-mod config;
-mod embed;
-mod index;
-mod ingest;
-mod progress;
-mod state;
-mod tui;
-mod types;
-mod vector;
-
 fn main() -> anyhow::Result<()> {
-    cli::run()
+    memex::cli::run()
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,52 @@
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+pub fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("lock test env")
+}
+
+pub struct EnvVarGuard {
+    prev: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvVarGuard {
+    pub fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
+        let vars = vars
+            .iter()
+            .map(|(key, value)| (*key, value.map(OsStr::new)))
+            .collect::<Vec<_>>();
+        Self::set_os(&vars)
+    }
+
+    pub fn set_os(vars: &[(&'static str, Option<&OsStr>)]) -> Self {
+        let prev = vars
+            .iter()
+            .map(|(key, _)| (*key, std::env::var_os(key)))
+            .collect::<Vec<_>>();
+        unsafe {
+            for (key, value) in vars {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self { prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            for (key, value) in &self.prev {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -442,7 +442,7 @@ impl App {
                     embeddings: embeddings_default,
                     backfill_embeddings,
                     model: model_choice,
-                    compute_units: config.resolve_compute_units(),
+                    embed_runtime: config.resolve_embed_runtime()?,
                 };
                 ingest_if_stale(&paths, &index, &opts, config.scan_cache_ttl())
             })();


### PR DESCRIPTION
## Summary
- add feature-gated CUDA execution provider support for embedding models
- add portable CUDA/cuDNN library discovery plus actionable failure messages
- thread explicit embed runtime config through indexing, search, and TUI paths

## Notes
- release/distribution handling for CUDA artifacts is intentionally left out of scope for this PR
- happy to follow your preference separately on whether this should ship as a separate binary/package variant

## Validation
- cargo fmt --check
- cargo build
- cargo build --features cuda
- cargo test --lib
- cargo test --lib --features cuda
- cargo clippy --all-targets --features cuda -- -D warnings