### PR TITLE
Bump workflow actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -38,7 +38,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -46,7 +46,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -62,7 +62,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             arch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -38,7 +38,7 @@ jobs:
           tar -C target/${{ matrix.target }}/release -czf "${artifact}" memex
           shasum -a 256 "${artifact}" > "${artifact}.sha256"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: memex-macos-${{ matrix.arch }}
           path: |
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -78,7 +78,7 @@ jobs:
           tar -C target/${{ matrix.target }}/release -czf "${artifact}" memex
           sha256sum "${artifact}" > "${artifact}.sha256"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: memex-linux-${{ matrix.arch }}
           path: |
@@ -90,12 +90,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: artifacts/*
 


### PR DESCRIPTION
## Summary

The v0.6.0 release run warned that `actions/checkout@v4` and `actions/upload-artifact@v4` target Node.js 20 and were being force-run on Node 24. This moves every pinned action to its current major, all of which run Node 24 natively.

| action | before | after |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

## Breaking changes reviewed

Checked the release notes for each major crossed, since `release.yml` only runs on a tag push and is not exercised by PR CI:

- **checkout v7** blocks fork checkouts under `pull_request_target` and `workflow_run`. Neither workflow uses those triggers.
- **upload-artifact v7** adds opt-in direct (unzipped) uploads behind a new `archive` param. We do not set it, so artifacts are still zipped as before.
- **download-artifact v8** skips unzipping non-zipped downloads, which only affects direct uploads we do not use. It also now **errors on a digest mismatch** instead of warning — a safer default, deliberately kept.
- **cache v6** and **action-gh-release v3** are ESM/Node 24 migrations with no behavior change for this usage.

The artifact upload/download pair stays within the same v4-generation artifact backend, so they remain compatible.

## Verification

PR CI covers the `ci.yml` half (checkout + cache). The `release.yml` half will be exercised by the next tag push; a failure there would fail the release job without publishing bad assets.