### PR TITLE
Fall back to lexical search and quiet auto-indexing under the daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ memex index-service disable
 `index-service` reads config defaults (mode, interval, log paths). Flags override.
 
 On Linux, creates systemd user units in `~/.config/systemd/user/`. On macOS, creates a launchd plist in `~/.memex/`.
+On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
 
 ## Embeddings
 

--- a/skills/codex/memex-search/SKILL.md
+++ b/skills/codex/memex-search/SKILL.md
@@ -78,13 +78,21 @@ Each JSON line includes:
 - `--fields score,ts,doc_id,session_id,snippet,event_id,parent_event_id` to reduce output
 - `-v/--verbose` for human output
 
-### Background index service (macOS launchd)
+### Background index service
 
 ```
 memex index-service enable
 memex index-service enable --continuous
 memex index-service disable
 ```
+
+- Use `memex index-service enable` to install the background indexer. It runs via launchd on macOS and systemd user services on Linux.
+- Default mode is periodic indexing, typically every 3600 seconds. Use `--interval <seconds>` to override.
+- Use `memex index-service enable --continuous` for a long-lived process that watches more frequently; use `--poll-interval <seconds>` to tune continuous mode.
+- The service inherits indexing flags, so pass source and embedding options at install time when needed, e.g. `memex index-service enable --include-agents --embeddings`.
+- On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
+- macOS writes `~/.memex/index-service.plist`, `~/.memex/index-service.log`, and `~/.memex/index-service.err.log`. Linux writes systemd user units under `~/.config/systemd/user/`.
+- Use `memex index-service disable` to unload and remove the service.
 
 ### Narrow first (fastest reducers)
 
@@ -129,6 +137,7 @@ background index service or `index --watch`, and consider setting
 
 - Semantic: `--semantic`
 - Hybrid (BM25 + vectors, RRF): `--hybrid`
+- If the vector index is unavailable, memex warns on stderr and falls back to lexical search. Treat this as degraded retrieval and mention `memex embed` as the recovery step when useful.
 - Recency tuning:
   - `--recency-weight <float>`
   - `--recency-half-life-days <float>`

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -79,13 +79,21 @@ Each JSON line includes:
 - `--fields score,ts,doc_id,session_id,snippet,event_id,parent_event_id` to reduce output
 - `-v/--verbose` for human output
 
-### Background index service (macOS launchd)
+### Background index service
 
 ```
 memex index-service enable
 memex index-service enable --continuous
 memex index-service disable
 ```
+
+- Use `memex index-service enable` to install the background indexer. It runs via launchd on macOS and systemd user services on Linux.
+- Default mode is periodic indexing, typically every 3600 seconds. Use `--interval <seconds>` to override.
+- Use `memex index-service enable --continuous` for a long-lived process that watches more frequently; use `--poll-interval <seconds>` to tune continuous mode.
+- The service inherits indexing flags, so pass source and embedding options at install time when needed, e.g. `memex index-service enable --include-agents --embeddings`.
+- On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
+- macOS writes `~/.memex/index-service.plist`, `~/.memex/index-service.log`, and `~/.memex/index-service.err.log`. Linux writes systemd user units under `~/.config/systemd/user/`.
+- Use `memex index-service disable` to unload and remove the service.
 
 ### Narrow first (fastest reducers)
 
@@ -130,6 +138,7 @@ background index service or `index --watch`, and consider setting
 
 - Semantic: `--semantic`
 - Hybrid (BM25 + vectors, RRF): `--hybrid`
+- If the vector index is unavailable, memex warns on stderr and falls back to lexical search. Treat this as degraded retrieval and mention `memex embed` as the recovery step when useful.
 - Recency tuning:
   - `--recency-weight <float>`
   - `--recency-half-life-days <float>`

--- a/skills/opencode/memex-search/SKILL.md
+++ b/skills/opencode/memex-search/SKILL.md
@@ -26,6 +26,18 @@ description: Search, filter, and retrieve Opencode history via memex CLI. Use fo
 | Concepts, intent         | `--semantic` | `memex search "auth flow" --semantic`   |
 | Mixed specific + fuzzy   | `--hybrid`   | `memex search "user_id logic" --hybrid` |
 
