### PR TITLE
Add tree linkage metadata for agent histories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, OpenCode, and Pi Coding Agent logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -185,7 +185,7 @@ This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents a
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|opencode|pi`
+- `--source claude|codex|cursor|opencode|pi|copilot`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -194,6 +194,12 @@ This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents a
 - `--unique-session`
 - `--fields score,ts,doc_id,session_id,snippet`
 - `--json-array`
+
+JSON output also includes `source` and, when available, tree/linkage metadata:
+`event_id`, `parent_event_id`, `logical_parent_event_id`,
+`parent_session_id`, `thread_source`, `conversation_kind`,
+`parent_tool_use_id`, `source_tool_use_id`, and
+`source_tool_assistant_uuid`.
 
 ## Background index service
 
@@ -287,8 +293,8 @@ claude_resume_cmd = "claude --resume {session_id}"
 codex_resume_cmd = "codex resume {session_id}"
 cursor_resume_cmd = "cursor-agent --resume {session_id}"
 opencode_resume_cmd = "opencode resume {session_id}"
-pi_resume_cmd
-copilot_resume_cmd = "pi --session {source_path_shell}"
+pi_resume_cmd = "pi --session {source_path_shell}"
+# copilot_resume_cmd = "your-copilot-resume-command {session_id}"
 ```
 
 Service logs and the plist live under `~/.memex` by default (macOS). On Linux, systemd units are created in `~/.config/systemd/user/`.

--- a/skills/codex/memex-search/SKILL.md
+++ b/skills/codex/memex-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memex-search
-description: Search, filter, and retrieve Claude/Codex/OpenCode/Pi history indexed by the memex CLI. Use when you want to search history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output.
+description: Search, filter, and retrieve Claude/Codex/Cursor/OpenCode/Pi/Copilot history indexed by the memex CLI. Use when you want to search history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output.
 ---
 
 # Memex Search
@@ -26,6 +26,7 @@ Use this skill to index local history and retrieve results in a structured way.
   - `--codex/--no-codex` to include or skip Codex logs
   - `--opencode/--no-opencode` to include or skip OpenCode logs
   - `--pi/--no-pi` to include or skip Pi logs
+  - `--copilot/--no-copilot` to include or skip GitHub Copilot CLI logs
   - `--model <minilm|bge|nomic|gemma|potion>` to select embedding model
   - `--root <path>` to change data root (default: `~/.memex`)
 
@@ -38,11 +39,12 @@ memex search "query" --limit 20
 ```
 
 Each JSON line includes:
-- `doc_id`, `ts` (ISO), `session_id`, `project`, `role`, `source_path`
+- `doc_id`, `ts` (ISO), `session_id`, `project`, `role`, `source`, `source_path`
 - `text` (full record text)
 - `snippet` (trimmed single-line summary)
 - `matches` (offsets + before/after context)
 - `score` (ranked score)
+- tree/linkage fields when available: `event_id`, `parent_event_id`, `logical_parent_event_id`, `parent_session_id`, `thread_source`, `conversation_kind`, `parent_tool_use_id`, `source_tool_use_id`, `source_tool_assistant_uuid`
 
 ### Mode decision table
 
@@ -58,7 +60,7 @@ Each JSON line includes:
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>` (search inside a transcript)
-- `--source claude|codex|opencode|pi`
+- `--source claude|codex|cursor|opencode|pi|copilot`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -73,7 +75,7 @@ Each JSON line includes:
 
 - JSONL default (one JSON per line)
 - `--json-array` for a single JSON array
-- `--fields score,ts,doc_id,session_id,snippet` to reduce output
+- `--fields score,ts,doc_id,session_id,snippet,event_id,parent_event_id` to reduce output
 - `-v/--verbose` for human output
 
 ### Background index service (macOS launchd)

--- a/skills/instruction-improver/SKILL.md
+++ b/skills/instruction-improver/SKILL.md
@@ -107,7 +107,7 @@ Use `memex search` to find patterns. Key options:
 - `--top-n-per-session N` - limit N results per session
 - `--limit N` - max total results
 - `--project NAME` - filter by project
-- `--source claude|codex|opencode|pi` - filter by source
+- `--source claude|codex|cursor|opencode|pi|copilot` - filter by source
 - `--since TIMESTAMP` - RFC3339 (2024-01-15T00:00:00Z) or unix seconds
 - `--fields score,ts,session_id,snippet` - select output fields
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memex-search
-description: Search, filter, and retrieve Claude/Codex/OpenCode/Pi history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
+description: Search, filter, and retrieve Claude/Codex/Cursor/OpenCode/Pi/Copilot history indexed by the memex CLI. Use when the user wants to index history, run lexical/semantic/hybrid search, fetch full transcripts, or produce LLM-friendly JSON output for RAG.
 allowed-tools: Bash(memex:*)
 ---
 
@@ -27,6 +27,7 @@ Use this skill to index local history and retrieve results in a structured, LLM-
   - `--codex/--no-codex` to include or skip Codex logs
   - `--opencode/--no-opencode` to include or skip OpenCode logs
   - `--pi/--no-pi` to include or skip Pi logs
+  - `--copilot/--no-copilot` to include or skip GitHub Copilot CLI logs
   - `--model <minilm|bge|nomic|gemma|potion>` to select embedding model
   - `--root <path>` to change data root (default: `~/.memex`)
 
@@ -39,11 +40,12 @@ memex search "query" --limit 20
 ```
 
 Each JSON line includes:
-- `doc_id`, `ts` (ISO), `session_id`, `project`, `role`, `source_path`
+- `doc_id`, `ts` (ISO), `session_id`, `project`, `role`, `source`, `source_path`
 - `text` (full record text)
 - `snippet` (trimmed single-line summary)
 - `matches` (offsets + before/after context)
 - `score` (ranked score)
+- tree/linkage fields when available: `event_id`, `parent_event_id`, `logical_parent_event_id`, `parent_session_id`, `thread_source`, `conversation_kind`, `parent_tool_use_id`, `source_tool_use_id`, `source_tool_assistant_uuid`
 
 ### Mode decision table
 
@@ -59,7 +61,7 @@ Each JSON line includes:
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>` (search inside a transcript)
-- `--source claude|codex|opencode|pi`
+- `--source claude|codex|cursor|opencode|pi|copilot`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -74,7 +76,7 @@ Each JSON line includes:
 
 - JSONL default (one JSON per line)
 - `--json-array` for a single JSON array
-- `--fields score,ts,doc_id,session_id,snippet` to reduce output
+- `--fields score,ts,doc_id,session_id,snippet,event_id,parent_event_id` to reduce output
 - `-v/--verbose` for human output
 
 ### Background index service (macOS launchd)

--- a/skills/opencode/memex-search/SKILL.md
+++ b/skills/opencode/memex-search/SKILL.md
@@ -46,12 +46,16 @@ Output is JSONL (JSON Lines). Each line is a valid JSON object.
 - `doc_id`: Unique record ID.
 - `session_id`: Conversation thread ID.
 - `ts`: ISO 8601 timestamp.
-- `role`: `user`, `assistant`, `system`.
+- `source`: Agent source name.
+- `source_path`: Transcript path.
+- `role`: `user`, `assistant`, `tool_use`, or `tool_result`.
 - `text`: Content payload.
 - `score`: Search relevance (float).
+- `event_id`, `parent_session_id`, `conversation_kind`: Fork/tree metadata when available.
 
 **Interpretation:**
 
 - **Filtering:** Discard results below a relevance threshold (e.g., `score < 0.5`) unless specific.
 - **Ordering:** Sort by `ts` for timeline reconstruction.
 - **Grouping:** Aggregate by `session_id` to view conversation turns.
+- **Forks:** Use `parent_session_id` to connect forked Opencode sessions back to the parent thread.

--- a/skills/pi/memex-search/SKILL.md
+++ b/skills/pi/memex-search/SKILL.md
@@ -44,12 +44,16 @@ Output is JSONL (JSON Lines). Each line is a valid JSON object.
 - `doc_id`: Unique record ID.
 - `session_id`: Conversation thread ID.
 - `ts`: ISO 8601 timestamp.
+- `source`: Agent source name.
+- `source_path`: Transcript path.
 - `role`: `user`, `assistant`, `tool_use`, or `tool_result`.
 - `text`: Content payload.
 - `score`: Search relevance (float).
+- `event_id`, `parent_event_id`, `logical_parent_event_id`, `conversation_kind`: Branch/tree metadata when available.
 
 **Interpretation:**
 
 - **Filtering:** Discard results below a relevance threshold unless the query is specific.
 - **Ordering:** Sort by `ts` for timeline reconstruction.
 - **Grouping:** Aggregate by `session_id` to view conversation turns.
+- **Branches:** Use `parent_event_id` and `logical_parent_event_id` to reconstruct Pi branch points.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_all, ingest_if_stale};
 use crate::tui;
-use crate::types::SourceFilter;
+use crate::types::{RecordLinks, SourceFilter};
 use crate::vector::VectorIndex;
 use anyhow::{Result, anyhow};
 use chrono::SecondsFormat;
