### PR TITLE
Add Cursor transcript indexing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "memex"
 version = "0.3.1"
 edition = "2024"
 build = "build.rs"
-description = "CLI tool for indexing and searching Claude Code conversation history"
+description = "CLI tool for indexing and searching local agent conversation history"
 license = "MIT"
 repository = "https://github.com/nicosuave/memex"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI & OpenCode logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, and OpenCode logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -285,6 +285,7 @@ index_service_label = "memex-index"  # service name (default: com.memex.index on
 index_service_systemd_dir = "~/.config/systemd/user"  # Linux only
 claude_resume_cmd = "claude --resume {session_id}"
 codex_resume_cmd = "codex resume {session_id}"
+cursor_resume_cmd = "cursor-agent --resume {session_id}"
 ```
 
 Service logs and the plist live under `~/.memex` by default (macOS). On Linux, systemd units are created in `~/.config/systemd/user/`.

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -41,6 +41,7 @@ in {
         - index_service_stderr (string): stderr log path (macOS)
         - claude_resume_cmd (string)
         - codex_resume_cmd (string)
+        - cursor_resume_cmd (string)
       '';
       example = {
         embeddings = true;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   meta = {
-    description = "Fast local history search for Claude and Codex logs";
+    description = "Fast local history search for local agent logs";
     homepage = "https://github.com/nicosuave/memex";
     license = lib.licenses.mit;
     mainProgram = "memex";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,10 +21,10 @@ use std::time::Duration;
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude and Codex",
+    about = "Fast local history search for Claude, Codex, Cursor, and Opencode",
     after_help = "\
 QUICK START:
-    memex index                     # Index your Claude/Codex history
+    memex index                     # Index your Claude/Codex/Cursor/Opencode history
     memex search \"error handling\"   # Search for keywords
     memex tui                       # Browse sessions interactively
 
@@ -50,6 +50,9 @@ struct IndexArgs {
     /// Index Opencode sessions from ~/.local/share/opencode [default: true]
     #[arg(long, default_value_t = true)]
     opencode: bool,
+    /// Index Cursor agent transcripts from ~/.cursor/projects [default: true]
+    #[arg(long = "no-cursor", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    cursor: bool,
     /// Generate embeddings for semantic search during indexing
     #[arg(long)]
     embeddings: bool,
@@ -67,10 +70,10 @@ struct IndexArgs {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Index Claude and Codex conversation history
+    /// Index Claude, Codex, Cursor, and Opencode conversation history
     #[command(after_help = "\
 EXAMPLES:
-    memex index                         # Index all Claude and Codex history
+    memex index                         # Index all supported local history
     memex index --embeddings            # Also generate embeddings for semantic search
     memex index --include-agents        # Include Claude Code subagent conversations
     memex index --source ~/custom/path  # Use custom Claude projects directory")]
@@ -131,7 +134,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude or codex
+        /// Filter by source: claude, codex, cursor, or opencode
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -456,6 +459,7 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
         index.include_agents,
         index.codex,
         index.opencode,
+        index.cursor,
         index.embeddings,
         index.no_embeddings,
         index.model.clone(),
@@ -470,6 +474,7 @@ fn run_index(
     include_agents: bool,
     codex: bool,
     opencode: bool,
+    cursor: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
     model: Option<String>,
@@ -499,6 +504,7 @@ fn run_index(
         include_agents,
         include_codex: codex,
         include_opencode: opencode,
+        include_cursor: cursor,
         embeddings,
         backfill_embeddings: false,
         model: model_choice,
@@ -538,10 +544,10 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     let mut vector =
         VectorIndex::open_or_create(&paths.vectors, embedder.dims, Some(model_choice.as_str()))?;
 
-    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 4], [0; 4], true));
+    let progress = std::sync::Arc::new(crate::progress::Progress::new([0; 5], [0; 5], true));
     progress.set_embed_ready();
 
-    let mut embedded_counts = [0u64; 4];
+    let mut embedded_counts = [0u64; 5];
     let mut embedded_total = 0u64;
     let mut batch: Vec<(u64, String, crate::types::SourceKind)> = Vec::with_capacity(BATCH_SIZE);
 
@@ -549,7 +555,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
                        embedder: &mut EmbedderHandle,
                        vector: &mut VectorIndex,
                        progress: &crate::progress::Progress,
-                       embedded_counts: &mut [u64; 4],
+                       embedded_counts: &mut [u64; 5],
                        embedded_total: &mut u64| {
         if batch.is_empty() {
             return Ok(());
@@ -608,12 +614,13 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {}, opencode {})",
+        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::CodexSession.idx()],
         embedded_counts[crate::types::SourceKind::CodexHistory.idx()],
         embedded_counts[crate::types::SourceKind::Opencode.idx()],
+        embedded_counts[crate::types::SourceKind::Cursor.idx()],
     );
 
     std::io::stdout().flush().ok();
@@ -659,6 +666,7 @@ fn run_search(
             include_agents: false,
             include_codex: true,
             include_opencode: true,
+            include_cursor: true,
             embeddings: embeddings_default,
             backfill_embeddings: false,
             model: model_choice,
@@ -1351,6 +1359,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Claude => "claude",
         crate::types::SourceKind::CodexSession | crate::types::SourceKind::CodexHistory => "codex",
         crate::types::SourceKind::Opencode => "opencode",
+        crate::types::SourceKind::Cursor => "cursor",
     };
     let source_path = &record.source_path;
 
@@ -1881,6 +1890,9 @@ fn build_index_command_args(
     }
     if !index.opencode {
         args.push("--no-opencode".to_string());
+    }
+    if !index.cursor {
+        args.push("--no-cursor".to_string());
     }
     if index.embeddings {
         args.push("--embeddings".to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,8 @@ pub struct UserConfig {
     pub codex_resume_cmd: Option<String>,
     /// Resume command template for Opencode sessions.
     pub opencode_resume_cmd: Option<String>,
+    /// Resume command template for Cursor sessions.
+    pub cursor_resume_cmd: Option<String>,
 }
 
 impl UserConfig {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -22,6 +22,9 @@ use walkdir::WalkDir;
 const EMBED_BATCH_SIZE: usize = 64;
 const EMBED_MAX_CHARS: usize = 8192;
 const INDEX_PROGRESS_BATCH: u64 = 1;
+const CURSOR_SUBAGENT_TURN_BASE: u32 = 1_000_000_000;
+const CURSOR_SUBAGENT_TURN_STRIDE: u32 = 50_000;
+const CURSOR_SUBAGENT_TURN_BUCKETS: u32 = 65_536;
 
 #[derive(Debug, Clone)]
 pub struct IngestOptions {
@@ -29,6 +32,7 @@ pub struct IngestOptions {
     pub include_agents: bool,
     pub include_codex: bool,
     pub include_opencode: bool,
+    pub include_cursor: bool,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
     pub model: ModelChoice,
@@ -279,6 +283,49 @@ pub fn ingest_all(
         }
     }
 
+    if options.include_cursor {
+        let cursor_files = collect_cursor_files()?;
+        for path in cursor_files {
+            let meta = path.metadata()?;
+            let size = meta.len();
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            files_scanned += 1;
+            total_bytes += size;
+            let key = path.to_string_lossy().to_string();
+            let prev = state.files.get(&key);
+            let (offset, turn_id, delete_first, skip) = match prev {
+                None => (0, 0, false, false),
+                Some(prev) => {
+                    if size < prev.size || mtime < prev.mtime {
+                        (0, 0, true, false)
+                    } else if size == prev.size && mtime == prev.mtime {
+                        (prev.offset, prev.turn_id, false, true)
+                    } else {
+                        (prev.offset, prev.turn_id, false, false)
+                    }
+                }
+            };
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(FileTask {
+                path,
+                source: SourceKind::Cursor,
+                offset,
+                turn_id,
+                size,
+                mtime,
+                delete_first,
+            });
+        }
+    }
+
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
@@ -333,6 +380,9 @@ pub fn ingest_all(
             )?,
             SourceKind::Opencode => {
                 parse_opencode_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
+            }
+            SourceKind::Cursor => {
+                parse_cursor_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
             }
         }
         Ok(())
@@ -454,7 +504,7 @@ fn writer_loop(
     let mut vector_index = None;
     let mut embedder: Option<EmbedderHandle> = None;
     let mut embed_buffer: Vec<(u64, String, SourceKind)> = Vec::new();
-    let mut index_pending: [u64; 4] = [0, 0, 0, 0];
+    let mut index_pending: [u64; 5] = [0, 0, 0, 0, 0];
     if embeddings {
         let handle = EmbedderHandle::with_model_and_runtime(model, &embed_runtime)?;
         let dims = handle.dims;
@@ -505,7 +555,8 @@ fn writer_loop(
                 0 => SourceKind::Claude,
                 1 => SourceKind::CodexSession,
                 2 => SourceKind::CodexHistory,
-                _ => SourceKind::Opencode,
+                3 => SourceKind::Opencode,
+                _ => SourceKind::Cursor,
             };
             progress.add_indexed(source, pending);
         }
@@ -648,6 +699,31 @@ fn collect_opencode_files() -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+fn collect_cursor_files() -> Result<Vec<PathBuf>> {
+    let root = cursor_projects_root();
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(path_str) = path.to_str() else {
+            continue;
+        };
+        if path_str.contains("/agent-transcripts/") || path_str.contains("\\agent-transcripts\\") {
+            files.push(path.to_path_buf());
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
 fn codex_root() -> PathBuf {
     let home = directories::BaseDirs::new()
         .map(|b| b.home_dir().to_path_buf())
@@ -687,6 +763,13 @@ fn opencode_parts_root() -> PathBuf {
 
 fn codex_history_path() -> PathBuf {
     codex_root().join("history.jsonl")
+}
+
+fn cursor_projects_root() -> PathBuf {
+    let home = directories::BaseDirs::new()
+        .map(|b| b.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".cursor").join("projects")
 }
 
 fn parse_claude_file(
@@ -1286,6 +1369,168 @@ fn parse_opencode_file(
     Ok(())
 }
 
+fn parse_cursor_file(
+    task: &FileTask,
+    tx_record: &Sender<Record>,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let file = File::open(&task.path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = task.offset as usize;
+    let mut turn_id = cursor_initial_turn_id(&task.path, task.turn_id);
+
+    let source_path = task.path.to_string_lossy().to_string();
+    let session_id = cursor_session_id_from_path(&task.path);
+    let project = project_from_cursor_path(&task.path);
+    let timestamp = task.mtime.max(0) as u64 * 1000;
+
+    let mut buf = Vec::new();
+    let mut parsed_bytes = 0u64;
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        let advanced = rel + 1;
+        start += advanced;
+        parsed_bytes += advanced as u64;
+        if parsed_bytes >= 64 * 1024 {
+            progress.add_parsed_bytes(SourceKind::Cursor, parsed_bytes);
+            parsed_bytes = 0;
+        }
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        let role = obj.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role != "user" && role != "assistant" {
+            continue;
+        }
+        let message = match obj.get("message").and_then(|v| v.as_object()) {
+            Some(m) => m,
+            None => continue,
+        };
+        let mut text_parts = Vec::new();
+        if let Some(content) = message.get("content") {
+            if let Some(text) = content.as_str() {
+                text_parts.push(text);
+            } else if let Some(arr) = content.as_array() {
+                for block in arr {
+                    let Some(block_obj) = block.as_object() else {
+                        continue;
+                    };
+                    let block_type = block_obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    if block_type == "text" {
+                        if let Some(text) = block_obj.get("text").and_then(|v| v.as_str()) {
+                            text_parts.push(text);
+                        }
+                    } else if block_type == "tool_use" {
+                        let tool_name = block_obj
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let tool_input = block_obj.get("input").map(|v| v.to_string());
+                        let text = tool_input.clone().unwrap_or_default();
+                        let record = Record {
+                            source: SourceKind::Cursor,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "tool_use".to_string(),
+                            text,
+                            tool_name,
+                            tool_input,
+                            tool_output: None,
+                            source_path: source_path.clone(),
+                        };
+                        progress.add_produced(SourceKind::Cursor, 1);
+                        tx_record.send(record)?;
+                        turn_id += 1;
+                    } else if block_type == "tool_result" {
+                        let tool_output = block_obj.get("content").map(|v| v.to_string());
+                        let mut text = extract_text_from_tool_result(block).unwrap_or_default();
+                        if text.is_empty()
+                            && let Some(content) = block_obj.get("content")
+                        {
+                            text = content.to_string();
+                        }
+                        if text.is_empty() {
+                            continue;
+                        }
+                        let record = Record {
+                            source: SourceKind::Cursor,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "tool_result".to_string(),
+                            text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output,
+                            source_path: source_path.clone(),
+                        };
+                        progress.add_produced(SourceKind::Cursor, 1);
+                        tx_record.send(record)?;
+                        turn_id += 1;
+                    }
+                }
+            }
+        }
+
+        let text = text_parts.join("\n").trim().to_string();
+        if !text.is_empty() {
+            let record = Record {
+                source: SourceKind::Cursor,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: role.to_string(),
+                text,
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                source_path: source_path.clone(),
+            };
+            progress.add_produced(SourceKind::Cursor, 1);
+            tx_record.send(record)?;
+            turn_id += 1;
+        }
+    }
+
+    if parsed_bytes > 0 {
+        progress.add_parsed_bytes(SourceKind::Cursor, parsed_bytes);
+    }
+    progress.add_files_done(SourceKind::Cursor, 1);
+    let state = FileState {
+        size: task.size,
+        mtime: task.mtime,
+        offset: mmap.len() as u64,
+        turn_id,
+    };
+    tx_update.send(FileUpdate {
+        path: source_path,
+        state,
+        session_id: Some(session_id),
+    })?;
+    Ok(())
+}
+
 fn parse_iso_millis(input: &str) -> Option<u64> {
     DateTime::parse_from_rfc3339(input)
         .ok()
@@ -1309,6 +1554,78 @@ fn project_from_path(path: &str) -> String {
         return name.to_string();
     }
     "codex".to_string()
+}
+
+fn project_from_cursor_path(path: &Path) -> String {
+    let root = cursor_projects_root();
+    let Ok(relative) = path.strip_prefix(root) else {
+        return "cursor".to_string();
+    };
+    let Some(project_folder) = relative
+        .components()
+        .next()
+        .and_then(|c| c.as_os_str().to_str())
+    else {
+        return "cursor".to_string();
+    };
+    if project_folder == "empty-window" {
+        return project_folder.to_string();
+    }
+    decode_project_name(project_folder)
+}
+
+fn cursor_session_id_from_path(path: &Path) -> String {
+    let components: Vec<_> = path.components().collect();
+    for (idx, component) in components.iter().enumerate() {
+        if component.as_os_str().to_str() == Some("agent-transcripts")
+            && let Some(session_id) = components
+                .get(idx + 1)
+                .and_then(|c| Path::new(c.as_os_str()).file_stem())
+                .and_then(|s| s.to_str())
+                .filter(|s| !s.is_empty())
+        {
+            return session_id.to_string();
+        }
+    }
+
+    session_id_from_filename(path).unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    })
+}
+
+fn cursor_initial_turn_id(path: &Path, cached_turn_id: u32) -> u32 {
+    if cached_turn_id != 0 {
+        return cached_turn_id;
+    }
+    cursor_subagent_turn_base(path).unwrap_or(cached_turn_id)
+}
+
+fn cursor_subagent_turn_base(path: &Path) -> Option<u32> {
+    if !path
+        .components()
+        .any(|component| component.as_os_str().to_str() == Some("subagents"))
+    {
+        return None;
+    }
+
+    let agent_id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())?;
+    let bucket = stable_cursor_turn_bucket(agent_id);
+    Some(CURSOR_SUBAGENT_TURN_BASE + bucket.saturating_mul(CURSOR_SUBAGENT_TURN_STRIDE))
+}
+
+fn stable_cursor_turn_bucket(value: &str) -> u32 {
+    let mut hash = 2_166_136_261u32;
+    for byte in value.as_bytes() {
+        hash ^= *byte as u32;
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    hash % CURSOR_SUBAGENT_TURN_BUCKETS
 }
 
 fn decode_project_name(folder_name: &str) -> String {
@@ -1429,8 +1746,8 @@ fn flush_embeddings(
     Ok(count)
 }
 
-fn compute_totals(tasks: &[FileTask]) -> [u64; 4] {
-    let mut totals = [0u64; 4];
+fn compute_totals(tasks: &[FileTask]) -> [u64; 5] {
+    let mut totals = [0u64; 5];
     for task in tasks {
         let remaining = task.size.saturating_sub(task.offset);
         totals[task.source.idx()] += remaining;
@@ -1438,8 +1755,8 @@ fn compute_totals(tasks: &[FileTask]) -> [u64; 4] {
     totals
 }
 
-fn compute_file_totals(tasks: &[FileTask]) -> [u64; 4] {
-    let mut totals = [0u64; 4];
+fn compute_file_totals(tasks: &[FileTask]) -> [u64; 5] {
+    let mut totals = [0u64; 5];
     for task in tasks {
         totals[task.source.idx()] += 1;
     }
@@ -1477,6 +1794,7 @@ mod tests {
             include_agents: false,
             include_codex: false,
             include_opencode: false,
+            include_cursor: false,
             embeddings,
             backfill_embeddings: false,
             model,
@@ -1533,6 +1851,72 @@ mod tests {
             file_count: 0,
             total_bytes: 0,
         }
+    }
+
+    #[test]
+    fn cursor_session_id_uses_agent_transcripts_session_directory() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111/\
+             11111111-1111-1111-1111-111111111111.jsonl",
+        );
+
+        assert_eq!(
+            cursor_session_id_from_path(path),
+            "11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn cursor_session_id_strips_direct_transcript_extension() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111.jsonl",
+        );
+
+        assert_eq!(
+            cursor_session_id_from_path(path),
+            "11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn cursor_session_id_uses_parent_session_for_subagent_transcripts() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111/subagents/\
+             22222222-2222-2222-2222-222222222222.jsonl",
+        );
+
+        assert_eq!(
+            cursor_session_id_from_path(path),
+            "11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[test]
+    fn cursor_parent_transcripts_start_at_cached_turn_id() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111/\
+             11111111-1111-1111-1111-111111111111.jsonl",
+        );
+
+        assert_eq!(cursor_initial_turn_id(path, 0), 0);
+        assert_eq!(cursor_initial_turn_id(path, 42), 42);
+    }
+
+    #[test]
+    fn cursor_subagent_transcripts_use_reserved_turn_range() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111/subagents/\
+             22222222-2222-2222-2222-222222222222.jsonl",
+        );
+
+        let initial = cursor_initial_turn_id(path, 0);
+        assert!(initial >= CURSOR_SUBAGENT_TURN_BASE);
+        assert_eq!(cursor_initial_turn_id(path, initial + 3), initial + 3);
     }
 
     #[test]

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -3,7 +3,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-const SOURCE_COUNT: usize = 4;
+const SOURCE_COUNT: usize = 5;
 
 pub struct Progress {
     #[allow(dead_code)] // Kept alive to coordinate progress bars
@@ -13,22 +13,27 @@ pub struct Progress {
     claude_header: ProgressBar,
     codex_header: ProgressBar,
     opencode_header: ProgressBar,
+    cursor_header: ProgressBar,
 
     // All spinners
     claude_parse: ProgressBar,
     codex_parse: ProgressBar,
     opencode_parse: ProgressBar,
+    cursor_parse: ProgressBar,
     claude_index: ProgressBar,
     codex_index: ProgressBar,
     opencode_index: ProgressBar,
+    cursor_index: ProgressBar,
     claude_embed: ProgressBar,
     codex_embed: ProgressBar,
     opencode_embed: ProgressBar,
+    cursor_embed: ProgressBar,
 
     // Totals for display
     claude_files_total: u64,
     codex_files_total: u64,
     opencode_files_total: u64,
+    cursor_files_total: u64,
 
     // Tracking
     files_done: [AtomicU64; SOURCE_COUNT],
@@ -51,6 +56,7 @@ impl Progress {
         let codex_files = files_total[SourceKind::CodexSession.idx()]
             + files_total[SourceKind::CodexHistory.idx()];
         let opencode_files = files_total[SourceKind::Opencode.idx()];
+        let cursor_files = files_total[SourceKind::Cursor.idx()];
 
         // Header style (just text)
         let header_style = ProgressStyle::with_template("{msg}").unwrap();
@@ -116,7 +122,7 @@ impl Progress {
 
         // Opencode header
         let opencode_header = multi.add(ProgressBar::new_spinner());
-        opencode_header.set_style(header_style);
+        opencode_header.set_style(header_style.clone());
         opencode_header.set_message("opencode");
         opencode_header.tick();
 
@@ -133,6 +139,33 @@ impl Progress {
 
         let opencode_embed = if embeddings {
             let bar = multi.add(ProgressBar::new_spinner());
+            bar.set_style(spinner_style.clone());
+            bar.set_message("embedded 0");
+            bar.enable_steady_tick(Duration::from_millis(80));
+            bar
+        } else {
+            ProgressBar::hidden()
+        };
+
+        // Cursor header
+        let cursor_header = multi.add(ProgressBar::new_spinner());
+        cursor_header.set_style(header_style);
+        cursor_header.set_message("cursor");
+        cursor_header.tick();
+
+        // Cursor spinners
+        let cursor_parse = multi.add(ProgressBar::new_spinner());
+        cursor_parse.set_style(spinner_style.clone());
+        cursor_parse.set_message(format!("parsed 0 B / {cursor_files} files"));
+        cursor_parse.enable_steady_tick(Duration::from_millis(80));
+
+        let cursor_index = multi.add(ProgressBar::new_spinner());
+        cursor_index.set_style(spinner_style.clone());
+        cursor_index.set_message("indexed 0 rec");
+        cursor_index.enable_steady_tick(Duration::from_millis(80));
+
+        let cursor_embed = if embeddings {
+            let bar = multi.add(ProgressBar::new_spinner());
             bar.set_style(spinner_style);
             bar.set_message("embedded 0");
             bar.enable_steady_tick(Duration::from_millis(80));
@@ -146,18 +179,23 @@ impl Progress {
             claude_header,
             codex_header,
             opencode_header,
+            cursor_header,
             claude_parse,
             codex_parse,
             opencode_parse,
+            cursor_parse,
             claude_index,
             codex_index,
             opencode_index,
+            cursor_index,
             claude_embed,
             codex_embed,
             opencode_embed,
+            cursor_embed,
             claude_files_total: claude_files,
             codex_files_total: codex_files,
             opencode_files_total: opencode_files,
+            cursor_files_total: cursor_files,
             files_done: std::array::from_fn(|_| AtomicU64::new(0)),
             produced: std::array::from_fn(|_| AtomicU64::new(0)),
             embed_total: std::array::from_fn(|_| AtomicU64::new(0)),
@@ -204,6 +242,17 @@ impl Progress {
                     self.opencode_files_total
                 ));
             }
+            SourceKind::Cursor => {
+                self.cursor_parse.inc(bytes);
+                let total = self.cursor_parse.position();
+                let files_done = self.files_done[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                self.cursor_parse.set_message(format!(
+                    "parsed {} {}/{} files",
+                    format_bytes(total),
+                    files_done,
+                    self.cursor_files_total
+                ));
+            }
         }
     }
 
@@ -243,6 +292,16 @@ impl Progress {
                         "parsed {} {} files done",
                         format_bytes(bytes),
                         self.opencode_files_total
+                    ));
+                }
+            }
+            SourceKind::Cursor => {
+                if done >= self.cursor_files_total {
+                    let bytes = self.cursor_parse.position();
+                    self.cursor_parse.finish_with_message(format!(
+                        "parsed {} {} files done",
+                        format_bytes(bytes),
+                        self.cursor_files_total
                     ));
                 }
             }
@@ -302,6 +361,19 @@ impl Progress {
                         .set_message(format!("indexed {} rec", format_count(indexed)));
                 }
             }
+            SourceKind::Cursor => {
+                self.cursor_index.inc(count);
+                let indexed = self.cursor_index.position();
+                let produced = self.produced[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                let files_done = self.files_done[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                if files_done >= self.cursor_files_total && indexed >= produced && produced > 0 {
+                    self.cursor_index
+                        .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
+                } else {
+                    self.cursor_index
+                        .set_message(format!("indexed {} rec", format_count(indexed)));
+                }
+            }
         }
     }
 
@@ -329,6 +401,7 @@ impl Progress {
             SourceKind::Claude => self.claude_embed.position(),
             SourceKind::CodexSession | SourceKind::CodexHistory => self.codex_embed.position(),
             SourceKind::Opencode => self.opencode_embed.position(),
+            SourceKind::Cursor => self.cursor_embed.position(),
         };
         let total = match source {
             SourceKind::Claude => {
@@ -341,6 +414,9 @@ impl Progress {
             SourceKind::Opencode => {
                 self.embed_total[SourceKind::Opencode.idx()].load(Ordering::Relaxed)
             }
+            SourceKind::Cursor => {
+                self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed)
+            }
         };
         let pending = match source {
             SourceKind::Claude => {
@@ -352,6 +428,9 @@ impl Progress {
             }
             SourceKind::Opencode => {
                 self.embed_pending[SourceKind::Opencode.idx()].load(Ordering::Relaxed)
+            }
+            SourceKind::Cursor => {
+                self.embed_pending[SourceKind::Cursor.idx()].load(Ordering::Relaxed)
             }
         };
 
@@ -380,6 +459,7 @@ impl Progress {
                 self.codex_embed.set_message(msg)
             }
             SourceKind::Opencode => self.opencode_embed.set_message(msg),
+            SourceKind::Cursor => self.cursor_embed.set_message(msg),
         }
     }
 
@@ -434,6 +514,19 @@ impl Progress {
                     return;
                 }
             }
+            SourceKind::Cursor => {
+                self.cursor_embed.inc(count);
+                let embedded = self.cursor_embed.position();
+                let total = self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                let pending = self.embed_pending[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                let indexed = self.cursor_index.position();
+                let produced = self.produced[SourceKind::Cursor.idx()].load(Ordering::Relaxed);
+                if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
+                    self.cursor_embed
+                        .finish_with_message(format!("embedded {} done", format_count(embedded)));
+                    return;
+                }
+            }
         }
         self.update_embed_message(source);
     }
@@ -453,6 +546,9 @@ impl Progress {
             if self.embed_total[SourceKind::Opencode.idx()].load(Ordering::Relaxed) == 0 {
                 self.opencode_embed.set_message("embedded 0 ready");
             }
+            if self.embed_total[SourceKind::Cursor.idx()].load(Ordering::Relaxed) == 0 {
+                self.cursor_embed.set_message("embedded 0 ready");
+            }
         }
     }
 
@@ -461,6 +557,7 @@ impl Progress {
         self.claude_header.finish();
         self.codex_header.finish();
         self.opencode_header.finish();
+        self.cursor_header.finish();
 
         // Finish parse spinners
         let claude_parsed = self.claude_parse.position();
@@ -493,6 +590,16 @@ impl Progress {
         } else {
             self.opencode_parse.finish_and_clear();
         }
+        let cursor_parsed = self.cursor_parse.position();
+        if cursor_parsed > 0 {
+            self.cursor_parse.finish_with_message(format!(
+                "parsed {} {} files",
+                format_bytes(cursor_parsed),
+                self.cursor_files_total
+            ));
+        } else {
+            self.cursor_parse.finish_and_clear();
+        }
 
         // Finish index bars
         let claude_indexed = self.claude_index.position();
@@ -516,6 +623,13 @@ impl Progress {
         } else {
             self.opencode_index.finish_and_clear();
         }
+        let cursor_indexed = self.cursor_index.position();
+        if cursor_indexed > 0 {
+            self.cursor_index
+                .finish_with_message(format!("indexed {} rec", format_count(cursor_indexed)));
+        } else {
+            self.cursor_index.finish_and_clear();
+        }
 
         // Finish embed bars
         let claude_embedded = self.claude_embed.position();
@@ -538,6 +652,13 @@ impl Progress {
                 .finish_with_message(format!("embedded {}", format_count(opencode_embedded)));
         } else {
             self.opencode_embed.finish_and_clear();
+        }
+        let cursor_embedded = self.cursor_embed.position();
+        if self.embeddings_enabled && cursor_embedded > 0 {
+            self.cursor_embed
+                .finish_with_message(format!("embedded {}", format_count(cursor_embedded)));
+        } else {
+            self.cursor_embed.finish_and_clear();
         }
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -102,6 +102,7 @@ enum SourceChoice {
     Claude,
     Codex,
     Opencode,
+    Cursor,
 }
 
 impl SourceChoice {
@@ -110,7 +111,8 @@ impl SourceChoice {
             SourceChoice::All => SourceChoice::Claude,
             SourceChoice::Claude => SourceChoice::Codex,
             SourceChoice::Codex => SourceChoice::Opencode,
-            SourceChoice::Opencode => SourceChoice::All,
+            SourceChoice::Opencode => SourceChoice::Cursor,
+            SourceChoice::Cursor => SourceChoice::All,
         }
     }
 
@@ -120,6 +122,7 @@ impl SourceChoice {
             SourceChoice::Claude => Some(SourceFilter::Claude),
             SourceChoice::Codex => Some(SourceFilter::Codex),
             SourceChoice::Opencode => Some(SourceFilter::Opencode),
+            SourceChoice::Cursor => Some(SourceFilter::Cursor),
         }
     }
 
@@ -129,6 +132,7 @@ impl SourceChoice {
             SourceChoice::Claude => "claude",
             SourceChoice::Codex => "codex",
             SourceChoice::Opencode => "opencode",
+            SourceChoice::Cursor => "cursor",
         }
     }
 }
@@ -434,6 +438,7 @@ impl App {
                     include_agents: false,
                     include_codex: true,
                     include_opencode: true,
+                    include_cursor: true,
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
                     model: model_choice,
@@ -694,6 +699,11 @@ impl App {
                 .opencode_resume_cmd
                 .clone()
                 .or_else(|| default_resume_template("opencode")),
+            SourceKind::Cursor => self
+                .config
+                .cursor_resume_cmd
+                .clone()
+                .or_else(|| default_resume_template("cursor")),
         };
         let Some(template) = template else {
             self.set_status("resume command not configured in config.toml");
@@ -726,6 +736,7 @@ impl App {
             SourceKind::Claude => "claude",
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
             SourceKind::Opencode => "opencode",
+            SourceKind::Cursor => "cursor",
         };
         let source_path = session.source_path.clone();
 
@@ -1627,6 +1638,9 @@ fn default_resume_template(cmd: &str) -> Option<String> {
         }
         "codex" => find_in_path("codex").map(|_| "codex resume {session_id}".to_string()),
         "opencode" => find_in_path("opencode").map(|_| "opencode resume {session_id}".to_string()),
+        "cursor" => {
+            find_in_path("cursor-agent").map(|_| "cursor-agent --resume {session_id}".to_string())
+        }
         _ => None,
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ pub enum SourceKind {
     CodexSession,
     CodexHistory,
     Opencode,
+    Cursor,
 }
 
 impl SourceKind {
@@ -17,6 +18,7 @@ impl SourceKind {
             SourceKind::CodexSession => 1,
             SourceKind::CodexHistory => 2,
             SourceKind::Opencode => 3,
+            SourceKind::Cursor => 4,
         }
     }
 
@@ -25,6 +27,7 @@ impl SourceKind {
             SourceKind::Claude => "claude",
             SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
             SourceKind::Opencode => "opencode",
+            SourceKind::Cursor => "cursor",
         }
     }
 
@@ -41,6 +44,11 @@ impl SourceKind {
             || path.contains("opencode\\storage\\message")
         {
             SourceKind::Opencode
+        } else if path.contains(".cursor/projects")
+            || path.contains(".cursor\\projects")
+            || path.contains("agent-transcripts")
+        {
+            SourceKind::Cursor
         } else {
             SourceKind::Claude
         }
@@ -53,6 +61,7 @@ pub enum SourceFilter {
     Claude,
     Codex,
     Opencode,
+    Cursor,
 }
 
 impl SourceFilter {
@@ -63,6 +72,7 @@ impl SourceFilter {
                 source == SourceKind::CodexSession || source == SourceKind::CodexHistory
             }
             SourceFilter::Opencode => source == SourceKind::Opencode,
+            SourceFilter::Cursor => source == SourceKind::Cursor,
         }
     }
 
@@ -71,6 +81,7 @@ impl SourceFilter {
             SourceFilter::Claude => "claude",
             SourceFilter::Codex => "codex",
             SourceFilter::Opencode => "opencode",
+            SourceFilter::Cursor => "cursor",
         }
     }
 }
@@ -110,5 +121,16 @@ mod tests {
             SourceKind::from_path(windows_path),
             SourceKind::CodexSession
         );
+    }
+
+    #[test]
+    fn from_path_recognizes_cursor_agent_transcripts() {
+        let unix_path =
+            "/Users/nico/.cursor/projects/Users-nico-Code-app/agent-transcripts/abc/abc.jsonl";
+        let windows_path =
+            "C:\\Users\\nico\\.cursor\\projects\\app\\agent-transcripts\\abc\\abc.jsonl";
+
+        assert_eq!(SourceKind::from_path(unix_path), SourceKind::Cursor);
+        assert_eq!(SourceKind::from_path(windows_path), SourceKind::Cursor);
     }
 }


### PR DESCRIPTION
Adds Cursor as a searchable source by indexing local agent transcript JSONL files under ~/.cursor/projects.

Also wires Cursor through source filters, progress accounting, embedding counters, the TUI source picker, and package descriptions.

Validation: cargo fmt --check; CARGO_TARGET_DIR=/tmp/memex-pr-target cargo clippy -- -D warnings