+If the vector index is unavailable, memex warns on stderr and falls back to lexical search. Treat this as degraded retrieval and mention `memex embed` as the recovery step when useful.
+
+## Background Index Service
+
+- Use `memex index-service enable` to install the background indexer. It runs via launchd on macOS and systemd user services on Linux.
+- Use `memex index-service enable --continuous` for a long-lived watcher; add `--poll-interval <seconds>` to tune continuous mode.
+- Default mode is periodic indexing, typically every 3600 seconds; add `--interval <seconds>` to tune interval mode.
+- The service inherits indexing flags, so pass source and embedding options at install time when needed, e.g. `memex index-service enable --opencode --embeddings`.
+- On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
+- macOS writes `~/.memex/index-service.plist`, `~/.memex/index-service.log`, and `~/.memex/index-service.err.log`. Linux writes systemd user units under `~/.config/systemd/user/`.
+- Use `memex index-service disable` to unload and remove the service.
+
 ## Session Context
 
 Use `--session {session_id}` to isolate a specific interaction thread.

--- a/skills/pi/memex-search/SKILL.md
+++ b/skills/pi/memex-search/SKILL.md
@@ -24,6 +24,18 @@ description: Search, filter, and retrieve Pi Coding Agent history via memex CLI.
 | Concepts, intent         | `--semantic` | `memex search "auth flow" --source pi --semantic` |
 | Mixed specific + fuzzy   | `--hybrid`   | `memex search "user_id logic" --source pi --hybrid` |
 
+If the vector index is unavailable, memex warns on stderr and falls back to lexical search. Treat this as degraded retrieval and mention `memex embed` as the recovery step when useful.
+
+## Background Index Service
+
+- Use `memex index-service enable` to install the background indexer. It runs via launchd on macOS and systemd user services on Linux.
+- Use `memex index-service enable --continuous` for a long-lived watcher; add `--poll-interval <seconds>` to tune continuous mode.
+- Default mode is periodic indexing, typically every 3600 seconds; add `--interval <seconds>` to tune interval mode.
+- The service inherits indexing flags, so pass source and embedding options at install time when needed, e.g. `memex index-service enable --pi --embeddings`.
+- On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
+- macOS writes `~/.memex/index-service.plist`, `~/.memex/index-service.log`, and `~/.memex/index-service.err.log`. Linux writes systemd user units under `~/.config/systemd/user/`.
+- Use `memex index-service disable` to unload and remove the service.
+
 ## Session Context
 
 Use `--session {session_id}` to isolate a specific interaction thread.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -877,14 +877,13 @@ fn run_search(
             },
         );
     }
-    let results = index.search(&options)?;
-    let now_ms = chrono::Utc::now().timestamp_millis() as u64;
-    let mut reranked =
-        apply_recency_to_results(results, now_ms, recency_weight, recency_half_life_days);
-    reranked.retain(|(_, record)| matches_filters(record, &options));
-    let reranked = apply_post_processing(reranked, &render);
-    render_results(reranked, &render)?;
-    Ok(())
+    run_lexical_search(
+        &index,
+        &options,
+        &render,
+        recency_weight,
+        recency_half_life_days,
+    )
 }
 
 struct SearchContext<'a> {
