### PR TITLE
Track vector metadata and skip no-op indexing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -493,10 +493,6 @@ fn run_index(
     }
     paths.ensure_dirs()?;
     let index = SearchIndex::open_or_create(&paths.index)?;
-    let vector_exists = paths.vectors.join("meta.json").exists()
-        && paths.vectors.join("vectors.f32").exists()
-        && paths.vectors.join("doc_ids.u64").exists();
-    let backfill_embeddings = embeddings && !vector_exists && index.doc_count()? > 0;
 
     let opts = IngestOptions {
         claude_source: source.unwrap_or_else(default_claude_source),
@@ -504,7 +500,7 @@ fn run_index(
         include_codex: codex,
         include_opencode: opencode,
         embeddings,
-        backfill_embeddings,
+        backfill_embeddings: false,
         model: model_choice,
         embed_runtime,
     };
@@ -539,7 +535,8 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
 
     let index = SearchIndex::open_or_create(&paths.index)?;
     let mut embedder = EmbedderHandle::with_model_and_runtime(model_choice, &embed_runtime)?;
-    let mut vector = VectorIndex::open_or_create(&paths.vectors, embedder.dims)?;
+    let mut vector =
+        VectorIndex::open_or_create(&paths.vectors, embedder.dims, Some(model_choice.as_str()))?;
 
     let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 4], [0; 4], true));
     progress.set_embed_ready();
