### PR TITLE
Make TUI base colors inherit terminal theme

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -71,10 +71,10 @@ const FOOTER_HEIGHT: u16 = 2;
 const PROJECT_PANEL_HEIGHT: u16 = 6;
 const SPLIT_GAP: u16 = 1;
 
-const COLOR_BASE: Color = Color::Black;
-const COLOR_PANEL: Color = Color::Black;
-const COLOR_PANEL_ALT: Color = Color::Black;
-const COLOR_TEXT: Color = Color::Rgb(220, 220, 220);
+const COLOR_BASE: Color = Color::Reset;
+const COLOR_PANEL: Color = Color::Reset;
+const COLOR_PANEL_ALT: Color = Color::Reset;
+const COLOR_TEXT: Color = Color::Reset;
 const COLOR_MUTED: Color = Color::Rgb(140, 140, 140);
 const COLOR_ACCENT: Color = Color::Rgb(198, 150, 115);
 const COLOR_SELECTION_BG: Color = Color::Rgb(214, 160, 120);


### PR DESCRIPTION
Switches the TUI's base, panel, panel-alt, and default text colors to `Color::Reset` instead of hardcoded `Color::Black` backgrounds and `Color::Rgb(220, 220, 220)` foreground.

With `Color::Reset`, the terminal uses its configured default background and foreground, so the TUI now sits on the real terminal background and picks up the shell theme's base colors instead of forcing a black box.

Scope is intentionally minimal: the curated accent, selection, muted, divider, and per-role RGB colors are left untouched, since truecolor values can't be remapped by a terminal theme.

Checks: `cargo fmt --check` and `cargo clippy -- -D warnings` both pass.