### PR TITLE
Add Pi history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, and OpenCode logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, and Pi Coding Agent logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -107,7 +107,7 @@ Then run setup to install the skills:
 memex setup
 ```
 
-Restart Claude/Codex after setup.
+Restart Claude, Codex, OpenCode, or Pi after setup.
 
 ## Quickstart
 
@@ -170,7 +170,7 @@ If you built from source, run setup to install:
 memex setup
 ```
 
-This detects which tools are installed (Claude/Codex) and presents an interactive menu to select which to configure.
+This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents an interactive menu to select which to configure.
 ## Search modes
 
 | Need | Command |
@@ -185,7 +185,7 @@ This detects which tools are installed (Claude/Codex) and presents an interactiv
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex`
+- `--source claude|codex|opencode|pi`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -286,6 +286,8 @@ index_service_systemd_dir = "~/.config/systemd/user"  # Linux only
 claude_resume_cmd = "claude --resume {session_id}"
 codex_resume_cmd = "codex resume {session_id}"
 cursor_resume_cmd = "cursor-agent --resume {session_id}"
+opencode_resume_cmd = "opencode resume {session_id}"
+pi_resume_cmd = "pi --session {source_path_shell}"
 ```
 
 Service logs and the plist live under `~/.memex` by default (macOS). On Linux, systemd units are created in `~/.config/systemd/user/`.
@@ -295,6 +297,6 @@ Service logs and the plist live under `~/.memex` by default (macOS). On Linux, s
 `cuda_library_paths` and `cudnn_library_paths` accept path lists and are only used
 when `execution_provider = "cuda"`.
 
-Resume command templates accept `{session_id}`, `{project}`, `{source}`, `{source_path}`, `{source_dir}`, `{cwd}`.
+Resume command templates accept `{session_id}`, `{project}`, `{source}`, `{source_path}`, `{source_dir}`, `{cwd}`, plus shell-quoted `{source_path_shell}`, `{source_dir_shell}`, and `{cwd_shell}`.
 
 The skill definitions are bundled in `skills/`.

--- a/skills/codex/memex-search/SKILL.md
+++ b/skills/codex/memex-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memex-search
-description: Search, filter, and retrieve Claude/Codex history indexed by the memex CLI. Use when you want to search history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output.
+description: Search, filter, and retrieve Claude/Codex/OpenCode/Pi history indexed by the memex CLI. Use when you want to search history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output.
 ---
 
 # Memex Search
@@ -24,6 +24,8 @@ Use this skill to index local history and retrieve results in a structured way.
   - `--source <path>` for Claude logs
   - `--include-agents` to include agent transcripts
   - `--codex/--no-codex` to include or skip Codex logs
+  - `--opencode/--no-opencode` to include or skip OpenCode logs
+  - `--pi/--no-pi` to include or skip Pi logs
   - `--model <minilm|bge|nomic|gemma|potion>` to select embedding model
   - `--root <path>` to change data root (default: `~/.memex`)
 
@@ -56,7 +58,7 @@ Each JSON line includes:
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>` (search inside a transcript)
-- `--source claude|codex`
+- `--source claude|codex|opencode|pi`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`

--- a/skills/instruction-improver/SKILL.md
+++ b/skills/instruction-improver/SKILL.md
@@ -107,7 +107,7 @@ Use `memex search` to find patterns. Key options:
 - `--top-n-per-session N` - limit N results per session
 - `--limit N` - max total results
 - `--project NAME` - filter by project
-- `--source claude|codex` - filter by source
+- `--source claude|codex|opencode|pi` - filter by source
 - `--since TIMESTAMP` - RFC3339 (2024-01-15T00:00:00Z) or unix seconds
 - `--fields score,ts,session_id,snippet` - select output fields
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memex-search
-description: Search, filter, and retrieve Claude/Codex history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
+description: Search, filter, and retrieve Claude/Codex/OpenCode/Pi history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
 allowed-tools: Bash(memex:*)
 ---
 
@@ -25,6 +25,8 @@ Use this skill to index local history and retrieve results in a structured, LLM-
   - `--source <path>` for Claude logs
   - `--include-agents` to include agent transcripts
   - `--codex/--no-codex` to include or skip Codex logs
+  - `--opencode/--no-opencode` to include or skip OpenCode logs
+  - `--pi/--no-pi` to include or skip Pi logs
   - `--model <minilm|bge|nomic|gemma|potion>` to select embedding model
   - `--root <path>` to change data root (default: `~/.memex`)
 
@@ -57,7 +59,7 @@ Each JSON line includes:
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>` (search inside a transcript)
-- `--source claude|codex`
+- `--source claude|codex|opencode|pi`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`

--- a/skills/pi/memex-search/SKILL.md
+++ b/skills/pi/memex-search/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: memex-search
+description: Search, filter, and retrieve Pi Coding Agent history via memex CLI. Use for context resumption, finding past code/decisions, and self-correction based on history.
+---
+
+# Memex for Pi
+
+`memex` is the primary memory retrieval tool. Use it to access historical sessions and indexed code interactions.
+
+## Usage Patterns
+
+- **Context Retrieval:** "What did we discuss in the last session regarding the API?"
+  - `memex search "API discussion" --source pi --sort ts --limit 10`
+- **Code Discovery:** "Find the specific function implementation from last week."
+  - `memex search "function implementation" --source pi --hybrid`
+- **Session Identification:** "Which session covered the database migration?"
+  - `memex search "database migration" --source pi --unique-session`
+
+## Search Modes
+
+| Need                     | Flag         | Example                                      |
+| ------------------------ | ------------ | -------------------------------------------- |
+| Exact terms, IDs, errors | (default)    | `memex search "Error: 500" --source pi`      |
+| Concepts, intent         | `--semantic` | `memex search "auth flow" --source pi --semantic` |
+| Mixed specific + fuzzy   | `--hybrid`   | `memex search "user_id logic" --source pi --hybrid` |
+
+## Session Context
+
+Use `--session {session_id}` to isolate a specific interaction thread.
+
+1. **Find Session ID:**
+   - `memex search "topic" --source pi --unique-session`
+2. **Narrow Search:**
+   - `memex search "detail" --session <session_id>`
+3. **Fetch Transcript:**
+   - `memex session <session_id>`
+
+## Output Parsing
+
+Output is JSONL (JSON Lines). Each line is a valid JSON object.
+
+**Schema:**
+
+- `doc_id`: Unique record ID.
+- `session_id`: Conversation thread ID.
+- `ts`: ISO 8601 timestamp.
+- `role`: `user`, `assistant`, `tool_use`, or `tool_result`.
+- `text`: Content payload.
+- `score`: Search relevance (float).
+
+**Interpretation:**
+
+- **Filtering:** Discard results below a relevance threshold unless the query is specific.
+- **Ordering:** Sort by `ts` for timeline reconstruction.
+- **Grouping:** Aggregate by `session_id` to view conversation turns.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,10 +21,10 @@ use std::time::Duration;
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude, Codex, Cursor, and Opencode",
+    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, and Pi",
     after_help = "\
 QUICK START:
-    memex index                     # Index your Claude/Codex/Cursor/Opencode history
+    memex index                     # Index your agent history
     memex search \"error handling\"   # Search for keywords
     memex tui                       # Browse sessions interactively
 
@@ -47,12 +47,24 @@ struct IndexArgs {
     /// Index Codex sessions from ~/.codex [default: true]
     #[arg(long, default_value_t = true)]
     codex: bool,
+    /// Skip indexing Codex sessions
+    #[arg(long = "no-codex", default_value_t = false)]
+    no_codex: bool,
     /// Index Opencode sessions from ~/.local/share/opencode [default: true]
     #[arg(long, default_value_t = true)]
     opencode: bool,
+    /// Skip indexing Opencode sessions
+    #[arg(long = "no-opencode", default_value_t = false)]
+    no_opencode: bool,
     /// Index Cursor agent transcripts from ~/.cursor/projects [default: true]
     #[arg(long = "no-cursor", action = clap::ArgAction::SetFalse, default_value_t = true)]
     cursor: bool,
+    /// Index Pi sessions from ~/.pi/agent/sessions or $PI_CODING_AGENT_DIR/sessions [default: true]
+    #[arg(long, default_value_t = true)]
+    pi: bool,
+    /// Skip indexing Pi sessions
+    #[arg(long = "no-pi", default_value_t = false)]
+    no_pi: bool,
     /// Generate embeddings for semantic search during indexing
     #[arg(long)]
     embeddings: bool,
@@ -70,7 +82,7 @@ struct IndexArgs {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Index Claude, Codex, Cursor, and Opencode conversation history
+    /// Index Claude, Codex, Cursor, OpenCode, and Pi conversation history
     #[command(after_help = "\
 EXAMPLES:
     memex index                         # Index all supported local history
@@ -134,7 +146,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, or opencode
+        /// Filter by source: claude, codex, cursor, opencode, or pi
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -222,7 +234,7 @@ OUTPUT FIELDS (--fields):
         #[arg(long)]
         root: Option<PathBuf>,
     },
-    /// Install the memex-search skill for Claude, Codex, and/or Opencode
+    /// Install the memex-search skill for Claude, Codex, Opencode, and/or Pi
     Setup {
         /// Overwrite existing skills/prompts (useful after memex update)
         #[arg(short, long)]
@@ -457,9 +469,10 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
     run_index(
         index.source.clone(),
         index.include_agents,
-        index.codex,
-        index.opencode,
+        index.codex && !index.no_codex,
+        index.opencode && !index.no_opencode,
         index.cursor,
+        index.pi && !index.no_pi,
         index.embeddings,
         index.no_embeddings,
         index.model.clone(),
@@ -475,6 +488,7 @@ fn run_index(
     codex: bool,
     opencode: bool,
     cursor: bool,
+    pi: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
     model: Option<String>,
@@ -505,6 +519,7 @@ fn run_index(
         include_codex: codex,
         include_opencode: opencode,
         include_cursor: cursor,
+        include_pi: pi,
         embeddings,
         backfill_embeddings: false,
         model: model_choice,
@@ -544,10 +559,10 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     let mut vector =
         VectorIndex::open_or_create(&paths.vectors, embedder.dims, Some(model_choice.as_str()))?;
 
-    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 5], [0; 5], true));
+    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 6], [0; 6], true));
     progress.set_embed_ready();
 
-    let mut embedded_counts = [0u64; 5];
+    let mut embedded_counts = [0u64; 6];
     let mut embedded_total = 0u64;
     let mut batch: Vec<(u64, String, crate::types::SourceKind)> = Vec::with_capacity(BATCH_SIZE);
 