@@ -902,7 +901,20 @@ fn run_semantic_search(
     limit: usize,
     ctx: &SearchContext,
 ) -> Result<()> {
-    let vector = VectorIndex::open(&ctx.paths.vectors)?;
+    let vector = match VectorIndex::open(&ctx.paths.vectors) {
+        Ok(vector) => vector,
+        Err(err) if is_missing_vector_index_error(&err) => {
+            warn_vector_index_missing("semantic");
+            return run_lexical_search(
+                index,
+                options,
+                ctx.render,
+                ctx.recency_weight,
+                ctx.recency_half_life_days,
+            );
+        }
+        Err(err) => return Err(err),
+    };
     let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
     let embeddings = embedder.embed_texts(&[options.query.as_str()])?;
     let embedding = embeddings
@@ -936,7 +948,20 @@ fn run_hybrid_search(
     limit: usize,
     ctx: &SearchContext,
 ) -> Result<()> {
-    let vector = VectorIndex::open(&ctx.paths.vectors)?;
+    let vector = match VectorIndex::open(&ctx.paths.vectors) {
+        Ok(vector) => vector,
+        Err(err) if is_missing_vector_index_error(&err) => {
+            warn_vector_index_missing("hybrid");
+            return run_lexical_search(
+                index,
+                options,
+                ctx.render,
+                ctx.recency_weight,
+                ctx.recency_half_life_days,
+            );
+        }
+        Err(err) => return Err(err),
+    };
     let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
 
     let bm25_k = (limit * 5).clamp(50, 500);
@@ -1004,6 +1029,33 @@ fn run_hybrid_search(
     let merged = apply_post_processing(merged, ctx.render);
     render_results(merged, ctx.render)?;
     Ok(())
+}
+
+fn run_lexical_search(
+    index: &SearchIndex,
+    options: &QueryOptions,
+    render: &RenderOptions,
+    recency_weight: f32,
+    recency_half_life_days: f32,
+) -> Result<()> {
+    let results = index.search(options)?;
+    let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+    let mut reranked =
+        apply_recency_to_results(results, now_ms, recency_weight, recency_half_life_days);
+    reranked.retain(|(_, record)| matches_filters(record, options));
+    let reranked = apply_post_processing(reranked, render);
+    render_results(reranked, render)?;
+    Ok(())
+}
+
+fn is_missing_vector_index_error(err: &anyhow::Error) -> bool {
+    err.to_string() == "vector index not found"
+}
+
+fn warn_vector_index_missing(mode: &str) {
+    eprintln!(
+        "Warning: {mode} search requested, but the local vector index is not available; falling back to lexical search. Run 'memex embed' to build embeddings."
+    );
 }
 
 fn score_from_distance(distance: f32) -> f32 {
@@ -1763,7 +1815,7 @@ fn run_index_service_enable(
 
     std::fs::create_dir_all(&paths.root)?;
 
-    if cfg!(target_os = "macos") {
+    let result = if cfg!(target_os = "macos") {
         run_index_service_enable_launchd(
             &config,
             &paths,
@@ -1791,7 +1843,43 @@ fn run_index_service_enable(
         Err(anyhow!(
             "background service scheduling is only supported on macOS and Linux"
         ))
+    };
+
+    result?;
+    disable_auto_index_on_search_by_default(&paths, &config)?;
+    Ok(())
+}
+
+fn disable_auto_index_on_search_by_default(paths: &Paths, config: &UserConfig) -> Result<()> {
+    if config.auto_index_on_search.is_some() {
+        return Ok(());
     }
+
+    std::fs::create_dir_all(&paths.root)?;
+    let path = paths.root.join("config.toml");
+    let mut contents = if path.exists() {
+        std::fs::read_to_string(&path)?
+    } else {
+        String::new()
+    };
+
+    if !contents.trim().is_empty() {
+        if !contents.ends_with('\n') {
+            contents.push('\n');
+        }
+        contents.push('\n');
+    }
+    contents.push_str(
+        "# Background indexing handles freshness; avoid duplicate scan work during search.\n",
+    );
+    contents.push_str("auto_index_on_search = false\n");
+
+    std::fs::write(&path, contents)?;
+    println!(
+        "updated config: {} (auto_index_on_search = false)",
+        path.display()
+    );
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2909,6 +2997,36 @@ mod tests {
         assert!(args.contains(&"--no-cursor".to_string()));
         assert!(args.contains(&"--no-pi".to_string()));
         assert!(args.contains(&"--no-copilot".to_string()));
+    }
+
+    #[test]
+    fn disabling_auto_index_on_search_creates_config_when_unset() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).unwrap();
+
+        disable_auto_index_on_search_by_default(&paths, &UserConfig::default()).unwrap();
+
+        let config_path = tmp.path().join("config.toml");
+        let contents = std::fs::read_to_string(config_path).unwrap();
+        assert!(contents.contains("auto_index_on_search = false"));
+    }
+
+    #[test]
+    fn disabling_auto_index_on_search_preserves_explicit_config() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).unwrap();
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        std::fs::write(
+            tmp.path().join("config.toml"),
+            "auto_index_on_search = true\n",
+        )
+        .unwrap();
+        let config = UserConfig::load(&paths).unwrap();
+
+        disable_auto_index_on_search_by_default(&paths, &config).unwrap();
+
+        let contents = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+        assert_eq!(contents, "auto_index_on_search = true\n");
     }
 
     fn make_vector(dims: usize) -> Vec<f32> {


### PR DESCRIPTION
## Summary

Two small, related robustness fixes around search and the background index service.

**Semantic/hybrid search degrades instead of failing.** `--semantic` and `--hybrid` previously errored out when the vector index was missing. They now print a warning to stderr pointing at `memex embed` and fall back to lexical results. The shared lexical path is extracted into `run_lexical_search` so all three entry points use it.

**`index-service enable` disables `auto_index_on_search`.** Once a daemon is indexing, a search re-scanning sources is duplicated work. Enabling the service now writes `auto_index_on_search = false` to config, but only when the setting is absent — an explicit user value is preserved.

## Docs

README and the four `memex-search` SKILL.md variants (claude, codex, opencode, pi) document both behaviors, gain a proper "Background Index Service" section, and drop the macOS-only framing now that systemd is supported.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (131 passing, including two new tests covering the config write and the preserve-explicit-value case).