@@ -657,17 +654,13 @@ fn run_search(
     if auto_index_on_search {
         paths.ensure_dirs()?;
         let index = SearchIndex::open_or_create(&paths.index)?;
-        let vector_exists = paths.vectors.join("meta.json").exists()
-            && paths.vectors.join("vectors.f32").exists()
-            && paths.vectors.join("doc_ids.u64").exists();
-        let backfill_embeddings = embeddings_default && !vector_exists && index.doc_count()? > 0;
         let opts = IngestOptions {
             claude_source: default_claude_source(),
             include_agents: false,
             include_codex: true,
             include_opencode: true,
             embeddings: embeddings_default,
-            backfill_embeddings,
+            backfill_embeddings: false,
             model: model_choice,
             embed_runtime: embed_runtime.clone(),
         };
@@ -1108,32 +1101,31 @@ fn run_stats(root: Option<PathBuf>) -> Result<()> {
 }
 
 fn print_vector_stats(vectors_dir: &std::path::Path) -> Result<()> {
-    let meta_path = vectors_dir.join("meta.json");
-    let vectors_path = vectors_dir.join("vectors.f32");
-    let ids_path = vectors_dir.join("doc_ids.u64");
-    if !meta_path.exists() || !vectors_path.exists() || !ids_path.exists() {
-        println!("vectors: none");
-        return Ok(());
-    }
-    #[derive(serde::Deserialize)]
-    struct Meta {
-        dimensions: usize,
-    }
-    let meta_str = std::fs::read_to_string(&meta_path)?;
-    let meta: Meta = serde_json::from_str(&meta_str)?;
-    let ids_bytes = std::fs::metadata(&ids_path)?.len();
-    let vec_bytes = std::fs::metadata(&vectors_path)?.len();
-    let ids = ids_bytes / 8;
-    let vecs = if meta.dimensions == 0 {
-        0
-    } else {
-        (vec_bytes / 4) / meta.dimensions as u64
-    };
-    println!(
-        "vectors: {} (dims {}, ids {}, vectors.f32 {}, doc_ids.u64 {})",
-        vecs, meta.dimensions, ids, vec_bytes, ids_bytes
-    );
+    println!("{}", vector_stats_line(vectors_dir)?);
     Ok(())
+}
+
+fn vector_stats_line(vectors_dir: &std::path::Path) -> Result<String> {
+    let vector = match VectorIndex::open(vectors_dir) {
+        Ok(vector) => vector,
+        Err(_) => {
+            return Ok("vectors: none".to_string());
+        }
+    };
+    let index_path = vectors_dir.join("usearch.index");
+    let ids_path = vectors_dir.join("doc_ids.bin");
+    let index_bytes = std::fs::metadata(&index_path).map(|m| m.len()).unwrap_or(0);
+    let ids_bytes = std::fs::metadata(&ids_path).map(|m| m.len()).unwrap_or(0);
+    let model = vector.model().unwrap_or("unknown");
+    Ok(format!(
+        "vectors: {} (dims {}, model {}, ids {}, usearch.index {}, doc_ids.bin {})",
+        vector.len(),
+        vector.dimensions(),
+        model,
+        vector.doc_id_count(),
+        index_bytes,
+        ids_bytes
+    ))
 }
 
 fn run_setup(force: bool) -> Result<()> {
@@ -2535,4 +2527,38 @@ fn parse_version_parts(value: &str) -> Option<(u64, u64, u64)> {
         return None;
     }
     Some((parts[0], parts[1], parts[2]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::VectorIndex;
+    use tempfile::TempDir;
+
+    fn make_vector(dims: usize) -> Vec<f32> {
+        (0..dims).map(|i| (i as f32).sin()).collect()
+    }
+
+    #[test]
+    fn vector_stats_line_reports_current_usearch_store() {
+        let tmp = TempDir::new().unwrap();
+        let mut index = VectorIndex::open_or_create(tmp.path(), 64, Some("bge")).unwrap();
+        index.add(42, &make_vector(64)).unwrap();
+        index.save().unwrap();
+
+        let line = vector_stats_line(tmp.path()).unwrap();
+
+        assert!(line.starts_with("vectors: 1 (dims 64, model bge, ids 1,"));
+        assert!(line.contains("usearch.index"));
+        assert!(line.contains("doc_ids.bin"));
+        assert!(!line.contains("vectors.f32"));
+        assert!(!line.contains("doc_ids.u64"));
+    }
+
+    #[test]
+    fn vector_stats_line_reports_none_without_vector_store() {
+        let tmp = TempDir::new().unwrap();
+
+        assert_eq!(vector_stats_line(tmp.path()).unwrap(), "vectors: none");
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1106,12 +1106,10 @@ fn print_vector_stats(vectors_dir: &std::path::Path) -> Result<()> {
 }
 
 fn vector_stats_line(vectors_dir: &std::path::Path) -> Result<String> {
-    let vector = match VectorIndex::open(vectors_dir) {
-        Ok(vector) => vector,
-        Err(_) => {
-            return Ok("vectors: none".to_string());
-        }
-    };
+    if !vectors_dir.join("usearch.index").exists() {
+        return Ok("vectors: none".to_string());
+    }
+    let vector = VectorIndex::open(vectors_dir)?;
     let index_path = vectors_dir.join("usearch.index");
     let ids_path = vectors_dir.join("doc_ids.bin");
     let index_bytes = std::fs::metadata(&index_path).map(|m| m.len()).unwrap_or(0);
@@ -2200,7 +2198,7 @@ fn apply_post_processing(
             results.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
         }
         SortBy::Ts => {
-            results.sort_by(|a, b| b.1.ts.cmp(&a.1.ts));
+            results.sort_by_key(|result| std::cmp::Reverse(result.1.ts));
         }
     }
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -55,7 +55,7 @@ const CUDNN_DYLIBS: &[&str] = &[
 ];
 
 /// Supported embedding models
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ModelChoice {
     /// AllMiniLML6V2 - 22M params, 384 dims, very fast
     MiniLM,
@@ -94,6 +94,16 @@ impl ModelChoice {
             _ => Err(anyhow!(
                 "unknown model '{s}', options: minilm, bge, nomic, gemma, potion"
             )),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ModelChoice::MiniLM => "minilm",
+            ModelChoice::BGESmall => "bge",
+            ModelChoice::Nomic => "nomic",
+            ModelChoice::Gemma => "gemma",
+            ModelChoice::Potion => "potion",
         }
     }
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -106,6 +106,10 @@ impl ModelChoice {
             ModelChoice::Potion => "potion",
         }
     }
+
+    pub fn known_dimensions(self) -> Option<usize> {
+        self.fastembed_config().map(|(_, dimensions)| dimensions)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -81,7 +81,7 @@ pub fn ingest_if_stale(
     let cache_path = paths.state.join("scan_cache.json");
     let cache = ScanCache::load(&cache_path)?;
 
-    if can_skip_fresh_scan(&cache, paths, options, ttl_seconds) {
+    if can_skip_fresh_scan(&cache, paths, index, options, ttl_seconds)? {
         return Ok(None);
     }
 
@@ -281,7 +281,7 @@ pub fn ingest_all(
 
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
-    if tasks.is_empty() && can_skip_noop_index(paths, options) {
+    if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
         update_scan_cache(paths, files_scanned, total_bytes);
         return Ok(IngestReport {
             records_added: 0,
@@ -379,24 +379,55 @@ fn update_scan_cache(paths: &Paths, files_scanned: usize, total_bytes: u64) {
 fn can_skip_fresh_scan(
     cache: &ScanCache,
     paths: &Paths,
+    index: &SearchIndex,
     options: &IngestOptions,
     ttl_seconds: u64,
-) -> bool {
-    cache.is_fresh(ttl_seconds) && can_skip_noop_index(paths, options)
+) -> Result<bool> {
+    if !cache.is_fresh(ttl_seconds) {
+        return Ok(false);
+    }
+    can_skip_noop_index(paths, index, options)
 }
 
-fn can_skip_noop_index(paths: &Paths, options: &IngestOptions) -> bool {
+fn can_skip_noop_index(
+    paths: &Paths,
+    index: &SearchIndex,
+    options: &IngestOptions,
+) -> Result<bool> {
     if !options.embeddings {
-        return true;
+        return Ok(true);
     }
     let Some(dimensions) = options.model.known_dimensions() else {
-        return false;
+        return Ok(false);
     };
-    crate::vector::VectorIndex::is_model_compatible(
-        &paths.vectors,
-        options.model.as_str(),
-        dimensions,
-    )
+    if !paths.vectors.join("usearch.index").exists() {
+        return Ok(false);
+    }
+    let vector_index = crate::vector::VectorIndex::open(&paths.vectors)?;
+    if vector_index.model() != Some(options.model.as_str())
+        || vector_index.dimensions() != dimensions
+    {
+        return Ok(false);
+    }
+    vector_index_covers_embeddable_records(index, &vector_index)
+}
+
+fn vector_index_covers_embeddable_records(
+    index: &SearchIndex,
+    vector_index: &crate::vector::VectorIndex,
+) -> Result<bool> {
+    let mut covers_all = true;
+    index.for_each_record(|record| {
+        if record_needs_embedding(&record) && !vector_index.contains(record.doc_id) {
+            covers_all = false;
+        }
+        Ok(())
+    })?;
+    Ok(covers_all)
+}
+
+fn record_needs_embedding(record: &Record) -> bool {
+    is_embedding_role(&record.role) && !record.text.is_empty()
 }
 
 fn writer_loop(
@@ -491,9 +522,12 @@ fn writer_loop(
             )?;
         }
 
-        let needs_vector_backfill = vector_index
-            .as_ref()
-            .is_some_and(crate::vector::VectorIndex::needs_backfill);
+        let needs_vector_backfill = match vector_index.as_ref() {
+            Some(vindex) => {
+                vindex.needs_backfill() || !vector_index_covers_embeddable_records(&index, vindex)?
+            }
+            None => false,
+        };
         if do_backfill_embeddings || needs_vector_backfill {
             embedded_count += backfill_embeddings(
                 &index,
@@ -1457,6 +1491,38 @@ mod tests {
         vector.save().unwrap();
     }
 
+    fn open_search_index(paths: &Paths) -> SearchIndex {
+        fs::create_dir_all(&paths.index).expect("create index dir");
+        SearchIndex::open_or_create(&paths.index).expect("open search index")
+    }
+
+    fn save_search_records(paths: &Paths, records: &[Record]) -> SearchIndex {
+        let index = open_search_index(paths);
+        let mut writer = index.writer().expect("open index writer");
+        for record in records {
+            index.add_record(&mut writer, record).expect("add record");
+        }
+        writer.commit().expect("commit records");
+        index
+    }
+
+    fn record(doc_id: u64, role: &str, text: &str) -> Record {
+        Record {
+            source: SourceKind::Claude,
+            doc_id,
+            ts: doc_id,
+            project: "project".to_string(),
+            session_id: "session".to_string(),
+            turn_id: doc_id as u32,
+            role: role.to_string(),
+            text: text.to_string(),
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            source_path: format!("source-{doc_id}.jsonl"),
+        }
+    }
+
     fn fresh_scan_cache() -> ScanCache {
         let last_scan_ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1498,19 +1564,21 @@ mod tests {
     fn can_skip_noop_index_when_embeddings_are_disabled() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let index = open_search_index(&paths);
         let options = ingest_options(false, ModelChoice::BGESmall);
 
-        assert!(can_skip_noop_index(&paths, &options));
+        assert!(can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 
     #[test]
     fn can_skip_fresh_scan_when_embeddings_are_disabled() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let index = open_search_index(&paths);
         let options = ingest_options(false, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
-        assert!(can_skip_fresh_scan(&cache, &paths, &options, 60));
+        assert!(can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
 
     #[test]
@@ -1518,20 +1586,22 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "bge", 384);
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
-        assert!(can_skip_fresh_scan(&cache, &paths, &options, 60));
+        assert!(can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
 
     #[test]
     fn cannot_skip_fresh_scan_when_vectors_are_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
-        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+        assert!(!can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
 
     #[test]
@@ -1539,16 +1609,18 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "minilm", 384);
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
-        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+        assert!(!can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
 
     #[test]
     fn cannot_skip_fresh_scan_when_cache_is_stale() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let index = open_search_index(&paths);
         let options = ingest_options(false, ModelChoice::BGESmall);
         let cache = ScanCache {
             last_scan_ts: 0,
@@ -1556,7 +1628,7 @@ mod tests {
             total_bytes: 0,
         };
 
-        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+        assert!(!can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
 
     #[test]
@@ -1564,18 +1636,55 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "bge", 384);
+        let index = save_search_records(&paths, &[record(1, "user", "hello")]);
         let options = ingest_options(true, ModelChoice::BGESmall);
 
-        assert!(can_skip_noop_index(&paths, &options));
+        assert!(can_skip_noop_index(&paths, &index, &options).unwrap());
+    }
+
+    #[test]
+    fn cannot_skip_noop_index_with_partial_compatible_vectors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let index = save_search_records(
+            &paths,
+            &[
+                record(1, "user", "embedded"),
+                record(2, "assistant", "missing vector"),
+            ],
+        );
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
+    }
+
+    #[test]
+    fn can_skip_noop_index_ignores_records_that_do_not_need_embeddings() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let index = save_search_records(
+            &paths,
+            &[
+                record(1, "user", "embedded"),
+                record(2, "tool_result", "not embedded"),
+                record(3, "assistant", ""),
+            ],
+        );
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 
     #[test]
     fn cannot_skip_noop_index_when_vectors_are_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
 
-        assert!(!can_skip_noop_index(&paths, &options));
+        assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 
     #[test]
@@ -1583,9 +1692,10 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "minilm", 384);
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
 
-        assert!(!can_skip_noop_index(&paths, &options));
+        assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 
     #[test]
@@ -1593,9 +1703,10 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "bge", 768);
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::BGESmall);
 
-        assert!(!can_skip_noop_index(&paths, &options));
+        assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 
     #[test]
@@ -1603,8 +1714,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "potion", 256);
+        let index = open_search_index(&paths);
         let options = ingest_options(true, ModelChoice::Potion);
 
-        assert!(!can_skip_noop_index(&paths, &options));
+        assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -394,6 +394,7 @@ fn writer_loop(
         vector_index = Some(crate::vector::VectorIndex::open_or_create(
             &vector_dir,
             dims,
+            Some(model.as_str()),
         )?);
         embedder = Some(handle);
         progress.set_embed_ready();
@@ -445,7 +446,10 @@ fn writer_loop(
 
     writer.commit()?;
     if embeddings {
-        if do_backfill_embeddings {
+        let needs_vector_backfill = vector_index
+            .as_ref()
+            .is_some_and(crate::vector::VectorIndex::needs_backfill);
+        if do_backfill_embeddings || needs_vector_backfill {
             embedded_count += backfill_embeddings(
                 &index,
                 embedder.as_mut().unwrap(),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -70,7 +70,7 @@ struct WriterContext {
     embed_runtime: EmbedRuntimeConfig,
 }
 
-/// Check if scan cache is fresh; if so, skip indexing entirely.
+/// Check if scan cache is fresh and vector state is usable; if so, skip indexing entirely.
 /// Returns Ok(None) if skipped due to fresh cache, Ok(Some(report)) if indexing ran.
 pub fn ingest_if_stale(
     paths: &Paths,
@@ -81,7 +81,7 @@ pub fn ingest_if_stale(
     let cache_path = paths.state.join("scan_cache.json");
     let cache = ScanCache::load(&cache_path)?;
 
-    if cache.is_fresh(ttl_seconds) {
+    if can_skip_fresh_scan(&cache, paths, options, ttl_seconds) {
         return Ok(None);
     }
 
@@ -281,6 +281,16 @@ pub fn ingest_all(
 
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
+    if tasks.is_empty() && can_skip_noop_index(paths, options) {
+        update_scan_cache(paths, files_scanned, total_bytes);
+        return Ok(IngestReport {
+            records_added: 0,
+            records_embedded: 0,
+            files_scanned,
+            files_skipped,
+        });
+    }
+
     let progress = Arc::new(Progress::new(totals, file_totals, options.embeddings));
 
     let (tx_record, rx_record) = unbounded::<Record>();
@@ -349,11 +359,7 @@ pub fn ingest_all(
     state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
     state.save(&state_path)?;
 
-    // Update scan cache with current scan results
-    let cache_path = paths.state.join("scan_cache.json");
-    let mut cache = ScanCache::load(&cache_path).unwrap_or_default();
-    cache.update(files_scanned, total_bytes);
-    let _ = cache.save(&cache_path);
+    update_scan_cache(paths, files_scanned, total_bytes);
 
     Ok(IngestReport {
         records_added,
@@ -361,6 +367,36 @@ pub fn ingest_all(
         files_scanned,
         files_skipped,
     })
+}
+
+fn update_scan_cache(paths: &Paths, files_scanned: usize, total_bytes: u64) {
+    let cache_path = paths.state.join("scan_cache.json");
+    let mut cache = ScanCache::load(&cache_path).unwrap_or_default();
+    cache.update(files_scanned, total_bytes);
+    let _ = cache.save(&cache_path);
+}
+
+fn can_skip_fresh_scan(
+    cache: &ScanCache,
+    paths: &Paths,
+    options: &IngestOptions,
+    ttl_seconds: u64,
+) -> bool {
+    cache.is_fresh(ttl_seconds) && can_skip_noop_index(paths, options)
+}
+
+fn can_skip_noop_index(paths: &Paths, options: &IngestOptions) -> bool {
+    if !options.embeddings {
+        return true;
+    }
+    let Some(dimensions) = options.model.known_dimensions() else {
+        return false;
+    };
+    crate::vector::VectorIndex::is_model_compatible(
+        &paths.vectors,
+        options.model.as_str(),
+        dimensions,
+    )
 }
 
 fn writer_loop(
@@ -446,21 +482,21 @@ fn writer_loop(
 
     writer.commit()?;
     if embeddings {
-        let needs_vector_backfill = vector_index
-            .as_ref()
-            .is_some_and(crate::vector::VectorIndex::needs_backfill);
-        if do_backfill_embeddings || needs_vector_backfill {
-            embedded_count += backfill_embeddings(
-                &index,
+        if !embed_buffer.is_empty() {
+            embedded_count += flush_embeddings(
+                &mut embed_buffer,
                 embedder.as_mut().unwrap(),
                 vector_index.as_mut().unwrap(),
                 &progress,
             )?;
         }
 
-        if !embed_buffer.is_empty() {
-            embedded_count += flush_embeddings(
-                &mut embed_buffer,
+        let needs_vector_backfill = vector_index
+            .as_ref()
+            .is_some_and(crate::vector::VectorIndex::needs_backfill);
+        if do_backfill_embeddings || needs_vector_backfill {
+            embedded_count += backfill_embeddings(
+                &index,
                 embedder.as_mut().unwrap(),
                 vector_index.as_mut().unwrap(),
                 &progress,
@@ -1395,7 +1431,43 @@ fn is_embedding_role(role: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Paths;
+    use crate::embed::{EmbedRuntimeConfig, ModelChoice};
+    use crate::vector::VectorIndex;
     use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn ingest_options(embeddings: bool, model: ModelChoice) -> IngestOptions {
+        IngestOptions {
+            claude_source: PathBuf::from("/does/not/exist"),
+            include_agents: false,
+            include_codex: false,
+            include_opencode: false,
+            embeddings,
+            backfill_embeddings: false,
+            model,
+            embed_runtime: EmbedRuntimeConfig::default(),
+        }
+    }
+
+    fn save_vector_store(paths: &Paths, model: &str, dimensions: usize) {
+        let mut vector = VectorIndex::open_or_create(&paths.vectors, dimensions, Some(model))
+            .expect("open vector store");
+        vector.add(1, &vec![0.0; dimensions]).expect("add vector");
+        vector.save().unwrap();
+    }
+
+    fn fresh_scan_cache() -> ScanCache {
+        let last_scan_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+        ScanCache {
+            last_scan_ts,
+            file_count: 0,
+            total_bytes: 0,
+        }
+    }
 
     #[test]
     fn collect_codex_session_files_includes_archived_sessions() {
@@ -1420,5 +1492,119 @@ mod tests {
         files.sort();
 
         assert_eq!(files, vec![archived, live]);
+    }
+
+    #[test]
+    fn can_skip_noop_index_when_embeddings_are_disabled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let options = ingest_options(false, ModelChoice::BGESmall);
+
+        assert!(can_skip_noop_index(&paths, &options));
+    }
+
+    #[test]
+    fn can_skip_fresh_scan_when_embeddings_are_disabled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let options = ingest_options(false, ModelChoice::BGESmall);
+        let cache = fresh_scan_cache();
+
+        assert!(can_skip_fresh_scan(&cache, &paths, &options, 60));
+    }
+
+    #[test]
+    fn can_skip_fresh_scan_with_compatible_vectors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let options = ingest_options(true, ModelChoice::BGESmall);
+        let cache = fresh_scan_cache();
+
+        assert!(can_skip_fresh_scan(&cache, &paths, &options, 60));
+    }
+
+    #[test]
+    fn cannot_skip_fresh_scan_when_vectors_are_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let options = ingest_options(true, ModelChoice::BGESmall);
+        let cache = fresh_scan_cache();
+
+        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+    }
+
+    #[test]
+    fn cannot_skip_fresh_scan_with_incompatible_vectors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "minilm", 384);
+        let options = ingest_options(true, ModelChoice::BGESmall);
+        let cache = fresh_scan_cache();
+
+        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+    }
+
+    #[test]
+    fn cannot_skip_fresh_scan_when_cache_is_stale() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let options = ingest_options(false, ModelChoice::BGESmall);
+        let cache = ScanCache {
+            last_scan_ts: 0,
+            file_count: 0,
+            total_bytes: 0,
+        };
+
+        assert!(!can_skip_fresh_scan(&cache, &paths, &options, 60));
+    }
+
+    #[test]
+    fn can_skip_noop_index_with_compatible_vectors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(can_skip_noop_index(&paths, &options));
+    }
+
+    #[test]
+    fn cannot_skip_noop_index_when_vectors_are_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(!can_skip_noop_index(&paths, &options));
+    }
+
+    #[test]
+    fn cannot_skip_noop_index_with_incompatible_vectors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "minilm", 384);
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(!can_skip_noop_index(&paths, &options));
+    }
+
+    #[test]
+    fn cannot_skip_noop_index_with_wrong_vector_dimensions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 768);
+        let options = ingest_options(true, ModelChoice::BGESmall);
+
+        assert!(!can_skip_noop_index(&paths, &options));
+    }
+
+    #[test]
+    fn cannot_skip_noop_index_when_model_dimensions_are_dynamic() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "potion", 256);
+        let options = ingest_options(true, ModelChoice::Potion);
+
+        assert!(!can_skip_noop_index(&paths, &options));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -429,18 +429,13 @@ impl App {
                 let index = SearchIndex::open_or_create(&paths.index)?;
                 let embeddings_default = config.embeddings_default();
                 let model_choice = config.resolve_model(None)?;
-                let vector_exists = paths.vectors.join("meta.json").exists()
-                    && paths.vectors.join("vectors.f32").exists()
-                    && paths.vectors.join("doc_ids.u64").exists();
-                let backfill_embeddings =
-                    embeddings_default && !vector_exists && index.doc_count()? > 0;
                 let opts = IngestOptions {
                     claude_source: default_claude_source(),
                     include_agents: false,
                     include_codex: true,
                     include_opencode: true,
                     embeddings: embeddings_default,
-                    backfill_embeddings,
+                    backfill_embeddings: false,
                     model: model_choice,
                     embed_runtime: config.resolve_embed_runtime()?,
                 };

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -923,18 +923,16 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
                     app.move_project_selection(1);
                 }
             }
-            KeyCode::Char(ch) => {
-                if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                    match app.focus {
-                        Focus::Query => app.query.push(ch),
-                        Focus::Project => {
-                            app.project.push(ch);
-                            app.update_project_options();
-                        }
-                        Focus::List => {}
-                        Focus::Preview => {}
-                        Focus::Find => {}
+            KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                match app.focus {
+                    Focus::Query => app.query.push(ch),
+                    Focus::Project => {
+                        app.project.push(ch);
+                        app.update_project_options();
                     }
+                    Focus::List => {}
+                    Focus::Preview => {}
+                    Focus::Find => {}
                 }
             }
             _ => {}
@@ -955,11 +953,9 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
             KeyCode::Esc => {
                 app.focus = Focus::Preview;
             }
-            KeyCode::Char(ch) => {
-                if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                    app.find_query.push(ch);
-                    app.update_find();
-                }
+            KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                app.find_query.push(ch);
+                app.update_find();
             }
             _ => {}
         }
@@ -1467,7 +1463,7 @@ fn sessions_from_recent(
         }
     }
     let mut out: Vec<SessionSummary> = sessions.into_values().collect();
-    out.sort_by(|a, b| b.last_ts.cmp(&a.last_ts));
+    out.sort_by_key(|summary| std::cmp::Reverse(summary.last_ts));
     Ok(out)
 }
 
@@ -1874,10 +1870,7 @@ fn strip_ansi_and_controls(line: &str) -> String {
     let mut out = String::with_capacity(line.len());
     let mut chars = line.chars().peekable();
     let mut count = 0usize;
-    loop {
-        let Some(ch) = chars.next() else {
-            break;
-        };
+    while let Some(ch) = chars.next() {
         if ch == '\u{1b}' {
             if matches!(chars.peek(), Some('[')) {
                 chars.next();

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,30 +1,52 @@
 use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VectorMetadata {
+    dimensions: usize,
+    model: Option<String>,
+    index_file: String,
+    ids_file: String,
+}
+
 pub struct VectorIndex {
     dims: usize,
+    model: Option<String>,
     path: PathBuf,
     index: Index,
     doc_id_set: HashSet<u64>,
+    needs_backfill: bool,
 }
 
 impl VectorIndex {
-    pub fn open_or_create(dir: &Path, dimensions: usize) -> Result<Self> {
+    pub fn open_or_create(dir: &Path, dimensions: usize, model: Option<&str>) -> Result<Self> {
         fs::create_dir_all(dir)?;
         let index_path = dir.join("usearch.index");
         let ids_path = dir.join("doc_ids.bin");
+        let meta_path = dir.join("meta.json");
+        let mut needs_backfill = false;
+        let model = model.map(str::to_string);
 
-        // Check if existing index has different dimensions
+        // Check if existing index has different dimensions or an incompatible embedding model.
         if index_path.exists() {
             let existing = Index::new(&IndexOptions::default())?;
             existing.load(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
-            if existing.dimensions() != dimensions {
-                // Dimension mismatch, remove old files
+            let existing_meta = load_metadata(&meta_path).ok();
+            let model_mismatch = match (&existing_meta, &model) {
+                (Some(meta), Some(model)) => meta.model.as_deref() != Some(model),
+                (None, Some(_)) => true,
+                _ => false,
+            };
+            if existing.dimensions() != dimensions || model_mismatch {
+                // Dimension or model mismatch; remove the old vector store and backfill.
                 let _ = fs::remove_file(&index_path);
                 let _ = fs::remove_file(&ids_path);
+                let _ = fs::remove_file(&meta_path);
+                needs_backfill = true;
             }
         }
 
@@ -46,20 +68,24 @@ impl VectorIndex {
             }
         } else {
             index.reserve(10000)?;
+            needs_backfill = true;
             HashSet::new()
         };
 
         Ok(Self {
             dims: dimensions,
+            model,
             path: dir.to_path_buf(),
             index,
             doc_id_set,
+            needs_backfill,
         })
     }
 
     pub fn open(dir: &Path) -> Result<Self> {
         let index_path = dir.join("usearch.index");
         let ids_path = dir.join("doc_ids.bin");
+        let meta_path = dir.join("meta.json");
 
         if !index_path.exists() {
             return Err(anyhow!("vector index not found"));
@@ -73,12 +99,15 @@ impl VectorIndex {
         } else {
             HashSet::new()
         };
+        let model = load_metadata(&meta_path).ok().and_then(|meta| meta.model);
 
         Ok(Self {
             dims: index.dimensions(),
+            model,
             path: dir.to_path_buf(),
             index,
             doc_id_set,
+            needs_backfill: false,
         })
     }
 
@@ -123,6 +152,7 @@ impl VectorIndex {
     pub fn save(&self) -> Result<()> {
         let index_path = self.path.join("usearch.index");
         let ids_path = self.path.join("doc_ids.bin");
+        let meta_path = self.path.join("meta.json");
 
         // Save index
         self.index
@@ -130,6 +160,15 @@ impl VectorIndex {
 
         // Save doc_ids
         save_doc_ids(&ids_path, &self.doc_id_set)?;
+        save_metadata(
+            &meta_path,
+            &VectorMetadata {
+                dimensions: self.dims,
+                model: self.model.clone(),
+                index_file: "usearch.index".to_string(),
+                ids_file: "doc_ids.bin".to_string(),
+            },
+        )?;
 
         Ok(())
     }
@@ -138,10 +177,38 @@ impl VectorIndex {
         self.doc_id_set.contains(&doc_id)
     }
 
+    pub fn len(&self) -> usize {
+        self.index.size()
+    }
+
+    pub fn doc_id_count(&self) -> usize {
+        self.doc_id_set.len()
+    }
+
+    pub fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    pub fn needs_backfill(&self) -> bool {
+        self.needs_backfill
+    }
+
     #[allow(dead_code)]
     pub fn dimensions(&self) -> usize {
         self.dims
     }
+}
+
+fn load_metadata(path: &Path) -> Result<VectorMetadata> {
+    let data = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+fn save_metadata(path: &Path, metadata: &VectorMetadata) -> Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, serde_json::to_string_pretty(metadata)?)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
 }
 
 fn load_doc_ids(path: &Path) -> Result<HashSet<u64>> {
@@ -176,7 +243,7 @@ mod tests {
     #[test]
     fn test_create_and_add() {
         let tmp = TempDir::new().unwrap();
-        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         let v1 = make_vector(64, 1.0);
         idx.add(1, &v1).unwrap();
@@ -189,7 +256,7 @@ mod tests {
     #[test]
     fn test_duplicate_add_ignored() {
         let tmp = TempDir::new().unwrap();
-        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         let v1 = make_vector(64, 1.0);
         idx.add(1, &v1).unwrap();
@@ -201,7 +268,7 @@ mod tests {
     #[test]
     fn test_dimension_mismatch_error() {
         let tmp = TempDir::new().unwrap();
-        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         let wrong_dims = make_vector(32, 1.0);
         let result = idx.add(1, &wrong_dims);
@@ -211,7 +278,7 @@ mod tests {
     #[test]
     fn test_search_empty_index() {
         let tmp = TempDir::new().unwrap();
-        let idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         let query = make_vector(64, 1.0);
         let results = idx.search(&query, 10).unwrap();
@@ -221,7 +288,7 @@ mod tests {
     #[test]
     fn test_search_returns_nearest() {
         let tmp = TempDir::new().unwrap();
-        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         let v1 = make_vector(64, 1.0);
         let v2 = make_vector(64, 2.0);
@@ -244,7 +311,7 @@ mod tests {
 
         // Create and populate index
         {
-            let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
             let v1 = make_vector(64, 1.0);
             let v2 = make_vector(64, 2.0);
             idx.add(100, &v1).unwrap();
@@ -269,6 +336,25 @@ mod tests {
     }
 
     #[test]
+    fn test_save_writes_model_metadata() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("bge")).unwrap();
+            idx.add(100, &make_vector(64, 1.0)).unwrap();
+            idx.save().unwrap();
+        }
+
+        let metadata: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(tmp.path().join("meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(metadata["dimensions"], 64);
+        assert_eq!(metadata["model"], "bge");
+        assert_eq!(metadata["index_file"], "usearch.index");
+        assert_eq!(metadata["ids_file"], "doc_ids.bin");
+    }
+
+    #[test]
     fn test_open_nonexistent_fails() {
         let tmp = TempDir::new().unwrap();
         let result = VectorIndex::open(tmp.path());
@@ -281,7 +367,7 @@ mod tests {
 
         // Create index with 64 dims
         {
-            let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
             let v = make_vector(64, 1.0);
             idx.add(1, &v).unwrap();
             idx.save().unwrap();
@@ -289,16 +375,57 @@ mod tests {
 
         // Reopen with different dims, should reset
         {
-            let idx = VectorIndex::open_or_create(tmp.path(), 128).unwrap();
+            let idx = VectorIndex::open_or_create(tmp.path(), 128, Some("test")).unwrap();
             assert!(!idx.contains(1)); // old data should be gone
             assert_eq!(idx.dimensions(), 128);
         }
     }
 
     #[test]
+    fn test_model_change_resets_index() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).unwrap();
+            let v = make_vector(64, 1.0);
+            idx.add(1, &v).unwrap();
+            idx.save().unwrap();
+        }
+
+        {
+            let idx = VectorIndex::open_or_create(tmp.path(), 64, Some("beta")).unwrap();
+            assert!(!idx.contains(1));
+            assert_eq!(idx.dimensions(), 64);
+            assert_eq!(idx.model(), Some("beta"));
+            assert!(idx.needs_backfill());
+        }
+    }
+
+    #[test]
+    fn test_missing_model_metadata_resets_when_model_specified() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).unwrap();
+            let v = make_vector(64, 1.0);
+            idx.add(1, &v).unwrap();
+            idx.save().unwrap();
+        }
+
+        fs::remove_file(tmp.path().join("meta.json")).unwrap();
+
+        {
+            let idx = VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).unwrap();
+            assert!(!idx.contains(1));
+            assert_eq!(idx.model(), Some("alpha"));
+            assert!(idx.needs_backfill());
+        }
+    }
+
+    #[test]
     fn test_search_with_limit() {
         let tmp = TempDir::new().unwrap();
-        let mut idx = VectorIndex::open_or_create(tmp.path(), 64).unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
 
         for i in 0..10 {
             let v = make_vector(64, i as f32);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -111,6 +111,13 @@ impl VectorIndex {
         })
     }
 
+    pub fn is_model_compatible(dir: &Path, model: &str, dimensions: usize) -> bool {
+        match Self::open(dir) {
+            Ok(index) => index.model() == Some(model) && index.dimensions() == dimensions,
+            Err(_) => false,
+        }
+    }
+
     pub fn add(&mut self, doc_id: u64, embedding: &[f32]) -> Result<()> {
         if embedding.len() != self.dims {
             return Err(anyhow!(
@@ -420,6 +427,21 @@ mod tests {
             assert_eq!(idx.model(), Some("alpha"));
             assert!(idx.needs_backfill());
         }
+    }
+
+    #[test]
+    fn test_model_compatibility_checks_metadata() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).unwrap();
+            idx.add(1, &make_vector(64, 1.0)).unwrap();
+            idx.save().unwrap();
+        }
+
+        assert!(VectorIndex::is_model_compatible(tmp.path(), "alpha", 64));
+        assert!(!VectorIndex::is_model_compatible(tmp.path(), "beta", 64));
+        assert!(!VectorIndex::is_model_compatible(tmp.path(), "alpha", 128));
     }
 
     #[test]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -35,7 +35,7 @@ impl VectorIndex {
         if index_path.exists() {
             let existing = Index::new(&IndexOptions::default())?;
             existing.load(index_path.to_str().ok_or_else(|| anyhow!("invalid path"))?)?;
-            let existing_meta = load_metadata(&meta_path).ok();
+            let existing_meta = load_metadata_if_exists(&meta_path)?;
             let model_mismatch = match (&existing_meta, &model) {
                 (Some(meta), Some(model)) => meta.model.as_deref() != Some(model),
                 (None, Some(_)) => true,
@@ -99,7 +99,7 @@ impl VectorIndex {
         } else {
             HashSet::new()
         };
-        let model = load_metadata(&meta_path).ok().and_then(|meta| meta.model);
+        let model = load_metadata_if_exists(&meta_path)?.and_then(|meta| meta.model);
 
         Ok(Self {
             dims: index.dimensions(),
@@ -109,13 +109,6 @@ impl VectorIndex {
             doc_id_set,
             needs_backfill: false,
         })
-    }
-
-    pub fn is_model_compatible(dir: &Path, model: &str, dimensions: usize) -> bool {
-        match Self::open(dir) {
-            Ok(index) => index.model() == Some(model) && index.dimensions() == dimensions,
-            Err(_) => false,
-        }
     }
 
     pub fn add(&mut self, doc_id: u64, embedding: &[f32]) -> Result<()> {
@@ -188,6 +181,10 @@ impl VectorIndex {
         self.index.size()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.index.size() == 0
+    }
+
     pub fn doc_id_count(&self) -> usize {
         self.doc_id_set.len()
     }
@@ -209,6 +206,13 @@ impl VectorIndex {
 fn load_metadata(path: &Path) -> Result<VectorMetadata> {
     let data = fs::read_to_string(path)?;
     Ok(serde_json::from_str(&data)?)
+}
+
+fn load_metadata_if_exists(path: &Path) -> Result<Option<VectorMetadata>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(load_metadata(path)?))
 }
 
 fn save_metadata(path: &Path, metadata: &VectorMetadata) -> Result<()> {
@@ -430,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn test_model_compatibility_checks_metadata() {
+    fn test_corrupt_model_metadata_errors() {
         let tmp = TempDir::new().unwrap();
 
         {
@@ -439,9 +443,25 @@ mod tests {
             idx.save().unwrap();
         }
 
-        assert!(VectorIndex::is_model_compatible(tmp.path(), "alpha", 64));
-        assert!(!VectorIndex::is_model_compatible(tmp.path(), "beta", 64));
-        assert!(!VectorIndex::is_model_compatible(tmp.path(), "alpha", 128));
+        fs::write(tmp.path().join("meta.json"), "{").unwrap();
+
+        assert!(VectorIndex::open(tmp.path()).is_err());
+        assert!(VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).is_err());
+    }
+
+    #[test]
+    fn test_open_exposes_model_metadata_for_compatibility_checks() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("alpha")).unwrap();
+            idx.add(1, &make_vector(64, 1.0)).unwrap();
+            idx.save().unwrap();
+        }
+
+        let idx = VectorIndex::open(tmp.path()).unwrap();
+        assert_eq!(idx.model(), Some("alpha"));
+        assert_eq!(idx.dimensions(), 64);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist the selected embedding model in vector metadata
- reset and backfill vectors when dimensions, model metadata, or model identity are incompatible
- update `memex stats` to report the current `usearch.index` / `doc_ids.bin` vector store layout
- short-circuit incremental indexing when all scanned files are unchanged and vectors are already compatible

## Why this is needed
The vector index currently validates compatibility by dimensions only. That is not enough because multiple supported models can produce the same dimensionality. For example, `minilm` and `bge` are both 384-dimensional, but their vectors are not interchangeable. Reusing a same-dimension index after switching models can make semantic search silently use mixed or stale vector spaces.

`memex stats` also checks for the older `vectors.f32` / `doc_ids.u64` layout, so a valid current vector store can be reported as `vectors: none`. That makes it hard to tell whether semantic search is actually available and hides model/index mismatches during troubleshooting.

`memex index` is the incremental command, but when a scan finds no changed files it can still start the writer/embedding pipeline. On large transcript collections this makes daily or repeated incremental runs much more expensive than the actual work requires.

This change records the model alongside the vector store, treats missing model metadata as incompatible for model-specific indexing, makes stats inspect the actual current vector files, and skips no-op indexing only when embeddings are disabled or the existing vector store matches both the configured model and known dimensions. Missing, wrong-model, wrong-dimension, or dynamic-dimension vector stores still fall through to normal backfill/reset behavior. The fresh scan-cache auto-index path uses the same compatibility guard, so a recent scan cannot bypass vector rebuild/backfill after a model/config change.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test ingest::tests --lib`
- `cargo test vector::tests --lib`
- `cargo test cli::tests --lib`
- `cargo test embed::tests --lib -- --test-threads=1`
- `cargo test --no-run`
