### PR TITLE
Add SQLite-backed project timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1295,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1870,6 +1891,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2042,7 @@ dependencies = [
  "ratatui",
  "rayon",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -2926,6 +2959,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec 1.15.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ memchr = "2.7"
 memmap2 = "0.9"
 rayon = "1.10"
 regex = "1.10"
+rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,0 +1,805 @@
+use crate::types::{Record, SourceFilter, SourceKind};
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SCHEMA_VERSION: i64 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProjectGrouping {
+    Flat,
+    Repository,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionRow {
+    pub source: SourceKind,
+    pub session_id: String,
+    pub source_path: String,
+    pub project: String,
+    pub display_project: String,
+    pub cwd: Option<String>,
+    pub last_at: u64,
+    pub message_count: u64,
+}
+
+pub struct AnalyticsStore {
+    conn: Connection,
+}
+
+pub struct AnalyticsWriter {
+    store: AnalyticsStore,
+    sessions: HashMap<SessionKey, SessionAccumulator>,
+    metadata_cache: HashMap<SessionKey, SessionMetadata>,
+    git_cache: HashMap<String, GitMetadata>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct SessionKey {
+    source: SourceKind,
+    session_id: String,
+    source_path: String,
+}
+
+#[derive(Clone, Debug)]
+struct SessionAccumulator {
+    key: SessionKey,
+    project: String,
+    started_at: u64,
+    last_at: u64,
+    message_count: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SessionMetadata {
+    pub cwd: Option<String>,
+    pub git_root: Option<String>,
+    pub git_common_dir: Option<String>,
+    pub repo_project: Option<String>,
+    pub resolution_status: String,
+}
+
+impl AnalyticsStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        let store = Self { conn };
+        store.init()?;
+        Ok(store)
+    }
+
+    fn init(&self) -> Result<()> {
+        self.conn.execute_batch(
+            r#"
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            CREATE TABLE IF NOT EXISTS meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS sessions (
+                source TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                source_path TEXT NOT NULL,
+                project TEXT NOT NULL,
+                cwd TEXT,
+                git_root TEXT,
+                git_common_dir TEXT,
+                repo_project TEXT,
+                started_at INTEGER NOT NULL,
+                last_at INTEGER NOT NULL,
+                message_count INTEGER NOT NULL DEFAULT 0,
+                resolution_status TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (source, session_id, source_path)
+            );
+            CREATE INDEX IF NOT EXISTS sessions_last_at_idx ON sessions(last_at);
+            CREATE INDEX IF NOT EXISTS sessions_project_last_at_idx ON sessions(project, last_at);
+            CREATE INDEX IF NOT EXISTS sessions_repo_project_last_at_idx ON sessions(repo_project, last_at);
+            CREATE INDEX IF NOT EXISTS sessions_source_last_at_idx ON sessions(source, last_at);
+            "#,
+        )?;
+        self.conn.execute(
+            "INSERT INTO meta(key, value) VALUES('schema_version', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+        Ok(())
+    }
+
+    pub fn session_count(&self) -> Result<u64> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))?;
+        Ok(count.max(0) as u64)
+    }
+
+    pub fn is_ready(path: impl AsRef<Path>) -> bool {
+        Self::open(path)
+            .and_then(|store| store.session_count())
+            .map(|count| count > 0)
+            .unwrap_or(false)
+    }
+
+    pub fn is_complete(path: impl AsRef<Path>) -> bool {
+        Self::open(path)
+            .and_then(|store| store.complete())
+            .unwrap_or(false)
+    }
+
+    pub fn complete(&self) -> Result<bool> {
+        let value: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'analytics_complete'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(value.as_deref() == Some("1"))
+    }
+
+    pub fn mark_complete(&self) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO meta(key, value) VALUES('analytics_complete', '1')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [],
+        )?;
+        Ok(())
+    }
+
+    pub fn clear(&self) -> Result<()> {
+        self.conn.execute("DELETE FROM sessions", [])?;
+        Ok(())
+    }
+
+    pub fn delete_source_path(&self, source_path: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM sessions WHERE source_path = ?1",
+            params![source_path],
+        )?;
+        Ok(())
+    }
+
+    pub fn query_sessions(
+        &self,
+        source: Option<SourceFilter>,
+        since_ms: Option<u64>,
+        project: Option<&str>,
+        grouping: ProjectGrouping,
+        limit: Option<usize>,
+    ) -> Result<Vec<SessionRow>> {
+        let mut sql = String::from(
+            "SELECT source, session_id, source_path, project,
+                    COALESCE(NULLIF(repo_project, ''), project) AS display_project,
+                    cwd, last_at, message_count
+             FROM sessions",
+        );
+        let mut clauses = Vec::new();
+        let mut values: Vec<rusqlite::types::Value> = Vec::new();
+
+        if let Some(source) = source {
+            let labels = source.storage_labels();
+            let placeholders = std::iter::repeat_n("?", labels.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            clauses.push(format!("source IN ({placeholders})"));
+            values.extend(
+                labels
+                    .iter()
+                    .map(|label| rusqlite::types::Value::Text((*label).to_string())),
+            );
+        }
+        if let Some(since_ms) = since_ms {
+            clauses.push("last_at >= ?".to_string());
+            values.push(rusqlite::types::Value::Integer(since_ms as i64));
+        }
+        if let Some(project) = project {
+            match grouping {
+                ProjectGrouping::Flat => clauses.push("project = ?".to_string()),
+                ProjectGrouping::Repository => {
+                    clauses.push("COALESCE(NULLIF(repo_project, ''), project) = ?".to_string())
+                }
+            }
+            values.push(rusqlite::types::Value::Text(project.to_string()));
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        sql.push_str(" ORDER BY last_at DESC");
+        if let Some(limit) = limit {
+            sql.push_str(" LIMIT ?");
+            values.push(rusqlite::types::Value::Integer(limit as i64));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values), |row| {
+            let source_label: String = row.get(0)?;
+            let source = SourceKind::from_label(&source_label).unwrap_or(SourceKind::Claude);
+            let project: String = row.get(3)?;
+            let raw_display_project: String = match grouping {
+                ProjectGrouping::Flat => project.clone(),
+                ProjectGrouping::Repository => row.get(4)?,
+            };
+            let display_project = display_project_name(&raw_display_project);
+            Ok(SessionRow {
+                source,
+                session_id: row.get(1)?,
+                source_path: row.get(2)?,
+                project,
+                display_project,
+                cwd: row.get(5)?,
+                last_at: row.get::<_, i64>(6)?.max(0) as u64,
+                message_count: row.get::<_, i64>(7)?.max(0) as u64,
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    pub fn project_for_session(
+        &self,
+        source: SourceKind,
+        session_id: &str,
+        source_path: &str,
+        grouping: ProjectGrouping,
+    ) -> Result<Option<String>> {
+        let display_expr = match grouping {
+            ProjectGrouping::Flat => "project",
+            ProjectGrouping::Repository => "COALESCE(NULLIF(repo_project, ''), project)",
+        };
+        self.conn
+            .query_row(
+                &format!(
+                    "SELECT {display_expr} FROM sessions
+                     WHERE source = ?1 AND session_id = ?2 AND source_path = ?3"
+                ),
+                params![source.storage_label(), session_id, source_path],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+}
+
+impl AnalyticsWriter {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        Ok(Self {
+            store: AnalyticsStore::open(path)?,
+            sessions: HashMap::new(),
+            metadata_cache: HashMap::new(),
+            git_cache: HashMap::new(),
+        })
+    }
+
+    pub fn clear(&self) -> Result<()> {
+        self.store.clear()
+    }
+
+    pub fn delete_source_path(&self, source_path: &str) -> Result<()> {
+        self.store.delete_source_path(source_path)
+    }
+
+    pub fn record(&mut self, record: &Record) -> Result<()> {
+        let key = SessionKey {
+            source: record.source,
+            session_id: record.session_id.clone(),
+            source_path: record.source_path.clone(),
+        };
+        let entry = self
+            .sessions
+            .entry(key.clone())
+            .or_insert_with(|| SessionAccumulator {
+                key,
+                project: record.project.clone(),
+                started_at: record.ts,
+                last_at: record.ts,
+                message_count: 0,
+            });
+        if record.ts < entry.started_at {
+            entry.started_at = record.ts;
+        }
+        if record.ts >= entry.last_at {
+            entry.last_at = record.ts;
+            if !record.project.is_empty() {
+                entry.project = record.project.clone();
+            }
+        }
+        entry.message_count = entry.message_count.saturating_add(1);
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        if self.sessions.is_empty() {
+            return Ok(());
+        }
+        let pending_sessions: Vec<SessionAccumulator> = self.sessions.values().cloned().collect();
+        let sessions: Vec<(SessionAccumulator, SessionMetadata)> = pending_sessions
+            .into_iter()
+            .map(|session| {
+                let metadata = self.resolve_metadata(&session.key);
+                (session, metadata)
+            })
+            .collect();
+        let tx = self.store.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                r#"
+                INSERT INTO sessions(
+                    source, session_id, source_path, project, cwd, git_root, git_common_dir,
+                    repo_project, started_at, last_at, message_count, resolution_status
+                )
+                VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                ON CONFLICT(source, session_id, source_path) DO UPDATE SET
+                    project = excluded.project,
+                    cwd = excluded.cwd,
+                    git_root = excluded.git_root,
+                    git_common_dir = excluded.git_common_dir,
+                    repo_project = excluded.repo_project,
+                    started_at = MIN(sessions.started_at, excluded.started_at),
+                    last_at = MAX(sessions.last_at, excluded.last_at),
+                    message_count = sessions.message_count + excluded.message_count,
+                    resolution_status = excluded.resolution_status
+                "#,
+            )?;
+            for (session, metadata) in sessions {
+                stmt.execute(params![
+                    session.key.source.storage_label(),
+                    session.key.session_id,
+                    session.key.source_path,
+                    session.project,
+                    metadata.cwd,
+                    metadata.git_root,
+                    metadata.git_common_dir,
+                    metadata.repo_project,
+                    session.started_at as i64,
+                    session.last_at as i64,
+                    session.message_count as i64,
+                    metadata.resolution_status,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        self.sessions.clear();
+        Ok(())
+    }
+
+    fn resolve_metadata(&mut self, key: &SessionKey) -> SessionMetadata {
+        if let Some(cached) = self.metadata_cache.get(key) {
+            return cached.clone();
+        }
+        let metadata = self.resolve_uncached_metadata(key);
+        self.metadata_cache.insert(key.clone(), metadata.clone());
+        metadata
+    }
+
+    fn resolve_uncached_metadata(&mut self, key: &SessionKey) -> SessionMetadata {
+        let cwd = resolve_session_cwd_from_parts(key.source, &key.source_path, &key.session_id);
+        let Some(cwd) = cwd else {
+            return SessionMetadata {
+                resolution_status: "no-cwd".to_string(),
+                ..SessionMetadata::default()
+            };
+        };
+        let git = self
+            .git_cache
+            .entry(cwd.clone())
+            .or_insert_with(|| git_metadata_for_cwd(&cwd))
+            .clone();
+        SessionMetadata {
+            cwd: Some(cwd),
+            git_root: git.git_root,
+            git_common_dir: git.git_common_dir,
+            repo_project: git.repo_project,
+            resolution_status: git.status,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct GitMetadata {
+    git_root: Option<String>,
+    git_common_dir: Option<String>,
+    repo_project: Option<String>,
+    status: String,
+}
+
+fn git_metadata_for_cwd(cwd: &str) -> GitMetadata {
+    let root = git_rev_parse(cwd, &["rev-parse", "--show-toplevel"]);
+    let common_dir = git_rev_parse(
+        cwd,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    );
+    let repo_project = common_dir
+        .as_deref()
+        .and_then(common_dir_project_name)
+        .or_else(|| root.as_deref().and_then(path_file_name));
+
+    let status = if repo_project.is_some() {
+        "ok"
+    } else if root.is_some() || common_dir.is_some() {
+        "git-partial"
+    } else {
+        "not-git"
+    }
+    .to_string();
+
+    GitMetadata {
+        git_root: root,
+        git_common_dir: common_dir,
+        repo_project,
+        status,
+    }
+}
+
+fn git_rev_parse(cwd: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let text = text.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+fn common_dir_project_name(path: &str) -> Option<String> {
+    let path = Path::new(path);
+    if path.file_name().and_then(|n| n.to_str()) == Some(".git") {
+        return path
+            .parent()
+            .and_then(|p| path_file_name(p.to_string_lossy().as_ref()));
+    }
+    path_file_name(path.to_string_lossy().as_ref())
+}
+
+fn display_project_name(project: &str) -> String {
+    decode_encoded_project_path(project).unwrap_or_else(|| project.to_string())
+}
+
+fn decode_encoded_project_path(project: &str) -> Option<String> {
+    let trimmed = project.trim_matches('-');
+    let lower = trimmed.to_lowercase();
+    if !(lower.starts_with("users-") || lower.starts_with("home-") || lower.contains("-users-")) {
+        return None;
+    }
+    let parts: Vec<&str> = trimmed.split('-').filter(|part| !part.is_empty()).collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    if let Some(home) = home_relative_encoded_path(&parts) {
+        return Some(home);
+    }
+
+    if parts[0].eq_ignore_ascii_case("home") {
+        let tail = parts.get(2..)?;
+        if tail.is_empty() {
+            return None;
+        }
+        return Some(encoded_tail_display(tail));
+    }
+
+    let users_idx = parts
+        .iter()
+        .position(|part| part.eq_ignore_ascii_case("Users"))?;
+    let tail = parts.get(users_idx + 2..)?;
+    if tail.is_empty() {
+        return None;
+    }
+    Some(encoded_tail_display(tail))
+}
+
+fn home_relative_encoded_path(parts: &[&str]) -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let mut home_parts = Path::new(&home)
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .filter(|part| !part.is_empty());
+    let home_parent = home_parts.next_back()?;
+    let users_idx = parts
+        .iter()
+        .position(|part| part.eq_ignore_ascii_case("Users"))?;
+    if parts.get(users_idx + 1)? != &home_parent {
+        return None;
+    }
+    let tail = parts.get(users_idx + 2..)?;
+    if tail.is_empty() {
+        return None;
+    }
+    Some(encoded_tail_display(tail))
+}
+
+fn encoded_tail_display(tail: &[&str]) -> String {
+    if tail.len() == 1 {
+        return format!("~/{}", tail[0]);
+    }
+    let common_dirs = [
+        "projects",
+        "code",
+        "repos",
+        "src",
+        "dev",
+        "work",
+        "documents",
+    ];
+    if common_dirs.contains(&tail[0].to_lowercase().as_str()) && tail.len() > 1 {
+        return tail[1..].join("-");
+    }
+    tail.join("-")
+}
+
+fn path_file_name(path: &str) -> Option<String> {
+    Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .filter(|name| !name.is_empty())
+        .map(|name| name.to_string())
+}
+
+fn resolve_session_cwd_from_parts(
+    source: SourceKind,
+    source_path: &str,
+    session_id: &str,
+) -> Option<String> {
+    if source == SourceKind::Copilot
+        && let Some(cwd) = resolve_copilot_workspace_cwd(source_path)
+    {
+        return Some(cwd);
+    }
+    let file = std::fs::File::open(source_path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let mut fallback: Option<String> = None;
+    for line in std::io::BufRead::lines(reader).map_while(std::result::Result::ok) {
+        let value: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let cwd = value
+            .get("cwd")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        if fallback.is_none() {
+            fallback = cwd.clone();
+        }
+
+        let session_id_match = value
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .or_else(|| value.get("session_id").and_then(|v| v.as_str()))
+            .map(|s| s == session_id)
+            .unwrap_or(false);
+
+        if session_id_match && cwd.is_some() {
+            return cwd;
+        }
+
+        if source == SourceKind::CodexSession
+            && value.get("type").and_then(|v| v.as_str()) == Some("session_meta")
+        {
+            let payload_cwd = value
+                .get("payload")
+                .and_then(|v| v.get("cwd"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if payload_cwd.is_some() {
+                return payload_cwd;
+            }
+        }
+
+        if source == SourceKind::Pi && value.get("type").and_then(|v| v.as_str()) == Some("session")
+        {
+            let cwd = value
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if cwd.is_some() {
+                return cwd;
+            }
+        }
+    }
+    fallback
+}
+
+#[derive(Default)]
+struct CopilotWorkspaceCwd {
+    cwd: Option<String>,
+    git_root: Option<String>,
+}
+
+fn resolve_copilot_workspace_cwd(source_path: &str) -> Option<String> {
+    let workspace_path = Path::new(source_path).parent()?.join("workspace.yaml");
+    let contents = std::fs::read_to_string(workspace_path).ok()?;
+    let workspace = parse_copilot_workspace_cwd(&contents);
+    workspace.cwd.or(workspace.git_root)
+}
+
+fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
+    let mut workspace = CopilotWorkspaceCwd::default();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('#')
+            || line.chars().next().is_some_and(|c| c.is_whitespace())
+        {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let value = value
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
+        if value.is_empty() {
+            continue;
+        }
+        match key.trim() {
+            "cwd" => workspace.cwd = Some(value),
+            "gitRoot" | "git_root" => workspace.git_root = Some(value),
+            _ => {}
+        }
+    }
+    workspace
+}
+
+pub fn analytics_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("analytics.sqlite")
+}
+
+pub fn rebuild_from_records(
+    path: impl AsRef<Path>,
+    records: impl IntoIterator<Item = Record>,
+) -> Result<()> {
+    let mut writer = AnalyticsWriter::open(path)?;
+    writer.clear()?;
+    for record in records {
+        writer.record(&record)?;
+    }
+    writer.flush()?;
+    writer.store.mark_complete()
+}
+
+pub fn backfill_from_index(
+    path: impl AsRef<Path>,
+    index: &crate::index::SearchIndex,
+) -> Result<()> {
+    let mut writer = AnalyticsWriter::open(path)?;
+    writer.clear()?;
+    index
+        .for_each_record(|record| {
+            writer.record(&record)?;
+            Ok(())
+        })
+        .context("read records for analytics backfill")?;
+    writer.flush()?;
+    writer.store.mark_complete()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RecordLinks;
+    use std::fs;
+
+    fn record(project: &str, session_id: &str, source_path: &Path, ts: u64) -> Record {
+        Record {
+            source: SourceKind::CodexSession,
+            doc_id: ts,
+            ts,
+            project: project.to_string(),
+            session_id: session_id.to_string(),
+            turn_id: ts as u32,
+            role: "user".to_string(),
+            text: "hello".to_string(),
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            links: RecordLinks::default(),
+            source_path: source_path.to_string_lossy().to_string(),
+        }
+    }
+
+    #[test]
+    fn display_project_decodes_path_shaped_project_slugs() {
+        assert_eq!(display_project_name("-Users-nico-Code"), "~/Code");
+        assert_eq!(
+            display_project_name("-Users-nico-Code-sidequery-backend"),
+            "sidequery-backend"
+        );
+        assert_eq!(display_project_name("model-serving"), "model-serving");
+    }
+
+    #[test]
+    fn analytics_writer_rolls_records_up_to_sessions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(
+            &transcript,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                tmp.path().display()
+            ),
+        )
+        .expect("write transcript");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open analytics");
+        writer
+            .record(&record("memex", "s1", &transcript, 10))
+            .expect("record");
+        writer
+            .record(&record("memex", "s1", &transcript, 20))
+            .expect("record");
+        writer.flush().expect("flush");
+
+        let store = AnalyticsStore::open(&db).expect("open store");
+        let rows = store
+            .query_sessions(None, None, None, ProjectGrouping::Flat, None)
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].session_id, "s1");
+        assert_eq!(rows[0].message_count, 2);
+        assert_eq!(rows[0].last_at, 20);
+    }
+
+    #[test]
+    fn repository_grouping_uses_git_common_dir_project() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("memex");
+        fs::create_dir_all(&repo).expect("repo dir");
+        assert!(
+            Command::new("git")
+                .args(["init"])
+                .current_dir(&repo)
+                .output()
+                .expect("git init")
+                .status
+                .success()
+        );
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(
+            &transcript,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                repo.display()
+            ),
+        )
+        .expect("write transcript");
+
+        let db = tmp.path().join("analytics.sqlite");
+        rebuild_from_records(
+            &db,
+            [record(
+                "memex-claude-worktrees-feature",
+                "s1",
+                &transcript,
+                10,
+            )],
+        )
+        .expect("rebuild");
+
+        let store = AnalyticsStore::open(&db).expect("open store");
+        let rows = store
+            .query_sessions(None, None, None, ProjectGrouping::Repository, None)
+            .expect("query");
+        assert_eq!(rows[0].project, "memex-claude-worktrees-feature");
+        assert_eq!(rows[0].display_project, "memex");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::analytics::{AnalyticsStore, analytics_path, backfill_from_index};
 use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
@@ -242,6 +243,13 @@ OUTPUT FIELDS (--fields):
     },
     /// Show index statistics (document count, vector count, storage paths)
     Stats {
+        /// Path to memex data directory [default: ~/.memex]
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
+    /// Rebuild the SQLite analytics cache from the existing Tantivy index
+    #[command(hide = true)]
+    AnalyticsBackfill {
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -522,6 +530,9 @@ pub fn run() -> Result<()> {
         }
         Commands::Stats { root } => {
             run_stats(root)?;
+        }
+        Commands::AnalyticsBackfill { root } => {
+            run_analytics_backfill(root)?;
         }
         Commands::Setup { force } => {
             run_setup(force)?;
@@ -1295,6 +1306,19 @@ fn run_stats(root: Option<PathBuf>) -> Result<()> {
     println!("index: {}", paths.index.display());
     println!("documents: {}", index.doc_count()?);
     print_vector_stats(&paths.vectors)?;
+    Ok(())
+}
+
+fn run_analytics_backfill(root: Option<PathBuf>) -> Result<()> {
+    let paths = Paths::new(root)?;
+    paths.ensure_dirs()?;
+    let index = SearchIndex::open_or_create(&paths.index)?;
+    let db = analytics_path(&paths.state);
+    backfill_from_index(&db, &index)?;
+    let store = AnalyticsStore::open(&db)?;
+    println!("analytics: {}", db.display());
+    println!("documents: {}", index.doc_count()?);
+    println!("sessions: {}", store.session_count()?);
     Ok(())
 }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,3 +1,4 @@
+use crate::analytics::{AnalyticsStore, AnalyticsWriter, analytics_path, backfill_from_index};
 use crate::config::Paths;
 use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::SearchIndex;
@@ -71,6 +72,7 @@ struct WriterContext {
     embeddings: bool,
     do_backfill_embeddings: bool,
     vector_dir: PathBuf,
+    analytics_path: PathBuf,
     progress: Arc<Progress>,
     model: ModelChoice,
     embed_runtime: EmbedRuntimeConfig,
@@ -429,7 +431,13 @@ pub fn ingest_all(
 
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
+    let analytics_db = analytics_path(&paths.state);
+    let analytics_needs_backfill =
+        !AnalyticsStore::is_complete(&analytics_db) && index.doc_count()? > 0;
     if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
+        if analytics_needs_backfill {
+            backfill_from_index(&analytics_db, index)?;
+        }
         update_scan_cache(paths, files_scanned, total_bytes);
         return Ok(IngestReport {
             records_added: 0,
@@ -455,6 +463,7 @@ pub fn ingest_all(
         embeddings: options.embeddings,
         do_backfill_embeddings: options.backfill_embeddings,
         vector_dir: paths.vectors.clone(),
+        analytics_path: analytics_db.clone(),
         progress: progress.clone(),
         model: options.model,
         embed_runtime: options.embed_runtime.clone(),
@@ -506,6 +515,11 @@ pub fn ingest_all(
         .map_err(|_| anyhow!("writer thread panicked"))?;
     progress.finish();
     let (records_added, records_embedded) = writer_result?;
+    if analytics_needs_backfill {
+        backfill_from_index(&analytics_db, index)?;
+    } else {
+        AnalyticsStore::open(&analytics_db)?.mark_complete()?;
+    }
 
     let mut updated_files = HashMap::new();
     while let Ok(update) = rx_update.recv() {
@@ -547,6 +561,9 @@ fn can_skip_fresh_scan(
         return Ok(false);
     }
     if !cache.is_fresh(ttl_seconds) {
+        return Ok(false);
+    }
+    if !AnalyticsStore::is_complete(analytics_path(&paths.state)) && index.doc_count()? > 0 {
         return Ok(false);
     }
     can_skip_noop_index(paths, index, options)
@@ -603,13 +620,16 @@ fn writer_loop(
         embeddings,
         do_backfill_embeddings,
         vector_dir,
+        analytics_path,
         progress,
         model,
         embed_runtime,
     } = ctx;
     let mut writer = index.writer()?;
+    let mut analytics = AnalyticsWriter::open(&analytics_path)?;
     for path in delete_paths {
         index.delete_by_source_path(&mut writer, &path);
+        analytics.delete_source_path(&path)?;
     }
 
     let mut count = 0usize;
@@ -631,6 +651,7 @@ fn writer_loop(
     }
 
     for mut record in rx.iter() {
+        analytics.record(&record)?;
         index.add_record(&mut writer, &record)?;
         let source_idx = record.source.idx();
         index_pending[source_idx] += 1;
@@ -670,6 +691,7 @@ fn writer_loop(
         }
     }
 
+    analytics.flush()?;
     writer.commit()?;
     if embeddings {
         if !embed_buffer.is_empty() {
@@ -3361,6 +3383,13 @@ mod tests {
         index
     }
 
+    fn mark_analytics_complete(paths: &Paths) {
+        AnalyticsStore::open(analytics_path(&paths.state))
+            .expect("open analytics")
+            .mark_complete()
+            .expect("mark analytics complete");
+    }
+
     fn record(doc_id: u64, role: &str, text: &str) -> Record {
         Record {
             source: SourceKind::Claude,
@@ -3683,6 +3712,7 @@ mod tests {
         let index = save_search_records(&paths, &[record(1, "user", "hello")]);
         let options = ingest_options(false, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
+        mark_analytics_complete(&paths);
 
         assert!(can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
@@ -3695,6 +3725,7 @@ mod tests {
         let index = save_search_records(&paths, &[record(1, "user", "hello")]);
         let options = ingest_options(true, ModelChoice::BGESmall);
         let cache = fresh_scan_cache();
+        mark_analytics_complete(&paths);
 
         assert!(can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
     }
@@ -4213,6 +4244,7 @@ mod tests {
             embeddings: false,
             do_backfill_embeddings: false,
             vector_dir,
+            analytics_path: tmp.path().join("state").join("analytics.sqlite"),
             progress,
             model: ModelChoice::default(),
             embed_runtime: EmbedRuntimeConfig::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analytics;
 pub mod cli;
 pub mod config;
 pub mod embed;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,4 @@
+use crate::analytics::{AnalyticsStore, ProjectGrouping, SessionRow, analytics_path};
 use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_if_stale};
@@ -51,6 +52,12 @@ enum SearchUpdate {
     Projects {
         projects: Vec<String>,
         source: SourceChoice,
+    },
+    Timeline {
+        rows: Vec<ProjectTimelineRow>,
+        source: SourceChoice,
+        range: TimelineRange,
+        grouping: ProjectDisplayMode,
     },
     Error(String),
 }
@@ -125,7 +132,84 @@ enum PreviewMode {
 enum LayoutMode {
     Split,
     List,
+    Timeline,
     Detail,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TimelineRange {
+    Day,
+    Week,
+    Month,
+    All,
+}
+
+impl TimelineRange {
+    fn next(self) -> Self {
+        match self {
+            TimelineRange::Day => TimelineRange::Week,
+            TimelineRange::Week => TimelineRange::Month,
+            TimelineRange::Month => TimelineRange::All,
+            TimelineRange::All => TimelineRange::Day,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            TimelineRange::Day => TimelineRange::All,
+            TimelineRange::Week => TimelineRange::Day,
+            TimelineRange::Month => TimelineRange::Week,
+            TimelineRange::All => TimelineRange::Month,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            TimelineRange::Day => "last 24h",
+            TimelineRange::Week => "last 7d",
+            TimelineRange::Month => "last 30d",
+            TimelineRange::All => "all history",
+        }
+    }
+
+    fn since_ms(self, now_ms: u64) -> Option<u64> {
+        let day = 24 * 60 * 60 * 1000;
+        match self {
+            TimelineRange::Day => Some(now_ms.saturating_sub(day)),
+            TimelineRange::Week => Some(now_ms.saturating_sub(7 * day)),
+            TimelineRange::Month => Some(now_ms.saturating_sub(30 * day)),
+            TimelineRange::All => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectDisplayMode {
+    Flat,
+    NestedWorktrees,
+}
+
+impl ProjectDisplayMode {
+    fn toggle(self) -> Self {
+        match self {
+            ProjectDisplayMode::Flat => ProjectDisplayMode::NestedWorktrees,
+            ProjectDisplayMode::NestedWorktrees => ProjectDisplayMode::Flat,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            ProjectDisplayMode::Flat => "flat",
+            ProjectDisplayMode::NestedWorktrees => "repo",
+        }
+    }
+
+    fn grouping(self) -> ProjectGrouping {
+        match self {
+            ProjectDisplayMode::Flat => ProjectGrouping::Flat,
+            ProjectDisplayMode::NestedWorktrees => ProjectGrouping::Repository,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -190,6 +274,14 @@ struct SessionSummary {
     source_dir: String,
 }
 
+#[derive(Clone, Debug)]
+struct ProjectTimelineRow {
+    project: String,
+    session_count: usize,
+    last_ts: u64,
+    session_ts: Vec<u64>,
+}
+
 struct App {
     paths: Paths,
     config: UserConfig,
@@ -205,6 +297,12 @@ struct App {
     results: Vec<SessionSummary>,
     selected: ListState,
     layout_mode: LayoutMode,
+    project_display: ProjectDisplayMode,
+    session_project_cache: HashMap<String, String>,
+    timeline_range: TimelineRange,
+    timeline_rows: Vec<ProjectTimelineRow>,
+    timeline_scroll: usize,
+    timeline_loaded: Option<(SourceChoice, TimelineRange, ProjectDisplayMode)>,
     quick_popup: bool,
     quick_scroll: usize,
     quick_lines: Vec<PreviewLine>,
@@ -438,6 +536,12 @@ impl App {
             results: Vec::new(),
             selected: ListState::default(),
             layout_mode: LayoutMode::Split,
+            project_display: ProjectDisplayMode::NestedWorktrees,
+            session_project_cache: HashMap::new(),
+            timeline_range: TimelineRange::All,
+            timeline_rows: Vec::new(),
+            timeline_scroll: 0,
+            timeline_loaded: None,
             quick_popup: false,
             quick_scroll: 0,
             quick_lines: Vec::new(),
@@ -592,21 +696,41 @@ impl App {
         let source = self.source;
         let paths = self.paths.clone();
         let tx = self.search_tx.clone();
+        let grouping = self.project_display.grouping();
         self.set_status("searching...");
         std::thread::spawn(move || {
             let _ = tx.send(SearchUpdate::Started);
             let result = (|| -> Result<(Vec<SessionSummary>, Option<Vec<String>>)> {
-                let index = SearchIndex::open_or_create(&paths.index)?;
                 let sessions = if query.is_empty() {
-                    sessions_from_recent(&index, source.as_filter(), project_opt.as_deref())?
+                    sessions_from_analytics(
+                        &paths,
+                        source.as_filter(),
+                        project_opt.as_deref(),
+                        grouping,
+                    )
+                    .or_else(|_| {
+                        let index = SearchIndex::open_or_create(&paths.index)?;
+                        sessions_from_recent(&index, source.as_filter(), project_opt.as_deref())
+                    })?
                 } else {
-                    sessions_from_query(
+                    let index = SearchIndex::open_or_create(&paths.index)?;
+                    let tantivy_project = if grouping == ProjectGrouping::Flat {
+                        project_opt.as_deref()
+                    } else {
+                        None
+                    };
+                    let mut sessions = sessions_from_query(
                         &index,
                         &query,
                         source.as_filter(),
-                        project_opt.as_deref(),
+                        tantivy_project,
                         RESULT_LIMIT,
-                    )?
+                    )?;
+                    enrich_session_projects(&paths, &mut sessions, grouping);
+                    if let Some(project) = project_opt.as_deref() {
+                        sessions.retain(|session| session.project == project);
+                    }
+                    sessions
                 };
                 Ok((sessions, None))
             })();
@@ -628,14 +752,42 @@ impl App {
         let source = self.source;
         let paths = self.paths.clone();
         let tx = self.search_tx.clone();
+        let grouping = self.project_display.grouping();
         std::thread::spawn(move || {
-            let result = (|| -> Result<Vec<String>> {
-                let index = SearchIndex::open_or_create(&paths.index)?;
-                collect_projects(&index, source.as_filter())
-            })();
+            let result = collect_projects_from_analytics(&paths, source.as_filter(), grouping)
+                .or_else(|_| {
+                    let index = SearchIndex::open_or_create(&paths.index)?;
+                    collect_projects(&index, source.as_filter())
+                });
             match result {
                 Ok(projects) => {
                     let _ = tx.send(SearchUpdate::Projects { projects, source });
+                }
+                Err(err) => {
+                    let _ = tx.send(SearchUpdate::Error(err.to_string()));
+                }
+            }
+        });
+    }
+
+    fn kickoff_timeline_load(&mut self) {
+        let source = self.source;
+        let range = self.timeline_range;
+        let grouping = self.project_display;
+        let paths = self.paths.clone();
+        let tx = self.search_tx.clone();
+        self.timeline_loaded = Some((source, range, grouping));
+        self.set_status("loading timeline...");
+        std::thread::spawn(move || {
+            let result = build_project_timeline(&paths, source.as_filter(), range, grouping);
+            match result {
+                Ok(rows) => {
+                    let _ = tx.send(SearchUpdate::Timeline {
+                        rows,
+                        source,
+                        range,
+                        grouping,
+                    });
                 }
                 Err(err) => {
                     let _ = tx.send(SearchUpdate::Error(err.to_string()));
@@ -720,6 +872,7 @@ impl App {
                 Focus::List | Focus::Preview => Focus::Find,
                 Focus::Find => Focus::Query,
             },
+            LayoutMode::Timeline => Focus::List,
             LayoutMode::Detail => match self.focus {
                 Focus::Preview => Focus::Find,
                 Focus::Find | Focus::Query | Focus::Project | Focus::List => Focus::Preview,
@@ -736,6 +889,7 @@ impl App {
                 Focus::List | Focus::Preview => Focus::Project,
                 Focus::Find => Focus::List,
             },
+            LayoutMode::Timeline => Focus::List,
             LayoutMode::Detail => match self.focus {
                 Focus::Preview | Focus::Query | Focus::Project | Focus::List => Focus::Find,
                 Focus::Find => Focus::Preview,
@@ -779,8 +933,56 @@ impl App {
                 self.quick_lines.clear();
                 LayoutMode::List
             }
-            LayoutMode::List | LayoutMode::Detail => LayoutMode::Split,
+            LayoutMode::List => {
+                self.focus = Focus::List;
+                self.quick_popup = false;
+                self.quick_lines.clear();
+                self.kickoff_timeline_load();
+                LayoutMode::Timeline
+            }
+            LayoutMode::Timeline | LayoutMode::Detail => LayoutMode::Split,
         };
+    }
+
+    fn toggle_project_display(&mut self) {
+        self.project_display = self.project_display.toggle();
+        self.session_project_cache.clear();
+        self.set_status(format!("projects: {}", self.project_display.label()));
+        if matches!(self.layout_mode, LayoutMode::Timeline) {
+            self.kickoff_timeline_load();
+        } else {
+            self.refresh_results();
+            if self.project_source == self.source {
+                self.kickoff_project_load();
+            }
+        }
+    }
+
+    fn cycle_timeline_range(&mut self, delta: isize) {
+        self.timeline_range = if delta < 0 {
+            self.timeline_range.prev()
+        } else {
+            self.timeline_range.next()
+        };
+        if matches!(self.layout_mode, LayoutMode::Timeline) {
+            self.timeline_scroll = 0;
+            self.kickoff_timeline_load();
+        }
+    }
+
+    fn scroll_timeline(&mut self, delta: isize) {
+        if self.timeline_rows.is_empty() {
+            self.timeline_scroll = 0;
+            return;
+        }
+        let view_height = self.list_area.height as usize;
+        let max_scroll = if view_height == 0 {
+            self.timeline_rows.len().saturating_sub(1)
+        } else {
+            self.timeline_rows.len().saturating_sub(view_height)
+        };
+        self.timeline_scroll =
+            (self.timeline_scroll as isize + delta).clamp(0, max_scroll as isize) as usize;
     }
 
     fn toggle_quick_popup(&mut self) {
@@ -1017,6 +1219,18 @@ fn run_loop(terminal: &mut TuiTerminal, app: &mut App) -> Result<()> {
                     app.project_source = source;
                     app.update_project_options();
                 }
+                SearchUpdate::Timeline {
+                    rows,
+                    source,
+                    range,
+                    grouping,
+                } => {
+                    if app.timeline_loaded == Some((source, range, grouping)) {
+                        app.timeline_rows = rows;
+                        app.timeline_scroll = 0;
+                        app.set_status(format!("{} projects", app.timeline_rows.len()));
+                    }
+                }
                 SearchUpdate::Error(msg) => app.set_status(format!("search error: {msg}")),
             }
             dirty = true;
@@ -1208,24 +1422,32 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
             app.focus_prev();
         }
         KeyCode::Up => {
-            if matches!(app.focus, Focus::List) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(-1);
+            } else if matches!(app.focus, Focus::List) {
                 app.move_selection(-1);
             }
         }
         KeyCode::Down => {
-            if matches!(app.focus, Focus::List) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(1);
+            } else if matches!(app.focus, Focus::List) {
                 app.move_selection(1);
             }
         }
         KeyCode::Char('j') => {
-            if matches!(app.focus, Focus::Preview) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(1);
+            } else if matches!(app.focus, Focus::Preview) {
                 app.scroll_detail(1);
             } else {
                 app.move_selection(1);
             }
         }
         KeyCode::Char('k') => {
-            if matches!(app.focus, Focus::Preview) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(-1);
+            } else if matches!(app.focus, Focus::Preview) {
                 app.scroll_detail(-1);
             } else {
                 app.move_selection(-1);
@@ -1259,12 +1481,16 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
             }
         }
         KeyCode::PageDown => {
-            if matches!(app.focus, Focus::Preview) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(8);
+            } else if matches!(app.focus, Focus::Preview) {
                 app.scroll_detail(8);
             }
         }
         KeyCode::PageUp => {
-            if matches!(app.focus, Focus::Preview) {
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.scroll_timeline(-8);
+            } else if matches!(app.focus, Focus::Preview) {
                 app.scroll_detail(-8);
             }
         }
@@ -1272,7 +1498,20 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
             app.source = app.source.cycle();
             app.set_status("searching...");
             terminal.draw(|f| draw_ui(f, app))?;
-            app.refresh_results();
+            if matches!(app.layout_mode, LayoutMode::Timeline) {
+                app.kickoff_timeline_load();
+            } else {
+                app.refresh_results();
+            }
+        }
+        KeyCode::Char('[') => {
+            app.cycle_timeline_range(-1);
+        }
+        KeyCode::Char(']') => {
+            app.cycle_timeline_range(1);
+        }
+        KeyCode::Char('g') => {
+            app.toggle_project_display();
         }
         KeyCode::Char('m') => {
             app.toggle_preview_mode();
@@ -1458,6 +1697,14 @@ fn draw_body(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         return;
     }
 
+    if app.layout_mode == LayoutMode::Timeline {
+        app.preview_area = Rect::default();
+        app.project_area = None;
+        app.dragging = false;
+        app.list_area = draw_project_timeline(frame, app, theme, area);
+        return;
+    }
+
     let min_left = 20u16;
     let min_right = 24u16;
     let total = area.width.max(min_left + min_right + SPLIT_GAP);
@@ -1540,24 +1787,25 @@ fn draw_sessions_panel(
             theme.muted,
         )))]
     } else {
-        app.results
-            .iter()
-            .map(|session| {
-                let ts = format_relative_ts(session.last_ts);
-                let line = Line::from(vec![
-                    Span::styled(format!("{:>4}", session.hit_count), theme.accent),
-                    Span::raw(" "),
-                    Span::styled(session.project.as_str(), theme.text),
-                    Span::raw(" "),
-                    Span::styled(session.source.label(), theme.muted),
-                    Span::raw(" "),
-                    Span::styled(format!("{ts:>4}"), theme.accent),
-                    Span::raw(" "),
-                    Span::styled(session.session_id.as_str(), theme.text),
-                ]);
-                ListItem::new(line)
-            })
-            .collect()
+        let sessions = app.results.clone();
+        let mut items = Vec::with_capacity(sessions.len());
+        for session in &sessions {
+            let ts = format_relative_ts(session.last_ts);
+            let project = display_project_for_session(app, session);
+            let line = Line::from(vec![
+                Span::styled(format!("{:>4}", session.hit_count), theme.accent),
+                Span::raw(" "),
+                Span::styled(project, theme.text),
+                Span::raw(" "),
+                Span::styled(session.source.label(), theme.muted),
+                Span::raw(" "),
+                Span::styled(format!("{ts:>4}"), theme.accent),
+                Span::raw(" "),
+                Span::styled(session.session_id.clone(), theme.text),
+            ]);
+            items.push(ListItem::new(line));
+        }
+        items
     };
 
     let list = List::new(list_items)
@@ -1566,6 +1814,123 @@ fn draw_sessions_panel(
         .highlight_symbol("");
 
     frame.render_stateful_widget(list, content, &mut app.selected);
+    content
+}
+
+fn display_project_for_session(app: &mut App, session: &SessionSummary) -> String {
+    if app.project_display == ProjectDisplayMode::Flat {
+        return session.project.clone();
+    }
+    let key = format!(
+        "{}\0{}\0{}",
+        session.source.storage_label(),
+        session.session_id,
+        session.source_path
+    );
+    if let Some(project) = app.session_project_cache.get(&key) {
+        return project.clone();
+    }
+    let project = AnalyticsStore::open(analytics_path(&app.paths.state))
+        .ok()
+        .and_then(|store| {
+            store
+                .project_for_session(
+                    session.source,
+                    &session.session_id,
+                    &session.source_path,
+                    app.project_display.grouping(),
+                )
+                .ok()
+                .flatten()
+        })
+        .unwrap_or_else(|| session.project.clone());
+    app.session_project_cache.insert(key, project.clone());
+    project
+}
+
+fn draw_project_timeline(
+    frame: &mut ratatui::Frame,
+    app: &mut App,
+    theme: &Theme,
+    area: Rect,
+) -> Rect {
+    frame.render_widget(Block::default().style(theme.panel), area);
+    let inner = inset(area, PANEL_PAD_X, PANEL_PAD_X, PANEL_PAD_Y, PANEL_PAD_Y);
+    let content = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: inner.height,
+    };
+
+    if app.timeline_rows.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "no sessions in this window",
+                theme.muted,
+            ))),
+            content,
+        );
+        return content;
+    }
+
+    let rows_area = Rect {
+        x: content.x,
+        y: content.y,
+        width: content.width,
+        height: content.height,
+    };
+    let rows_visible = rows_area.height as usize;
+    let start = app.timeline_scroll.min(app.timeline_rows.len());
+    let end = if rows_visible == 0 {
+        start
+    } else {
+        (start + rows_visible).min(app.timeline_rows.len())
+    };
+    let project_width = timeline_project_width(&app.timeline_rows[start..end], content.width);
+    let count_width = 5u16;
+    let last_width = 4u16;
+    let chart_width = timeline_chart_width(content.width, project_width, count_width, last_width);
+    let row_widths = [
+        Constraint::Length(project_width),
+        Constraint::Length(chart_width as u16),
+        Constraint::Length(1),
+        Constraint::Length(count_width),
+        Constraint::Length(1),
+        Constraint::Length(last_width),
+        Constraint::Min(0),
+    ];
+    let range = timeline_bounds(&app.timeline_rows, app.timeline_range);
+    let density_max = timeline_density_max(&app.timeline_rows[start..end], range, chart_width);
+
+    for (line_idx, row) in app.timeline_rows[start..end].iter().enumerate() {
+        let row_area = Rect {
+            x: rows_area.x,
+            y: rows_area.y.saturating_add(line_idx as u16),
+            width: rows_area.width,
+            height: 1,
+        };
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(row_widths)
+            .split(row_area);
+        frame.render_widget(
+            Paragraph::new(truncate_middle(&row.project, cols[0].width as usize)).style(theme.text),
+            cols[0],
+        );
+        let chart = timeline_chart(&row.session_ts, range, cols[1].width as usize, density_max);
+        frame.render_widget(Paragraph::new(chart).style(theme.muted), cols[1]);
+        frame.render_widget(
+            Paragraph::new(row.session_count.to_string())
+                .style(theme.accent)
+                .alignment(Alignment::Right),
+            cols[3],
+        );
+        frame.render_widget(
+            Paragraph::new(format_relative_ts(row.last_ts)).style(theme.accent),
+            cols[5],
+        );
+    }
     content
 }
 
@@ -1726,6 +2091,7 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
     let view = match app.layout_mode {
         LayoutMode::Split => "split",
         LayoutMode::List => "list",
+        LayoutMode::Timeline => "timeline",
         LayoutMode::Detail => "detail",
     };
     let mut right_spans = Vec::new();
@@ -1741,11 +2107,32 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
         right_spans.push(Span::styled(app.source.label(), theme.accent));
         right_spans.push(Span::raw("   "));
     }
+    if app.layout_mode == LayoutMode::Timeline {
+        if app.source == SourceChoice::All {
+            right_spans.push(Span::styled("source ", theme.muted));
+            right_spans.push(Span::styled(app.source.label(), theme.accent));
+            right_spans.push(Span::raw("   "));
+        }
+        right_spans.push(Span::styled("range ", theme.muted));
+        right_spans.push(Span::styled(app.timeline_range.label(), theme.text));
+        right_spans.push(Span::raw("   "));
+        right_spans.push(Span::styled("dates ", theme.muted));
+        right_spans.push(Span::styled(
+            timeline_date_range(&app.timeline_rows, app.timeline_range),
+            theme.text,
+        ));
+        right_spans.push(Span::raw("   "));
+        right_spans.push(Span::styled("group ", theme.muted));
+        right_spans.push(Span::styled(app.project_display.label(), theme.text));
+        right_spans.push(Span::raw("   "));
+    }
     right_spans.push(Span::styled("view ", theme.muted));
     right_spans.push(Span::styled(view, theme.text));
-    right_spans.push(Span::raw("   "));
-    right_spans.push(Span::styled("mode ", theme.muted));
-    right_spans.push(Span::styled(mode, theme.text));
+    if app.layout_mode != LayoutMode::Timeline {
+        right_spans.push(Span::raw("   "));
+        right_spans.push(Span::styled("mode ", theme.muted));
+        right_spans.push(Span::styled(mode, theme.text));
+    }
     let right = Line::from(right_spans);
     let right_width = right.width() as u16;
     let shortcut_width = inner.width.saturating_sub(right_width);
@@ -1822,6 +2209,21 @@ fn footer_shortcuts<'a>(app: &App, theme: &Theme, width: u16) -> Line<'a> {
             Span::styled(" list  ", theme.muted),
             Span::styled("r", theme.accent),
             Span::styled(" resume", theme.muted),
+        ]);
+    }
+
+    if app.layout_mode == LayoutMode::Timeline {
+        return Line::from(vec![
+            Span::styled("j/k", theme.accent),
+            Span::styled(" scroll  ", theme.muted),
+            Span::styled("[/]", theme.accent),
+            Span::styled(" range  ", theme.muted),
+            Span::styled("s", theme.accent),
+            Span::styled(" source  ", theme.muted),
+            Span::styled("g", theme.accent),
+            Span::styled(" grouping  ", theme.muted),
+            Span::styled("v", theme.accent),
+            Span::styled(" split", theme.muted),
         ]);
     }
 
@@ -1947,6 +2349,120 @@ fn sessions_from_recent(
     }
     let mut out: Vec<SessionSummary> = sessions.into_values().collect();
     out.sort_by_key(|summary| std::cmp::Reverse(summary.last_ts));
+    Ok(out)
+}
+
+fn sessions_from_analytics(
+    paths: &Paths,
+    source: Option<SourceFilter>,
+    project: Option<&str>,
+    grouping: ProjectGrouping,
+) -> Result<Vec<SessionSummary>> {
+    let store = AnalyticsStore::open(analytics_path(&paths.state))?;
+    let rows =
+        store.query_sessions(source, None, project, grouping, Some(RECENT_SESSIONS_LIMIT))?;
+    if rows.is_empty() {
+        anyhow::bail!("no analytics sessions");
+    }
+    Ok(rows.into_iter().map(session_summary_from_row).collect())
+}
+
+fn session_summary_from_row(row: SessionRow) -> SessionSummary {
+    SessionSummary {
+        session_id: row.session_id,
+        project: row.display_project,
+        source: row.source,
+        last_ts: row.last_at,
+        hit_count: row.message_count.max(1) as usize,
+        top_score: 0.0,
+        snippet: String::new(),
+        source_dir: row.cwd.unwrap_or_else(|| parent_dir(&row.source_path)),
+        source_path: row.source_path,
+    }
+}
+
+fn enrich_session_projects(
+    paths: &Paths,
+    sessions: &mut [SessionSummary],
+    grouping: ProjectGrouping,
+) {
+    if grouping == ProjectGrouping::Flat {
+        return;
+    }
+    let Ok(store) = AnalyticsStore::open(analytics_path(&paths.state)) else {
+        return;
+    };
+    for session in sessions {
+        if let Ok(Some(project)) = store.project_for_session(
+            session.source,
+            &session.session_id,
+            &session.source_path,
+            grouping,
+        ) {
+            session.project = project;
+        }
+    }
+}
+
+fn collect_projects_from_analytics(
+    paths: &Paths,
+    source: Option<SourceFilter>,
+    grouping: ProjectGrouping,
+) -> Result<Vec<String>> {
+    let store = AnalyticsStore::open(analytics_path(&paths.state))?;
+    let rows = store.query_sessions(source, None, None, grouping, None)?;
+    if rows.is_empty() {
+        anyhow::bail!("no analytics projects");
+    }
+    let mut set = HashSet::new();
+    for row in rows {
+        if !row.display_project.is_empty() {
+            set.insert(row.display_project);
+        }
+    }
+    let mut projects: Vec<String> = set.into_iter().collect();
+    projects.sort();
+    Ok(projects)
+}
+
+fn build_project_timeline(
+    paths: &Paths,
+    source: Option<SourceFilter>,
+    range: TimelineRange,
+    display: ProjectDisplayMode,
+) -> Result<Vec<ProjectTimelineRow>> {
+    let store = AnalyticsStore::open(analytics_path(&paths.state))?;
+    let now = now_ms();
+    let rows = store.query_sessions(source, range.since_ms(now), None, display.grouping(), None)?;
+    let mut projects: HashMap<String, ProjectTimelineRow> = HashMap::new();
+    for row in rows {
+        let project_name = if row.display_project.is_empty() {
+            row.project
+        } else {
+            row.display_project
+        };
+        let entry = projects
+            .entry(project_name.clone())
+            .or_insert_with(|| ProjectTimelineRow {
+                project: project_name,
+                session_count: 0,
+                last_ts: 0,
+                session_ts: Vec::new(),
+            });
+        entry.session_count += 1;
+        entry.last_ts = entry.last_ts.max(row.last_at);
+        entry.session_ts.push(row.last_at);
+    }
+    let mut out: Vec<ProjectTimelineRow> = projects.into_values().collect();
+    for row in &mut out {
+        row.session_ts.sort_unstable();
+    }
+    out.sort_by(|a, b| {
+        b.session_count
+            .cmp(&a.session_count)
+            .then_with(|| b.last_ts.cmp(&a.last_ts))
+            .then_with(|| a.project.cmp(&b.project))
+    });
     Ok(out)
 }
 
@@ -2287,6 +2803,149 @@ fn format_relative_ts_at(ts: u64, now: u64) -> String {
     } else {
         format!("{}y", age_secs / YEAR)
     }
+}
+
+fn now_ms() -> u64 {
+    let now = chrono::Utc::now().timestamp_millis();
+    u64::try_from(now).unwrap_or(0)
+}
+
+fn timeline_bounds(rows: &[ProjectTimelineRow], range: TimelineRange) -> (u64, u64) {
+    let now = now_ms();
+    let min_seen = rows
+        .iter()
+        .flat_map(|row| row.session_ts.iter())
+        .copied()
+        .min()
+        .unwrap_or(now);
+    let max_seen = rows
+        .iter()
+        .flat_map(|row| row.session_ts.iter())
+        .copied()
+        .max()
+        .unwrap_or(now);
+    match range.since_ms(now) {
+        Some(since) => (since, now.max(since.saturating_add(1))),
+        None => (min_seen, max_seen.max(min_seen.saturating_add(1))),
+    }
+}
+
+fn timeline_date_range(rows: &[ProjectTimelineRow], range: TimelineRange) -> String {
+    let (start, end) = timeline_bounds(rows, range);
+    format!("{}..{}", format_day(start), format_day(end))
+}
+
+fn format_day(ts: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ts as i64)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn timeline_project_width(rows: &[ProjectTimelineRow], total_width: u16) -> u16 {
+    let max_sessions = rows.iter().map(|row| row.session_count).max().unwrap_or(0);
+    let significant_sessions = (max_sessions / 20).max(3);
+    let mut widths: Vec<usize> = rows
+        .iter()
+        .filter(|row| row.session_count >= significant_sessions)
+        .map(|row| row.project.chars().count().saturating_add(1))
+        .collect();
+    if widths.is_empty() {
+        widths = rows
+            .iter()
+            .map(|row| row.project.chars().count().saturating_add(1))
+            .collect();
+    }
+    let width = widths.iter().max().copied().unwrap_or(12);
+    let max_project = total_width.saturating_sub(24).clamp(12, 32);
+    (width as u16).clamp(12, max_project)
+}
+
+fn timeline_chart_width(
+    total_width: u16,
+    project_width: u16,
+    count_width: u16,
+    last_width: u16,
+) -> usize {
+    const MAX_TIMELINE_CHART_WIDTH: usize = 56;
+    let gutter_width = 2u16;
+    let available = total_width
+        .saturating_sub(project_width)
+        .saturating_sub(gutter_width)
+        .saturating_sub(count_width)
+        .saturating_sub(last_width) as usize;
+    available.min(MAX_TIMELINE_CHART_WIDTH)
+}
+
+fn timeline_density_max(rows: &[ProjectTimelineRow], bounds: (u64, u64), width: usize) -> usize {
+    rows.iter()
+        .flat_map(|row| timeline_bucket_counts(&row.session_ts, bounds, width))
+        .max()
+        .unwrap_or(0)
+}
+
+fn timeline_bucket_counts(session_ts: &[u64], bounds: (u64, u64), width: usize) -> Vec<usize> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let mut buckets = vec![0usize; width];
+    let span = bounds.1.saturating_sub(bounds.0).max(1);
+    for &ts in session_ts {
+        let clamped = ts.clamp(bounds.0, bounds.1);
+        let offset = clamped.saturating_sub(bounds.0);
+        let mut idx = ((offset as u128 * width as u128) / span as u128) as usize;
+        if idx >= width {
+            idx = width - 1;
+        }
+        buckets[idx] += 1;
+    }
+    buckets
+}
+
+fn timeline_chart(
+    session_ts: &[u64],
+    bounds: (u64, u64),
+    width: usize,
+    density_max: usize,
+) -> String {
+    timeline_bucket_counts(session_ts, bounds, width)
+        .into_iter()
+        .map(|count| timeline_glyph(count, density_max))
+        .collect()
+}
+
+fn timeline_glyph(count: usize, max: usize) -> char {
+    if count == 0 || max == 0 {
+        return ' ';
+    }
+    if max == 1 {
+        return '⠁';
+    }
+    match ((count * 4).saturating_add(max - 1)) / max {
+        0 => ' ',
+        1 => '⠁',
+        2 => '⠃',
+        3 => '⠇',
+        _ => '⣿',
+    }
+}
+
+fn truncate_middle(value: &str, width: usize) -> String {
+    let len = value.chars().count();
+    if len <= width {
+        return value.to_string();
+    }
+    if width <= 1 {
+        return "…".to_string();
+    }
+    let keep = width.saturating_sub(1);
+    let head = keep / 2;
+    let tail = keep.saturating_sub(head);
+    let mut out = String::new();
+    out.extend(value.chars().take(head));
+    out.push('…');
+    let tail_chars: Vec<char> = value.chars().rev().take(tail).collect();
+    out.extend(tail_chars.into_iter().rev());
+    out
 }
 
 fn build_matchers(query: &str) -> Result<Vec<regex::Regex>> {
@@ -2986,6 +3645,63 @@ mod tests {
             record_preview_text(&record),
             "{\n  \"cmd\": \"printf '{x: [1,2]}'\",\n  \"args\": [\n    \"a,b\",\n    \"c:d\"\n  ]\n}"
         );
+    }
+
+    #[test]
+    fn timeline_chart_uses_shared_density_scale() {
+        let dense = timeline_chart(&[10, 10, 10, 50], (0, 100), 5, 3);
+        let sparse = timeline_chart(&[50], (0, 100), 5, 3);
+
+        assert!(dense.contains('⣿'));
+        assert!(sparse.contains('⠃'));
+        assert!(!sparse.contains('⣿'));
+    }
+
+    #[test]
+    fn timeline_default_range_is_all_history() {
+        assert_eq!(TimelineRange::All.label(), "all history");
+        assert_eq!(TimelineRange::All.since_ms(123), None);
+    }
+
+    #[test]
+    fn timeline_chart_width_reserves_numeric_gutters() {
+        assert_eq!(timeline_chart_width(100, 20, 5, 4), 56);
+        assert_eq!(timeline_chart_width(40, 20, 5, 4), 9);
+    }
+
+    #[test]
+    fn timeline_project_width_ignores_low_count_long_names() {
+        let rows = vec![
+            timeline_row("mdnb", 925),
+            timeline_row("sidequery-backend", 413),
+            timeline_row("nico-duckdb-iceberg", 51),
+            timeline_row(
+                "generated-harness-directory-name-that-should-not-set-width",
+                1,
+            ),
+        ];
+
+        assert_eq!(timeline_project_width(&rows, 120), 20);
+    }
+
+    #[test]
+    fn timeline_project_width_keeps_significant_long_names() {
+        let rows = vec![
+            timeline_row("mdnb", 925),
+            timeline_row("sidequery-backend", 413),
+            timeline_row("important-long-project-name", 300),
+        ];
+
+        assert_eq!(timeline_project_width(&rows, 120), 28);
+    }
+
+    fn timeline_row(project: &str, session_count: usize) -> ProjectTimelineRow {
+        ProjectTimelineRow {
+            project: project.to_string(),
+            session_count,
+            last_ts: 0,
+            session_ts: Vec::new(),
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum SourceKind {
     #[default]
     Claude,


### PR DESCRIPTION
Adds a SQLite analytics cache derived from the existing search index so project/session timeline aggregation can run quickly without scanning Tantivy at render time.

Includes a timeline TUI view with all-history default range, source/range/group controls, repo-based worktree grouping, real backfill support, and compact project-name width heuristics for generated low-activity paths.

Validation run:
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test