@@ -21,7 +21,7 @@ use std::time::Duration;
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, and Pi",
+    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, and Copilot",
     after_help = "\
 QUICK START:
     memex index                     # Index your agent history
@@ -88,7 +88,7 @@ struct IndexArgs {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Index Claude, Codex, Cursor, OpenCode, and Pi conversation history
+    /// Index Claude, Codex, Cursor, OpenCode, Pi, and Copilot conversation history
     #[command(after_help = "\
 EXAMPLES:
     memex index                         # Index all supported local history
@@ -136,7 +136,9 @@ TIMESTAMP FORMAT:
     Unix milliseconds: 1705315800000
 
 OUTPUT FIELDS (--fields):
-    score, ts, doc_id, project, role, session_id, source_path, text, snippet, matches")]
+    score, ts, doc_id, project, role, session_id, source, source_path, text, snippet, matches
+    event_id, parent_event_id, logical_parent_event_id, parent_session_id, thread_source, conversation_kind
+    parent_tool_use_id, source_tool_use_id, source_tool_assistant_uuid")]
     Search {
         /// Search query (keywords or natural language for semantic search)
         query: String,
@@ -152,7 +154,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, or pi
+        /// Filter by source: claude, codex, cursor, opencode, pi, or copilot
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -985,10 +987,13 @@ struct SearchHit {
     project: String,
     role: String,
     session_id: String,
+    source: String,
     source_path: String,
     text: String,
     snippet: String,
     matches: Vec<MatchSpan>,
+    #[serde(flatten)]
+    links: RecordLinks,
 }
 
 fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOptions) -> Result<()> {
@@ -1047,6 +1052,58 @@ fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOpti
             if fields.contains("session_id") {
                 map.insert("session_id".to_string(), Value::from(record.session_id));
             }
+            if fields.contains("source") {
+                map.insert("source".to_string(), Value::from(record.source.label()));
+            }
+            insert_optional_field(&mut map, fields, "event_id", &record.links.event_id);
+            insert_optional_field(
+                &mut map,
+                fields,
+                "parent_event_id",
+                &record.links.parent_event_id,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "logical_parent_event_id",
+                &record.links.logical_parent_event_id,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "parent_session_id",
+                &record.links.parent_session_id,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "thread_source",
+                &record.links.thread_source,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "conversation_kind",
+                &record.links.conversation_kind,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "parent_tool_use_id",
+                &record.links.parent_tool_use_id,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "source_tool_use_id",
+                &record.links.source_tool_use_id,
+            );
+            insert_optional_field(
+                &mut map,
+                fields,
+                "source_tool_assistant_uuid",
+                &record.links.source_tool_assistant_uuid,
+            );
             if fields.contains("source_path") {
                 map.insert("source_path".to_string(), Value::from(record.source_path));
             }
@@ -1068,10 +1125,12 @@ fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOpti
                 project: record.project,
                 role: record.role,
                 session_id: record.session_id,
+                source: record.source.label().to_string(),
                 source_path: record.source_path,
                 text,
                 snippet,
                 matches,
+                links: record.links,
             })?
         };
         if render.json_array {
@@ -1085,6 +1144,19 @@ fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOpti
         println!("{}", serde_json::to_string(&output)?);
     }
     Ok(())
+}
+
+fn insert_optional_field(
+    map: &mut serde_json::Map<String, Value>,
+    fields: &HashSet<String>,
+    name: &str,
+    value: &Option<String>,
+) {
+    if fields.contains(name)
+        && let Some(value) = value
+    {
+        map.insert(name.to_string(), Value::from(value.clone()));
+    }
 }
 
 fn run_session(session_id: String, verbose: bool, root: Option<PathBuf>) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -521,7 +521,7 @@ fn run_index(
         std::fs::remove_dir_all(&paths.root)?;
     }
     paths.ensure_dirs()?;