@@ -555,7 +570,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
                        embedder: &mut EmbedderHandle,
                        vector: &mut VectorIndex,
                        progress: &crate::progress::Progress,
-                       embedded_counts: &mut [u64; 5],
+                       embedded_counts: &mut [u64; 6],
                        embedded_total: &mut u64| {
         if batch.is_empty() {
             return Ok(());
@@ -614,13 +629,14 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {})",
+        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::CodexSession.idx()],
         embedded_counts[crate::types::SourceKind::CodexHistory.idx()],
         embedded_counts[crate::types::SourceKind::Opencode.idx()],
         embedded_counts[crate::types::SourceKind::Cursor.idx()],
+        embedded_counts[crate::types::SourceKind::Pi.idx()],
     );
 
     std::io::stdout().flush().ok();
@@ -667,6 +683,7 @@ fn run_search(
             include_codex: true,
             include_opencode: true,
             include_cursor: true,
+            include_pi: true,
             embeddings: embeddings_default,
             backfill_embeddings: false,
             model: model_choice,
@@ -1143,9 +1160,13 @@ fn run_setup(force: bool) -> Result<()> {
     let claude_path = find_in_path("claude");
     let codex_path = find_in_path("codex");
     let opencode_path = find_in_path("opencode");
+    let pi_path = find_in_path("pi");
 
-    if claude_path.is_none() && codex_path.is_none() && opencode_path.is_none() {
-        return Err(anyhow!("Neither claude, codex, nor opencode found in PATH"));
+    if claude_path.is_none() && codex_path.is_none() && opencode_path.is_none() && pi_path.is_none()
+    {
+        return Err(anyhow!(
+            "Neither claude, codex, opencode, nor pi found in PATH"
+        ));
     }
 
     // Show what will be installed
@@ -1159,6 +1180,9 @@ fn run_setup(force: bool) -> Result<()> {
     }
     if opencode_path.is_some() {
         println!("  Opencode: memex-search skill");
+    }
+    if pi_path.is_some() {
+        println!("  Pi: memex-search skill");
     }
     if force {
         println!();
@@ -1180,6 +1204,10 @@ fn run_setup(force: bool) -> Result<()> {
     }
     if let Some(path) = &opencode_path {
         items.push(("opencode", format!("Opencode ({})", path.display())));
+        defaults.push(true);
+    }
+    if let Some(path) = &pi_path {
+        items.push(("pi", format!("Pi ({})", path.display())));
         defaults.push(true);
     }
 
@@ -1212,6 +1240,7 @@ fn run_setup(force: bool) -> Result<()> {
         // Gen 2: flat-file skill paths (now directory-based)
         home.join(".codex/skills/memex-search.md"),
         home.join(".local/share/opencode/skills/memex-search.md"),
+        pi_agent_root().join("skills/memex-search.md"),
     ];
     for path in &stale_paths {
         if path.is_dir() {
@@ -1233,6 +1262,7 @@ fn run_setup(force: bool) -> Result<()> {
     let instruction_improver_skill = include_str!("../skills/instruction-improver/SKILL.md");
     let codex_skill = include_str!("../skills/codex/memex-search/SKILL.md");
     let opencode_skill = include_str!("../skills/opencode/memex-search/SKILL.md");
+    let pi_skill = include_str!("../skills/pi/memex-search/SKILL.md");
 
     for index in selected {
         let (tool, _) = &items[index];
@@ -1325,12 +1355,31 @@ fn run_setup(force: bool) -> Result<()> {
                     println!("{verb} Opencode skill at {}.", dest.display());
                 }
             }
+            "pi" => {
+                let dest_dir = pi_agent_root().join("skills").join("memex-search");
+                let dest = dest_dir.join("SKILL.md");
+                if dest.exists() && !force {
+                    println!(
+                        "Skipping Pi skill (already installed at {}). Use --force to overwrite.",
+                        dest.display()
+                    );
+                } else {
+                    std::fs::create_dir_all(&dest_dir)?;
+                    std::fs::write(&dest, pi_skill)?;
+                    let verb = if dest.exists() {
+                        "Updated"
+                    } else {
+                        "Installed"
+                    };
+                    println!("{verb} Pi skill at {}.", dest.display());
+                }
+            }
             _ => {}
         }
     }
 
     println!();
-    println!("Done! Restart Claude Code, Codex, or Opencode to pick up changes.");
+    println!("Done! Restart Claude Code, Codex, Opencode, or Pi to pick up changes.");
 
     Ok(())
 }
@@ -1360,6 +1409,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::CodexSession | crate::types::SourceKind::CodexHistory => "codex",
         crate::types::SourceKind::Opencode => "opencode",
         crate::types::SourceKind::Cursor => "cursor",
+        crate::types::SourceKind::Pi => "pi",
     };
     let source_path = &record.source_path;
 
@@ -1398,6 +1448,16 @@ fn find_in_path(binary: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+fn pi_agent_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("PI_CODING_AGENT_DIR") {
+        return PathBuf::from(root);
+    }
+    let home = directories::BaseDirs::new()
+        .map(|b| b.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".pi").join("agent")
 }
 
 #[cfg(unix)]
@@ -1536,7 +1596,7 @@ fn run_index_service_enable_launchd(
     } else {
         (Some(interval), false)
     };
-    let env_vars = launchd_environment_variables(paths)?;
+    let env_vars = service_environment_variables(Some(paths))?;
 
     let contents = build_launchd_plist(
         &label,
@@ -1619,7 +1679,9 @@ fn run_index_service_enable_systemd(
     let service_path = systemd_dir.join(format!("{}.service", label));
     let timer_path = systemd_dir.join(format!("{}.timer", label));
 
-    let service_contents = build_systemd_service(&exe.to_string_lossy(), program_args, continuous);
+    let env_vars = service_environment_variables(None)?;
+    let service_contents =
+        build_systemd_service(&exe.to_string_lossy(), program_args, continuous, &env_vars);
     std::fs::write(&service_path, service_contents)?;
     println!("wrote systemd service: {}", service_path.display());
 
@@ -1885,14 +1947,17 @@ fn build_index_command_args(
     if index.include_agents {
         args.push("--include-agents".to_string());
     }
-    if !index.codex {
+    if !index.codex || index.no_codex {
         args.push("--no-codex".to_string());
     }
-    if !index.opencode {
+    if !index.opencode || index.no_opencode {
         args.push("--no-opencode".to_string());
     }
     if !index.cursor {
         args.push("--no-cursor".to_string());
+    }
+    if !index.pi || index.no_pi {
+        args.push("--no-pi".to_string());
     }
     if index.embeddings {
         args.push("--embeddings".to_string());
@@ -1981,7 +2046,7 @@ fn build_launchd_plist(
     out
 }
 
-fn launchd_environment_variables(paths: &Paths) -> Result<Vec<(String, String)>> {
+fn service_environment_variables(paths: Option<&Paths>) -> Result<Vec<(String, String)>> {
     let mut vars = Vec::new();
     if let Some(base) = directories::BaseDirs::new() {
         vars.push((
@@ -1995,11 +2060,21 @@ fn launchd_environment_variables(paths: &Paths) -> Result<Vec<(String, String)>>
         .unwrap_or_else(|| "/usr/bin:/bin:/usr/sbin:/sbin".to_string());
     vars.push(("PATH".to_string(), path));
 
-    let embed_cache = paths.root.join("embed-cache");
-    std::fs::create_dir_all(&embed_cache)?;
-    let embed_cache = embed_cache.to_string_lossy().to_string();
-    vars.push(("FASTEMBED_CACHE_DIR".to_string(), embed_cache.clone()));
-    vars.push(("HF_HOME".to_string(), embed_cache));
+    if let Some(paths) = paths {
+        let embed_cache = paths.root.join("embed-cache");
+        std::fs::create_dir_all(&embed_cache)?;
+        let embed_cache = embed_cache.to_string_lossy().to_string();
+        vars.push(("FASTEMBED_CACHE_DIR".to_string(), embed_cache.clone()));
+        vars.push(("HF_HOME".to_string(), embed_cache));
+    }
+
+    for key in ["PI_CODING_AGENT_DIR", "PI_CODING_AGENT_SESSION_DIR"] {
+        if let Some(value) = std::env::var_os(key)
+            && !value.is_empty()
+        {
+            vars.push((key.to_string(), value.to_string_lossy().to_string()));
+        }
+    }
 
     Ok(vars)
 }
@@ -2043,7 +2118,12 @@ fn default_systemd_user_dir() -> PathBuf {
     }
 }
 
-fn build_systemd_service(exe_path: &str, program_args: &[String], continuous: bool) -> String {
+fn build_systemd_service(
+    exe_path: &str,
+    program_args: &[String],
+    continuous: bool,
+    env_vars: &[(String, String)],
+) -> String {
     let exec_start = if program_args.is_empty() {
         exe_path.to_string()
     } else {
@@ -2055,6 +2135,13 @@ fn build_systemd_service(exe_path: &str, program_args: &[String], continuous: bo
     out.push_str("Description=Memex Index Service\n");
     out.push('\n');
     out.push_str("[Service]\n");
+    for (key, value) in env_vars {
+        out.push_str(&format!(
+            "Environment=\"{}={}\"\n",
+            systemd_escape_env_value(key),
+            systemd_escape_env_value(value)
+        ));
+    }
     out.push_str("Type=");
     if continuous {
         out.push_str("simple\n");
@@ -2070,6 +2157,13 @@ fn build_systemd_service(exe_path: &str, program_args: &[String], continuous: bo
         out.push_str("WantedBy=default.target\n");
     }
     out
+}
+
+fn systemd_escape_env_value(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('%', "%%")
 }
 
 fn build_systemd_timer(interval: u64) -> String {
@@ -2542,6 +2636,7 @@ fn parse_version_parts(value: &str) -> Option<(u64, u64, u64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use tempfile::TempDir;
 
@@ -2570,5 +2665,58 @@ mod tests {
         let tmp = TempDir::new().unwrap();
 
         assert_eq!(vector_stats_line(tmp.path()).unwrap(), "vectors: none");
+    }
+
+    #[test]
+    fn index_args_accept_negative_source_flags() {
+        let cli = Cli::try_parse_from(["memex", "index", "--no-codex", "--no-opencode", "--no-pi"])
+            .unwrap();
+
+        let Commands::Index { index, .. } = cli.command else {
+            panic!("expected index command");
+        };
+        assert!(index.no_codex);
+        assert!(index.no_opencode);
+        assert!(index.no_pi);
+    }
+
+    #[test]
+    fn service_environment_variables_include_pi_overrides() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set_os(&[
+            ("PI_CODING_AGENT_DIR", Some("/tmp/pi agent".as_ref())),
+            (
+                "PI_CODING_AGENT_SESSION_DIR",
+                Some("/tmp/pi sessions".as_ref()),
+            ),
+        ]);
+
+        let vars = service_environment_variables(None).unwrap();
+
+        assert!(
+            vars.iter()
+                .any(|(key, value)| { key == "PI_CODING_AGENT_DIR" && value == "/tmp/pi agent" })
+        );
+        assert!(vars.iter().any(|(key, value)| {
+            key == "PI_CODING_AGENT_SESSION_DIR" && value == "/tmp/pi sessions"
+        }));
+    }
+
+    #[test]
+    fn systemd_service_includes_environment_variables() {
+        let service = build_systemd_service(
+            "/usr/bin/memex",
+            &["index".to_string(), "--no-pi".to_string()],
+            false,
+            &[(
+                "PI_CODING_AGENT_SESSION_DIR".to_string(),
+                "/tmp/pi \"sessions\" 100%".to_string(),
+            )],
+        );
+
+        assert!(service.contains(
+            "Environment=\"PI_CODING_AGENT_SESSION_DIR=/tmp/pi \\\"sessions\\\" 100%%\"\n"
+        ));
+        assert!(service.contains("ExecStart=/usr/bin/memex index --no-pi\n"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,8 @@ pub struct UserConfig {
     pub opencode_resume_cmd: Option<String>,
     /// Resume command template for Cursor sessions.
     pub cursor_resume_cmd: Option<String>,
+    /// Resume command template for Pi sessions.
+    pub pi_resume_cmd: Option<String>,
 }
 
 impl UserConfig {

--- a/src/index.rs
+++ b/src/index.rs
@@ -309,7 +309,11 @@ fn record_from_doc(fields: &IndexFields, doc: &TantivyDocument) -> Record {
         |field: Field| -> u64 { doc.get_first(field).and_then(|v| v.as_u64()).unwrap_or(0) };
 
     let source_path = get_str(fields.source_path).unwrap_or_default();
-    let source = crate::types::SourceKind::from_path(&source_path);
+    let source = fields
+        .source
+        .and_then(&get_str)
+        .and_then(|label| crate::types::SourceKind::from_label(&label))
+        .unwrap_or_else(|| crate::types::SourceKind::from_path(&source_path));
     Record {
         source,
         doc_id: get_u64(fields.doc_id),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -33,6 +33,7 @@ pub struct IngestOptions {
     pub include_codex: bool,
     pub include_opencode: bool,
     pub include_cursor: bool,
+    pub include_pi: bool,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
     pub model: ModelChoice,
@@ -326,6 +327,49 @@ pub fn ingest_all(
         }
     }
 
+    if options.include_pi {
+        let pi_files = collect_pi_files()?;
+        for path in pi_files {
+            let meta = path.metadata()?;
+            let size = meta.len();
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            files_scanned += 1;
+            total_bytes += size;
+            let key = path.to_string_lossy().to_string();
+            let prev = state.files.get(&key);
+            let (offset, turn_id, delete_first, skip) = match prev {
+                None => (0, 0, false, false),
+                Some(prev) => {
+                    if size < prev.size || mtime < prev.mtime {
+                        (0, 0, true, false)
+                    } else if size == prev.size && mtime == prev.mtime {
+                        (prev.offset, prev.turn_id, false, true)
+                    } else {
+                        (prev.offset, prev.turn_id, false, false)
+                    }
+                }
+            };
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(FileTask {
+                path,
+                source: SourceKind::Pi,
+                offset,
+                turn_id,
+                size,
+                mtime,
+                delete_first,
+            });
+        }
+    }
+
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
@@ -384,6 +428,7 @@ pub fn ingest_all(
             SourceKind::Cursor => {
                 parse_cursor_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
             }
+            SourceKind::Pi => parse_pi_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?,
         }
         Ok(())
     })?;
@@ -504,7 +549,7 @@ fn writer_loop(
     let mut vector_index = None;
     let mut embedder: Option<EmbedderHandle> = None;
     let mut embed_buffer: Vec<(u64, String, SourceKind)> = Vec::new();
-    let mut index_pending: [u64; 5] = [0, 0, 0, 0, 0];
+    let mut index_pending = [0u64; 6];
     if embeddings {
         let handle = EmbedderHandle::with_model_and_runtime(model, &embed_runtime)?;
         let dims = handle.dims;
@@ -556,7 +601,8 @@ fn writer_loop(
                 1 => SourceKind::CodexSession,
                 2 => SourceKind::CodexHistory,
                 3 => SourceKind::Opencode,
-                _ => SourceKind::Cursor,
+                4 => SourceKind::Cursor,
+                _ => SourceKind::Pi,
             };
             progress.add_indexed(source, pending);
         }
@@ -724,6 +770,28 @@ fn collect_cursor_files() -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+fn collect_pi_files() -> Result<Vec<PathBuf>> {
+    collect_pi_files_from_root(&pi_sessions_root())
+}
+
+fn collect_pi_files_from_root(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        files.push(path.to_path_buf());
+    }
+    Ok(files)
+}
+
 fn codex_root() -> PathBuf {
     let home = directories::BaseDirs::new()
         .map(|b| b.home_dir().to_path_buf())
@@ -770,6 +838,57 @@ fn cursor_projects_root() -> PathBuf {
         .map(|b| b.home_dir().to_path_buf())
         .unwrap_or_else(|| PathBuf::from("/"));
     home.join(".cursor").join("projects")
+}
+
+fn pi_agent_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("PI_CODING_AGENT_DIR") {
+        return PathBuf::from(root);
+    }
+    let home = directories::BaseDirs::new()
+        .map(|b| b.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".pi").join("agent")
+}
+
+fn pi_sessions_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
+        return PathBuf::from(root);
+    }
+    let agent_root = pi_agent_root();
+    if let Some(root) = pi_configured_session_root(&agent_root) {
+        return root;
+    }
+    agent_root.join("sessions")
+}
+
+fn pi_configured_session_root(agent_root: &Path) -> Option<PathBuf> {
+    let settings_path = agent_root.join("settings.json");
+    let contents = std::fs::read_to_string(settings_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let session_dir = value.get("sessionDir")?.as_str()?.trim();
+    if session_dir.is_empty() {
+        return None;
+    }
+    Some(resolve_pi_settings_path(session_dir, agent_root))
+}
+
+fn resolve_pi_settings_path(raw: &str, base: &Path) -> PathBuf {
+    if raw == "~" {
+        return directories::BaseDirs::new()
+            .map(|b| b.home_dir().to_path_buf())
+            .unwrap_or_else(|| PathBuf::from(raw));
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        return directories::BaseDirs::new()
+            .map(|b| b.home_dir().join(rest))
+            .unwrap_or_else(|| PathBuf::from(raw));
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
 }
 
 fn parse_claude_file(
@@ -1531,6 +1650,347 @@ fn parse_cursor_file(
     Ok(())
 }
 
+fn parse_pi_file(
+    task: &FileTask,
+    tx_record: &Sender<Record>,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let file = File::open(&task.path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = task.offset as usize;
+    let mut turn_id = task.turn_id;
+
+    let source_path = task.path.to_string_lossy().to_string();
+    let mut session_id =
+        session_id_from_filename(&task.path).unwrap_or_else(|| source_path.clone());
+    let mut project = project_from_pi_session_path(&task.path);
+    let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
+
+    let mut buf = Vec::new();
+    if start > 0 && !mmap.is_empty() {
+        let rel = memchr(b'\n', &mmap).unwrap_or(mmap.len());
+        let line = &mmap[..rel];
+        if !line.is_empty() {
+            buf.extend_from_slice(line);
+            if let Ok(value) = simd_json::to_borrowed_value(&mut buf)
+                && let Some(obj) = value.as_object()
+                && obj.get("type").and_then(|v| v.as_str()) == Some("session")
+            {
+                apply_pi_session_header(obj, &mut session_id, &mut project);
+            }
+            buf.clear();
+        }
+    }
+    let mut parsed_bytes = 0u64;
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        let advanced = rel + 1;
+        start += advanced;
+        parsed_bytes += advanced as u64;
+        if parsed_bytes >= 64 * 1024 {
+            progress.add_parsed_bytes(SourceKind::Pi, parsed_bytes);
+            parsed_bytes = 0;
+        }
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let timestamp = obj
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(parse_iso_millis)
+            .unwrap_or(0);
+
+        if entry_type == "session" {
+            apply_pi_session_header(obj, &mut session_id, &mut project);
+            continue;
+        }
+
+        if entry_type == "compaction" || entry_type == "branch_summary" {
+            let summary = obj
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            if summary.is_empty() {
+                continue;
+            }
+            let record = Record {
+                source: SourceKind::Pi,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: "assistant".to_string(),
+                text: format!("{entry_type}: {summary}"),
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                source_path: source_path.clone(),
+            };
+            progress.add_produced(SourceKind::Pi, 1);
+            tx_record.send(record)?;
+            turn_id += 1;
+            continue;
+        }
+
+        if entry_type == "custom_message" {
+            let text = pi_content_text(obj.get("content")).trim().to_string();
+            if text.is_empty() {
+                continue;
+            }
+            let custom_type = obj.get("customType").and_then(|v| v.as_str()).unwrap_or("");
+            let prefix = if custom_type.is_empty() {
+                "custom_message".to_string()
+            } else {
+                format!("custom_message({custom_type})")
+            };
+            let record = Record {
+                source: SourceKind::Pi,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: "assistant".to_string(),
+                text: format!("{prefix}: {text}"),
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                source_path: source_path.clone(),
+            };
+            progress.add_produced(SourceKind::Pi, 1);
+            tx_record.send(record)?;
+            turn_id += 1;
+            continue;
+        }
+
+        if entry_type != "message" {
+            continue;
+        }
+        let message = match obj.get("message").and_then(|v| v.as_object()) {
+            Some(m) => m,
+            None => continue,
+        };
+        let timestamp = if timestamp == 0 {
+            message
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .and_then(parse_iso_millis)
+                .unwrap_or(0)
+        } else {
+            timestamp
+        };
+        let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
+
+        match role {
+            "user" | "assistant" => {
+                let content = message.get("content");
+                if role == "assistant"
+                    && let Some(arr) = content.and_then(|v| v.as_array())
+                {
+                    for block in arr {
+                        let Some(block_obj) = block.as_object() else {
+                            continue;
+                        };
+                        if block_obj.get("type").and_then(|v| v.as_str()) != Some("toolCall") {
+                            continue;
+                        }
+                        let tool_name = block_obj
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        if let (Some(id), Some(name)) = (
+                            block_obj.get("id").and_then(|v| v.as_str()),
+                            tool_name.clone(),
+                        ) {
+                            tool_id_to_name.insert(id.to_string(), name);
+                        }
+                        let tool_input = block_obj.get("arguments").map(|v| v.to_string());
+                        let record = Record {
+                            source: SourceKind::Pi,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "tool_use".to_string(),
+                            text: tool_input.clone().unwrap_or_default(),
+                            tool_name,
+                            tool_input,
+                            tool_output: None,
+                            source_path: source_path.clone(),
+                        };
+                        progress.add_produced(SourceKind::Pi, 1);
+                        tx_record.send(record)?;
+                        turn_id += 1;
+                    }
+                }
+
+                let text = pi_content_text(content).trim().to_string();
+                if text.is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: role.to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    source_path: source_path.clone(),
+                };
+                progress.add_produced(SourceKind::Pi, 1);
+                tx_record.send(record)?;
+                turn_id += 1;
+            }
+            "toolResult" => {
+                let tool_call_id = message
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let tool_name = message
+                    .get("toolName")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .or_else(|| tool_id_to_name.get(tool_call_id).cloned());
+                let tool_output = Some(pi_content_text(message.get("content")));
+                let text = tool_output.clone().unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    source_path: source_path.clone(),
+                };
+                progress.add_produced(SourceKind::Pi, 1);
+                tx_record.send(record)?;
+                turn_id += 1;
+            }
+            "bashExecution" => {
+                if message
+                    .get("excludeFromContext")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                let command = message
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let output = message
+                    .get("output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let exit_code = message.get("exitCode").and_then(|v| v.as_i64());
+                let text = pi_bash_text(&command, &output, exit_code);
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name: Some("Bash".to_string()),
+                    tool_input: if command.is_empty() {
+                        None
+                    } else {
+                        Some(command)
+                    },
+                    tool_output: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output)
+                    },
+                    source_path: source_path.clone(),
+                };
+                progress.add_produced(SourceKind::Pi, 1);
+                tx_record.send(record)?;
+                turn_id += 1;
+            }
+            "custom" | "branchSummary" | "compactionSummary" => {
+                let text = pi_summary_message_text(message, role);
+                if text.is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text: format!("{role}: {text}"),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    source_path: source_path.clone(),
+                };
+                progress.add_produced(SourceKind::Pi, 1);
+                tx_record.send(record)?;
+                turn_id += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if parsed_bytes > 0 {
+        progress.add_parsed_bytes(SourceKind::Pi, parsed_bytes);
+    }
+    progress.add_files_done(SourceKind::Pi, 1);
+    let state = FileState {
+        size: task.size,
+        mtime: task.mtime,
+        offset: mmap.len() as u64,
+        turn_id,
+    };
+    tx_update.send(FileUpdate {
+        path: source_path,
+        state,
+        session_id: Some(session_id),
+    })?;
+    Ok(())
+}
+
 fn parse_iso_millis(input: &str) -> Option<u64> {
     DateTime::parse_from_rfc3339(input)
         .ok()
@@ -1554,6 +2014,23 @@ fn project_from_path(path: &str) -> String {
         return name.to_string();
     }
     "codex".to_string()
+}
+
+fn apply_pi_session_header(
+    obj: &simd_json::borrowed::Object,
+    session_id: &mut String,
+    project: &mut String,
+) {
+    if let Some(id) = obj.get("id").and_then(|v| v.as_str())
+        && !id.is_empty()
+    {
+        *session_id = id.to_string();
+    }
+    if let Some(cwd) = obj.get("cwd").and_then(|v| v.as_str())
+        && !cwd.is_empty()
+    {
+        *project = project_from_path(cwd);
+    }
 }
 
 fn project_from_cursor_path(path: &Path) -> String {
@@ -1628,9 +2105,116 @@ fn stable_cursor_turn_bucket(value: &str) -> u32 {
     hash % CURSOR_SUBAGENT_TURN_BUCKETS
 }
 
+fn project_from_pi_session_path(path: &Path) -> String {
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .map(|name| decode_pi_project_name(pi_session_dir_project_key(name)))
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "pi".to_string())
+}
+
+fn pi_session_dir_project_key(name: &str) -> &str {
+    if name.starts_with("--") && name.ends_with("--") && name.len() > 4 {
+        &name[1..name.len() - 1]
+    } else {
+        name
+    }
+}
+
+fn pi_content_text(content: Option<&BorrowedValue>) -> String {
+    let Some(content) = content else {
+        return String::new();
+    };
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    if let Some(arr) = content.as_array() {
+        let mut parts = Vec::new();
+        for item in arr {
+            if let Some(text) = item.as_str() {
+                parts.push(text.to_string());
+                continue;
+            }
+            let Some(obj) = item.as_object() else {
+                continue;
+            };
+            match obj.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+                "text" => {
+                    if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
+                        parts.push(text.to_string());
+                    }
+                }
+                "thinking" => {
+                    if let Some(text) = obj.get("thinking").and_then(|v| v.as_str()) {
+                        parts.push(format!("Thinking:\n{text}"));
+                    }
+                }
+                "toolCall" => {}
+                _ => {
+                    if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
+                        parts.push(text.to_string());
+                    } else if let Some(text) = obj.get("content").and_then(|v| v.as_str()) {
+                        parts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        return parts.join("\n");
+    }
+    content.to_string()
+}
+
+fn pi_summary_message_text(message: &simd_json::borrowed::Object, role: &str) -> String {
+    let summary = if role == "branchSummary" || role == "compactionSummary" {
+        message.get("summary").and_then(|v| v.as_str())
+    } else {
+        None
+    };
+    summary
+        .map(str::to_string)
+        .unwrap_or_else(|| pi_content_text(message.get("content")))
+        .trim()
+        .to_string()
+}
+
+fn pi_bash_text(command: &str, output: &str, exit_code: Option<i64>) -> String {
+    let mut parts = Vec::new();
+    if !command.is_empty() {
+        parts.push(format!("$ {command}"));
+    }
+    if !output.is_empty() {
+        parts.push(output.to_string());
+    }
+    if let Some(code) = exit_code {
+        parts.push(format!("exit code: {code}"));
+    }
+    parts.join("\n")
+}
+
+fn decode_pi_project_name(folder_name: &str) -> String {
+    let decoded = decode_project_name(folder_name);
+    decoded
+        .rsplit('-')
+        .find(|part| !part.is_empty())
+        .unwrap_or(&decoded)
+        .to_string()
+}
+
 fn decode_project_name(folder_name: &str) -> String {
     let prefixes_to_strip = ["-home-", "-mnt-c-Users-", "-mnt-c-users-", "-Users-"];
     let mut name = folder_name;
+    if name.len() > 10 {
+        let bytes = name.as_bytes();
+        if bytes[0] == b'-'
+            && bytes[2] == b'-'
+            && bytes[3] == b'-'
+            && bytes[1].is_ascii_alphabetic()
+            && name[4..].to_lowercase().starts_with("users-")
+        {
+            name = &name[10..];
+        }
+    }
     for prefix in prefixes_to_strip {
         if name.to_lowercase().starts_with(&prefix.to_lowercase()) {
             name = &name[prefix.len()..];
@@ -1746,8 +2330,8 @@ fn flush_embeddings(
     Ok(count)
 }
 
-fn compute_totals(tasks: &[FileTask]) -> [u64; 5] {
-    let mut totals = [0u64; 5];
+fn compute_totals(tasks: &[FileTask]) -> [u64; 6] {
+    let mut totals = [0u64; 6];
     for task in tasks {
         let remaining = task.size.saturating_sub(task.offset);
         totals[task.source.idx()] += remaining;
@@ -1755,8 +2339,8 @@ fn compute_totals(tasks: &[FileTask]) -> [u64; 5] {
     totals
 }
 
-fn compute_file_totals(tasks: &[FileTask]) -> [u64; 5] {
-    let mut totals = [0u64; 5];
+fn compute_file_totals(tasks: &[FileTask]) -> [u64; 6] {
+    let mut totals = [0u64; 6];
     for task in tasks {
         totals[task.source.idx()] += 1;
     }
@@ -1784,6 +2368,8 @@ mod tests {
     use super::*;
     use crate::config::Paths;
     use crate::embed::{EmbedRuntimeConfig, ModelChoice};
+    use crate::index::SearchIndex;
+    use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1795,6 +2381,7 @@ mod tests {
             include_codex: false,
             include_opencode: false,
             include_cursor: false,
+            include_pi: false,
             embeddings,
             backfill_embeddings: false,
             model,
@@ -2102,5 +2689,215 @@ mod tests {
         let options = ingest_options(true, ModelChoice::Potion);
 
         assert!(!can_skip_noop_index(&paths, &index, &options).unwrap());
+    }
+    #[test]
+    fn collect_pi_files_recurses_under_sessions_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_root = tmp.path().join("sessions");
+        let project_root = sessions_root.join("--Users-nico-Code-memex--");
+        fs::create_dir_all(&project_root).expect("create pi session dir");
+
+        let session =
+            project_root.join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        let ignored = project_root.join("notes.json");
+        fs::write(&session, "{}\n").expect("write pi session");
+        fs::write(&ignored, "{}\n").expect("write ignored");
+
+        let files = collect_pi_files_from_root(&sessions_root).expect("collect pi files");
+
+        assert_eq!(files, vec![session]);
+    }
+
+    #[test]
+    fn pi_sessions_root_honors_session_dir_override() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let custom_sessions = tmp.path().join("custom-sessions");
+        let _env = EnvVarGuard::set_os(&[
+            (
+                "PI_CODING_AGENT_SESSION_DIR",
+                Some(custom_sessions.as_os_str()),
+            ),
+            ("PI_CODING_AGENT_DIR", None),
+        ]);
+
+        assert_eq!(pi_sessions_root(), custom_sessions);
+    }
+
+    #[test]
+    fn pi_sessions_root_honors_settings_session_dir() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pi_root = tmp.path().join("pi-agent");
+        fs::create_dir_all(&pi_root).expect("create pi root");
+        fs::write(
+            pi_root.join("settings.json"),
+            r#"{ "sessionDir": ".pi/sessions" }"#,
+        )
+        .expect("write settings");
+        let _env = EnvVarGuard::set_os(&[
+            ("PI_CODING_AGENT_SESSION_DIR", None),
+            ("PI_CODING_AGENT_DIR", Some(pi_root.as_os_str())),
+        ]);
+
+        assert_eq!(pi_sessions_root(), pi_root.join(".pi/sessions"));
+    }
+
+    #[test]
+    fn pi_session_path_fallback_preserves_project_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home_path = tmp
+            .path()
+            .join("sessions")
+            .join("--home-alice-code-memex--")
+            .join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        let users_path = tmp
+            .path()
+            .join("sessions")
+            .join("--Users-nico-Code-memex--")
+            .join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        let windows_path = tmp
+            .path()
+            .join("sessions")
+            .join("--C--Users-alice-Code-memex--")
+            .join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        let nested_path = tmp
+            .path()
+            .join("sessions")
+            .join("--home-alice-code-acme-memex--")
+            .join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+
+        assert_eq!(project_from_pi_session_path(&home_path), "memex");
+        assert_eq!(project_from_pi_session_path(&users_path), "memex");
+        assert_eq!(project_from_pi_session_path(&windows_path), "memex");
+        assert_eq!(project_from_pi_session_path(&nested_path), "memex");
+    }
+
+    #[test]
+    fn ingest_pi_session_records_supported_message_shapes() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pi_root = tmp.path().join("pi-agent");
+        let sessions_root = pi_root.join("sessions").join("--Users-nico-Code-memex--");
+        fs::create_dir_all(&sessions_root).expect("create pi sessions");
+        let session_file =
+            sessions_root.join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        fs::write(
+            &session_file,
+            r#"{"type":"session","version":3,"id":"11111111-1111-1111-1111-111111111111","timestamp":"2026-07-03T01:02:03Z","cwd":"/Users/nico/Code/memex"}
+{"type":"message","id":"u1","timestamp":"2026-07-03T01:02:04Z","message":{"role":"user","content":[{"type":"text","text":"hello pi"}]}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-07-03T01:02:05Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"considering options"},{"type":"text","text":"I will run a command"},{"type":"toolCall","id":"tc1","name":"Read","arguments":{"file_path":"README.md"}}]}}
+{"type":"message","id":"tr1","parentId":"a1","timestamp":"2026-07-03T01:02:06Z","message":{"role":"toolResult","toolCallId":"tc1","toolName":"Read","content":[{"type":"text","text":"README contents"}],"isError":false}}
+{"type":"message","id":"b1","parentId":"tr1","timestamp":"2026-07-03T01:02:07Z","message":{"role":"bashExecution","command":"cargo test","output":"ok","exitCode":0,"cancelled":false,"truncated":false}}
+{"type":"message","id":"bh1","parentId":"b1","timestamp":"2026-07-03T01:02:07Z","message":{"role":"bashExecution","command":"echo secret","output":"secret output","exitCode":0,"excludeFromContext":true}}
+{"type":"compaction","id":"c1","parentId":"b1","timestamp":"2026-07-03T01:02:08Z","summary":"compacted top-level summary","firstKeptEntryId":"tr1","tokensBefore":50000}
+{"type":"branch_summary","id":"br1","parentId":"u1","timestamp":"2026-07-03T01:02:09Z","fromId":"c1","summary":"branch top-level summary"}
+{"type":"custom_message","id":"cm1","parentId":"br1","timestamp":"2026-07-03T01:02:10Z","customType":"memex","content":[{"type":"text","text":"extension context"}],"display":true}
+{"type":"message","id":"mcs1","parentId":"cm1","timestamp":"2026-07-03T01:02:11Z","message":{"role":"compactionSummary","content":"summary text"}}
+{"type":"message","id":"mbs1","parentId":"mcs1","timestamp":"2026-07-03T01:02:12Z","message":{"role":"branchSummary","summary":"message summary text"}}
+"#,
+        )
+        .expect("write pi fixture");
+        let _env = EnvVarGuard::set_os(&[("PI_CODING_AGENT_DIR", Some(pi_root.as_os_str()))]);
+
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        paths.ensure_dirs().expect("ensure dirs");
+        let index = SearchIndex::open_or_create(&paths.index).expect("index");
+        let options = IngestOptions {
+            claude_source: tmp.path().join("missing-claude"),
+            include_agents: false,
+            include_codex: false,
+            include_opencode: false,
+            include_cursor: false,
+            include_pi: true,
+            embeddings: false,
+            backfill_embeddings: false,
+            model: ModelChoice::default(),
+            embed_runtime: EmbedRuntimeConfig::default(),
+        };
+
+        let report = ingest_all(&paths, &index, &options).expect("ingest");
+        assert_eq!(report.records_added, 10);
+
+        let mut records = index
+            .records_by_session_id("11111111-1111-1111-1111-111111111111")
+            .expect("records by session");
+        records.sort_by_key(|record| record.turn_id);
+
+        assert_eq!(records.len(), 10);
+        assert!(records.iter().all(|record| record.source == SourceKind::Pi));
+        assert!(records.iter().all(|record| record.project == "memex"));
+        let source_path = session_file.to_string_lossy().to_string();
+        assert!(
+            records
+                .iter()
+                .all(|record| record.source_path == source_path)
+        );
+        assert_eq!(records[0].role, "user");
+        assert_eq!(records[0].text, "hello pi");
+        assert_eq!(records[1].role, "tool_use");
+        assert_eq!(records[1].tool_name.as_deref(), Some("Read"));
+        assert!(records[1].text.contains("README.md"));
+        assert_eq!(records[2].role, "assistant");
+        assert!(records[2].text.contains("I will run a command"));
+        assert!(records[2].text.contains("Thinking:"));
+        assert_eq!(records[3].role, "tool_result");
+        assert_eq!(records[3].tool_name.as_deref(), Some("Read"));
+        assert_eq!(records[3].text, "README contents");
+        assert_eq!(records[4].role, "tool_result");
+        assert_eq!(records[4].tool_name.as_deref(), Some("Bash"));
+        assert!(records[4].text.contains("$ cargo test"));
+        assert!(records[4].text.contains("exit code: 0"));
+        assert_eq!(records[5].role, "assistant");
+        assert_eq!(records[5].text, "compaction: compacted top-level summary");
+        assert_eq!(records[6].role, "assistant");
+        assert_eq!(records[6].text, "branch_summary: branch top-level summary");
+        assert_eq!(records[7].role, "assistant");
+        assert_eq!(records[7].text, "custom_message(memex): extension context");
+        assert_eq!(records[8].role, "assistant");
+        assert_eq!(records[8].text, "compactionSummary: summary text");
+        assert_eq!(records[9].role, "assistant");
+        assert_eq!(records[9].text, "branchSummary: message summary text");
+        assert!(!records.iter().any(|record| record.text.contains("secret")));
+    }
+
+    #[test]
+    fn ingest_pi_incremental_records_keep_header_project() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_root = tmp
+            .path()
+            .join("sessions")
+            .join("--home-alice-code-my-project--");
+        fs::create_dir_all(&sessions_root).expect("create pi sessions");
+        let session_file =
+            sessions_root.join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
+        let existing = r#"{"type":"session","version":3,"id":"22222222-2222-2222-2222-222222222222","timestamp":"2026-07-03T01:02:03Z","cwd":"/home/alice/code/my-project"}
+{"type":"message","id":"u1","timestamp":"2026-07-03T01:02:04Z","message":{"role":"user","content":"first"}}
+"#;
+        let appended = r#"{"type":"message","id":"a1","timestamp":"2026-07-03T01:02:05Z","message":{"role":"assistant","content":"second"}}
+"#;
+        fs::write(&session_file, format!("{existing}{appended}")).expect("write pi fixture");
+
+        let (tx_record, rx_record) = unbounded();
+        let (tx_update, _rx_update) = unbounded();
+        let task = FileTask {
+            path: session_file,
+            source: SourceKind::Pi,
+            offset: existing.len() as u64,
+            turn_id: 1,
+            size: (existing.len() + appended.len()) as u64,
+            mtime: 0,
+            delete_first: false,
+        };
+        let progress = Arc::new(Progress::new([0; 6], [0; 6], false));
+        let next_doc_id = AtomicU64::new(1);
+
+        parse_pi_file(&task, &tx_record, &tx_update, &next_doc_id, &progress).expect("parse pi");
+        drop(tx_record);
+        let records: Vec<_> = rx_record.try_iter().collect();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].project, "my-project");
+        assert_eq!(records[0].text, "second");
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -3,44 +3,28 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-const SOURCE_COUNT: usize = 5;
+const SOURCE_COUNT: usize = 6;
+const SOURCES: [SourceKind; SOURCE_COUNT] = [
+    SourceKind::Claude,
+    SourceKind::CodexSession,
+    SourceKind::CodexHistory,
+    SourceKind::Opencode,
+    SourceKind::Cursor,
+    SourceKind::Pi,
+];
 
 pub struct Progress {
-    #[allow(dead_code)] // Kept alive to coordinate progress bars
+    #[allow(dead_code)] // Kept alive to coordinate progress bars.
     multi: MultiProgress,
-
-    // Headers
-    claude_header: ProgressBar,
-    codex_header: ProgressBar,
-    opencode_header: ProgressBar,
-    cursor_header: ProgressBar,
-
-    // All spinners
-    claude_parse: ProgressBar,
-    codex_parse: ProgressBar,
-    opencode_parse: ProgressBar,
-    cursor_parse: ProgressBar,
-    claude_index: ProgressBar,
-    codex_index: ProgressBar,
-    opencode_index: ProgressBar,
-    cursor_index: ProgressBar,
-    claude_embed: ProgressBar,
-    codex_embed: ProgressBar,
-    opencode_embed: ProgressBar,
-    cursor_embed: ProgressBar,
-
-    // Totals for display
-    claude_files_total: u64,
-    codex_files_total: u64,
-    opencode_files_total: u64,
-    cursor_files_total: u64,
-
-    // Tracking
+    headers: Vec<ProgressBar>,
+    parse: Vec<ProgressBar>,
+    index: Vec<ProgressBar>,
+    embed: Vec<ProgressBar>,
+    files_total: [u64; SOURCE_COUNT],
     files_done: [AtomicU64; SOURCE_COUNT],
     produced: [AtomicU64; SOURCE_COUNT],
     embed_total: [AtomicU64; SOURCE_COUNT],
     embed_pending: [AtomicU64; SOURCE_COUNT],
-
     embeddings_enabled: bool,
 }
 
@@ -51,151 +35,55 @@ impl Progress {
         embeddings: bool,
     ) -> Self {
         let multi = MultiProgress::new();
-
-        let claude_files = files_total[SourceKind::Claude.idx()];
-        let codex_files = files_total[SourceKind::CodexSession.idx()]
-            + files_total[SourceKind::CodexHistory.idx()];
-        let opencode_files = files_total[SourceKind::Opencode.idx()];
-        let cursor_files = files_total[SourceKind::Cursor.idx()];
-
-        // Header style (just text)
         let header_style = ProgressStyle::with_template("{msg}").unwrap();
-
-        // Spinner style for all phases
         let spinner_style = ProgressStyle::with_template("  {spinner:.cyan} {msg}")
             .unwrap()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
 
-        // Claude header
-        let claude_header = multi.add(ProgressBar::new_spinner());
-        claude_header.set_style(header_style.clone());
-        claude_header.set_message("claude");
-        claude_header.tick();
+        let mut headers = Vec::with_capacity(SOURCE_COUNT);
+        let mut parse = Vec::with_capacity(SOURCE_COUNT);
+        let mut index = Vec::with_capacity(SOURCE_COUNT);
+        let mut embed = Vec::with_capacity(SOURCE_COUNT);
 
-        // Claude spinners
-        let claude_parse = multi.add(ProgressBar::new_spinner());
-        claude_parse.set_style(spinner_style.clone());
-        claude_parse.set_message(format!("parsed 0 B / {claude_files} files"));
-        claude_parse.enable_steady_tick(Duration::from_millis(80));
+        for source in SOURCES {
+            let idx = source.idx();
+            let header = multi.add(ProgressBar::new_spinner());
+            header.set_style(header_style.clone());
+            header.set_message(progress_label(source));
+            header.tick();
+            headers.push(header);
 
-        let claude_index = multi.add(ProgressBar::new_spinner());
-        claude_index.set_style(spinner_style.clone());
-        claude_index.set_message("indexed 0 rec");
-        claude_index.enable_steady_tick(Duration::from_millis(80));
+            let parse_bar = multi.add(ProgressBar::new_spinner());
+            parse_bar.set_style(spinner_style.clone());
+            parse_bar.set_message(format!("parsed 0 B / {} files", files_total[idx]));
+            parse_bar.enable_steady_tick(Duration::from_millis(80));
+            parse.push(parse_bar);
 
-        let claude_embed = if embeddings {
-            let bar = multi.add(ProgressBar::new_spinner());
-            bar.set_style(spinner_style.clone());
-            bar.set_message("embedded 0");
-            bar.enable_steady_tick(Duration::from_millis(80));
-            bar
-        } else {
-            ProgressBar::hidden()
-        };
+            let index_bar = multi.add(ProgressBar::new_spinner());
+            index_bar.set_style(spinner_style.clone());
+            index_bar.set_message("indexed 0 rec");
+            index_bar.enable_steady_tick(Duration::from_millis(80));
+            index.push(index_bar);
 
-        // Codex header
-        let codex_header = multi.add(ProgressBar::new_spinner());
-        codex_header.set_style(header_style.clone());
-        codex_header.set_message("codex");
-        codex_header.tick();
-
-        // Codex spinners
-        let codex_parse = multi.add(ProgressBar::new_spinner());
-        codex_parse.set_style(spinner_style.clone());
-        codex_parse.set_message(format!("parsed 0 B / {codex_files} files"));
-        codex_parse.enable_steady_tick(Duration::from_millis(80));
-
-        let codex_index = multi.add(ProgressBar::new_spinner());
-        codex_index.set_style(spinner_style.clone());
-        codex_index.set_message("indexed 0 rec");
-        codex_index.enable_steady_tick(Duration::from_millis(80));
-
-        let codex_embed = if embeddings {
-            let bar = multi.add(ProgressBar::new_spinner());
-            bar.set_style(spinner_style.clone());
-            bar.set_message("embedded 0");
-            bar.enable_steady_tick(Duration::from_millis(80));
-            bar
-        } else {
-            ProgressBar::hidden()
-        };
-
-        // Opencode header
-        let opencode_header = multi.add(ProgressBar::new_spinner());
-        opencode_header.set_style(header_style.clone());
-        opencode_header.set_message("opencode");
-        opencode_header.tick();
-
-        // Opencode spinners
-        let opencode_parse = multi.add(ProgressBar::new_spinner());
-        opencode_parse.set_style(spinner_style.clone());
-        opencode_parse.set_message(format!("parsed 0 B / {opencode_files} files"));
-        opencode_parse.enable_steady_tick(Duration::from_millis(80));
-
-        let opencode_index = multi.add(ProgressBar::new_spinner());
-        opencode_index.set_style(spinner_style.clone());
-        opencode_index.set_message("indexed 0 rec");
-        opencode_index.enable_steady_tick(Duration::from_millis(80));
-
-        let opencode_embed = if embeddings {
-            let bar = multi.add(ProgressBar::new_spinner());
-            bar.set_style(spinner_style.clone());
-            bar.set_message("embedded 0");
-            bar.enable_steady_tick(Duration::from_millis(80));
-            bar
-        } else {
-            ProgressBar::hidden()
-        };
-
-        // Cursor header
-        let cursor_header = multi.add(ProgressBar::new_spinner());
-        cursor_header.set_style(header_style);
-        cursor_header.set_message("cursor");
-        cursor_header.tick();
-
-        // Cursor spinners
-        let cursor_parse = multi.add(ProgressBar::new_spinner());
-        cursor_parse.set_style(spinner_style.clone());
-        cursor_parse.set_message(format!("parsed 0 B / {cursor_files} files"));
-        cursor_parse.enable_steady_tick(Duration::from_millis(80));
-
-        let cursor_index = multi.add(ProgressBar::new_spinner());
-        cursor_index.set_style(spinner_style.clone());
-        cursor_index.set_message("indexed 0 rec");
-        cursor_index.enable_steady_tick(Duration::from_millis(80));
-
-        let cursor_embed = if embeddings {
-            let bar = multi.add(ProgressBar::new_spinner());
-            bar.set_style(spinner_style);
-            bar.set_message("embedded 0");
-            bar.enable_steady_tick(Duration::from_millis(80));
-            bar
-        } else {
-            ProgressBar::hidden()
-        };
+            let embed_bar = if embeddings {
+                let bar = multi.add(ProgressBar::new_spinner());
+                bar.set_style(spinner_style.clone());
+                bar.set_message("embedded 0");
+                bar.enable_steady_tick(Duration::from_millis(80));
+                bar
+            } else {
+                ProgressBar::hidden()
+            };
+            embed.push(embed_bar);
+        }
 
         Self {
             multi,
-            claude_header,
-            codex_header,
-            opencode_header,
-            cursor_header,
-            claude_parse,
-            codex_parse,
-            opencode_parse,
-            cursor_parse,
-            claude_index,
-            codex_index,
-            opencode_index,
-            cursor_index,
-            claude_embed,
-            codex_embed,
-            opencode_embed,
-            cursor_embed,
-            claude_files_total: claude_files,
-            codex_files_total: codex_files,
-            opencode_files_total: opencode_files,
-            cursor_files_total: cursor_files,
+            headers,
+            parse,
+            index,
+            embed,
+            files_total,
             files_done: std::array::from_fn(|_| AtomicU64::new(0)),
             produced: std::array::from_fn(|_| AtomicU64::new(0)),
             embed_total: std::array::from_fn(|_| AtomicU64::new(0)),
@@ -205,106 +93,28 @@ impl Progress {
     }
 
     pub fn add_parsed_bytes(&self, source: SourceKind, bytes: u64) {
-        match source {
-            SourceKind::Claude => {
-                self.claude_parse.inc(bytes);
-                let total = self.claude_parse.position();
-                let files_done = self.files_done[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                self.claude_parse.set_message(format!(
-                    "parsed {} {}/{} files",
-                    format_bytes(total),
-                    files_done,
-                    self.claude_files_total
-                ));
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.codex_parse.inc(bytes);
-                let total = self.codex_parse.position();
-                let files_done = self.files_done[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.files_done[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                self.codex_parse.set_message(format!(
-                    "parsed {} {}/{} files",
-                    format_bytes(total),
-                    files_done,
-                    self.codex_files_total
-                ));
-            }
-            SourceKind::Opencode => {
-                self.opencode_parse.inc(bytes);
-                let total = self.opencode_parse.position();
-                let files_done =
-                    self.files_done[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                self.opencode_parse.set_message(format!(
-                    "parsed {} {}/{} files",
-                    format_bytes(total),
-                    files_done,
-                    self.opencode_files_total
-                ));
-            }
-            SourceKind::Cursor => {
-                self.cursor_parse.inc(bytes);
-                let total = self.cursor_parse.position();
-                let files_done = self.files_done[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                self.cursor_parse.set_message(format!(
-                    "parsed {} {}/{} files",
-                    format_bytes(total),
-                    files_done,
-                    self.cursor_files_total
-                ));
-            }
-        }
+        let idx = source.idx();
+        self.parse[idx].inc(bytes);
+        let total = self.parse[idx].position();
+        let files_done = self.files_done[idx].load(Ordering::Relaxed);
+        self.parse[idx].set_message(format!(
+            "parsed {} {}/{} files",
+            format_bytes(total),
+            files_done,
+            self.files_total[idx]
+        ));
     }
 
     pub fn add_files_done(&self, source: SourceKind, count: u64) {
         let idx = source.idx();
         let done = self.files_done[idx].fetch_add(count, Ordering::Relaxed) + count;
-
-        // Check if parsing is complete for this source
-        match source {
-            SourceKind::Claude => {
-                if done >= self.claude_files_total {
-                    let bytes = self.claude_parse.position();
-                    self.claude_parse.finish_with_message(format!(
-                        "parsed {} {} files done",
-                        format_bytes(bytes),
-                        self.claude_files_total
-                    ));
-                }
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                let codex_done = self.files_done[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.files_done[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                if codex_done >= self.codex_files_total {
-                    let bytes = self.codex_parse.position();
-                    self.codex_parse.finish_with_message(format!(
-                        "parsed {} {} files done",
-                        format_bytes(bytes),
-                        self.codex_files_total
-                    ));
-                }
-            }
-            SourceKind::Opencode => {
-                if done >= self.opencode_files_total {
-                    let bytes = self.opencode_parse.position();
-                    self.opencode_parse.finish_with_message(format!(
-                        "parsed {} {} files done",
-                        format_bytes(bytes),
-                        self.opencode_files_total
-                    ));
-                }
-            }
-            SourceKind::Cursor => {
-                if done >= self.cursor_files_total {
-                    let bytes = self.cursor_parse.position();
-                    self.cursor_parse.finish_with_message(format!(
-                        "parsed {} {} files done",
-                        format_bytes(bytes),
-                        self.cursor_files_total
-                    ));
-                }
-            }
+        if done >= self.files_total[idx] {
+            let bytes = self.parse[idx].position();
+            self.parse[idx].finish_with_message(format!(
+                "parsed {} {} files done",
+                format_bytes(bytes),
+                self.files_total[idx]
+            ));
         }
     }
 
@@ -313,67 +123,16 @@ impl Progress {
     }
 
     pub fn add_indexed(&self, source: SourceKind, count: u64) {
-        match source {
-            SourceKind::Claude => {
-                self.claude_index.inc(count);
-                let indexed = self.claude_index.position();
-                let produced = self.produced[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                let files_done = self.files_done[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                // If parsing done and all produced are indexed, finish
-                if files_done >= self.claude_files_total && indexed >= produced && produced > 0 {
-                    self.claude_index
-                        .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
-                } else {
-                    self.claude_index
-                        .set_message(format!("indexed {} rec", format_count(indexed)));
-                }
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.codex_index.inc(count);
-                let indexed = self.codex_index.position();
-                let produced = self.produced[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.produced[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                let files_done = self.files_done[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.files_done[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                // If parsing done and all produced are indexed, finish
-                if files_done >= self.codex_files_total && indexed >= produced && produced > 0 {
-                    self.codex_index
-                        .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
-                } else {
-                    self.codex_index
-                        .set_message(format!("indexed {} rec", format_count(indexed)));
-                }
-            }
-            SourceKind::Opencode => {
-                self.opencode_index.inc(count);
-                let indexed = self.opencode_index.position();
-                let produced = self.produced[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                let files_done =
-                    self.files_done[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                // If parsing done and all produced are indexed, finish
-                if files_done >= self.opencode_files_total && indexed >= produced && produced > 0 {
-                    self.opencode_index
-                        .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
-                } else {
-                    self.opencode_index
-                        .set_message(format!("indexed {} rec", format_count(indexed)));
-                }
-            }
-            SourceKind::Cursor => {
-                self.cursor_index.inc(count);
-                let indexed = self.cursor_index.position();
-                let produced = self.produced[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                let files_done = self.files_done[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                if files_done >= self.cursor_files_total && indexed >= produced && produced > 0 {
-                    self.cursor_index
-                        .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
-                } else {
-                    self.cursor_index
-                        .set_message(format!("indexed {} rec", format_count(indexed)));
-                }
-            }
+        let idx = source.idx();
+        self.index[idx].inc(count);
+        let indexed = self.index[idx].position();
+        let produced = self.produced[idx].load(Ordering::Relaxed);
+        let files_done = self.files_done[idx].load(Ordering::Relaxed);
+        if files_done >= self.files_total[idx] && indexed >= produced && produced > 0 {
+            self.index[idx]
+                .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
+        } else {
+            self.index[idx].set_message(format!("indexed {} rec", format_count(indexed)));
         }
     }
 
@@ -397,43 +156,10 @@ impl Progress {
         if !self.embeddings_enabled {
             return;
         }
-        let embedded = match source {
-            SourceKind::Claude => self.claude_embed.position(),
-            SourceKind::CodexSession | SourceKind::CodexHistory => self.codex_embed.position(),
-            SourceKind::Opencode => self.opencode_embed.position(),
-            SourceKind::Cursor => self.cursor_embed.position(),
-        };
-        let total = match source {
-            SourceKind::Claude => {
-                self.embed_total[SourceKind::Claude.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.embed_total[SourceKind::CodexSession.idx()].load(Ordering::Relaxed)
-                    + self.embed_total[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::Opencode => {
-                self.embed_total[SourceKind::Opencode.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::Cursor => {
-                self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed)
-            }
-        };
-        let pending = match source {
-            SourceKind::Claude => {
-                self.embed_pending[SourceKind::Claude.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.embed_pending[SourceKind::CodexSession.idx()].load(Ordering::Relaxed)
-                    + self.embed_pending[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::Opencode => {
-                self.embed_pending[SourceKind::Opencode.idx()].load(Ordering::Relaxed)
-            }
-            SourceKind::Cursor => {
-                self.embed_pending[SourceKind::Cursor.idx()].load(Ordering::Relaxed)
-            }
-        };
-
+        let idx = source.idx();
+        let embedded = self.embed[idx].position();
+        let total = self.embed_total[idx].load(Ordering::Relaxed);
+        let pending = self.embed_pending[idx].load(Ordering::Relaxed);
         let msg = if total > 0 {
             if pending > 0 {
                 format!(
@@ -452,214 +178,79 @@ impl Progress {
         } else {
             format!("embedded {}", format_count(embedded))
         };
-
-        match source {
-            SourceKind::Claude => self.claude_embed.set_message(msg),
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.codex_embed.set_message(msg)
-            }
-            SourceKind::Opencode => self.opencode_embed.set_message(msg),
-            SourceKind::Cursor => self.cursor_embed.set_message(msg),
-        }
+        self.embed[idx].set_message(msg);
     }
 
     pub fn add_embedded(&self, source: SourceKind, count: u64) {
-        match source {
-            SourceKind::Claude => {
-                self.claude_embed.inc(count);
-                let embedded = self.claude_embed.position();
-                let total = self.embed_total[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                let pending = self.embed_pending[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                let indexed = self.claude_index.position();
-                let produced = self.produced[SourceKind::Claude.idx()].load(Ordering::Relaxed);
-                // If indexing done and all embeddings done, finish
-                if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
-                    self.claude_embed
-                        .finish_with_message(format!("embedded {} done", format_count(embedded)));
-                    return;
-                }
-            }
-            SourceKind::CodexSession | SourceKind::CodexHistory => {
-                self.codex_embed.inc(count);
-                let embedded = self.codex_embed.position();
-                let total = self.embed_total[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.embed_total[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                let pending = self.embed_pending[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.embed_pending[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                let indexed = self.codex_index.position();
-                let produced = self.produced[SourceKind::CodexSession.idx()]
-                    .load(Ordering::Relaxed)
-                    + self.produced[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-                // If indexing done and all embeddings done, finish
-                if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
-                    self.codex_embed
-                        .finish_with_message(format!("embedded {} done", format_count(embedded)));
-                    return;
-                }
-            }
-            SourceKind::Opencode => {
-                self.opencode_embed.inc(count);
-                let embedded = self.opencode_embed.position();
-                let total = self.embed_total[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                let pending =
-                    self.embed_pending[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                let indexed = self.opencode_index.position();
-                let produced = self.produced[SourceKind::Opencode.idx()].load(Ordering::Relaxed);
-                // If indexing done and all embeddings done, finish
-                if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
-                    self.opencode_embed
-                        .finish_with_message(format!("embedded {} done", format_count(embedded)));
-                    return;
-                }
-            }
-            SourceKind::Cursor => {
-                self.cursor_embed.inc(count);
-                let embedded = self.cursor_embed.position();
-                let total = self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                let pending = self.embed_pending[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                let indexed = self.cursor_index.position();
-                let produced = self.produced[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
-                if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
-                    self.cursor_embed
-                        .finish_with_message(format!("embedded {} done", format_count(embedded)));
-                    return;
-                }
-            }
+        let idx = source.idx();
+        self.embed[idx].inc(count);
+        let embedded = self.embed[idx].position();
+        let total = self.embed_total[idx].load(Ordering::Relaxed);
+        let pending = self.embed_pending[idx].load(Ordering::Relaxed);
+        let indexed = self.index[idx].position();
+        let produced = self.produced[idx].load(Ordering::Relaxed);
+        if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
+            self.embed[idx]
+                .finish_with_message(format!("embedded {} done", format_count(embedded)));
+            return;
         }
         self.update_embed_message(source);
     }
 
     pub fn set_embed_ready(&self) {
-        // Model loaded, update messages if still in spinner mode
-        if self.embeddings_enabled {
-            if self.embed_total[SourceKind::Claude.idx()].load(Ordering::Relaxed) == 0 {
-                self.claude_embed.set_message("embedded 0 ready");
-            }
-            let codex_total = self.embed_total[SourceKind::CodexSession.idx()]
-                .load(Ordering::Relaxed)
-                + self.embed_total[SourceKind::CodexHistory.idx()].load(Ordering::Relaxed);
-            if codex_total == 0 {
-                self.codex_embed.set_message("embedded 0 ready");
-            }
-            if self.embed_total[SourceKind::Opencode.idx()].load(Ordering::Relaxed) == 0 {
-                self.opencode_embed.set_message("embedded 0 ready");
-            }
-            if self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed) == 0 {
-                self.cursor_embed.set_message("embedded 0 ready");
+        if !self.embeddings_enabled {
+            return;
+        }
+        for source in SOURCES {
+            let idx = source.idx();
+            if self.embed_total[idx].load(Ordering::Relaxed) == 0 {
+                self.embed[idx].set_message("embedded 0 ready");
             }
         }
     }
 
     pub fn finish(&self) {
-        // Finish headers
-        self.claude_header.finish();
-        self.codex_header.finish();
-        self.opencode_header.finish();
-        self.cursor_header.finish();
+        for source in SOURCES {
+            let idx = source.idx();
+            self.headers[idx].finish();
 
-        // Finish parse spinners
-        let claude_parsed = self.claude_parse.position();
-        if claude_parsed > 0 {
-            self.claude_parse.finish_with_message(format!(
-                "parsed {} {} files",
-                format_bytes(claude_parsed),
-                self.claude_files_total
-            ));
-        } else {
-            self.claude_parse.finish_and_clear();
-        }
-        let codex_parsed = self.codex_parse.position();
-        if codex_parsed > 0 {
-            self.codex_parse.finish_with_message(format!(
-                "parsed {} {} files",
-                format_bytes(codex_parsed),
-                self.codex_files_total
-            ));
-        } else {
-            self.codex_parse.finish_and_clear();
-        }
-        let opencode_parsed = self.opencode_parse.position();
-        if opencode_parsed > 0 {
-            self.opencode_parse.finish_with_message(format!(
-                "parsed {} {} files",
-                format_bytes(opencode_parsed),
-                self.opencode_files_total
-            ));
-        } else {
-            self.opencode_parse.finish_and_clear();
-        }
-        let cursor_parsed = self.cursor_parse.position();
-        if cursor_parsed > 0 {
-            self.cursor_parse.finish_with_message(format!(
-                "parsed {} {} files",
-                format_bytes(cursor_parsed),
-                self.cursor_files_total
-            ));
-        } else {
-            self.cursor_parse.finish_and_clear();
-        }
+            let parsed = self.parse[idx].position();
+            if parsed > 0 {
+                self.parse[idx].finish_with_message(format!(
+                    "parsed {} {} files",
+                    format_bytes(parsed),
+                    self.files_total[idx]
+                ));
+            } else {
+                self.parse[idx].finish_and_clear();
+            }
 
-        // Finish index bars
-        let claude_indexed = self.claude_index.position();
-        if claude_indexed > 0 {
-            self.claude_index
-                .finish_with_message(format!("indexed {} rec", format_count(claude_indexed)));
-        } else {
-            self.claude_index.finish_and_clear();
-        }
-        let codex_indexed = self.codex_index.position();
-        if codex_indexed > 0 {
-            self.codex_index
-                .finish_with_message(format!("indexed {} rec", format_count(codex_indexed)));
-        } else {
-            self.codex_index.finish_and_clear();
-        }
-        let opencode_indexed = self.opencode_index.position();
-        if opencode_indexed > 0 {
-            self.opencode_index
-                .finish_with_message(format!("indexed {} rec", format_count(opencode_indexed)));
-        } else {
-            self.opencode_index.finish_and_clear();
-        }
-        let cursor_indexed = self.cursor_index.position();
-        if cursor_indexed > 0 {
-            self.cursor_index
-                .finish_with_message(format!("indexed {} rec", format_count(cursor_indexed)));
-        } else {
-            self.cursor_index.finish_and_clear();
-        }
+            let indexed = self.index[idx].position();
+            if indexed > 0 {
+                self.index[idx]
+                    .finish_with_message(format!("indexed {} rec", format_count(indexed)));
+            } else {
+                self.index[idx].finish_and_clear();
+            }
 
-        // Finish embed bars
-        let claude_embedded = self.claude_embed.position();
-        if self.embeddings_enabled && claude_embedded > 0 {
-            self.claude_embed
-                .finish_with_message(format!("embedded {}", format_count(claude_embedded)));
-        } else {
-            self.claude_embed.finish_and_clear();
+            let embedded = self.embed[idx].position();
+            if self.embeddings_enabled && embedded > 0 {
+                self.embed[idx].finish_with_message(format!("embedded {}", format_count(embedded)));
+            } else {
+                self.embed[idx].finish_and_clear();
+            }
         }
-        let codex_embedded = self.codex_embed.position();
-        if self.embeddings_enabled && codex_embedded > 0 {
-            self.codex_embed
-                .finish_with_message(format!("embedded {}", format_count(codex_embedded)));
-        } else {
-            self.codex_embed.finish_and_clear();
-        }
-        let opencode_embedded = self.opencode_embed.position();
-        if self.embeddings_enabled && opencode_embedded > 0 {
-            self.opencode_embed
-                .finish_with_message(format!("embedded {}", format_count(opencode_embedded)));
-        } else {
-            self.opencode_embed.finish_and_clear();
-        }
-        let cursor_embedded = self.cursor_embed.position();
-        if self.embeddings_enabled && cursor_embedded > 0 {
-            self.cursor_embed
-                .finish_with_message(format!("embedded {}", format_count(cursor_embedded)));
-        } else {
-            self.cursor_embed.finish_and_clear();
-        }
+    }
+}
+
+fn progress_label(source: SourceKind) -> &'static str {
+    match source {
+        SourceKind::Claude => "claude",
+        SourceKind::CodexSession => "codex",
+        SourceKind::CodexHistory => "codex-history",
+        SourceKind::Opencode => "opencode",
+        SourceKind::Cursor => "cursor",
+        SourceKind::Pi => "pi",
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -103,6 +103,7 @@ enum SourceChoice {
     Codex,
     Opencode,
     Cursor,
+    Pi,
 }
 
 impl SourceChoice {
@@ -112,7 +113,8 @@ impl SourceChoice {
             SourceChoice::Claude => SourceChoice::Codex,
             SourceChoice::Codex => SourceChoice::Opencode,
             SourceChoice::Opencode => SourceChoice::Cursor,
-            SourceChoice::Cursor => SourceChoice::All,
+            SourceChoice::Cursor => SourceChoice::Pi,
+            SourceChoice::Pi => SourceChoice::All,
         }
     }
 
@@ -123,6 +125,7 @@ impl SourceChoice {
             SourceChoice::Codex => Some(SourceFilter::Codex),
             SourceChoice::Opencode => Some(SourceFilter::Opencode),
             SourceChoice::Cursor => Some(SourceFilter::Cursor),
+            SourceChoice::Pi => Some(SourceFilter::Pi),
         }
     }
 
@@ -133,6 +136,7 @@ impl SourceChoice {
             SourceChoice::Codex => "codex",
             SourceChoice::Opencode => "opencode",
             SourceChoice::Cursor => "cursor",
+            SourceChoice::Pi => "pi",
         }
     }
 }
@@ -439,6 +443,7 @@ impl App {
                     include_codex: true,
                     include_opencode: true,
                     include_cursor: true,
+                    include_pi: true,
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
                     model: model_choice,
@@ -704,6 +709,11 @@ impl App {
                 .cursor_resume_cmd
                 .clone()
                 .or_else(|| default_resume_template("cursor")),
+            SourceKind::Pi => self
+                .config
+                .pi_resume_cmd
+                .clone()
+                .or_else(|| default_resume_template("pi")),
         };
         let Some(template) = template else {
             self.set_status("resume command not configured in config.toml");
@@ -737,6 +747,7 @@ impl App {
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
+            SourceKind::Pi => "pi",
         };
         let source_path = session.source_path.clone();
 
@@ -1626,8 +1637,11 @@ fn expand_resume_template(template: &str, session: &SessionSummary, cwd: &str) -
         .replace("{session_id}", &session.session_id)
         .replace("{project}", &session.project)
         .replace("{source}", session.source.label())
+        .replace("{source_path_shell}", &shell_quote(&session.source_path))
         .replace("{source_path}", &session.source_path)
+        .replace("{source_dir_shell}", &shell_quote(&session.source_dir))
         .replace("{source_dir}", &session.source_dir)
+        .replace("{cwd_shell}", &shell_quote(cwd))
         .replace("{cwd}", cwd)
 }
 
@@ -1641,8 +1655,26 @@ fn default_resume_template(cmd: &str) -> Option<String> {
         "cursor" => {
             find_in_path("cursor-agent").map(|_| "cursor-agent --resume {session_id}".to_string())
         }
+        "pi" => find_in_path("pi").map(|_| "pi --session {source_path_shell}".to_string()),
         _ => None,
     }
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
 }
 
 fn find_in_path(name: &str) -> Option<PathBuf> {
@@ -1967,6 +1999,18 @@ fn resolve_session_cwd(session: &SessionSummary) -> Option<String> {
                 .map(|s| s.to_string());
             if payload_cwd.is_some() {
                 return payload_cwd;
+            }
+        }
+
+        if session.source == SourceKind::Pi
+            && value.get("type").and_then(|v| v.as_str()) == Some("session")
+        {
+            let cwd = value
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if cwd.is_some() {
+                return cwd;
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ pub enum SourceKind {
     CodexHistory,
     Opencode,
     Cursor,
+    Pi,
 }
 
 impl SourceKind {
@@ -19,6 +20,7 @@ impl SourceKind {
             SourceKind::CodexHistory => 2,
             SourceKind::Opencode => 3,
             SourceKind::Cursor => 4,
+            SourceKind::Pi => 5,
         }
     }
 
@@ -28,6 +30,7 @@ impl SourceKind {
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
+            SourceKind::Pi => "pi",
         }
     }
 
@@ -49,8 +52,25 @@ impl SourceKind {
             || path.contains("agent-transcripts")
         {
             SourceKind::Cursor
+        } else if path.contains(".pi/agent/sessions")
+            || path.contains(".pi\\agent\\sessions")
+            || path.contains("pi/agent/sessions")
+            || path.contains("pi\\agent\\sessions")
+        {
+            SourceKind::Pi
         } else {
             SourceKind::Claude
+        }
+    }
+
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "claude" => Some(SourceKind::Claude),
+            "codex" => Some(SourceKind::CodexSession),
+            "opencode" => Some(SourceKind::Opencode),
+            "cursor" => Some(SourceKind::Cursor),
+            "pi" => Some(SourceKind::Pi),
+            _ => None,
         }
     }
 }
@@ -62,6 +82,7 @@ pub enum SourceFilter {
     Codex,
     Opencode,
     Cursor,
+    Pi,
 }
 
 impl SourceFilter {
@@ -73,6 +94,7 @@ impl SourceFilter {
             }
             SourceFilter::Opencode => source == SourceKind::Opencode,
             SourceFilter::Cursor => source == SourceKind::Cursor,
+            SourceFilter::Pi => source == SourceKind::Pi,
         }
     }
 
@@ -82,6 +104,7 @@ impl SourceFilter {
             SourceFilter::Codex => "codex",
             SourceFilter::Opencode => "opencode",
             SourceFilter::Cursor => "cursor",
+            SourceFilter::Pi => "pi",
         }
     }
 }
@@ -132,5 +155,15 @@ mod tests {
 
         assert_eq!(SourceKind::from_path(unix_path), SourceKind::Cursor);
         assert_eq!(SourceKind::from_path(windows_path), SourceKind::Cursor);
+    }
+
+    #[test]
+    fn from_path_recognizes_pi_sessions() {
+        let unix_path = "/tmp/.pi/agent/sessions/--Users-nico-Code/20260703_session.jsonl";
+        let windows_path =
+            "C:\\tmp\\.pi\\agent\\sessions\\--Users-nico-Code\\20260703_session.jsonl";
+
+        assert_eq!(SourceKind::from_path(unix_path), SourceKind::Pi);
+        assert_eq!(SourceKind::from_path(windows_path), SourceKind::Pi);
     }
 }


### PR DESCRIPTION
Adds Pi Coding Agent as a first-class memex history source, including JSONL ingest, source filtering, TUI resume support, progress/embedding accounting, setup skill installation, and docs/skill updates.

Validation run:
- cargo fmt --check
- CARGO_TARGET_DIR=target/codex-check cargo clippy -- -D warnings
- CARGO_TARGET_DIR=target/codex-check cargo test --no-run

Note: exact shared-target cargo clippy was SIGTERM'd twice in this environment; the isolated target clippy run passed.