-    let index = SearchIndex::open_or_create(&paths.index)?;
+    let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
 
     let opts = IngestOptions {
         claude_source: source.unwrap_or_else(default_claude_source),
@@ -692,7 +692,7 @@ fn run_search(
     let scan_cache_ttl = config.scan_cache_ttl();
     if auto_index_on_search {
         paths.ensure_dirs()?;
-        let index = SearchIndex::open_or_create(&paths.index)?;
+        let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
         let opts = IngestOptions {
             claude_source: default_claude_source(),
             include_agents: false,

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,7 @@
-use crate::types::Record;
+use crate::types::{Record, RecordLinks};
 use anyhow::{Result, anyhow};
 use std::ops::Bound;
+use std::path::Path;
 use tantivy::collector::TopDocs;
 use tantivy::query::{AllQuery, BooleanQuery, Occur, Query, RangeQuery, TermQuery};
 use tantivy::schema::Value;
@@ -23,6 +24,15 @@ pub struct IndexFields {
     pub tool_name: Field,
     pub tool_input: Field,
     pub tool_output: Field,
+    pub event_id: Field,
+    pub parent_event_id: Field,
+    pub logical_parent_event_id: Field,
+    pub parent_session_id: Field,
+    pub thread_source: Field,
+    pub conversation_kind: Field,
+    pub parent_tool_use_id: Field,
+    pub source_tool_use_id: Field,
+    pub source_tool_assistant_uuid: Field,
     pub source_path: Field,
 }
 
@@ -46,10 +56,19 @@ pub struct QueryOptions {
 }
 
 impl SearchIndex {
-    pub fn open_or_create(dir: &std::path::Path) -> Result<Self> {
+    pub fn open_or_create(dir: &Path) -> Result<Self> {
         let meta_path = dir.join("meta.json");
         if meta_path.exists() {
             let index = Index::open_in_dir(dir)?;
+            if !schema_is_current(&index.schema()) {
+                drop(index);
+                std::fs::remove_dir_all(dir)?;
+                std::fs::create_dir_all(dir)?;
+                let schema = build_schema()?;
+                let index = Index::create_in_dir(dir, schema.clone())?;
+                let fields = load_fields(schema)?;
+                return Ok(Self { index, fields });
+            }
             let fields = load_fields(index.schema())?;
             Ok(Self { index, fields })
         } else {
@@ -94,6 +113,47 @@ impl SearchIndex {
         if let Some(tool_output) = &record.tool_output {
             doc.add_text(self.fields.tool_output, tool_output);
         }
+        add_optional_text(&mut doc, self.fields.event_id, &record.links.event_id);
+        add_optional_text(
+            &mut doc,
+            self.fields.parent_event_id,
+            &record.links.parent_event_id,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.logical_parent_event_id,
+            &record.links.logical_parent_event_id,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.parent_session_id,
+            &record.links.parent_session_id,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.thread_source,
+            &record.links.thread_source,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.conversation_kind,
+            &record.links.conversation_kind,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.parent_tool_use_id,
+            &record.links.parent_tool_use_id,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.source_tool_use_id,
+            &record.links.source_tool_use_id,
+        );
+        add_optional_text(
+            &mut doc,
+            self.fields.source_tool_assistant_uuid,
+            &record.links.source_tool_assistant_uuid,
+        );
         doc.add_text(self.fields.source_path, &record.source_path);
         writer.add_document(doc)?;
         Ok(())
@@ -200,9 +260,46 @@ fn build_schema() -> Result<Schema> {
     builder.add_text_field("tool_name", STRING | STORED);
     builder.add_text_field("tool_input", TEXT | STORED);
     builder.add_text_field("tool_output", TEXT | STORED);
+    builder.add_text_field("event_id", STRING | STORED);
+    builder.add_text_field("parent_event_id", STRING | STORED);
+    builder.add_text_field("logical_parent_event_id", STRING | STORED);
+    builder.add_text_field("parent_session_id", STRING | STORED);
+    builder.add_text_field("thread_source", STRING | STORED);
+    builder.add_text_field("conversation_kind", STRING | STORED);
+    builder.add_text_field("parent_tool_use_id", STRING | STORED);
+    builder.add_text_field("source_tool_use_id", STRING | STORED);
+    builder.add_text_field("source_tool_assistant_uuid", STRING | STORED);
     builder.add_text_field("source_path", STRING | STORED);
 
     Ok(builder.build())
+}
+
+fn schema_is_current(schema: &Schema) -> bool {
+    [
+        "doc_id",
+        "ts",
+        "project",
+        "session_id",
+        "turn_id",
+        "role",
+        "source",
+        "text",
+        "tool_name",
+        "tool_input",
+        "tool_output",
+        "event_id",
+        "parent_event_id",
+        "logical_parent_event_id",
+        "parent_session_id",
+        "thread_source",
+        "conversation_kind",
+        "parent_tool_use_id",
+        "source_tool_use_id",
+        "source_tool_assistant_uuid",
+        "source_path",
+    ]
+    .into_iter()
+    .all(|field| schema.get_field(field).is_ok())
 }
 
 fn load_fields(schema: Schema) -> Result<IndexFields> {
@@ -223,6 +320,15 @@ fn load_fields(schema: Schema) -> Result<IndexFields> {
         tool_name: get("tool_name")?,
         tool_input: get("tool_input")?,
         tool_output: get("tool_output")?,
+        event_id: get("event_id")?,
+        parent_event_id: get("parent_event_id")?,
+        logical_parent_event_id: get("logical_parent_event_id")?,
+        parent_session_id: get("parent_session_id")?,
+        thread_source: get("thread_source")?,
+        conversation_kind: get("conversation_kind")?,
+        parent_tool_use_id: get("parent_tool_use_id")?,
+        source_tool_use_id: get("source_tool_use_id")?,
+        source_tool_assistant_uuid: get("source_tool_assistant_uuid")?,
         source_path: get("source_path")?,
     })
 }
@@ -326,6 +432,23 @@ fn record_from_doc(fields: &IndexFields, doc: &TantivyDocument) -> Record {
         tool_name: get_str(fields.tool_name),
         tool_input: get_str(fields.tool_input),
         tool_output: get_str(fields.tool_output),
+        links: RecordLinks {
+            event_id: get_str(fields.event_id),
+            parent_event_id: get_str(fields.parent_event_id),
+            logical_parent_event_id: get_str(fields.logical_parent_event_id),
+            parent_session_id: get_str(fields.parent_session_id),
+            thread_source: get_str(fields.thread_source),
+            conversation_kind: get_str(fields.conversation_kind),
+            parent_tool_use_id: get_str(fields.parent_tool_use_id),
+            source_tool_use_id: get_str(fields.source_tool_use_id),
+            source_tool_assistant_uuid: get_str(fields.source_tool_assistant_uuid),
+        },
         source_path,
+    }
+}
+
+fn add_optional_text(doc: &mut TantivyDocument, field: Field, value: &Option<String>) {
+    if let Some(value) = value {
+        doc.add_text(field, value);
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -57,25 +57,33 @@ pub struct QueryOptions {
 
 impl SearchIndex {
     pub fn open_or_create(dir: &Path) -> Result<Self> {
+        Self::open_or_create_with_policy(dir, StaleSchemaPolicy::Error)
+    }
+
+    pub fn open_or_create_for_ingest(dir: &Path) -> Result<Self> {
+        Self::open_or_create_with_policy(dir, StaleSchemaPolicy::Recreate)
+    }
+
+    fn open_or_create_with_policy(
+        dir: &Path,
+        stale_schema_policy: StaleSchemaPolicy,
+    ) -> Result<Self> {
         let meta_path = dir.join("meta.json");
         if meta_path.exists() {
             let index = Index::open_in_dir(dir)?;
             if !schema_is_current(&index.schema()) {
-                drop(index);
-                std::fs::remove_dir_all(dir)?;
-                std::fs::create_dir_all(dir)?;
-                let schema = build_schema()?;
-                let index = Index::create_in_dir(dir, schema.clone())?;
-                let fields = load_fields(schema)?;
-                return Ok(Self { index, fields });
+                return match stale_schema_policy {
+                    StaleSchemaPolicy::Error => Err(stale_schema_error(dir)),
+                    StaleSchemaPolicy::Recreate => {
+                        drop(index);
+                        recreate_index_dir(dir)
+                    }
+                };
             }
             let fields = load_fields(index.schema())?;
             Ok(Self { index, fields })
         } else {
-            let schema = build_schema()?;
-            let index = Index::create_in_dir(dir, schema.clone())?;
-            let fields = load_fields(schema)?;
-            Ok(Self { index, fields })
+            create_index_in_dir(dir)
         }
     }
 
@@ -236,6 +244,32 @@ impl SearchIndex {
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StaleSchemaPolicy {
+    Error,
+    Recreate,
+}
+
+fn stale_schema_error(dir: &Path) -> anyhow::Error {
+    anyhow!(
+        "index schema at {} is stale; run `memex index` or `memex reindex` to rebuild it",
+        dir.display()
+    )
+}
+
+fn recreate_index_dir(dir: &Path) -> Result<SearchIndex> {
+    std::fs::remove_dir_all(dir)?;
+    std::fs::create_dir_all(dir)?;
+    create_index_in_dir(dir)
+}
+
+fn create_index_in_dir(dir: &Path) -> Result<SearchIndex> {
+    let schema = build_schema()?;
+    let index = Index::create_in_dir(dir, schema.clone())?;
+    let fields = load_fields(schema)?;
+    Ok(SearchIndex { index, fields })
 }
 
 fn build_schema() -> Result<Schema> {
@@ -450,5 +484,58 @@ fn record_from_doc(fields: &IndexFields, doc: &TantivyDocument) -> Record {
 fn add_optional_text(doc: &mut TantivyDocument, field: Field, value: &Option<String>) {
     if let Some(value) = value {
         doc.add_text(field, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_stale_schema_index(dir: &Path) {
+        let mut builder = SchemaBuilder::default();
+        builder.add_u64_field("doc_id", INDEXED | STORED);
+        builder.add_u64_field("ts", FAST | STORED | INDEXED);
+        builder.add_text_field("project", STRING | STORED);
+        builder.add_text_field("session_id", STRING | STORED);
+        builder.add_u64_field("turn_id", FAST | STORED);
+        builder.add_text_field("role", STRING | STORED);
+        builder.add_text_field("source", STRING | STORED);
+        builder.add_text_field("text", TEXT | STORED);
+        builder.add_text_field("tool_name", STRING | STORED);
+        builder.add_text_field("tool_input", TEXT | STORED);
+        builder.add_text_field("tool_output", TEXT | STORED);
+        builder.add_text_field("source_path", STRING | STORED);
+
+        let index = Index::create_in_dir(dir, builder.build()).expect("create stale index");
+        drop(index);
+        std::fs::write(dir.join("sentinel"), "keep").expect("write sentinel");
+    }
+
+    #[test]
+    fn read_only_open_preserves_stale_schema_index() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        create_stale_schema_index(tmp.path());
+
+        let err = match SearchIndex::open_or_create(tmp.path()) {
+            Ok(_) => panic!("stale index unexpectedly opened"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("index schema"));
+        assert!(tmp.path().join("meta.json").exists());
+        assert!(tmp.path().join("sentinel").exists());
+    }
+
+    #[test]
+    fn ingest_open_recreates_stale_schema_index() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        create_stale_schema_index(tmp.path());
+
+        let index =
+            SearchIndex::open_or_create_for_ingest(tmp.path()).expect("recreate stale index");
+
+        assert_eq!(index.doc_count().expect("doc count"), 0);
+        assert!(tmp.path().join("meta.json").exists());
+        assert!(!tmp.path().join("sentinel").exists());
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -3,7 +3,7 @@ use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::SearchIndex;
 use crate::progress::{Progress, SOURCE_COUNT};
 use crate::state::{FileState, IngestState, ScanCache};
-use crate::types::{Record, SourceKind};
+use crate::types::{Record, RecordLinks, SourceKind};
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -102,6 +102,13 @@ pub fn ingest_all(
 ) -> Result<IngestReport> {
     let state_path = paths.state.join("ingest.json");
     let mut state = IngestState::load(&state_path)?;
+    if index.doc_count()? == 0 && !state.files.is_empty() {
+        state = IngestState::default();
+        if paths.vectors.exists() {
+            std::fs::remove_dir_all(&paths.vectors)?;
+            std::fs::create_dir_all(&paths.vectors)?;
+        }
+    }
     let next_doc_id = Arc::new(AtomicU64::new(state.next_doc_id));
 
     let mut tasks = Vec::new();
@@ -525,6 +532,9 @@ fn can_skip_fresh_scan(
     options: &IngestOptions,
     ttl_seconds: u64,
 ) -> Result<bool> {
+    if index.doc_count()? == 0 {
+        return Ok(false);
+    }
     if !cache.is_fresh(ttl_seconds) {
         return Ok(false);
     }
@@ -642,16 +652,9 @@ fn writer_loop(
 
     // Flush any remaining index progress
     for (idx, &pending) in index_pending.iter().enumerate() {
-        if pending > 0 {
-            let source = match idx {
-                0 => SourceKind::Claude,
-                1 => SourceKind::CodexSession,
-                2 => SourceKind::CodexHistory,
-                3 => SourceKind::Opencode,
-                4 => SourceKind::Cursor,
-                5 => SourceKind::Pi,
-                _ => SourceKind::Copilot,
-            };
+        if pending > 0
+            && let Some(source) = SourceKind::from_idx(idx)
+        {
             progress.add_indexed(source, pending);
         }
     }
@@ -912,6 +915,63 @@ fn opencode_parts_root() -> PathBuf {
         .join("part")
 }
 
+fn opencode_session_links(session_id: &str) -> SessionLinks {
+    opencode_session_links_from_root(&opencode_storage_root().join("session"), session_id)
+}
+
+fn opencode_session_links_from_root(root: &Path, session_id: &str) -> SessionLinks {
+    if !root.exists() {
+        return SessionLinks {
+            conversation_kind: Some("main".to_string()),
+            ..SessionLinks::default()
+        };
+    }
+    let needle = format!("{session_id}.json");
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name().to_str() != Some(needle.as_str()) {
+            continue;
+        }
+        let Ok(file) = File::open(entry.path()) else {
+            continue;
+        };
+        let reader = std::io::BufReader::new(file);
+        let Ok(value) = serde_json::from_reader::<_, serde_json::Value>(reader) else {
+            continue;
+        };
+        let parent_session_id = value
+            .get("parentID")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        return SessionLinks {
+            conversation_kind: Some(if parent_session_id.is_some() {
+                "fork".to_string()
+            } else {
+                "main".to_string()
+            }),
+            thread_source: parent_session_id.as_ref().map(|_| "fork".to_string()),
+            parent_session_id,
+        };
+    }
+    SessionLinks {
+        conversation_kind: Some("main".to_string()),
+        ..SessionLinks::default()
+    }
+}
+
+fn opencode_storage_root() -> PathBuf {
+    let home = directories::BaseDirs::new()
+        .map(|b| b.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".local")
+        .join("share")
+        .join("opencode")
+        .join("storage")
+}
+
 fn codex_history_path() -> PathBuf {
     codex_root().join("history.jsonl")
 }
@@ -974,6 +1034,130 @@ fn resolve_pi_settings_path(raw: &str, base: &Path) -> PathBuf {
     }
 }
 
+#[derive(Clone, Default)]
+struct SessionLinks {
+    parent_session_id: Option<String>,
+    thread_source: Option<String>,
+    conversation_kind: Option<String>,
+}
+
+impl SessionLinks {
+    fn record_links(&self) -> RecordLinks {
+        RecordLinks {
+            parent_session_id: self.parent_session_id.clone(),
+            thread_source: self.thread_source.clone(),
+            conversation_kind: self.conversation_kind.clone(),
+            ..RecordLinks::default()
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CodexSessionMeta {
+    session_id: String,
+    project: String,
+    links: SessionLinks,
+}
+
+fn codex_session_meta_from_path(path: &Path) -> CodexSessionMeta {
+    CodexSessionMeta {
+        session_id: session_id_from_filename(path).unwrap_or_else(|| "unknown".to_string()),
+        project: "codex".to_string(),
+        links: SessionLinks {
+            conversation_kind: Some("main".to_string()),
+            ..SessionLinks::default()
+        },
+    }
+}
+
+fn read_codex_session_meta_until(path: &Path, limit: u64) -> Result<CodexSessionMeta> {
+    let mut meta = codex_session_meta_from_path(path);
+    if limit == 0 {
+        return Ok(meta);
+    }
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = 0usize;
+    let limit = (limit as usize).min(mmap.len());
+    let mut buf = Vec::new();
+    while start < limit {
+        let slice = &mmap[start..limit];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + 1;
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(|v| v.as_str()) == Some("session_meta")
+            && let Some(payload) = value.get("payload").and_then(|v| v.as_object())
+        {
+            apply_codex_session_meta(payload, &mut meta);
+        }
+    }
+    Ok(meta)
+}
+
+fn apply_codex_session_meta(payload: &simd_json::borrowed::Object, meta: &mut CodexSessionMeta) {
+    if let Some(id) = payload.get("id").and_then(|v| v.as_str()) {
+        meta.session_id = id.to_string();
+    }
+    if let Some(cwd) = payload.get("cwd").and_then(|v| v.as_str()) {
+        meta.project = project_from_path(cwd);
+    }
+
+    let forked_from_id = payload
+        .get("forked_from_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let parent_thread_id = payload
+        .get("source")
+        .and_then(|v| v.as_object())
+        .and_then(|source| source.get("subagent"))
+        .and_then(|v| v.as_object())
+        .and_then(|subagent| subagent.get("thread_spawn"))
+        .and_then(|v| v.as_object())
+        .and_then(|spawn| spawn.get("parent_thread_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let thread_source = payload
+        .get("thread_source")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| parent_thread_id.as_ref().map(|_| "subagent".to_string()))
+        .or_else(|| forked_from_id.as_ref().map(|_| "fork".to_string()));
+
+    meta.links.parent_session_id = forked_from_id.clone().or(parent_thread_id);
+    meta.links.thread_source = thread_source.clone();
+    meta.links.conversation_kind = Some(if thread_source.as_deref() == Some("subagent") {
+        "subagent".to_string()
+    } else if forked_from_id.is_some() {
+        "fork".to_string()
+    } else {
+        "main".to_string()
+    });
+}
+
+fn opt_str(obj: &simd_json::borrowed::Object, key: &str) -> Option<String> {
+    obj.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn pi_base_links(obj: &simd_json::borrowed::Object, conversation_kind: &str) -> RecordLinks {
+    RecordLinks {
+        event_id: opt_str(obj, "id"),
+        parent_event_id: opt_str(obj, "parentId"),
+        logical_parent_event_id: opt_str(obj, "fromId"),
+        thread_source: (conversation_kind != "main").then(|| conversation_kind.to_string()),
+        conversation_kind: Some(conversation_kind.to_string()),
+        ..RecordLinks::default()
+    }
+}
+
 fn parse_claude_file(
     task: &FileTask,
     tx_record: &Sender<Record>,
@@ -993,6 +1177,11 @@ fn parse_claude_file(
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string();
+    let is_agent_file = session_id.starts_with("agent-")
+        || task
+            .path
+            .components()
+            .any(|component| component.as_os_str().to_str() == Some("subagents"));
     let source_path = task.path.to_string_lossy().to_string();
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
 
@@ -1026,6 +1215,37 @@ fn parse_claude_file(
         if entry_type != "user" && entry_type != "assistant" {
             continue;
         }
+        let entry_uuid = opt_str(obj, "uuid");
+        let entry_parent_uuid = opt_str(obj, "parentUuid");
+        let is_sidechain = obj
+            .get("isSidechain")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let conversation_kind = if is_agent_file {
+            "subagent"
+        } else if is_sidechain {
+            "sidechain"
+        } else {
+            "main"
+        };
+        let thread_source = if is_agent_file {
+            Some("subagent".to_string())
+        } else if is_sidechain {
+            Some("sidechain".to_string())
+        } else {
+            None
+        };
+        let entry_links = RecordLinks {
+            event_id: entry_uuid.clone(),
+            parent_event_id: entry_parent_uuid,
+            logical_parent_event_id: opt_str(obj, "logicalParentUuid"),
+            parent_session_id: is_agent_file.then(|| opt_str(obj, "sessionId")).flatten(),
+            thread_source,
+            conversation_kind: Some(conversation_kind.to_string()),
+            parent_tool_use_id: opt_str(obj, "parentToolUseID"),
+            source_tool_use_id: opt_str(obj, "sourceToolUseID"),
+            source_tool_assistant_uuid: opt_str(obj, "sourceToolAssistantUUID"),
+        };
         let timestamp = obj
             .get("timestamp")
             .and_then(|v| v.as_str())
@@ -1064,6 +1284,11 @@ fn parse_claude_file(
                         }
                         let tool_input = block_obj.get("input").map(|v| v.to_string());
                         let text = tool_input.clone().unwrap_or_default();
+                        let mut links = entry_links.clone();
+                        if let Some(tool_id) = block_obj.get("id").and_then(|v| v.as_str()) {
+                            links.event_id = Some(tool_id.to_string());
+                            links.parent_event_id = entry_uuid.clone();
+                        }
                         let record = Record {
                             source: SourceKind::Claude,
                             doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -1076,6 +1301,7 @@ fn parse_claude_file(
                             tool_name,
                             tool_input,
                             tool_output: None,
+                            links,
                             source_path: source_path.clone(),
                         };
                         progress.add_produced(SourceKind::Claude, 1);
@@ -1108,6 +1334,18 @@ fn parse_claude_file(
                         .and_then(|v| v.as_str())
                         .and_then(|id| tool_id_to_name.get(id))
                         .cloned();
+                    let tool_use_id = block_obj
+                        .get("tool_use_id")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    let mut links = entry_links.clone();
+                    if let Some(tool_use_id) = &tool_use_id {
+                        links.event_id = entry_uuid
+                            .as_ref()
+                            .map(|uuid| format!("{uuid}:tool_result:{tool_use_id}"));
+                        links.parent_event_id = Some(tool_use_id.clone());
+                        links.parent_tool_use_id = Some(tool_use_id.clone());
+                    }
                     let record = Record {
                         source: SourceKind::Claude,
                         doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -1120,6 +1358,7 @@ fn parse_claude_file(
                         tool_name,
                         tool_input: None,
                         tool_output,
+                        links,
                         source_path: source_path.clone(),
                     };
                     progress.add_produced(SourceKind::Claude, 1);
@@ -1143,6 +1382,7 @@ fn parse_claude_file(
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: entry_links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::Claude, 1);
@@ -1182,9 +1422,7 @@ fn parse_codex_session(
     let mut turn_id = task.turn_id;
 
     let source_path = task.path.to_string_lossy().to_string();
-    let mut session_id =
-        session_id_from_filename(&task.path).unwrap_or_else(|| "unknown".to_string());
-    let mut project = "codex".to_string();
+    let mut meta = read_codex_session_meta_until(&task.path, task.offset)?;
     let mut call_id_to_name: HashMap<String, String> = HashMap::new();
 
     let mut buf = Vec::new();
@@ -1221,12 +1459,7 @@ fn parse_codex_session(
             .unwrap_or(0);
         if entry_type == "session_meta" {
             if let Some(payload) = obj.get("payload").and_then(|v| v.as_object()) {
-                if let Some(id) = payload.get("id").and_then(|v| v.as_str()) {
-                    session_id = id.to_string();
-                }
-                if let Some(cwd) = payload.get("cwd").and_then(|v| v.as_str()) {
-                    project = project_from_path(cwd);
-                }
+                apply_codex_session_meta(payload, &mut meta);
             }
             continue;
         }
@@ -1238,6 +1471,8 @@ fn parse_codex_session(
             None => continue,
         };
         let payload_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let mut base_links = meta.links.record_links();
+        base_links.event_id = opt_str(payload, "id");
         if payload_type == "message" {
             let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("");
             let content = payload.get("content");
@@ -1266,14 +1501,15 @@ fn parse_codex_session(
                 source: SourceKind::CodexSession,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                 ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
+                project: meta.project.clone(),
+                session_id: meta.session_id.clone(),
                 turn_id,
                 role: role.to_string(),
                 text,
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: base_links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::CodexSession, 1);
@@ -1294,18 +1530,23 @@ fn parse_codex_session(
                 call_id_to_name.insert(call_id.to_string(), name);
             }
             let text = tool_input.clone().unwrap_or_default();
+            let mut links = base_links;
+            if let Some(call_id) = payload.get("call_id").and_then(|v| v.as_str()) {
+                links.event_id = Some(call_id.to_string());
+            }
             let record = Record {
                 source: SourceKind::CodexSession,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                 ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
+                project: meta.project.clone(),
+                session_id: meta.session_id.clone(),
                 turn_id,
                 role: "tool_use".to_string(),
                 text,
                 tool_name,
                 tool_input,
                 tool_output: None,
+                links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::CodexSession, 1);
@@ -1325,18 +1566,24 @@ fn parse_codex_session(
             if text.is_empty() {
                 continue;
             }
+            let mut links = base_links;
+            if !call_id.is_empty() {
+                links.parent_event_id = Some(call_id.to_string());
+                links.parent_tool_use_id = Some(call_id.to_string());
+            }
             let record = Record {
                 source: SourceKind::CodexSession,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                 ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
+                project: meta.project.clone(),
+                session_id: meta.session_id.clone(),
                 turn_id,
                 role: "tool_result".to_string(),
                 text,
                 tool_name,
                 tool_input: None,
                 tool_output,
+                links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::CodexSession, 1);
@@ -1358,7 +1605,7 @@ fn parse_codex_session(
     tx_update.send(FileUpdate {
         path: source_path,
         state,
-        session_id: Some(session_id),
+        session_id: Some(meta.session_id),
     })?;
     Ok(())
 }
@@ -1429,6 +1676,10 @@ fn parse_codex_history(
             tool_name: None,
             tool_input: None,
             tool_output: None,
+            links: RecordLinks {
+                conversation_kind: Some("main".to_string()),
+                ..RecordLinks::default()
+            },
             source_path: source_path.clone(),
         };
         progress.add_produced(SourceKind::CodexHistory, 1);
@@ -1468,6 +1719,7 @@ fn parse_opencode_file(
         .unwrap_or("unknown")
         .to_string();
     let project = "opencode".to_string();
+    let session_links = opencode_session_links(&session_id);
 
     let mut messages = Vec::new();
     for entry in std::fs::read_dir(session_dir)? {
@@ -1537,6 +1789,8 @@ fn parse_opencode_file(
         }
 
         let text = text_parts.join("\n");
+        let mut links = session_links.record_links();
+        links.event_id = Some(msg_id.clone());
         let record = Record {
             source: SourceKind::Opencode,
             doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -1549,6 +1803,7 @@ fn parse_opencode_file(
             tool_name: None,
             tool_input: None,
             tool_output: None,
+            links,
             source_path: session_dir.to_string_lossy().to_string(),
         };
         progress.add_produced(SourceKind::Opencode, 1);
@@ -1655,6 +1910,7 @@ fn parse_cursor_file(
                             tool_name,
                             tool_input,
                             tool_output: None,
+                            links: cursor_record_links(&task.path, &session_id, turn_id),
                             source_path: source_path.clone(),
                         };
                         progress.add_produced(SourceKind::Cursor, 1);
@@ -1683,6 +1939,7 @@ fn parse_cursor_file(
                             tool_name: None,
                             tool_input: None,
                             tool_output,
+                            links: cursor_record_links(&task.path, &session_id, turn_id),
                             source_path: source_path.clone(),
                         };
                         progress.add_produced(SourceKind::Cursor, 1);
@@ -1707,6 +1964,7 @@ fn parse_cursor_file(
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: cursor_record_links(&task.path, &session_id, turn_id),
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::Cursor, 1);
@@ -1797,6 +2055,12 @@ fn parse_pi_file(
             .and_then(|v| v.as_str())
             .and_then(parse_iso_millis)
             .unwrap_or(0);
+        let conversation_kind = match entry_type {
+            "branch_summary" => "branch",
+            "compaction" => "compaction",
+            _ => "main",
+        };
+        let mut base_links = pi_base_links(obj, conversation_kind);
 
         if entry_type == "session" {
             apply_pi_session_header(obj, &mut session_id, &mut project);
@@ -1824,6 +2088,7 @@ fn parse_pi_file(
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: base_links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::Pi, 1);
@@ -1855,6 +2120,7 @@ fn parse_pi_file(
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: base_links,
                 source_path: source_path.clone(),
             };
             progress.add_produced(SourceKind::Pi, 1);
@@ -1880,6 +2146,19 @@ fn parse_pi_file(
             timestamp
         };
         let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if conversation_kind == "main" {
+            match role {
+                "branchSummary" => {
+                    base_links.thread_source = Some("branch".to_string());
+                    base_links.conversation_kind = Some("branch".to_string());
+                }
+                "compactionSummary" => {
+                    base_links.thread_source = Some("compaction".to_string());
+                    base_links.conversation_kind = Some("compaction".to_string());
+                }
+                _ => {}
+            }
+        }
 
         match role {
             "user" | "assistant" => {
@@ -1905,6 +2184,11 @@ fn parse_pi_file(
                             tool_id_to_name.insert(id.to_string(), name);
                         }
                         let tool_input = block_obj.get("arguments").map(|v| v.to_string());
+                        let mut links = base_links.clone();
+                        if let Some(tool_call_id) = block_obj.get("id").and_then(|v| v.as_str()) {
+                            links.event_id = Some(tool_call_id.to_string());
+                            links.parent_event_id = base_links.event_id.clone();
+                        }
                         let record = Record {
                             source: SourceKind::Pi,
                             doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -1917,6 +2201,7 @@ fn parse_pi_file(
                             tool_name,
                             tool_input,
                             tool_output: None,
+                            links,
                             source_path: source_path.clone(),
                         };
                         progress.add_produced(SourceKind::Pi, 1);
@@ -1941,6 +2226,7 @@ fn parse_pi_file(
                     tool_name: None,
                     tool_input: None,
                     tool_output: None,
+                    links: base_links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Pi, 1);
@@ -1962,6 +2248,10 @@ fn parse_pi_file(
                 if text.trim().is_empty() {
                     continue;
                 }
+                let mut links = base_links;
+                if !tool_call_id.is_empty() {
+                    links.parent_tool_use_id = Some(tool_call_id.to_string());
+                }
                 let record = Record {
                     source: SourceKind::Pi,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -1974,6 +2264,7 @@ fn parse_pi_file(
                     tool_name,
                     tool_input: None,
                     tool_output,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Pi, 1);
@@ -2023,6 +2314,7 @@ fn parse_pi_file(
                     } else {
                         Some(output)
                     },
+                    links: base_links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Pi, 1);
@@ -2046,6 +2338,7 @@ fn parse_pi_file(
                     tool_name: None,
                     tool_input: None,
                     tool_output: None,
+                    links: base_links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Pi, 1);
@@ -2202,6 +2495,7 @@ fn parse_copilot_session(
                 if text.trim().is_empty() {
                     continue;
                 }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
                 let record = Record {
                     source: SourceKind::Copilot,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -2214,6 +2508,7 @@ fn parse_copilot_session(
                     tool_name: None,
                     tool_input: None,
                     tool_output: None,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Copilot, 1);
@@ -2228,6 +2523,7 @@ fn parse_copilot_session(
                 if text.trim().is_empty() {
                     continue;
                 }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
                 let record = Record {
                     source: SourceKind::Copilot,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -2240,6 +2536,7 @@ fn parse_copilot_session(
                     tool_name: None,
                     tool_input: None,
                     tool_output: None,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Copilot, 1);
@@ -2262,6 +2559,10 @@ fn parse_copilot_session(
                     .map(json_to_text)
                     .filter(|s| !s.is_empty());
                 let text = tool_input.clone().unwrap_or_default();
+                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
+                if let Some(call_id) = data.get("toolCallId").and_then(|v| v.as_str()) {
+                    links.event_id = Some(call_id.to_string());
+                }
                 let record = Record {
                     source: SourceKind::Copilot,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -2274,6 +2575,7 @@ fn parse_copilot_session(
                     tool_name,
                     tool_input,
                     tool_output: None,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Copilot, 1);
@@ -2296,6 +2598,11 @@ fn parse_copilot_session(
                 if text.trim().is_empty() {
                     continue;
                 }
+                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
+                if !call_id.is_empty() {
+                    links.parent_event_id = Some(call_id.to_string());
+                    links.parent_tool_use_id = Some(call_id.to_string());
+                }
                 let record = Record {
                     source: SourceKind::Copilot,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -2308,6 +2615,7 @@ fn parse_copilot_session(
                     tool_name,
                     tool_input: None,
                     tool_output,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Copilot, 1);
@@ -2322,6 +2630,7 @@ fn parse_copilot_session(
                 if text.trim().is_empty() {
                     continue;
                 }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
                 let record = Record {
                     source: SourceKind::Copilot,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -2334,6 +2643,7 @@ fn parse_copilot_session(
                     tool_name: None,
                     tool_input: None,
                     tool_output: None,
+                    links,
                     source_path: source_path.clone(),
                 };
                 progress.add_produced(SourceKind::Copilot, 1);
@@ -2450,6 +2760,86 @@ fn session_id_from_copilot_path(path: &Path) -> Option<String> {
         .and_then(|s| s.to_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
+}
+
+fn copilot_record_links(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    data: &serde_json::Value,
+    session_id: &str,
+    turn_id: u32,
+) -> RecordLinks {
+    let parent_session_id = copilot_string_field(data, obj, COPILOT_PARENT_SESSION_KEYS);
+    let explicit_thread_source =
+        copilot_string_field(data, obj, &["threadSource", "thread_source", "source"]);
+    let thread_source = explicit_thread_source.or_else(|| {
+        parent_session_id
+            .as_ref()
+            .filter(|parent| parent.as_str() != session_id)
+            .map(|_| "fork".to_string())
+    });
+    let conversation_kind = match thread_source.as_deref() {
+        Some("subagent") => "subagent",
+        Some("sidechain") => "sidechain",
+        Some("branch") => "branch",
+        Some("fork") => "fork",
+        _ => "main",
+    };
+
+    RecordLinks {
+        event_id: copilot_string_field(data, obj, COPILOT_EVENT_KEYS)
+            .or_else(|| Some(format!("{session_id}:{turn_id}"))),
+        parent_event_id: copilot_string_field(data, obj, COPILOT_PARENT_EVENT_KEYS),
+        logical_parent_event_id: copilot_string_field(data, obj, COPILOT_LOGICAL_PARENT_KEYS),
+        parent_session_id,
+        thread_source,
+        conversation_kind: Some(conversation_kind.to_string()),
+        ..RecordLinks::default()
+    }
+}
+
+const COPILOT_EVENT_KEYS: &[&str] = &[
+    "id",
+    "eventId",
+    "event_id",
+    "messageId",
+    "message_id",
+    "requestId",
+    "request_id",
+    "responseId",
+    "response_id",
+];
+const COPILOT_PARENT_EVENT_KEYS: &[&str] = &[
+    "parentId",
+    "parent_id",
+    "parentMessageId",
+    "parent_message_id",
+    "parentEventId",
+    "parent_event_id",
+];
+const COPILOT_LOGICAL_PARENT_KEYS: &[&str] = &["fromId", "from_id", "rootId", "root_id"];
+const COPILOT_PARENT_SESSION_KEYS: &[&str] = &[
+    "parentSessionId",
+    "parent_session_id",
+    "forkedFromSessionId",
+    "forked_from_session_id",
+];
+
+fn copilot_string_field(
+    data: &serde_json::Value,
+    obj: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    for key in keys {
+        if let Some(value) = data
+            .get(*key)
+            .or_else(|| obj.get(*key))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
 }
 
 fn json_timestamp_millis(value: &serde_json::Value) -> Option<u64> {
@@ -2590,6 +2980,30 @@ fn cursor_subagent_turn_base(path: &Path) -> Option<u32> {
         .filter(|s| !s.is_empty())?;
     let bucket = stable_cursor_turn_bucket(agent_id);
     Some(CURSOR_SUBAGENT_TURN_BASE + bucket.saturating_mul(CURSOR_SUBAGENT_TURN_STRIDE))
+}
+
+fn cursor_is_subagent_transcript(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str().to_str() == Some("subagents"))
+}
+
+fn cursor_transcript_id(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn cursor_record_links(path: &Path, session_id: &str, turn_id: u32) -> RecordLinks {
+    let is_subagent = cursor_is_subagent_transcript(path);
+    RecordLinks {
+        event_id: Some(format!("{}:{turn_id}", cursor_transcript_id(path))),
+        parent_session_id: is_subagent.then(|| session_id.to_string()),
+        thread_source: is_subagent.then(|| "subagent".to_string()),
+        conversation_kind: Some(if is_subagent { "subagent" } else { "main" }.to_string()),
+        ..RecordLinks::default()
+    }
 }
 
 fn stable_cursor_turn_bucket(value: &str) -> u32 {
@@ -2921,6 +3335,7 @@ mod tests {
             tool_name: None,
             tool_input: None,
             tool_output: None,
+            links: RecordLinks::default(),
             source_path: format!("source-{doc_id}.jsonl"),
         }
     }
@@ -3004,6 +3419,161 @@ mod tests {
     }
 
     #[test]
+    fn cursor_record_links_mark_subagent_parent_session() {
+        let path = Path::new(
+            "/Users/nico/.cursor/projects/-Users-nico-Code-memex/agent-transcripts/\
+             11111111-1111-1111-1111-111111111111/subagents/\
+             22222222-2222-2222-2222-222222222222.jsonl",
+        );
+
+        let links = cursor_record_links(path, "11111111-1111-1111-1111-111111111111", 42);
+
+        assert_eq!(
+            links.event_id.as_deref(),
+            Some("22222222-2222-2222-2222-222222222222:42")
+        );
+        assert_eq!(
+            links.parent_session_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        assert_eq!(links.thread_source.as_deref(), Some("subagent"));
+        assert_eq!(links.conversation_kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn opencode_session_links_preserve_parent_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).expect("create opencode project");
+        fs::write(
+            project.join("ses_child.json"),
+            r#"{"id":"ses_child","parentID":"ses_parent","projectID":"global"}"#,
+        )
+        .expect("write opencode session");
+
+        let links = opencode_session_links_from_root(tmp.path(), "ses_child");
+
+        assert_eq!(links.parent_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(links.thread_source.as_deref(), Some("fork"));
+        assert_eq!(links.conversation_kind.as_deref(), Some("fork"));
+    }
+
+    #[test]
+    fn codex_session_meta_preserves_fork_and_subagent_links() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-22T13-17-11-019e5155-b507-7d83-8c3d-9ecee5f93f12.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":"2026-05-22T20:17:12.595Z","type":"session_meta","payload":{"id":"019e5155-b507-7d83-8c3d-9ecee5f93f12","forked_from_id":"019e5117-c673-7660-b218-af0489416e0f","cwd":"/tmp/project","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019e5117-c673-7660-b218-af0489416e0f","depth":1}}},"thread_source":"subagent"}}"#
+                .to_string()
+                + "\n",
+        )
+        .expect("write codex session");
+
+        let meta = read_codex_session_meta_until(&path, fs::metadata(&path).unwrap().len())
+            .expect("read codex meta");
+
+        assert_eq!(meta.session_id, "019e5155-b507-7d83-8c3d-9ecee5f93f12");
+        assert_eq!(meta.project, "project");
+        assert_eq!(
+            meta.links.parent_session_id.as_deref(),
+            Some("019e5117-c673-7660-b218-af0489416e0f")
+        );
+        assert_eq!(meta.links.thread_source.as_deref(), Some("subagent"));
+        assert_eq!(meta.links.conversation_kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn ingest_claude_records_preserve_sidechain_and_tool_links() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_root = tmp.path().join("claude-projects");
+        let project_root = claude_root.join("-Users-nico-Code-memex");
+        fs::create_dir_all(&project_root).expect("create claude project");
+        let session_file = project_root.join("sess-claude.jsonl");
+        fs::write(
+            &session_file,
+            r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"sess-claude","isSidechain":false,"timestamp":"2026-03-11T01:23:43.844Z","message":{"content":"question"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","logicalParentUuid":"u0","sessionId":"sess-claude","isSidechain":true,"sourceToolUseID":"source-tool","sourceToolAssistantUUID":"source-assistant","timestamp":"2026-03-11T01:23:44.844Z","message":{"content":[{"type":"text","text":"answer"},{"type":"tool_use","id":"tool-claude","name":"Read","input":{"file_path":"Cargo.toml"}}]}}
+{"type":"user","uuid":"r1","parentUuid":"a1","sessionId":"sess-claude","isSidechain":true,"timestamp":"2026-03-11T01:23:45.844Z","message":{"content":[{"type":"tool_result","tool_use_id":"tool-claude","content":"ok"}]}}
+"#,
+        )
+        .expect("write claude fixture");
+
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        paths.ensure_dirs().expect("ensure dirs");
+        let index = SearchIndex::open_or_create(&paths.index).expect("index");
+        let options = IngestOptions {
+            claude_source: claude_root,
+            include_agents: false,
+            include_codex: false,
+            include_opencode: false,
+            include_cursor: false,
+            include_pi: false,
+            include_copilot: false,
+            embeddings: false,
+            backfill_embeddings: false,
+            model: ModelChoice::default(),
+            embed_runtime: EmbedRuntimeConfig::default(),
+        };
+
+        let report = ingest_all(&paths, &index, &options).expect("ingest");
+        assert_eq!(report.records_added, 4);
+
+        let mut records = index
+            .records_by_session_id("sess-claude")
+            .expect("records by session");
+        records.sort_by_key(|record| record.turn_id);
+
+        assert_eq!(records.len(), 4);
+        assert_eq!(records[0].role, "user");
+        assert_eq!(records[0].links.event_id.as_deref(), Some("u1"));
+        assert_eq!(records[0].links.conversation_kind.as_deref(), Some("main"));
+        assert_eq!(records[1].role, "tool_use");
+        assert_eq!(records[1].links.event_id.as_deref(), Some("tool-claude"));
+        assert_eq!(records[1].links.parent_event_id.as_deref(), Some("a1"));
+        assert_eq!(
+            records[1].links.logical_parent_event_id.as_deref(),
+            Some("u0")
+        );
+        assert_eq!(
+            records[1].links.source_tool_use_id.as_deref(),
+            Some("source-tool")
+        );
+        assert_eq!(
+            records[1].links.source_tool_assistant_uuid.as_deref(),
+            Some("source-assistant")
+        );
+        assert_eq!(records[1].links.thread_source.as_deref(), Some("sidechain"));
+        assert_eq!(
+            records[1].links.conversation_kind.as_deref(),
+            Some("sidechain")
+        );
+        assert_eq!(records[2].role, "assistant");
+        assert_eq!(records[2].links.event_id.as_deref(), Some("a1"));
+        assert_eq!(records[2].links.parent_event_id.as_deref(), Some("u1"));
+        assert_eq!(records[2].links.thread_source.as_deref(), Some("sidechain"));
+        assert_eq!(
+            records[2].links.conversation_kind.as_deref(),
+            Some("sidechain")
+        );
+        assert_eq!(records[3].role, "tool_result");
+        assert_eq!(
+            records[3].links.event_id.as_deref(),
+            Some("r1:tool_result:tool-claude")
+        );
+        assert_eq!(
+            records[3].links.parent_event_id.as_deref(),
+            Some("tool-claude")
+        );
+        assert_eq!(
+            records[3].links.parent_tool_use_id.as_deref(),
+            Some("tool-claude")
+        );
+    }
+
+    #[test]
     fn collect_codex_session_files_includes_archived_sessions() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let sessions_root = tmp.path().join("sessions");
@@ -3042,7 +3612,7 @@ mod tests {
     fn can_skip_fresh_scan_when_embeddings_are_disabled() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
-        let index = open_search_index(&paths);
+        let index = save_search_records(&paths, &[record(1, "user", "hello")]);
         let options = ingest_options(false, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
@@ -3054,7 +3624,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
         save_vector_store(&paths, "bge", 384);
-        let index = open_search_index(&paths);
+        let index = save_search_records(&paths, &[record(1, "user", "hello")]);
         let options = ingest_options(true, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
 
@@ -3333,29 +3903,66 @@ mod tests {
         );
         assert_eq!(records[0].role, "user");
         assert_eq!(records[0].text, "hello pi");
+        assert_eq!(records[0].links.event_id.as_deref(), Some("u1"));
+        assert_eq!(records[0].links.conversation_kind.as_deref(), Some("main"));
         assert_eq!(records[1].role, "tool_use");
         assert_eq!(records[1].tool_name.as_deref(), Some("Read"));
         assert!(records[1].text.contains("README.md"));
+        assert_eq!(records[1].links.event_id.as_deref(), Some("tc1"));
+        assert_eq!(records[1].links.parent_event_id.as_deref(), Some("a1"));
         assert_eq!(records[2].role, "assistant");
         assert!(records[2].text.contains("I will run a command"));
         assert!(records[2].text.contains("Thinking:"));
+        assert_eq!(records[2].links.event_id.as_deref(), Some("a1"));
+        assert_eq!(records[2].links.parent_event_id.as_deref(), Some("u1"));
         assert_eq!(records[3].role, "tool_result");
         assert_eq!(records[3].tool_name.as_deref(), Some("Read"));
         assert_eq!(records[3].text, "README contents");
+        assert_eq!(records[3].links.event_id.as_deref(), Some("tr1"));
+        assert_eq!(records[3].links.parent_event_id.as_deref(), Some("a1"));
+        assert_eq!(records[3].links.parent_tool_use_id.as_deref(), Some("tc1"));
         assert_eq!(records[4].role, "tool_result");
         assert_eq!(records[4].tool_name.as_deref(), Some("Bash"));
         assert!(records[4].text.contains("$ cargo test"));
         assert!(records[4].text.contains("exit code: 0"));
         assert_eq!(records[5].role, "assistant");
+        assert_eq!(records[5].links.event_id.as_deref(), Some("c1"));
+        assert_eq!(
+            records[5].links.thread_source.as_deref(),
+            Some("compaction")
+        );
+        assert_eq!(
+            records[5].links.conversation_kind.as_deref(),
+            Some("compaction")
+        );
         assert_eq!(records[5].text, "compaction: compacted top-level summary");
         assert_eq!(records[6].role, "assistant");
         assert_eq!(records[6].text, "branch_summary: branch top-level summary");
+        assert_eq!(records[6].links.event_id.as_deref(), Some("br1"));
+        assert_eq!(records[6].links.parent_event_id.as_deref(), Some("u1"));
+        assert_eq!(
+            records[6].links.logical_parent_event_id.as_deref(),
+            Some("c1")
+        );
+        assert_eq!(records[6].links.thread_source.as_deref(), Some("branch"));
+        assert_eq!(
+            records[6].links.conversation_kind.as_deref(),
+            Some("branch")
+        );
         assert_eq!(records[7].role, "assistant");
         assert_eq!(records[7].text, "custom_message(memex): extension context");
         assert_eq!(records[8].role, "assistant");
         assert_eq!(records[8].text, "compactionSummary: summary text");
+        assert_eq!(
+            records[8].links.conversation_kind.as_deref(),
+            Some("compaction")
+        );
         assert_eq!(records[9].role, "assistant");
         assert_eq!(records[9].text, "branchSummary: message summary text");
+        assert_eq!(
+            records[9].links.conversation_kind.as_deref(),
+            Some("branch")
+        );
         assert!(!records.iter().any(|record| record.text.contains("secret")));
     }
 
@@ -3471,13 +4078,28 @@ mod tests {
         assert!(records.iter().all(|r| r.project == "memex"));
         assert!(records.iter().all(|r| r.session_id == session_id));
         assert_eq!(records[0].role, "user");
+        assert_eq!(
+            records[0].links.event_id.as_deref(),
+            Some("11111111-1111-4111-8111-111111111111:0")
+        );
+        assert_eq!(records[0].links.conversation_kind.as_deref(), Some("main"));
         assert_eq!(records[1].role, "assistant");
+        assert_eq!(
+            records[1].links.event_id.as_deref(),
+            Some("11111111-1111-4111-8111-111111111111:1")
+        );
         assert_eq!(records[2].role, "tool_use");
         assert_eq!(records[2].tool_name.as_deref(), Some("grep"));
         assert!(records[2].text.contains("parse_copilot"));
+        assert_eq!(records[2].links.event_id.as_deref(), Some("call-1"));
         assert_eq!(records[3].role, "tool_result");
         assert_eq!(records[3].tool_name.as_deref(), Some("grep"));
         assert_eq!(records[3].tool_output.as_deref(), Some("src/ingest.rs"));
+        assert_eq!(records[3].links.parent_event_id.as_deref(), Some("call-1"));
+        assert_eq!(
+            records[3].links.parent_tool_use_id.as_deref(),
+            Some("call-1")
+        );
 
         let update = rx_update.try_recv().expect("file update");
         assert_eq!(update.state.offset, meta.len());
@@ -3506,6 +4128,7 @@ mod tests {
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
+                links: RecordLinks::default(),
                 source_path: tmp
                     .path()
                     .join(

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -421,6 +421,12 @@ pub fn ingest_all(
         }
     }
 
+    let opencode_session_links = if tasks.iter().any(|task| task.source == SourceKind::Opencode) {
+        opencode_session_links_by_id()
+    } else {
+        HashMap::new()
+    };
+
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
@@ -473,9 +479,14 @@ pub fn ingest_all(
                 &session_ids,
                 &progress,
             )?,
-            SourceKind::Opencode => {
-                parse_opencode_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
-            }
+            SourceKind::Opencode => parse_opencode_file(
+                task,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+                &opencode_session_links,
+            )?,
             SourceKind::Cursor => {
                 parse_cursor_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
             }
@@ -915,25 +926,39 @@ fn opencode_parts_root() -> PathBuf {
         .join("part")
 }
 
-fn opencode_session_links(session_id: &str) -> SessionLinks {
-    opencode_session_links_from_root(&opencode_storage_root().join("session"), session_id)
+fn opencode_default_session_links() -> SessionLinks {
+    SessionLinks {
+        conversation_kind: Some("main".to_string()),
+        ..SessionLinks::default()
+    }
 }
 
-fn opencode_session_links_from_root(root: &Path, session_id: &str) -> SessionLinks {
+fn opencode_session_links_by_id() -> HashMap<String, SessionLinks> {
+    opencode_session_links_by_id_from_root(&opencode_storage_root().join("session"))
+}
+
+fn opencode_session_links_by_id_from_root(root: &Path) -> HashMap<String, SessionLinks> {
+    let mut links_by_id = HashMap::new();
     if !root.exists() {
-        return SessionLinks {
-            conversation_kind: Some("main".to_string()),
-            ..SessionLinks::default()
-        };
+        return links_by_id;
     }
-    let needle = format!("{session_id}.json");
+
     for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
         if !entry.file_type().is_file() {
             continue;
         }
-        if entry.file_name().to_str() != Some(needle.as_str()) {
+        if entry.path().extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
+        let Some(session_id) = entry
+            .path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+        else {
+            continue;
+        };
         let Ok(file) = File::open(entry.path()) else {
             continue;
         };
@@ -941,24 +966,34 @@ fn opencode_session_links_from_root(root: &Path, session_id: &str) -> SessionLin
         let Ok(value) = serde_json::from_reader::<_, serde_json::Value>(reader) else {
             continue;
         };
-        let parent_session_id = value
-            .get("parentID")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
-        return SessionLinks {
-            conversation_kind: Some(if parent_session_id.is_some() {
-                "fork".to_string()
-            } else {
-                "main".to_string()
-            }),
-            thread_source: parent_session_id.as_ref().map(|_| "fork".to_string()),
-            parent_session_id,
-        };
+
+        links_by_id.insert(session_id, opencode_session_links_from_value(&value));
     }
+
+    links_by_id
+}
+
+#[cfg(test)]
+fn opencode_session_links_from_root(root: &Path, session_id: &str) -> SessionLinks {
+    opencode_session_links_by_id_from_root(root)
+        .remove(session_id)
+        .unwrap_or_else(opencode_default_session_links)
+}
+
+fn opencode_session_links_from_value(value: &serde_json::Value) -> SessionLinks {
+    let parent_session_id = value
+        .get("parentID")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     SessionLinks {
-        conversation_kind: Some("main".to_string()),
-        ..SessionLinks::default()
+        conversation_kind: Some(if parent_session_id.is_some() {
+            "fork".to_string()
+        } else {
+            "main".to_string()
+        }),
+        thread_source: parent_session_id.as_ref().map(|_| "fork".to_string()),
+        parent_session_id,
     }
 }
 
@@ -1711,6 +1746,7 @@ fn parse_opencode_file(
     tx_update: &Sender<FileUpdate>,
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
+    opencode_session_links: &HashMap<String, SessionLinks>,
 ) -> Result<()> {
     let session_dir = &task.path;
     let session_id = session_dir
@@ -1719,7 +1755,10 @@ fn parse_opencode_file(
         .unwrap_or("unknown")
         .to_string();
     let project = "opencode".to_string();
-    let session_links = opencode_session_links(&session_id);
+    let session_links = opencode_session_links
+        .get(&session_id)
+        .cloned()
+        .unwrap_or_else(opencode_default_session_links);
 
     let mut messages = Vec::new();
     for entry in std::fs::read_dir(session_dir)? {
@@ -3456,6 +3495,35 @@ mod tests {
         assert_eq!(links.parent_session_id.as_deref(), Some("ses_parent"));
         assert_eq!(links.thread_source.as_deref(), Some("fork"));
         assert_eq!(links.conversation_kind.as_deref(), Some("fork"));
+    }
+
+    #[test]
+    fn opencode_session_links_by_id_caches_metadata_tree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).expect("create opencode project");
+        fs::write(
+            project.join("ses_child.json"),
+            r#"{"id":"ses_child","parentID":"ses_parent","projectID":"global"}"#,
+        )
+        .expect("write child session");
+        fs::write(
+            project.join("ses_main.json"),
+            r#"{"id":"ses_main","projectID":"global"}"#,
+        )
+        .expect("write main session");
+
+        let links_by_id = opencode_session_links_by_id_from_root(tmp.path());
+        let child_links = links_by_id.get("ses_child").expect("child links");
+        let main_links = links_by_id.get("ses_main").expect("main links");
+
+        assert_eq!(links_by_id.len(), 2);
+        assert_eq!(child_links.parent_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(child_links.thread_source.as_deref(), Some("fork"));
+        assert_eq!(child_links.conversation_kind.as_deref(), Some("fork"));
+        assert_eq!(main_links.parent_session_id, None);
+        assert_eq!(main_links.thread_source, None);
+        assert_eq!(main_links.conversation_kind.as_deref(), Some("main"));
     }
 
     #[test]

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -3,7 +3,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-pub const SOURCE_COUNT: usize = 7;
+pub const SOURCE_COUNT: usize = SourceKind::COUNT;
 const SOURCES: [SourceKind; SOURCE_COUNT] = [
     SourceKind::Claude,
     SourceKind::CodexSession,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -352,7 +352,12 @@ pub fn run(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let index = SearchIndex::open_or_create(&paths.index)?;
+    let index = if config.auto_index_on_search_default() {
+        paths.ensure_dirs()?;
+        SearchIndex::open_or_create_for_ingest(&paths.index)?
+    } else {
+        SearchIndex::open_or_create(&paths.index)?
+    };
     let (index_tx, index_rx) = std::sync::mpsc::channel();
     let (search_tx, search_rx) = std::sync::mpsc::channel();
 
@@ -438,7 +443,7 @@ impl App {
         std::thread::spawn(move || {
             let _ = tx.send(IndexUpdate::Started);
             let result = (|| -> Result<Option<crate::ingest::IngestReport>> {
-                let index = SearchIndex::open_or_create(&paths.index)?;
+                let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
                 let embeddings_default = config.embeddings_default();
                 let model_choice = config.resolve_model(None)?;
                 let opts = IngestOptions {

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,8 @@ pub enum SourceKind {
 }
 
 impl SourceKind {
+    pub const COUNT: usize = 7;
+
     pub fn idx(self) -> usize {
         match self {
             SourceKind::Claude => 0,
@@ -23,6 +25,19 @@ impl SourceKind {
             SourceKind::Cursor => 4,
             SourceKind::Pi => 5,
             SourceKind::Copilot => 6,
+        }
+    }
+
+    pub fn from_idx(idx: usize) -> Option<Self> {
+        match idx {
+            0 => Some(SourceKind::Claude),
+            1 => Some(SourceKind::CodexSession),
+            2 => Some(SourceKind::CodexHistory),
+            3 => Some(SourceKind::Opencode),
+            4 => Some(SourceKind::Cursor),
+            5 => Some(SourceKind::Pi),
+            6 => Some(SourceKind::Copilot),
+            _ => None,
         }
     }
 
@@ -122,6 +137,28 @@ impl SourceFilter {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RecordLinks {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logical_parent_event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_tool_assistant_uuid: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
     #[serde(skip)]
@@ -139,6 +176,8 @@ pub struct Record {
     pub tool_input: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_output: Option<String>,
+    #[serde(flatten)]
+    pub links: RecordLinks,
     pub source_path: String,
 }
 
@@ -178,5 +217,15 @@ mod tests {
 
         assert_eq!(SourceKind::from_path(unix_path), SourceKind::Pi);
         assert_eq!(SourceKind::from_path(windows_path), SourceKind::Pi);
+    }
+
+    #[test]
+    fn from_path_recognizes_copilot_sessions() {
+        let unix_path =
+            "/Users/nico/.copilot/session-state/11111111-1111-4111-8111-111111111111/events.jsonl";
+        let windows_path = "C:\\Users\\nico\\.copilot\\session-state\\11111111-1111-4111-8111-111111111111\\events.jsonl";
+
+        assert_eq!(SourceKind::from_path(unix_path), SourceKind::Copilot);
+        assert_eq!(SourceKind::from_path(windows_path), SourceKind::Copilot);
     }
 }


### PR DESCRIPTION
Adds stored linkage metadata for agent history records, populates it across Claude, Codex, Cursor, OpenCode, Pi, and Copilot parsers, and exposes the fields in JSON output and docs.