### PR TITLE
Add local token usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ Human output:
 memex search "your query" -v
 ```
 
+## Token usage
+
+Reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, and Copilot logs:
+
+```
+memex usage
+memex usage --source codex --since 2026-07-01
+memex usage --json --events
+```
+
+`--cost auto` prefers a provider-stored request cost and otherwise applies the versioned built-in API price catalog. `--cost source` uses only stored costs; `--cost reprice` always applies the catalog. Calculated costs are API-equivalent estimates, not subscription charges. Events with unknown models or prices remain in token totals and are reported as unpriced.
+
+Local token history is reconstructed usage. It is deliberately kept separate from authoritative subscription quota percentages and reset windows.
+
+On the TUI home screen, press `Ctrl+T` to toggle the 30-day activity chart between session count and token volume. Token activity is loaded lazily and cached when first shown.
+
 ## Build from source
 
 ```

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -8,8 +8,9 @@ use std::time::Duration;
 
 const SCHEMA_VERSION: i64 = 2;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ProjectGrouping {
+    #[default]
     Flat,
     Repository,
 }
@@ -644,6 +645,10 @@ fn git_metadata_for_cwd(cwd: &str) -> GitMetadata {
         repo_project,
         status,
     }
+}
+
+pub(crate) fn repository_project_for_cwd(cwd: &str) -> Option<String> {
+    git_metadata_for_cwd(cwd).repo_project
 }
 
 fn claude_worktree_repo_project(cwd: &str) -> Option<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1417,6 +1417,7 @@ fn run_usage(
         source,
         project: None,
         project_grouping: crate::analytics::ProjectGrouping::Flat,
+        session_keys: None,
         since_ms: parse_ts_millis(since)?,
         until_ms: parse_ts_millis(until)?,
         cost_mode,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1415,6 +1415,8 @@ fn run_usage(
 ) -> Result<()> {
     let query = UsageQuery {
         source,
+        project: None,
+        project_grouping: crate::analytics::ProjectGrouping::Flat,
         since_ms: parse_ts_millis(since)?,
         until_ms: parse_ts_millis(until)?,
         cost_mode,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use crate::transfer::{
 };
 use crate::tui;
 use crate::types::{RecordLinks, SourceFilter};
+use crate::usage::{CostMode, UsageQuery, scan_usage};
 use crate::vector::VectorIndex;
 use anyhow::{Result, anyhow};
 use chrono::SecondsFormat;
@@ -247,6 +248,32 @@ OUTPUT FIELDS (--fields):
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
+    },
+    /// Reconstruct local token usage from agent logs
+    #[command(after_help = "\
+EXAMPLES:
+    memex usage
+    memex usage --source codex --since 2026-07-01
+    memex usage --json")]
+    Usage {
+        /// Filter by source: claude, codex, cursor, opencode, pi, or copilot
+        #[arg(long)]
+        source: Option<SourceFilter>,
+        /// Only include events on or after this date/timestamp
+        #[arg(long, value_name = "DATE_OR_TIMESTAMP")]
+        since: Option<String>,
+        /// Only include events before this date/timestamp
+        #[arg(long, value_name = "DATE_OR_TIMESTAMP")]
+        until: Option<String>,
+        /// Emit the report as JSON
+        #[arg(long)]
+        json: bool,
+        /// Include normalized request-level events in JSON output
+        #[arg(long, requires = "json")]
+        events: bool,
+        /// Cost source: stored source cost, automatic fallback, or API-rate repricing
+        #[arg(long, value_enum, default_value = "auto")]
+        cost: CostMode,
     },
     /// Rebuild the SQLite analytics cache from the existing Tantivy index
     #[command(hide = true)]
@@ -533,6 +560,16 @@ pub fn run() -> Result<()> {
         }
         Commands::Stats { root } => {
             run_stats(root)?;
+        }
+        Commands::Usage {
+            source,
+            since,
+            until,
+            json,
+            events,
+            cost,
+        } => {
+            run_usage(source, since, until, json, events, cost)?;
         }
         Commands::AnalyticsBackfill { root } => {
             run_analytics_backfill(root)?;
@@ -1365,6 +1402,69 @@ fn run_stats(root: Option<PathBuf>) -> Result<()> {
     println!("index: {}", paths.index.display());
     println!("documents: {}", index.doc_count()?);
     print_vector_stats(&paths.vectors)?;
+    Ok(())
+}
+
+fn run_usage(
+    source: Option<SourceFilter>,
+    since: Option<String>,
+    until: Option<String>,
+    json: bool,
+    include_events: bool,
+    cost_mode: CostMode,
+) -> Result<()> {
+    let query = UsageQuery {
+        source,
+        since_ms: parse_ts_millis(since)?,
+        until_ms: parse_ts_millis(until)?,
+        cost_mode,
+        include_events,
+    };
+    let report = scan_usage(&query)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("local reconstructed usage (not subscription quota)");
+        for row in &report.by_source {
+            println!(
+                "{:<10} {:>12} tokens  {:>9} input  {:>9} cache read  {:>9} cache write  {:>9} output  {:>5} events",
+                row.source,
+                row.total_tokens,
+                row.uncached_input,
+                row.cache_read,
+                row.cache_write,
+                row.output,
+                row.events,
+            );
+            if row.priced_events > 0 {
+                println!(
+                    "             ${:.4} API-equivalent cost ({} priced, {} unpriced)",
+                    row.known_cost_usd, row.priced_events, row.unpriced_events
+                );
+            }
+        }
+        println!(
+            "total      {:>12} tokens  {} events",
+            report.total_tokens, report.events
+        );
+        println!(
+            "cost       ${:.4} known API-equivalent ({} priced, {} unpriced; {:?}, {})",
+            report.known_cost_usd,
+            report.priced_events,
+            report.unpriced_events,
+            report.cost_mode,
+            report.price_catalog
+        );
+        if report.unknown_model_events > 0 || report.conservative_events > 0 {
+            println!(
+                "quality: {} unknown-model events, {} conservatively undercounted events",
+                report.unknown_model_events, report.conservative_events
+            );
+        }
+        for warning in &report.warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
     Ok(())
 }
 
@@ -2523,6 +2623,13 @@ fn parse_ts_millis(value: Option<String>) -> Result<Option<u64>> {
             return Ok(Some(num));
         }
         return Ok(Some(num * 1000));
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(&value, "%Y-%m-%d") {
+        let midnight = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| anyhow!("invalid date: {value}"))?
+            .and_utc();
+        return Ok(Some(midnight.timestamp_millis() as u64));
     }
     let dt = chrono::DateTime::parse_from_rfc3339(&value)
         .map_err(|_| anyhow!("invalid timestamp: {value}"))?;

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2100,8 +2100,7 @@ fn parse_pi_file(
     let mut turn_id = task.turn_id;
 
     let source_path = task.path.to_string_lossy().to_string();
-    let mut session_id =
-        session_id_from_filename(&task.path).unwrap_or_else(|| source_path.clone());
+    let mut session_id = pi_session_id_from_path(&task.path);
     let mut project = project_from_pi_session_path(&task.path);
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
 
@@ -2493,14 +2492,24 @@ fn apply_pi_session_header(
     session_id: &mut String,
     project: &mut String,
 ) {
-    if let Some(id) = obj.get("id").and_then(|v| v.as_str())
-        && !id.is_empty()
-    {
+    apply_pi_session_identity(
+        obj.get("id").and_then(|v| v.as_str()),
+        obj.get("cwd").and_then(|v| v.as_str()),
+        session_id,
+        project,
+    );
+}
+
+pub(crate) fn apply_pi_session_identity(
+    id: Option<&str>,
+    cwd: Option<&str>,
+    session_id: &mut String,
+    project: &mut String,
+) {
+    if let Some(id) = id.filter(|id| !id.is_empty()) {
         *session_id = id.to_string();
     }
-    if let Some(cwd) = obj.get("cwd").and_then(|v| v.as_str())
-        && !cwd.is_empty()
-    {
+    if let Some(cwd) = cwd.filter(|cwd| !cwd.is_empty()) {
         *project = project_from_path(cwd);
     }
 }
@@ -3293,6 +3302,10 @@ fn session_id_from_filename(path: &Path) -> Option<String> {
         .captures(&name)
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().to_string())
+}
+
+pub(crate) fn pi_session_id_from_path(path: &Path) -> String {
+    session_id_from_filename(path).unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
 
 fn is_system_instruction(text: &str) -> bool {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1085,7 +1085,7 @@ fn pi_agent_root() -> PathBuf {
     home.join(".pi").join("agent")
 }
 
-fn pi_sessions_root() -> PathBuf {
+pub(crate) fn pi_sessions_root() -> PathBuf {
     if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
         return PathBuf::from(root);
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1068,7 +1068,7 @@ fn codex_history_path() -> PathBuf {
     codex_root().join("history.jsonl")
 }
 
-fn cursor_projects_root() -> PathBuf {
+pub(crate) fn cursor_projects_root() -> PathBuf {
     let home = directories::BaseDirs::new()
         .map(|b| b.home_dir().to_path_buf())
         .unwrap_or_else(|| PathBuf::from("/"));
@@ -3015,7 +3015,7 @@ fn copilot_tool_output(data: &serde_json::Value) -> Option<String> {
     None
 }
 
-fn project_from_cursor_path(path: &Path) -> String {
+pub(crate) fn project_from_cursor_path(path: &Path) -> String {
     let root = cursor_projects_root();
     let Ok(relative) = path.strip_prefix(root) else {
         return "cursor".to_string();
@@ -3033,7 +3033,7 @@ fn project_from_cursor_path(path: &Path) -> String {
     decode_project_name(project_folder)
 }
 
-fn cursor_session_id_from_path(path: &Path) -> String {
+pub(crate) fn cursor_session_id_from_path(path: &Path) -> String {
     let components: Vec<_> = path.components().collect();
     for (idx, component) in components.iter().enumerate() {
         if component.as_os_str().to_str() == Some("agent-transcripts")
@@ -3083,7 +3083,7 @@ fn cursor_is_subagent_transcript(path: &Path) -> bool {
         .any(|component| component.as_os_str().to_str() == Some("subagents"))
 }
 
-fn cursor_transcript_id(path: &Path) -> String {
+pub(crate) fn cursor_transcript_id(path: &Path) -> String {
     path.file_stem()
         .and_then(|s| s.to_str())
         .filter(|s| !s.is_empty())
@@ -3111,7 +3111,7 @@ fn stable_cursor_turn_bucket(value: &str) -> u32 {
     hash % CURSOR_SUBAGENT_TURN_BUCKETS
 }
 
-fn project_from_pi_session_path(path: &Path) -> String {
+pub(crate) fn project_from_pi_session_path(path: &Path) -> String {
     path.parent()
         .and_then(|p| p.file_name())
         .and_then(|s| s.to_str())

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1811,7 +1811,7 @@ fn parse_opencode_file(
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
         .to_string();
-    let project = "opencode".to_string();
+    let project = SourceKind::Opencode.label().to_string();
     let session_links = opencode_session_links
         .get(&session_id)
         .cloned()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod state;
 pub mod transfer;
 pub mod tui;
 pub mod types;
+pub mod usage;
 pub mod vector;
 
 #[cfg(test)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1019,26 +1019,44 @@ impl App {
     }
 
     fn kickoff_search(&mut self) {
-        self.pending_home_search = None;
+        let was_pending = self.pending_home_search.take().is_some();
+        let refresh_home_tokens =
+            self.layout_mode == LayoutMode::Home && self.home_chart_mode == HomeChartMode::Tokens;
+        if refresh_home_tokens && !was_pending {
+            self.invalidate_home_token_activity();
+            self.home_token_activity_state = LoadState::Loading;
+        }
         let request_id = self.next_request_id();
         self.active_search_request = request_id;
         self.sessions_state = LoadState::Loading;
         self.last_spinner_at = Instant::now();
+        let query = self.query.trim().to_string();
+        let query_is_empty = query.is_empty();
         self.set_status("searching...");
         let request = SearchRequest {
             request_id,
-            query: self.query.trim().to_string(),
+            query,
             project: self.project.trim().to_string(),
             source: self.source,
             since: self.sessions_since,
             grouping: self.project_display.grouping(),
         };
         if self.search_request_tx.send(request).is_err() {
-            self.sessions_state = LoadState::Error("search worker stopped".to_string());
+            let message = "search worker stopped".to_string();
+            self.sessions_state = LoadState::Error(message.clone());
+            if refresh_home_tokens {
+                self.home_token_activity_state = LoadState::Error(message);
+            }
+        } else if refresh_home_tokens && query_is_empty {
+            self.kickoff_home_token_activity();
         }
     }
 
     fn schedule_home_search(&mut self) {
+        if self.home_chart_mode == HomeChartMode::Tokens {
+            self.invalidate_home_token_activity();
+            self.home_token_activity_state = LoadState::Loading;
+        }
         self.active_search_request = self.next_request_id();
         self.sessions_state = LoadState::Loading;
         self.pending_home_search = Some(Instant::now() + HOME_SEARCH_DEBOUNCE);
@@ -1180,6 +1198,7 @@ impl App {
             self.source,
             &self.project,
             self.project_display.grouping(),
+            home_token_session_keys(&self.query, &self.results),
             self.home_activity_range,
             now_ms(),
         );
@@ -1374,9 +1393,6 @@ impl App {
         }
         if refresh_search {
             self.kickoff_search();
-            if token_filter_changed && self.home_chart_mode == HomeChartMode::Tokens {
-                self.kickoff_home_token_activity();
-            }
         } else if refresh_activity {
             self.kickoff_home_activity();
         }
@@ -1418,12 +1434,30 @@ impl App {
 
     fn toggle_home_chart_mode(&mut self) {
         self.home_chart_mode = self.home_chart_mode.toggle();
-        if self.home_chart_mode == HomeChartMode::Tokens
-            && matches!(
-                self.home_token_activity_state,
-                LoadState::Idle | LoadState::Error(_)
-            )
-        {
+        if self.home_chart_mode != HomeChartMode::Tokens {
+            return;
+        }
+        if !self.query.trim().is_empty() {
+            match &self.sessions_state {
+                LoadState::Loading => {
+                    self.invalidate_home_token_activity();
+                    self.home_token_activity_state = LoadState::Loading;
+                }
+                LoadState::Empty => {
+                    self.invalidate_home_token_activity();
+                    self.home_token_activity_state = LoadState::Empty;
+                }
+                LoadState::Error(message) => {
+                    let message = message.clone();
+                    self.invalidate_home_token_activity();
+                    self.home_token_activity_state = LoadState::Error(message);
+                }
+                _ => self.kickoff_home_token_activity(),
+            }
+        } else if matches!(
+            self.home_token_activity_state,
+            LoadState::Idle | LoadState::Error(_)
+        ) {
             self.kickoff_home_token_activity();
         }
     }
@@ -1512,6 +1546,17 @@ impl App {
                     self.set_status(format!("{} sessions", self.results.len()));
                 }
                 self.update_detail();
+                if self.layout_mode == LayoutMode::Home
+                    && self.home_chart_mode == HomeChartMode::Tokens
+                    && !self.query.trim().is_empty()
+                {
+                    if self.results.is_empty() {
+                        self.invalidate_home_token_activity();
+                        self.home_token_activity_state = LoadState::Empty;
+                    } else {
+                        self.kickoff_home_token_activity();
+                    }
+                }
             }
             SearchUpdate::Projects {
                 request_id,
@@ -1560,6 +1605,13 @@ impl App {
                 message,
             } if request_id == self.active_search_request => {
                 self.sessions_state = LoadState::Error(message.clone());
+                if self.layout_mode == LayoutMode::Home
+                    && self.home_chart_mode == HomeChartMode::Tokens
+                    && !self.query.trim().is_empty()
+                {
+                    self.invalidate_home_token_activity();
+                    self.home_token_activity_state = LoadState::Error(message.clone());
+                }
                 self.set_status(format!("search error: {message}"));
             }
             SearchUpdate::ProjectsError {
@@ -3015,6 +3067,7 @@ fn home_token_usage_query(
     source: SourceChoice,
     project: &str,
     grouping: ProjectGrouping,
+    session_keys: Option<HashSet<(String, String)>>,
     range: TimelineRange,
     now: u64,
 ) -> UsageQuery {
@@ -3022,11 +3075,29 @@ fn home_token_usage_query(
         source: source.as_filter(),
         project: (!project.trim().is_empty()).then(|| project.to_string()),
         project_grouping: grouping,
+        session_keys,
         since_ms: range.since_ms(now),
         until_ms: None,
         cost_mode: CostMode::Source,
         include_events: true,
     }
+}
+
+fn home_token_session_keys(
+    query: &str,
+    sessions: &[SessionSummary],
+) -> Option<HashSet<(String, String)>> {
+    (!query.trim().is_empty()).then(|| {
+        sessions
+            .iter()
+            .map(|session| {
+                (
+                    session.source.label().to_string(),
+                    session.session_id.clone(),
+                )
+            })
+            .collect()
+    })
 }
 
 fn activity_count_in_bounds(points: &[HomeChartPoint], bounds: (u64, u64)) -> usize {
@@ -6261,6 +6332,7 @@ mod tests {
             SourceChoice::Opencode,
             "memex",
             ProjectGrouping::Repository,
+            None,
             TimelineRange::Week,
             10_000,
         );
@@ -6268,8 +6340,44 @@ mod tests {
         assert_eq!(query.source, Some(SourceFilter::Opencode));
         assert_eq!(query.project.as_deref(), Some("memex"));
         assert_eq!(query.project_grouping, ProjectGrouping::Repository);
+        assert!(query.session_keys.is_none());
         assert_eq!(query.since_ms, TimelineRange::Week.since_ms(10_000));
         assert!(query.include_events);
+    }
+
+    #[test]
+    fn token_session_filter_uses_accepted_source_qualified_results() {
+        let sessions = vec![
+            SessionSummary {
+                session_id: "shared".into(),
+                project: "memex".into(),
+                source: SourceKind::CodexHistory,
+                last_ts: 1,
+                hit_count: 1,
+                top_score: 1.0,
+                snippet: String::new(),
+                source_path: "codex.jsonl".into(),
+                source_dir: String::new(),
+            },
+            SessionSummary {
+                session_id: "shared".into(),
+                project: "memex".into(),
+                source: SourceKind::Claude,
+                last_ts: 1,
+                hit_count: 1,
+                top_score: 1.0,
+                snippet: String::new(),
+                source_path: "claude.jsonl".into(),
+                source_dir: String::new(),
+            },
+        ];
+
+        let keys = home_token_session_keys("needle", &sessions).expect("session keys");
+
+        assert!(keys.contains(&("codex".into(), "shared".into())));
+        assert!(keys.contains(&("claude".into(), "shared".into())));
+        assert_eq!(keys.len(), 2);
+        assert!(home_token_session_keys("  ", &sessions).is_none());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1176,7 +1176,13 @@ impl App {
         self.home_token_activity_state = LoadState::Loading;
         self.home_token_activity_partial = false;
         let tx = self.search_tx.clone();
-        let query = home_token_usage_query(self.source, self.home_activity_range, now_ms());
+        let query = home_token_usage_query(
+            self.source,
+            &self.project,
+            self.project_display.grouping(),
+            self.home_activity_range,
+            now_ms(),
+        );
         std::thread::spawn(move || {
             let result = scan_usage(&query).map(|report| {
                 let partial = !report.warnings.is_empty();
@@ -1328,6 +1334,8 @@ impl App {
         let refresh_activity = self.home_dropdown == HomeDropdown::Range;
         let source_selection = self.home_dropdown == HomeDropdown::Source;
         let previous_source = self.source;
+        let project_selection = self.home_dropdown == HomeDropdown::Project;
+        let previous_project = self.project.clone();
         let refresh_search = match self.home_dropdown {
             HomeDropdown::Range => {
                 self.home_activity_range = TimelineRange::ALL
@@ -1359,12 +1367,14 @@ impl App {
         };
         self.close_home_dropdown();
         let source_changed = source_selection && self.source != previous_source;
-        if source_changed {
+        let project_changed = project_selection && self.project != previous_project;
+        let token_filter_changed = source_changed || project_changed;
+        if token_filter_changed {
             self.invalidate_home_token_activity();
         }
         if refresh_search {
             self.kickoff_search();
-            if source_changed && self.home_chart_mode == HomeChartMode::Tokens {
+            if token_filter_changed && self.home_chart_mode == HomeChartMode::Tokens {
                 self.kickoff_home_token_activity();
             }
         } else if refresh_activity {
@@ -3001,9 +3011,17 @@ fn home_activity_bounds_at(
     (min_seen, max_seen.max(min_seen.saturating_add(1)))
 }
 
-fn home_token_usage_query(source: SourceChoice, range: TimelineRange, now: u64) -> UsageQuery {
+fn home_token_usage_query(
+    source: SourceChoice,
+    project: &str,
+    grouping: ProjectGrouping,
+    range: TimelineRange,
+    now: u64,
+) -> UsageQuery {
     UsageQuery {
         source: source.as_filter(),
+        project: (!project.trim().is_empty()).then(|| project.to_string()),
+        project_grouping: grouping,
         since_ms: range.since_ms(now),
         until_ms: None,
         cost_mode: CostMode::Source,
@@ -6239,9 +6257,17 @@ mod tests {
 
     #[test]
     fn token_usage_query_applies_home_source_and_range() {
-        let query = home_token_usage_query(SourceChoice::Opencode, TimelineRange::Week, 10_000);
+        let query = home_token_usage_query(
+            SourceChoice::Opencode,
+            "memex",
+            ProjectGrouping::Repository,
+            TimelineRange::Week,
+            10_000,
+        );
 
         assert_eq!(query.source, Some(SourceFilter::Opencode));
+        assert_eq!(query.project.as_deref(), Some("memex"));
+        assert_eq!(query.project_grouping, ProjectGrouping::Repository);
         assert_eq!(query.since_ms, TimelineRange::Week.since_ms(10_000));
         assert!(query.include_events);
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1133,6 +1133,9 @@ impl App {
 
     fn kickoff_home_activity(&mut self) {
         let refresh_tokens = self.home_chart_mode == HomeChartMode::Tokens;
+        if !refresh_tokens {
+            self.invalidate_home_token_activity();
+        }
         let request_id = self.next_request_id();
         self.active_home_activity_request = request_id;
         self.home_activity_state = LoadState::Loading;
@@ -1169,18 +1172,13 @@ impl App {
     fn kickoff_home_token_activity(&mut self) {
         let request_id = self.next_request_id();
         self.active_home_token_activity_request = request_id;
+        self.home_token_activity.clear();
         self.home_token_activity_state = LoadState::Loading;
+        self.home_token_activity_partial = false;
         let tx = self.search_tx.clone();
-        let range = self.home_activity_range;
+        let query = home_token_usage_query(self.source, self.home_activity_range, now_ms());
         std::thread::spawn(move || {
-            let result = scan_usage(&UsageQuery {
-                source: None,
-                since_ms: range.since_ms(now_ms()),
-                until_ms: None,
-                cost_mode: CostMode::Source,
-                include_events: true,
-            })
-            .map(|report| {
+            let result = scan_usage(&query).map(|report| {
                 let partial = !report.warnings.is_empty();
                 let points = report
                     .details
@@ -1328,6 +1326,8 @@ impl App {
             return;
         };
         let refresh_activity = self.home_dropdown == HomeDropdown::Range;
+        let source_selection = self.home_dropdown == HomeDropdown::Source;
+        let previous_source = self.source;
         let refresh_search = match self.home_dropdown {
             HomeDropdown::Range => {
                 self.home_activity_range = TimelineRange::ALL
@@ -1358,8 +1358,15 @@ impl App {
             HomeDropdown::None => false,
         };
         self.close_home_dropdown();
+        let source_changed = source_selection && self.source != previous_source;
+        if source_changed {
+            self.invalidate_home_token_activity();
+        }
         if refresh_search {
             self.kickoff_search();
+            if source_changed && self.home_chart_mode == HomeChartMode::Tokens {
+                self.kickoff_home_token_activity();
+            }
         } else if refresh_activity {
             self.kickoff_home_activity();
         }
@@ -1411,6 +1418,14 @@ impl App {
         }
     }
 
+    fn invalidate_home_token_activity(&mut self) {
+        let request_id = self.next_request_id();
+        self.active_home_token_activity_request = request_id;
+        self.home_token_activity.clear();
+        self.home_token_activity_state = LoadState::Idle;
+        self.home_token_activity_partial = false;
+    }
+
     fn home_focus_list(&mut self) {
         if self.results.is_empty() {
             return;
@@ -1448,10 +1463,6 @@ impl App {
                 self.index_state = IndexState::Complete;
                 self.refresh_results();
                 if self.layout_mode == LayoutMode::Home {
-                    if self.home_chart_mode == HomeChartMode::Sessions {
-                        self.home_token_activity_state = LoadState::Idle;
-                        self.home_token_activity_partial = false;
-                    }
                     self.kickoff_home_activity();
                     self.kickoff_home_filters();
                 }
@@ -2988,6 +2999,16 @@ fn home_activity_bounds_at(
         .max()
         .unwrap_or(now);
     (min_seen, max_seen.max(min_seen.saturating_add(1)))
+}
+
+fn home_token_usage_query(source: SourceChoice, range: TimelineRange, now: u64) -> UsageQuery {
+    UsageQuery {
+        source: source.as_filter(),
+        since_ms: range.since_ms(now),
+        until_ms: None,
+        cost_mode: CostMode::Source,
+        include_events: true,
+    }
 }
 
 fn activity_count_in_bounds(points: &[HomeChartPoint], bounds: (u64, u64)) -> usize {
@@ -6214,6 +6235,43 @@ mod tests {
         app.home_chart_mode = HomeChartMode::Tokens;
         app.home_token_activity_state = LoadState::Loading;
         assert!(app.has_active_loading());
+    }
+
+    #[test]
+    fn token_usage_query_applies_home_source_and_range() {
+        let query = home_token_usage_query(SourceChoice::Opencode, TimelineRange::Week, 10_000);
+
+        assert_eq!(query.source, Some(SourceFilter::Opencode));
+        assert_eq!(query.since_ms, TimelineRange::Week.since_ms(10_000));
+        assert!(query.include_events);
+    }
+
+    #[test]
+    fn invalidating_token_activity_discards_an_in_flight_result() {
+        let (_tmp, mut app) = test_app();
+        app.next_request_id = 7;
+        app.active_home_token_activity_request = 7;
+        app.home_token_activity_state = LoadState::Loading;
+        app.home_token_activity = vec![HomeChartPoint {
+            source: SourceKind::Claude,
+            timestamp_ms: 1,
+            value: 10,
+        }];
+
+        app.invalidate_home_token_activity();
+        app.handle_search_update(SearchUpdate::HomeTokenActivity {
+            request_id: 7,
+            points: vec![HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 2,
+                value: 20,
+            }],
+            partial: false,
+        });
+
+        assert_eq!(app.active_home_token_activity_request, 8);
+        assert_eq!(app.home_token_activity_state, LoadState::Idle);
+        assert!(app.home_token_activity.is_empty());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,6 +3,7 @@ use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_if_stale};
 use crate::types::{Record, SourceFilter, SourceKind};
+use crate::usage::{CostMode, UsageQuery, scan_usage};
 use anyhow::Result;
 use chrono::SecondsFormat;
 use crossterm::event::{
@@ -86,7 +87,20 @@ enum SearchUpdate {
     },
     HomeActivity {
         request_id: u64,
-        timestamps: Vec<(SourceKind, u64)>,
+        points: Vec<HomeChartPoint>,
+    },
+    HomeActivityError {
+        request_id: u64,
+        message: String,
+    },
+    HomeTokenActivity {
+        request_id: u64,
+        points: Vec<HomeChartPoint>,
+        partial: bool,
+    },
+    HomeTokenActivityError {
+        request_id: u64,
+        message: String,
     },
     HomeFilters {
         request_id: u64,
@@ -215,6 +229,35 @@ enum LayoutMode {
     List,
     Timeline,
     Detail,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HomeChartMode {
+    Sessions,
+    Tokens,
+}
+
+impl HomeChartMode {
+    fn toggle(self) -> Self {
+        match self {
+            HomeChartMode::Sessions => HomeChartMode::Tokens,
+            HomeChartMode::Tokens => HomeChartMode::Sessions,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            HomeChartMode::Sessions => "sessions",
+            HomeChartMode::Tokens => "tokens",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HomeChartPoint {
+    source: SourceKind,
+    timestamp_ms: u64,
+    value: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -453,11 +496,16 @@ struct App {
     timeline_displayed: Option<(SourceChoice, TimelineRange, ProjectDisplayMode, String)>,
     timeline_state: LoadState,
     active_timeline_request: u64,
-    home_activity: Vec<(SourceKind, u64)>,
-    home_result_activity: Vec<(SourceKind, u64)>,
+    home_activity: Vec<HomeChartPoint>,
+    home_result_activity: Vec<HomeChartPoint>,
     home_activity_range: TimelineRange,
     home_activity_state: LoadState,
+    home_token_activity: Vec<HomeChartPoint>,
+    home_token_activity_state: LoadState,
+    home_token_activity_partial: bool,
+    home_chart_mode: HomeChartMode,
     active_home_activity_request: u64,
+    active_home_token_activity_request: u64,
     home_input_area: Rect,
     home_list_area: Rect,
     home_dropdown: HomeDropdown,
@@ -719,7 +767,12 @@ impl App {
             home_result_activity: Vec::new(),
             home_activity_range: TimelineRange::Month,
             home_activity_state: LoadState::Idle,
+            home_token_activity: Vec::new(),
+            home_token_activity_state: LoadState::Idle,
+            home_token_activity_partial: false,
+            home_chart_mode: HomeChartMode::Sessions,
             active_home_activity_request: 0,
+            active_home_token_activity_request: 0,
             home_input_area: Rect::default(),
             home_list_area: Rect::default(),
             home_dropdown: HomeDropdown::None,
@@ -805,11 +858,11 @@ impl App {
             || !self.project.trim().is_empty()
     }
 
-    fn home_chart_activity(&self) -> &[(SourceKind, u64)] {
-        if self.home_chart_is_filtered() {
-            &self.home_result_activity
-        } else {
-            &self.home_activity
+    fn home_chart_activity(&self) -> &[HomeChartPoint] {
+        match self.home_chart_mode {
+            HomeChartMode::Tokens => &self.home_token_activity,
+            HomeChartMode::Sessions if self.home_chart_is_filtered() => &self.home_result_activity,
+            HomeChartMode::Sessions => &self.home_activity,
         }
     }
 
@@ -834,6 +887,8 @@ impl App {
             || self.timeline_state == LoadState::Loading
             || self.detail_state == LoadState::Loading
             || self.home_activity_state == LoadState::Loading
+            || (self.home_chart_mode == HomeChartMode::Tokens
+                && self.home_token_activity_state == LoadState::Loading)
     }
 
     fn spinner(&self) -> char {
@@ -1077,6 +1132,7 @@ impl App {
     }
 
     fn kickoff_home_activity(&mut self) {
+        let refresh_tokens = self.home_chart_mode == HomeChartMode::Tokens;
         let request_id = self.next_request_id();
         self.active_home_activity_request = request_id;
         self.home_activity_state = LoadState::Loading;
@@ -1084,16 +1140,74 @@ impl App {
         let tx = self.search_tx.clone();
         let range = self.home_activity_range;
         std::thread::spawn(move || {
-            let timestamps = (|| -> Result<Vec<(SourceKind, u64)>> {
+            let result = (|| -> Result<Vec<HomeChartPoint>> {
                 let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
                 let rows = store.query_source_timestamps(range.since_ms(now_ms()))?;
-                Ok(rows.into_iter().filter(|(_, ts)| *ts > 0).collect())
-            })()
-            .unwrap_or_default();
-            let _ = tx.send(SearchUpdate::HomeActivity {
-                request_id,
-                timestamps,
+                Ok(rows
+                    .into_iter()
+                    .filter(|(_, timestamp_ms)| *timestamp_ms > 0)
+                    .map(|(source, timestamp_ms)| HomeChartPoint {
+                        source,
+                        timestamp_ms,
+                        value: 1,
+                    })
+                    .collect())
+            })();
+            let _ = match result {
+                Ok(points) => tx.send(SearchUpdate::HomeActivity { request_id, points }),
+                Err(error) => tx.send(SearchUpdate::HomeActivityError {
+                    request_id,
+                    message: error.to_string(),
+                }),
+            };
+        });
+        if refresh_tokens {
+            self.kickoff_home_token_activity();
+        }
+    }
+
+    fn kickoff_home_token_activity(&mut self) {
+        let request_id = self.next_request_id();
+        self.active_home_token_activity_request = request_id;
+        self.home_token_activity_state = LoadState::Loading;
+        let tx = self.search_tx.clone();
+        let range = self.home_activity_range;
+        std::thread::spawn(move || {
+            let result = scan_usage(&UsageQuery {
+                source: None,
+                since_ms: range.since_ms(now_ms()),
+                until_ms: None,
+                cost_mode: CostMode::Source,
+                include_events: true,
+            })
+            .map(|report| {
+                let partial = !report.warnings.is_empty();
+                let points = report
+                    .details
+                    .into_iter()
+                    .filter_map(|event| {
+                        let source = SourceKind::from_label(&event.source)?;
+                        let value = event.tokens.total();
+                        (event.timestamp_ms > 0 && value > 0).then_some(HomeChartPoint {
+                            source,
+                            timestamp_ms: event.timestamp_ms,
+                            value,
+                        })
+                    })
+                    .collect();
+                (points, partial)
             });
+            let _ = match result {
+                Ok((points, partial)) => tx.send(SearchUpdate::HomeTokenActivity {
+                    request_id,
+                    points,
+                    partial,
+                }),
+                Err(error) => tx.send(SearchUpdate::HomeTokenActivityError {
+                    request_id,
+                    message: error.to_string(),
+                }),
+            };
         });
     }
 
@@ -1277,6 +1391,26 @@ impl App {
         self.kickoff_home_filters();
     }
 
+    fn home_chart_state(&self) -> &LoadState {
+        match self.home_chart_mode {
+            HomeChartMode::Sessions if self.home_chart_is_filtered() => &self.sessions_state,
+            HomeChartMode::Sessions => &self.home_activity_state,
+            HomeChartMode::Tokens => &self.home_token_activity_state,
+        }
+    }
+
+    fn toggle_home_chart_mode(&mut self) {
+        self.home_chart_mode = self.home_chart_mode.toggle();
+        if self.home_chart_mode == HomeChartMode::Tokens
+            && matches!(
+                self.home_token_activity_state,
+                LoadState::Idle | LoadState::Error(_)
+            )
+        {
+            self.kickoff_home_token_activity();
+        }
+    }
+
     fn home_focus_list(&mut self) {
         if self.results.is_empty() {
             return;
@@ -1314,6 +1448,10 @@ impl App {
                 self.index_state = IndexState::Complete;
                 self.refresh_results();
                 if self.layout_mode == LayoutMode::Home {
+                    if self.home_chart_mode == HomeChartMode::Sessions {
+                        self.home_token_activity_state = LoadState::Idle;
+                        self.home_token_activity_partial = false;
+                    }
                     self.kickoff_home_activity();
                     self.kickoff_home_filters();
                 }
@@ -1436,16 +1574,40 @@ impl App {
                 self.detail_lines = vec![PreviewLine::Text(format!("preview error: {message}"))];
                 self.detail_scroll = 0;
             }
-            SearchUpdate::HomeActivity {
-                request_id,
-                timestamps,
-            } if request_id == self.active_home_activity_request => {
-                self.home_activity = timestamps;
+            SearchUpdate::HomeActivity { request_id, points }
+                if request_id == self.active_home_activity_request =>
+            {
+                self.home_activity = points;
                 self.home_activity_state = if self.home_activity.is_empty() {
                     LoadState::Empty
                 } else {
                     LoadState::Loaded
                 };
+            }
+            SearchUpdate::HomeActivityError {
+                request_id,
+                message,
+            } if request_id == self.active_home_activity_request => {
+                self.home_activity_state = LoadState::Error(message);
+            }
+            SearchUpdate::HomeTokenActivity {
+                request_id,
+                points,
+                partial,
+            } if request_id == self.active_home_token_activity_request => {
+                self.home_token_activity = points;
+                self.home_token_activity_partial = partial;
+                self.home_token_activity_state = if self.home_token_activity.is_empty() {
+                    LoadState::Empty
+                } else {
+                    LoadState::Loaded
+                };
+            }
+            SearchUpdate::HomeTokenActivityError {
+                request_id,
+                message,
+            } if request_id == self.active_home_token_activity_request => {
+                self.home_token_activity_state = LoadState::Error(message);
             }
             SearchUpdate::HomeFilters {
                 request_id,
@@ -2313,6 +2475,11 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
         return Ok(false);
     }
 
+    if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        app.toggle_home_chart_mode();
+        return Ok(false);
+    }
+
     if matches!(app.focus, Focus::Query) {
         match key.code {
             KeyCode::Esc if !app.query.is_empty() => {
@@ -2486,7 +2653,8 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         height: h,
     };
 
-    let filtered_chart = app.home_chart_is_filtered();
+    let filtered_chart =
+        app.home_chart_mode == HomeChartMode::Sessions && app.home_chart_is_filtered();
     let chart_activity = app.home_chart_activity();
     let now = now_ms();
     let bounds = home_activity_bounds_at(chart_activity, app.home_activity_range, now);
@@ -2496,7 +2664,10 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     // Chart grows with the terminal: each braille row adds 4 dot levels. Keep
     // its space while a filtered search has no matches so the input does not
     // jump vertically as results arrive.
-    let chart_height: u16 = if !chart_activity.is_empty() || filtered_chart {
+    let chart_height: u16 = if !chart_activity.is_empty()
+        || filtered_chart
+        || app.home_chart_state() == &LoadState::Loading
+    {
         home_chart_height(area.height)
     } else {
         0
@@ -2524,38 +2695,48 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         // order the chart stacks bottom-up.
         let groups = home_chart_groups(chart_activity, bounds);
         let mut spans: Vec<Span> = Vec::new();
-        if groups.is_empty() {
-            if !filtered_chart {
-                spans.push(Span::styled("memex", theme.focus));
+        match app.home_chart_state() {
+            LoadState::Loading => spans.push(Span::styled(
+                format!("{} loading {}…", app.spinner(), app.home_chart_mode.label()),
+                theme.muted,
+            )),
+            LoadState::Loaded | LoadState::Empty => {
+                let metric = match app.home_chart_mode {
+                    HomeChartMode::Sessions if filtered_chart => {
+                        format!("{plotted_count}/{total_count} matches")
+                    }
+                    HomeChartMode::Sessions => format!("{plotted_count} sessions"),
+                    HomeChartMode::Tokens => {
+                        let total = activity_value_in_bounds(chart_activity, bounds);
+                        format!(
+                            "{} tokens{}",
+                            compact_metric(total),
+                            if app.home_token_activity_partial {
+                                " · partial"
+                            } else {
+                                ""
+                            }
+                        )
+                    }
+                };
+                spans.push(Span::styled(metric, theme.muted));
             }
-        } else {
+            LoadState::Error(_) => spans.push(Span::styled(
+                format!("{} unavailable", app.home_chart_mode.label()),
+                theme.muted,
+            )),
+            _ => {}
+        }
+        if !groups.is_empty() {
+            spans.push(Span::raw("  ·  "));
             for (label, color, _) in &groups {
                 spans.push(Span::styled("● ", Style::default().fg(*color)));
                 spans.push(Span::styled((*label).to_string(), theme.text));
                 spans.push(Span::raw("  "));
             }
         }
-        let chart_state = if filtered_chart {
-            &app.sessions_state
-        } else {
-            &app.home_activity_state
-        };
-        let count_text = if filtered_chart {
-            format!("{plotted_count}/{total_count} matches")
-        } else {
-            format!("{plotted_count} sessions")
-        };
-        match chart_state {
-            LoadState::Loading => spans.push(Span::styled(
-                format!(" ·  {} {count_text}", app.spinner()),
-                theme.muted,
-            )),
-            LoadState::Loaded => spans.push(Span::styled(format!("·  {count_text}"), theme.muted)),
-            LoadState::Empty if filtered_chart => spans.push(Span::styled(
-                format!("{plotted_count}/{total_count} matches"),
-                theme.muted,
-            )),
-            _ => {}
+        if spans.is_empty() {
+            spans.push(Span::styled("memex", theme.focus));
         }
         let range_word = format!("{} ▾", app.home_activity_range.short_label());
         let range_width = range_word.chars().count() as u16;
@@ -2787,52 +2968,59 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
 }
 
 fn home_activity_bounds_at(
-    events: &[(SourceKind, u64)],
+    points: &[HomeChartPoint],
     range: TimelineRange,
     now: u64,
 ) -> (u64, u64) {
     if let Some(since) = range.since_ms(now) {
         return (since, now.max(since.saturating_add(1)));
     }
-    let min_seen = events
+    let min_seen = points
         .iter()
-        .map(|(_, ts)| *ts)
+        .map(|point| point.timestamp_ms)
         .filter(|ts| *ts > 0)
         .min()
         .unwrap_or(now);
-    let max_seen = events
+    let max_seen = points
         .iter()
-        .map(|(_, ts)| *ts)
+        .map(|point| point.timestamp_ms)
         .filter(|ts| *ts > 0)
         .max()
         .unwrap_or(now);
     (min_seen, max_seen.max(min_seen.saturating_add(1)))
 }
 
-fn activity_count_in_bounds(events: &[(SourceKind, u64)], bounds: (u64, u64)) -> usize {
-    events
+fn activity_count_in_bounds(points: &[HomeChartPoint], bounds: (u64, u64)) -> usize {
+    points
         .iter()
-        .filter(|(_, ts)| *ts >= bounds.0 && *ts <= bounds.1)
+        .filter(|point| point.timestamp_ms >= bounds.0 && point.timestamp_ms <= bounds.1)
         .count()
+}
+
+fn activity_value_in_bounds(points: &[HomeChartPoint], bounds: (u64, u64)) -> u64 {
+    points
+        .iter()
+        .filter(|point| point.timestamp_ms >= bounds.0 && point.timestamp_ms <= bounds.1)
+        .fold(0u64, |sum, point| sum.saturating_add(point.value))
 }
 
 /// Per-agent totals for the visible home chart window, largest volume first.
 /// Codex session and history records collapse into one "codex" group via their
 /// shared label.
 fn home_chart_groups(
-    events: &[(SourceKind, u64)],
+    points: &[HomeChartPoint],
     bounds: (u64, u64),
-) -> Vec<(&'static str, Color, usize)> {
-    let mut totals: Vec<(&'static str, Color, usize)> = Vec::new();
-    for (kind, ts) in events {
-        if *ts < bounds.0 || *ts > bounds.1 {
+) -> Vec<(&'static str, Color, u64)> {
+    let mut totals: Vec<(&'static str, Color, u64)> = Vec::new();
+    for point in points {
+        if point.timestamp_ms < bounds.0 || point.timestamp_ms > bounds.1 {
             continue;
         }
-        let label = kind.label();
+        let label = point.source.label();
         if let Some(entry) = totals.iter_mut().find(|(l, _, _)| *l == label) {
-            entry.2 += 1;
+            entry.2 = entry.2.saturating_add(point.value);
         } else {
-            totals.push((label, source_color(*kind), 1));
+            totals.push((label, source_color(point.source), point.value));
         }
     }
     totals.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(b.0)));
@@ -2843,7 +3031,7 @@ fn home_chart_groups(
 /// levels are split among agents proportionally, biggest group at the bottom.
 /// Returns rows top-to-bottom of (glyph, color) cells.
 fn home_chart_grid(
-    events: &[(SourceKind, u64)],
+    points: &[HomeChartPoint],
     bounds: (u64, u64),
     width: usize,
     height: usize,
@@ -2852,20 +3040,17 @@ fn home_chart_grid(
     if width == 0 {
         return Vec::new();
     }
-    let groups = home_chart_groups(events, bounds);
-    let group_buckets: Vec<Vec<usize>> = groups
+    let groups = home_chart_groups(points, bounds);
+    let group_buckets: Vec<Vec<u64>> = groups
         .iter()
-        .map(|(label, _, _)| {
-            let ts: Vec<u64> = events
-                .iter()
-                .filter(|(kind, _)| kind.label() == *label)
-                .map(|(_, ts)| *ts)
-                .collect();
-            timeline_bucket_counts(&ts, bounds, width)
-        })
+        .map(|(label, _, _)| home_bucket_values(points, label, bounds, width))
         .collect();
-    let totals: Vec<usize> = (0..width)
-        .map(|col| group_buckets.iter().map(|buckets| buckets[col]).sum())
+    let totals: Vec<u64> = (0..width)
+        .map(|col| {
+            group_buckets
+                .iter()
+                .fold(0u64, |sum, buckets| sum.saturating_add(buckets[col]))
+        })
         .collect();
     let max_total = totals.iter().copied().max().unwrap_or(0);
     let mut grid = vec![vec![(' ', COLOR_MUTED); width]; height];
@@ -2874,12 +3059,12 @@ fn home_chart_grid(
         if total == 0 {
             continue;
         }
-        let level = timeline_density_level(total, max_total, height * 4);
+        let level = weighted_density_level(total, max_total, height * 4);
         let mut dot_colors: Vec<Color> = Vec::with_capacity(level);
-        let mut cum = 0usize;
+        let mut cum = 0u64;
         for (group_idx, (_, color, _)) in groups.iter().enumerate() {
-            cum += group_buckets[group_idx][col];
-            let boundary = (cum * level) / total;
+            cum = cum.saturating_add(group_buckets[group_idx][col]);
+            let boundary = ((cum as u128 * level as u128) / total as u128) as usize;
             while dot_colors.len() < boundary {
                 dot_colors.push(*color);
             }
@@ -2895,6 +3080,72 @@ fn home_chart_grid(
         }
     }
     grid
+}
+
+fn home_bucket_values(
+    points: &[HomeChartPoint],
+    label: &str,
+    bounds: (u64, u64),
+    width: usize,
+) -> Vec<u64> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let mut buckets = vec![0u64; width];
+    let span = bounds.1.saturating_sub(bounds.0).max(1);
+    for point in points.iter().filter(|point| {
+        point.source.label() == label
+            && point.timestamp_ms >= bounds.0
+            && point.timestamp_ms <= bounds.1
+    }) {
+        let offset = point.timestamp_ms.saturating_sub(bounds.0);
+        let mut idx = ((offset as u128 * width as u128) / span as u128) as usize;
+        if idx >= width {
+            idx = width - 1;
+        }
+        buckets[idx] = buckets[idx].saturating_add(point.value);
+    }
+    buckets
+}
+
+fn weighted_density_level(value: u64, max: u64, levels: usize) -> usize {
+    if value == 0 || max == 0 || levels == 0 {
+        return 0;
+    }
+    (value as u128 * levels as u128).div_ceil(max as u128) as usize
+}
+
+fn compact_metric(value: u64) -> String {
+    const UNITS: [(u64, &str); 4] = [
+        (1_000_000_000_000, "T"),
+        (1_000_000_000, "B"),
+        (1_000_000, "M"),
+        (1_000, "K"),
+    ];
+    for (divisor, suffix) in UNITS {
+        if value >= divisor {
+            let scaled = value as f64 / divisor as f64;
+            if scaled >= 10.0 {
+                return format!("{scaled:.0}{suffix}");
+            }
+            return format!("{scaled:.1}{suffix}");
+        }
+    }
+    value.to_string()
+}
+
+fn session_chart_groups(events: &[(SourceKind, u64)]) -> Vec<(&'static str, Color, usize)> {
+    let mut totals: Vec<(&'static str, Color, usize)> = Vec::new();
+    for (kind, _) in events {
+        let label = kind.label();
+        if let Some(entry) = totals.iter_mut().find(|(l, _, _)| *l == label) {
+            entry.2 += 1;
+        } else {
+            totals.push((label, source_color(*kind), 1));
+        }
+    }
+    totals.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(b.0)));
+    totals
 }
 
 fn home_chart_row_line(cells: &[(char, Color)]) -> Line<'static> {
@@ -2933,7 +3184,7 @@ fn timeline_chart_grid(
     if width == 0 {
         return Vec::new();
     }
-    let groups = home_chart_groups(events, bounds);
+    let groups = session_chart_groups(events);
     let group_buckets: Vec<Vec<usize>> = groups
         .iter()
         .map(|(label, _, _)| {
@@ -3465,7 +3716,7 @@ fn draw_project_timeline(
         .flat_map(|row| row.session_events.iter().copied())
         .collect();
     let range = timeline_bounds(&app.timeline_rows, app.timeline_range);
-    let groups = home_chart_groups(&all_events, range);
+    let groups = session_chart_groups(&all_events);
     let legend = Line::from(
         groups
             .iter()
@@ -3880,6 +4131,12 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
         right_spans.push(Span::raw(" "));
     }
     right_spans.push(Span::styled(view, theme.text));
+    if app.layout_mode == LayoutMode::Home {
+        right_spans.push(Span::raw("   "));
+        right_spans.push(Span::styled("chart", theme.muted));
+        right_spans.push(Span::styled("(^t) ", theme.accent));
+        right_spans.push(Span::styled(app.home_chart_mode.label(), theme.text));
+    }
     if !matches!(app.layout_mode, LayoutMode::Timeline | LayoutMode::Home) {
         right_spans.push(Span::raw("   "));
         right_spans.push(Span::styled("mode ", theme.muted));
@@ -4117,11 +4374,15 @@ fn sessions_from_query(
 
 /// Reduces accepted search results to the only two values the home chart
 /// needs. This is computed once per completed search, not once per frame.
-fn session_activity(sessions: &[SessionSummary]) -> Vec<(SourceKind, u64)> {
+fn session_activity(sessions: &[SessionSummary]) -> Vec<HomeChartPoint> {
     sessions
         .iter()
         .filter(|session| session.last_ts > 0)
-        .map(|session| (session.source, session.last_ts))
+        .map(|session| HomeChartPoint {
+            source: session.source,
+            timestamp_ms: session.last_ts,
+            value: 1,
+        })
         .collect()
 }
 
@@ -5760,17 +6021,32 @@ mod tests {
 
     #[test]
     fn home_chart_groups_order_by_volume_and_merge_codex() {
-        let events = vec![
-            (SourceKind::Claude, 1),
-            (SourceKind::Claude, 2),
-            (SourceKind::Claude, 3),
-            (SourceKind::CodexSession, 4),
-            (SourceKind::CodexHistory, 5),
+        let points = vec![
+            HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 1,
+                value: 2,
+            },
+            HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 2,
+                value: 3,
+            },
+            HomeChartPoint {
+                source: SourceKind::CodexSession,
+                timestamp_ms: 4,
+                value: 1,
+            },
+            HomeChartPoint {
+                source: SourceKind::CodexHistory,
+                timestamp_ms: 5,
+                value: 1,
+            },
         ];
-        let groups = home_chart_groups(&events, (0, 10));
+        let groups = home_chart_groups(&points, (0, 10));
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].0, "claude");
-        assert_eq!(groups[0].2, 3);
+        assert_eq!(groups[0].2, 5);
         assert_eq!(groups[1].0, "codex");
         assert_eq!(groups[1].2, 2);
     }
@@ -5778,8 +6054,16 @@ mod tests {
     #[test]
     fn home_chart_uses_accepted_results_while_searching() {
         let (_tmp, mut app) = test_app();
-        app.home_activity = vec![(SourceKind::Claude, 10)];
-        app.home_result_activity = vec![(SourceKind::CodexSession, 20)];
+        app.home_activity = vec![HomeChartPoint {
+            source: SourceKind::Claude,
+            timestamp_ms: 10,
+            value: 1,
+        }];
+        app.home_result_activity = vec![HomeChartPoint {
+            source: SourceKind::CodexSession,
+            timestamp_ms: 20,
+            value: 1,
+        }];
 
         assert_eq!(app.home_chart_activity(), app.home_activity.as_slice());
 
@@ -5816,13 +6100,24 @@ mod tests {
             }],
         });
 
-        assert_eq!(app.home_result_activity, vec![(SourceKind::Pi, 42)]);
+        assert_eq!(
+            app.home_result_activity,
+            vec![HomeChartPoint {
+                source: SourceKind::Pi,
+                timestamp_ms: 42,
+                value: 1,
+            }]
+        );
     }
 
     #[test]
     fn home_chart_grid_scales_with_height() {
-        let events = vec![(SourceKind::Claude, 500); 4];
-        let grid = home_chart_grid(&events, (0, 1000), 1, 4);
+        let points = vec![HomeChartPoint {
+            source: SourceKind::Claude,
+            timestamp_ms: 500,
+            value: 4,
+        }];
+        let grid = home_chart_grid(&points, (0, 1000), 1, 4);
         assert_eq!(grid.len(), 4);
         assert!(grid.iter().all(|row| row[0].0 == '⣿'));
         assert!(
@@ -5833,47 +6128,92 @@ mod tests {
 
     #[test]
     fn home_chart_grid_stacks_sources_bottom_up() {
-        let events = vec![
-            (SourceKind::Claude, 500),
-            (SourceKind::Claude, 500),
-            (SourceKind::CodexSession, 500),
-            (SourceKind::CodexSession, 500),
+        let points = vec![
+            HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 500,
+                value: 2,
+            },
+            HomeChartPoint {
+                source: SourceKind::CodexSession,
+                timestamp_ms: 500,
+                value: 2,
+            },
         ];
         // Height 2 → 8 dot levels split evenly: claude fills the bottom cell,
         // codex the top cell.
-        let grid = home_chart_grid(&events, (0, 1000), 1, 2);
+        let grid = home_chart_grid(&points, (0, 1000), 1, 2);
         assert_eq!(grid[1][0].1, source_color(SourceKind::Claude));
         assert_eq!(grid[0][0].1, source_color(SourceKind::CodexSession));
     }
 
     #[test]
     fn home_chart_excludes_activity_outside_selected_range() {
-        let events = vec![
-            (SourceKind::Claude, 10),
-            (SourceKind::CodexSession, 50),
-            (SourceKind::Pi, 90),
+        let points = vec![
+            HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 10,
+                value: 2,
+            },
+            HomeChartPoint {
+                source: SourceKind::CodexSession,
+                timestamp_ms: 50,
+                value: 3,
+            },
+            HomeChartPoint {
+                source: SourceKind::Pi,
+                timestamp_ms: 90,
+                value: 4,
+            },
         ];
         let bounds = (25, 75);
 
-        assert_eq!(activity_count_in_bounds(&events, bounds), 1);
-        let groups = home_chart_groups(&events, bounds);
+        assert_eq!(activity_count_in_bounds(&points, bounds), 1);
+        assert_eq!(activity_value_in_bounds(&points, bounds), 3);
+        let groups = home_chart_groups(&points, bounds);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].0, "codex");
-        assert_eq!(timeline_bucket_counts(&[10, 50, 90], bounds, 2), vec![0, 1]);
+        assert_eq!(home_bucket_values(&points, "codex", bounds, 2), vec![0, 3]);
     }
 
     #[test]
     fn all_home_activity_range_uses_matching_event_bounds() {
-        let events = vec![(SourceKind::Claude, 10), (SourceKind::CodexSession, 90)];
+        let points = vec![
+            HomeChartPoint {
+                source: SourceKind::Claude,
+                timestamp_ms: 10,
+                value: 1,
+            },
+            HomeChartPoint {
+                source: SourceKind::CodexSession,
+                timestamp_ms: 90,
+                value: 1,
+            },
+        ];
 
         assert_eq!(
-            home_activity_bounds_at(&events, TimelineRange::All, 100),
+            home_activity_bounds_at(&points, TimelineRange::All, 100),
             (10, 90)
         );
         assert_eq!(
-            home_activity_bounds_at(&events, TimelineRange::Month, 100),
+            home_activity_bounds_at(&points, TimelineRange::Month, 100),
             (0, 100)
         );
+    }
+
+    #[test]
+    fn compact_metric_keeps_chart_caption_short() {
+        assert_eq!(compact_metric(184), "184");
+        assert_eq!(compact_metric(1_240_000), "1.2M");
+        assert_eq!(compact_metric(12_400_000), "12M");
+    }
+
+    #[test]
+    fn visible_token_loading_keeps_spinner_active() {
+        let (_tmp, mut app) = test_app();
+        app.home_chart_mode = HomeChartMode::Tokens;
+        app.home_token_activity_state = LoadState::Loading;
+        assert!(app.has_active_loading());
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -4,7 +4,7 @@
 //! request-level accounting, but they are not authoritative subscription-limit telemetry.
 
 use crate::analytics::ProjectGrouping;
-use crate::types::SourceFilter;
+use crate::types::{SourceFilter, SourceKind};
 use anyhow::{Context, Result};
 use chrono::DateTime;
 use clap::ValueEnum;
@@ -1103,7 +1103,9 @@ fn push_opencode_event(value: &Value, path: &Path, id: Option<String>, out: &mut
             .pointer("/time/created")
             .map(timestamp_ms)
             .unwrap_or(0),
-        project: str_at(value, &["directory", "cwd"]),
+        // Ingestion currently groups all OpenCode sessions under this
+        // synthetic project, so usage must use the same attribution.
+        project: Some(SourceKind::Opencode.label().to_string()),
         provider: str_at(value, &["providerID", "provider"]),
         model: str_at(value, &["modelID", "model"]),
         tokens,
@@ -1658,6 +1660,7 @@ mod tests {
     #[test]
     fn opencode_reasoning_is_included_in_output_and_total() {
         let value = serde_json::json!({
+            "path": { "cwd": "/repo/memex" },
             "tokens": {
                 "input": 100,
                 "output": 20,
@@ -1678,6 +1681,50 @@ mod tests {
         assert_eq!(events[0].tokens.reasoning, 30);
         assert_eq!(events[0].tokens.output, 50);
         assert_eq!(events[0].tokens.total(), 200);
+        assert_eq!(events[0].project.as_deref(), Some("opencode"));
+    }
+
+    #[test]
+    fn opencode_project_filter_matches_indexed_project() {
+        use crate::test_support::{EnvVarGuard, env_lock};
+
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let message_dir = tmp.path().join("storage/message/ses_test");
+        std::fs::create_dir_all(&message_dir).expect("create message directory");
+        std::fs::write(
+            message_dir.join("msg_test.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "id": "msg_test",
+                "sessionID": "ses_test",
+                "path": { "cwd": "/repo/memex" },
+                "time": { "created": 1_750_000_000_000u64 },
+                "tokens": {
+                    "input": 10,
+                    "output": 5,
+                    "reasoning": 0,
+                    "cache": { "read": 0, "write": 0 }
+                }
+            }))
+            .expect("serialize message"),
+        )
+        .expect("write message");
+        let _env = EnvVarGuard::set_os(&[("OPENCODE_DATA_DIR", Some(tmp.path().as_os_str()))]);
+        let mut query = UsageQuery {
+            source: Some(SourceFilter::Opencode),
+            project: Some("opencode".into()),
+            project_grouping: ProjectGrouping::Flat,
+            include_events: true,
+            ..UsageQuery::default()
+        };
+
+        let matching = scan_usage(&query).expect("scan matching project");
+        query.project = Some("memex".into());
+        let mismatched = scan_usage(&query).expect("scan mismatched project");
+
+        assert_eq!(matching.events, 1);
+        assert_eq!(matching.details[0].project.as_deref(), Some("opencode"));
+        assert_eq!(mismatched.events, 0);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -22,6 +22,7 @@ pub struct UsageQuery {
     pub source: Option<SourceFilter>,
     pub project: Option<String>,
     pub project_grouping: ProjectGrouping,
+    pub session_keys: Option<HashSet<(String, String)>>,
     pub since_ms: Option<u64>,
     pub until_ms: Option<u64>,
     pub cost_mode: CostMode,
@@ -182,6 +183,11 @@ pub fn scan_usage(query: &UsageQuery) -> Result<UsageReport> {
                         query.project_grouping,
                         &mut project_cache,
                     )
+                })
+            })
+            && query.session_keys.as_ref().is_none_or(|session_keys| {
+                event.session_id.as_ref().is_some_and(|session_id| {
+                    session_keys.contains(&(event.source.clone(), session_id.clone()))
                 })
             })
     });
@@ -866,11 +872,7 @@ fn scan_pi(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()>
             .file_stem()
             .and_then(|n| n.to_str())
             .map(str::to_string);
-        let project = path
-            .parent()
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .map(str::to_string);
+        let project = Some(crate::ingest::project_from_pi_session_path(&path));
         let mut current_model = None;
         let mut current_provider = None;
         for (index, value) in lines(&path)? {
@@ -1133,18 +1135,38 @@ fn scan_cursor(out: &mut Vec<UsageEvent>, warnings: &mut Vec<String>) -> Result<
             .map(|e| e.path().to_path_buf()),
     );
     let mut seen = HashSet::new();
+    let project_by_session = cursor_project_by_session();
     for path in databases.into_iter().filter(|path| path.exists()) {
-        if let Err(error) = scan_cursor_db(&path, out, &mut seen) {
+        if let Err(error) = scan_cursor_db(&path, out, &mut seen, &project_by_session) {
             warnings.push(format!("{}: {error:#}", path.display()));
         }
     }
     Ok(())
 }
 
+fn cursor_project_by_session() -> HashMap<String, String> {
+    let root = crate::ingest::cursor_projects_root();
+    let mut projects = HashMap::new();
+    for entry in WalkDir::new(root).into_iter().flatten().filter(|entry| {
+        entry.file_type().is_file()
+            && entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+    }) {
+        let path = entry.path();
+        let project = crate::ingest::project_from_cursor_path(path);
+        projects.insert(
+            crate::ingest::cursor_session_id_from_path(path),
+            project.clone(),
+        );
+        projects.insert(crate::ingest::cursor_transcript_id(path), project);
+    }
+    projects
+}
+
 fn scan_cursor_db(
     path: &Path,
     out: &mut Vec<UsageEvent>,
     seen: &mut HashSet<String>,
+    project_by_session: &HashMap<String, String>,
 ) -> Result<()> {
     let conn = Connection::open_with_flags(
         path,
@@ -1178,7 +1200,7 @@ fn scan_cursor_db(
             let Ok(value) = serde_json::from_str::<Value>(&raw) else {
                 continue;
             };
-            extract_cursor_objects(&value, &key, table, path, out, seen);
+            extract_cursor_objects(&value, &key, table, path, out, seen, project_by_session);
         }
     }
     Ok(())
@@ -1191,16 +1213,35 @@ fn extract_cursor_objects(
     path: &Path,
     out: &mut Vec<UsageEvent>,
     seen: &mut HashSet<String>,
+    project_by_session: &HashMap<String, String>,
 ) {
     match value {
         Value::Array(values) => {
             for value in values {
-                extract_cursor_objects(value, fallback_id, table, path, out, seen);
+                extract_cursor_objects(
+                    value,
+                    fallback_id,
+                    table,
+                    path,
+                    out,
+                    seen,
+                    project_by_session,
+                );
             }
         }
         Value::Object(object) => {
             let input = nested_u64(object, &["inputTokens", "input_tokens"]);
             let output = nested_u64(object, &["outputTokens", "output_tokens"]);
+            let session_id = object_string(object, &["sessionId", "composerId"]).or_else(|| {
+                fallback_id
+                    .strip_prefix("composerData:")
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_string)
+            });
+            let project = session_id
+                .as_ref()
+                .and_then(|session_id| project_by_session.get(session_id))
+                .cloned();
             let counted = input > 0 || output > 0;
             if counted {
                 let id = object_string(
@@ -1220,7 +1261,7 @@ fn extract_cursor_objects(
                         source: "cursor".into(),
                         source_path: path.to_string_lossy().to_string(),
                         source_record_id: Some(id),
-                        session_id: object_string(object, &["sessionId", "composerId"]),
+                        session_id,
                         request_id: None,
                         message_id: None,
                         timestamp_ms: object
@@ -1228,7 +1269,7 @@ fn extract_cursor_objects(
                             .or_else(|| object.get("timestamp"))
                             .map(timestamp_ms)
                             .unwrap_or(0),
-                        project: None,
+                        project,
                         provider: None,
                         model: object_string(object, &["model", "modelName"])
                             .or_else(|| {
@@ -1259,7 +1300,15 @@ fn extract_cursor_objects(
                     continue;
                 }
                 if child.is_array() || child.is_object() {
-                    extract_cursor_objects(child, fallback_id, table, path, out, seen);
+                    extract_cursor_objects(
+                        child,
+                        fallback_id,
+                        table,
+                        path,
+                        out,
+                        seen,
+                        project_by_session,
+                    );
                 }
             }
         }
@@ -1721,10 +1770,17 @@ mod tests {
         let matching = scan_usage(&query).expect("scan matching project");
         query.project = Some("memex".into());
         let mismatched = scan_usage(&query).expect("scan mismatched project");
+        query.project = Some("opencode".into());
+        query.session_keys = Some(HashSet::from([("opencode".into(), "ses_test".into())]));
+        let matching_session = scan_usage(&query).expect("scan matching session");
+        query.session_keys = Some(HashSet::from([("opencode".into(), "ses_other".into())]));
+        let mismatched_session = scan_usage(&query).expect("scan mismatched session");
 
         assert_eq!(matching.events, 1);
         assert_eq!(matching.details[0].project.as_deref(), Some("opencode"));
         assert_eq!(mismatched.events, 0);
+        assert_eq!(matching_session.events, 1);
+        assert_eq!(mismatched_session.events, 0);
     }
 
     #[test]
@@ -1732,6 +1788,7 @@ mod tests {
         let value = serde_json::json!([
             {
                 "generationUUID": "usage-parent",
+                "composerId": "composer-main",
                 "usage": { "inputTokens": 10, "outputTokens": 5 },
                 "children": [
                     {
@@ -1748,6 +1805,8 @@ mod tests {
         ]);
         let mut events = Vec::new();
         let mut seen = HashSet::new();
+        let project_by_session =
+            HashMap::from([("composer-main".to_string(), "memex".to_string())]);
 
         extract_cursor_objects(
             &value,
@@ -1756,6 +1815,7 @@ mod tests {
             Path::new("state.vscdb"),
             &mut events,
             &mut seen,
+            &project_by_session,
         );
 
         assert_eq!(events.len(), 3);
@@ -1771,6 +1831,7 @@ mod tests {
             events.iter().map(|event| event.tokens.total()).sum::<u64>(),
             53
         );
+        assert_eq!(events[0].project.as_deref(), Some("memex"));
     }
 
     #[test]
@@ -1804,7 +1865,7 @@ mod tests {
         let _guard = env_lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let agent_root = tmp.path().join("pi-agent");
-        let session_root = agent_root.join("custom/sessions/project");
+        let session_root = agent_root.join("custom/sessions/--C--Users-alice-Code-memex--");
         std::fs::create_dir_all(&session_root).expect("create session root");
         std::fs::write(
             agent_root.join("settings.json"),
@@ -1823,19 +1884,23 @@ mod tests {
             ("PI_CODING_AGENT_SESSION_DIR", None),
             ("PI_CODING_AGENT_DIR", Some(agent_root.as_os_str())),
         ]);
-        let mut events = Vec::new();
-        let mut warnings = Vec::new();
+        let report = scan_usage(&UsageQuery {
+            source: Some(SourceFilter::Pi),
+            project: Some("memex".into()),
+            project_grouping: ProjectGrouping::Flat,
+            include_events: true,
+            ..UsageQuery::default()
+        })
+        .expect("scan pi");
 
-        scan_pi(&mut events, &mut warnings).expect("scan pi");
-
-        assert!(warnings.is_empty());
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].tokens.total(), 19);
-        assert_eq!(events[0].project.as_deref(), Some("project"));
+        assert!(report.warnings.is_empty());
+        assert_eq!(report.events, 1);
+        assert_eq!(report.details[0].tokens.total(), 19);
+        assert_eq!(report.details[0].project.as_deref(), Some("memex"));
         assert!(
-            events[0]
+            report.details[0]
                 .source_path
-                .ends_with("custom/sessions/project/session.jsonl")
+                .ends_with("custom/sessions/--C--Users-alice-Code-memex--/session.jsonl")
         );
     }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -3,6 +3,7 @@
 //! This module intentionally does not model provider quota percentages. Local logs are useful for
 //! request-level accounting, but they are not authoritative subscription-limit telemetry.
 
+use crate::analytics::ProjectGrouping;
 use crate::types::SourceFilter;
 use anyhow::{Context, Result};
 use chrono::DateTime;
@@ -19,6 +20,8 @@ use walkdir::WalkDir;
 #[derive(Clone, Debug, Default)]
 pub struct UsageQuery {
     pub source: Option<SourceFilter>,
+    pub project: Option<String>,
+    pub project_grouping: ProjectGrouping,
     pub since_ms: Option<u64>,
     pub until_ms: Option<u64>,
     pub cost_mode: CostMode,
@@ -163,6 +166,7 @@ pub fn scan_usage(query: &UsageQuery) -> Result<UsageReport> {
 
     reconcile_claude(&mut events);
     reconcile_codex_copies(&mut events);
+    let mut project_cache = HashMap::new();
     events.retain(|event| {
         query
             .since_ms
@@ -170,6 +174,16 @@ pub fn scan_usage(query: &UsageQuery) -> Result<UsageReport> {
             && query
                 .until_ms
                 .is_none_or(|until| event.timestamp_ms < until)
+            && query.project.as_deref().is_none_or(|project| {
+                event.project.as_deref().is_some_and(|candidate| {
+                    usage_project_matches(
+                        candidate,
+                        project,
+                        query.project_grouping,
+                        &mut project_cache,
+                    )
+                })
+            })
     });
     events.sort_by(|a, b| {
         (a.timestamp_ms, &a.source_path, a.source_order).cmp(&(
@@ -296,6 +310,44 @@ fn str_at(value: &Value, aliases: &[&str]) -> Option<String> {
         .find_map(|key| value.get(*key).and_then(Value::as_str))
         .filter(|s| !s.is_empty())
         .map(str::to_string)
+}
+
+fn usage_project_matches(
+    candidate: &str,
+    project: &str,
+    grouping: ProjectGrouping,
+    cache: &mut HashMap<String, String>,
+) -> bool {
+    let candidate_key = match grouping {
+        ProjectGrouping::Flat => usage_project_key(candidate),
+        ProjectGrouping::Repository => cache
+            .entry(candidate.to_string())
+            .or_insert_with(|| {
+                if Path::new(candidate).is_dir() {
+                    crate::analytics::repository_project_for_cwd(candidate)
+                        .unwrap_or_else(|| usage_project_key(candidate))
+                } else {
+                    usage_project_key(candidate)
+                }
+            })
+            .clone(),
+    };
+    candidate.eq_ignore_ascii_case(project)
+        || candidate_key.eq_ignore_ascii_case(&usage_project_key(project))
+}
+
+fn usage_project_key(value: &str) -> String {
+    let trimmed = value.trim().trim_end_matches(['/', '\\']);
+    let tail = trimmed.rsplit(['/', '\\', ':']).next().unwrap_or(trimmed);
+    let tail = tail.strip_suffix(".git").unwrap_or(tail);
+    let encoded = tail.trim_matches('-');
+    if tail.starts_with('-')
+        && (encoded.to_ascii_lowercase().starts_with("users-")
+            || encoded.to_ascii_lowercase().starts_with("home-"))
+    {
+        return encoded.rsplit('-').next().unwrap_or(encoded).to_string();
+    }
+    tail.to_string()
 }
 
 fn scan_claude(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
@@ -807,13 +859,7 @@ fn reconcile_codex_copies(events: &mut Vec<UsageEvent>) {
 }
 
 fn scan_pi(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
-    let roots = if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
-        vec![PathBuf::from(root)]
-    } else if let Some(root) = std::env::var_os("PI_CODING_AGENT_DIR") {
-        vec![PathBuf::from(root).join("sessions")]
-    } else {
-        vec![home().join(".pi/agent/sessions")]
-    };
+    let roots = [crate::ingest::pi_sessions_root()];
     for path in jsonl_files(roots) {
         let source_path = path.to_string_lossy().to_string();
         let session = path
@@ -1153,7 +1199,8 @@ fn extract_cursor_objects(
         Value::Object(object) => {
             let input = nested_u64(object, &["inputTokens", "input_tokens"]);
             let output = nested_u64(object, &["outputTokens", "output_tokens"]);
-            if input > 0 || output > 0 {
+            let counted = input > 0 || output > 0;
+            if counted {
                 let id = object_string(
                     object,
                     &["generationUUID", "generationId", "bubbleId", "id"],
@@ -1205,7 +1252,10 @@ fn extract_cursor_objects(
                     });
                 }
             }
-            for child in object.values() {
+            for (key, child) in object {
+                if counted && matches!(key.as_str(), "usage" | "tokenCount") {
+                    continue;
+                }
                 if child.is_array() || child.is_object() {
                     extract_cursor_objects(child, fallback_id, table, path, out, seen);
                 }
@@ -1628,6 +1678,118 @@ mod tests {
         assert_eq!(events[0].tokens.reasoning, 30);
         assert_eq!(events[0].tokens.output, 50);
         assert_eq!(events[0].tokens.total(), 200);
+    }
+
+    #[test]
+    fn cursor_nested_token_containers_are_not_recounted() {
+        let value = serde_json::json!([
+            {
+                "generationUUID": "usage-parent",
+                "usage": { "inputTokens": 10, "outputTokens": 5 },
+                "children": [
+                    {
+                        "generationId": "nested-request",
+                        "inputTokens": 7,
+                        "outputTokens": 3
+                    }
+                ]
+            },
+            {
+                "generationUUID": "count-parent",
+                "tokenCount": { "input_tokens": 20, "output_tokens": 8 }
+            }
+        ]);
+        let mut events = Vec::new();
+        let mut seen = HashSet::new();
+
+        extract_cursor_objects(
+            &value,
+            "fixture",
+            "cursorDiskKV",
+            Path::new("state.vscdb"),
+            &mut events,
+            &mut seen,
+        );
+
+        assert_eq!(events.len(), 3);
+        let ids: HashSet<_> = events
+            .iter()
+            .filter_map(|event| event.source_record_id.as_deref())
+            .collect();
+        assert_eq!(
+            ids,
+            HashSet::from(["usage-parent", "nested-request", "count-parent"])
+        );
+        assert_eq!(
+            events.iter().map(|event| event.tokens.total()).sum::<u64>(),
+            53
+        );
+    }
+
+    #[test]
+    fn usage_project_matching_normalizes_paths_slugs_and_remotes() {
+        let mut cache = HashMap::new();
+
+        for candidate in [
+            "/Users/nico/Code/memex",
+            "--Users-nico-Code-memex--",
+            "git@github.com:nicosuave/memex.git",
+        ] {
+            assert!(usage_project_matches(
+                candidate,
+                "memex",
+                ProjectGrouping::Flat,
+                &mut cache,
+            ));
+        }
+        assert!(!usage_project_matches(
+            "/Users/nico/Code/other",
+            "memex",
+            ProjectGrouping::Flat,
+            &mut cache,
+        ));
+    }
+
+    #[test]
+    fn pi_scanner_uses_configured_session_directory() {
+        use crate::test_support::{EnvVarGuard, env_lock};
+
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent_root = tmp.path().join("pi-agent");
+        let session_root = agent_root.join("custom/sessions/project");
+        std::fs::create_dir_all(&session_root).expect("create session root");
+        std::fs::write(
+            agent_root.join("settings.json"),
+            r#"{ "sessionDir": "custom/sessions" }"#,
+        )
+        .expect("write settings");
+        std::fs::write(
+            session_root.join("session.jsonl"),
+            concat!(
+                r#"{"type":"message","id":"a1","timestamp":"2026-07-03T01:02:05Z","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4-6","usage":{"input":10,"cacheRead":2,"cacheWrite":3,"output":4}}}"#,
+                "\n"
+            ),
+        )
+        .expect("write session");
+        let _env = EnvVarGuard::set_os(&[
+            ("PI_CODING_AGENT_SESSION_DIR", None),
+            ("PI_CODING_AGENT_DIR", Some(agent_root.as_os_str())),
+        ]);
+        let mut events = Vec::new();
+        let mut warnings = Vec::new();
+
+        scan_pi(&mut events, &mut warnings).expect("scan pi");
+
+        assert!(warnings.is_empty());
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tokens.total(), 19);
+        assert_eq!(events[0].project.as_deref(), Some("project"));
+        assert!(
+            events[0]
+                .source_path
+                .ends_with("custom/sessions/project/session.jsonl")
+        );
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -868,14 +868,20 @@ fn scan_pi(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()>
     let roots = [crate::ingest::pi_sessions_root()];
     for path in jsonl_files(roots) {
         let source_path = path.to_string_lossy().to_string();
-        let session = path
-            .file_stem()
-            .and_then(|n| n.to_str())
-            .map(str::to_string);
-        let project = Some(crate::ingest::project_from_pi_session_path(&path));
+        let mut session = crate::ingest::pi_session_id_from_path(&path);
+        let mut project = crate::ingest::project_from_pi_session_path(&path);
         let mut current_model = None;
         let mut current_provider = None;
         for (index, value) in lines(&path)? {
+            if value.get("type").and_then(Value::as_str) == Some("session") {
+                crate::ingest::apply_pi_session_identity(
+                    value.get("id").and_then(Value::as_str),
+                    value.get("cwd").and_then(Value::as_str),
+                    &mut session,
+                    &mut project,
+                );
+                continue;
+            }
             if value.get("type").and_then(Value::as_str) == Some("model_change") {
                 current_model = str_at(&value, &["modelId", "model", "model_id"]);
                 current_provider = str_at(&value, &["provider", "providerId", "provider_id"]);
@@ -946,11 +952,11 @@ fn scan_pi(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()>
                 source: "pi".into(),
                 source_path: source_path.clone(),
                 source_record_id: Some(format!("line:{index}")),
-                session_id: session.clone(),
+                session_id: Some(session.clone()),
                 request_id: None,
                 message_id: str_at(&value, &["id"]),
                 timestamp_ms: value.get("timestamp").map(timestamp_ms).unwrap_or(0),
-                project: project.clone(),
+                project: Some(project.clone()),
                 provider: str_at(message, &["provider"])
                     .or_else(|| str_at(&value, &["provider"]))
                     .or_else(|| current_provider.clone()),
@@ -1902,6 +1908,67 @@ mod tests {
                 .source_path
                 .ends_with("custom/sessions/--C--Users-alice-Code-memex--/session.jsonl")
         );
+    }
+
+    #[test]
+    fn pi_scanner_matches_indexed_header_and_filename_session_ids() {
+        use crate::test_support::{EnvVarGuard, env_lock};
+
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session_root = tmp.path().join("--Users-nico-Code-other--");
+        std::fs::create_dir_all(&session_root).expect("create session root");
+
+        let filename_id = "11111111-1111-1111-1111-111111111111";
+        let header_id = "22222222-2222-2222-2222-222222222222";
+        std::fs::write(
+            session_root.join(format!("20260703T010203Z_{filename_id}.jsonl")),
+            format!(
+                concat!(
+                    r#"{{"type":"session","id":"{header_id}","cwd":"/Users/nico/Code/memex"}}"#,
+                    "\n",
+                    r#"{{"type":"message","id":"a1","timestamp":"2026-07-03T01:02:05Z","message":{{"role":"assistant","usage":{{"input":10,"output":4}}}}}}"#,
+                    "\n"
+                ),
+            ),
+        )
+        .expect("write header session");
+
+        let fallback_id = "33333333-3333-3333-3333-333333333333";
+        let fallback_stem = format!("20260703T010204Z_{fallback_id}");
+        std::fs::write(
+            session_root.join(format!("{fallback_stem}.jsonl")),
+            concat!(
+                r#"{"type":"message","id":"a2","timestamp":"2026-07-03T01:02:06Z","message":{"role":"assistant","usage":{"input":20,"output":5}}}"#,
+                "\n"
+            ),
+        )
+        .expect("write filename session");
+
+        let _env =
+            EnvVarGuard::set_os(&[("PI_CODING_AGENT_SESSION_DIR", Some(tmp.path().as_os_str()))]);
+        let mut query = UsageQuery {
+            source: Some(SourceFilter::Pi),
+            include_events: true,
+            ..UsageQuery::default()
+        };
+
+        query.session_keys = Some(HashSet::from([("pi".into(), header_id.into())]));
+        let header = scan_usage(&query).expect("scan header session");
+        query.session_keys = Some(HashSet::from([("pi".into(), filename_id.into())]));
+        let overridden_filename = scan_usage(&query).expect("scan overridden filename session");
+        query.session_keys = Some(HashSet::from([("pi".into(), fallback_id.into())]));
+        let fallback = scan_usage(&query).expect("scan filename session");
+        query.session_keys = Some(HashSet::from([("pi".into(), fallback_stem)]));
+        let full_stem = scan_usage(&query).expect("scan full filename stem");
+
+        assert_eq!(header.events, 1);
+        assert_eq!(header.details[0].session_id.as_deref(), Some(header_id));
+        assert_eq!(header.details[0].project.as_deref(), Some("memex"));
+        assert_eq!(overridden_filename.events, 0);
+        assert_eq!(fallback.events, 1);
+        assert_eq!(fallback.details[0].session_id.as_deref(), Some(fallback_id));
+        assert_eq!(full_stem.events, 0);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,1651 @@
+//! Reconstructed local token usage.
+//!
+//! This module intentionally does not model provider quota percentages. Local logs are useful for
+//! request-level accounting, but they are not authoritative subscription-limit telemetry.
+
+use crate::types::SourceFilter;
+use anyhow::{Context, Result};
+use chrono::DateTime;
+use clap::ValueEnum;
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+#[derive(Clone, Debug, Default)]
+pub struct UsageQuery {
+    pub source: Option<SourceFilter>,
+    pub since_ms: Option<u64>,
+    pub until_ms: Option<u64>,
+    pub cost_mode: CostMode,
+    pub include_events: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum CostMode {
+    Source,
+    #[default]
+    Auto,
+    Reprice,
+}
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq, Hash)]
+pub struct TokenBuckets {
+    /// Provider-reported input. For OpenAI-shaped records this includes the cached subset.
+    pub raw_input: u64,
+    pub uncached_input: u64,
+    pub cache_read: u64,
+    pub cache_write: u64,
+    /// One-hour cache writes, a subset of `cache_write`.
+    pub cache_write_1h: u64,
+    pub output: u64,
+    pub reasoning: u64,
+}
+
+impl TokenBuckets {
+    fn additive_total(&self) -> u64 {
+        self.uncached_input
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_write)
+            .saturating_add(self.output)
+    }
+
+    pub fn total(&self) -> u64 {
+        self.additive_total()
+    }
+
+    fn codex(input: u64, cached: u64, output: u64, reasoning: u64) -> Self {
+        let cache_read = cached.min(input);
+        Self {
+            raw_input: input,
+            uncached_input: input.saturating_sub(cache_read),
+            cache_read,
+            cache_write: 0,
+            cache_write_1h: 0,
+            output,
+            reasoning,
+        }
+    }
+
+    fn disjoint(input: u64, cache_read: u64, cache_write: u64, output: u64) -> Self {
+        Self {
+            raw_input: input,
+            uncached_input: input,
+            cache_read,
+            cache_write,
+            cache_write_1h: 0,
+            output,
+            reasoning: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct UsageEvent {
+    pub source: String,
+    pub source_path: String,
+    pub source_record_id: Option<String>,
+    pub session_id: Option<String>,
+    pub request_id: Option<String>,
+    pub message_id: Option<String>,
+    pub timestamp_ms: u64,
+    pub project: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub tokens: TokenBuckets,
+    pub source_cost_usd: Option<f64>,
+    pub dedupe_confidence: &'static str,
+    pub conservative_undercount: bool,
+    #[serde(skip)]
+    sidechain: bool,
+    #[serde(skip)]
+    source_order: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct UsageSummary {
+    pub source: String,
+    pub events: u64,
+    pub uncached_input: u64,
+    pub cache_read: u64,
+    pub cache_write: u64,
+    pub output: u64,
+    pub reasoning: u64,
+    pub total_tokens: u64,
+    pub known_cost_usd: f64,
+    pub priced_events: u64,
+    pub unpriced_events: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct UsageReport {
+    pub authority: &'static str,
+    pub events: u64,
+    pub total_tokens: u64,
+    pub unknown_model_events: u64,
+    pub conservative_events: u64,
+    pub cost_mode: CostMode,
+    pub price_catalog: &'static str,
+    pub known_cost_usd: f64,
+    pub priced_events: u64,
+    pub unpriced_events: u64,
+    pub by_source: Vec<UsageSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<UsageEvent>,
+    pub warnings: Vec<String>,
+}
+
+pub fn scan_usage(query: &UsageQuery) -> Result<UsageReport> {
+    let mut events = Vec::new();
+    let mut warnings = Vec::new();
+    let mut scan =
+        |filter: SourceFilter, f: fn(&mut Vec<UsageEvent>, &mut Vec<String>) -> Result<()>| {
+            if query.source.is_none_or(|source| source == filter)
+                && let Err(error) = f(&mut events, &mut warnings)
+            {
+                warnings.push(format!("{} scanner: {error:#}", filter.as_str()));
+            }
+        };
+    scan(SourceFilter::Claude, scan_claude);
+    scan(SourceFilter::Codex, scan_codex);
+    scan(SourceFilter::Opencode, scan_opencode);
+    scan(SourceFilter::Pi, scan_pi);
+    scan(SourceFilter::Cursor, scan_cursor);
+    scan(SourceFilter::Copilot, scan_copilot);
+
+    reconcile_claude(&mut events);
+    reconcile_codex_copies(&mut events);
+    events.retain(|event| {
+        query
+            .since_ms
+            .is_none_or(|since| event.timestamp_ms >= since)
+            && query
+                .until_ms
+                .is_none_or(|until| event.timestamp_ms < until)
+    });
+    events.sort_by(|a, b| {
+        (a.timestamp_ms, &a.source_path, a.source_order).cmp(&(
+            b.timestamp_ms,
+            &b.source_path,
+            b.source_order,
+        ))
+    });
+
+    let mut by_source: HashMap<String, UsageSummary> = HashMap::new();
+    let mut report = UsageReport {
+        authority: "local_log",
+        cost_mode: query.cost_mode,
+        price_catalog: PRICE_CATALOG_ID,
+        warnings,
+        ..UsageReport::default()
+    };
+    for event in &events {
+        let total = event.tokens.additive_total();
+        report.events += 1;
+        report.total_tokens = report.total_tokens.saturating_add(total);
+        report.unknown_model_events += u64::from(event.model.is_none());
+        report.conservative_events += u64::from(event.conservative_undercount);
+        let cost = event_cost_nanos(event, query.cost_mode);
+        if let Some(cost) = cost {
+            report.priced_events += 1;
+            report.known_cost_usd += cost as f64 / 1_000_000_000.0;
+        } else {
+            report.unpriced_events += 1;
+        }
+        let row = by_source
+            .entry(event.source.clone())
+            .or_insert_with(|| UsageSummary {
+                source: event.source.clone(),
+                ..UsageSummary::default()
+            });
+        row.events += 1;
+        row.uncached_input = row
+            .uncached_input
+            .saturating_add(event.tokens.uncached_input);
+        row.cache_read = row.cache_read.saturating_add(event.tokens.cache_read);
+        row.cache_write = row.cache_write.saturating_add(event.tokens.cache_write);
+        row.output = row.output.saturating_add(event.tokens.output);
+        row.reasoning = row.reasoning.saturating_add(event.tokens.reasoning);
+        row.total_tokens = row.total_tokens.saturating_add(total);
+        if let Some(cost) = cost {
+            row.priced_events += 1;
+            row.known_cost_usd += cost as f64 / 1_000_000_000.0;
+        } else {
+            row.unpriced_events += 1;
+        }
+    }
+    report.by_source = by_source.into_values().collect();
+    report.by_source.sort_by(|a, b| a.source.cmp(&b.source));
+    if query.include_events {
+        report.details = events;
+    }
+    Ok(report)
+}
+
+fn home() -> PathBuf {
+    directories::BaseDirs::new()
+        .map(|dirs| dirs.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+fn jsonl_files(roots: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for root in roots {
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root).follow_links(false).into_iter().flatten() {
+            let path = entry.path();
+            if entry.file_type().is_file()
+                && path.extension().and_then(|v| v.to_str()) == Some("jsonl")
+            {
+                files.push(path.to_path_buf());
+            }
+        }
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn lines(path: &Path) -> Result<impl Iterator<Item = (u64, Value)>> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    Ok(BufReader::new(file)
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let line = line.ok()?;
+            serde_json::from_str(&line)
+                .ok()
+                .map(|value| (index as u64, value))
+        }))
+}
+
+fn timestamp_ms(value: &Value) -> u64 {
+    value
+        .as_u64()
+        .map(|n| if n < 10_000_000_000 { n * 1000 } else { n })
+        .or_else(|| value.as_i64().filter(|n| *n >= 0).map(|n| n as u64))
+        .or_else(|| {
+            value
+                .as_str()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|d| d.timestamp_millis().max(0) as u64)
+        })
+        .unwrap_or(0)
+}
+
+fn u64_at(value: &Value, aliases: &[&str]) -> u64 {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+fn str_at(value: &Value, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn scan_claude(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
+    let roots = if let Some(config) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        config
+            .to_string_lossy()
+            .split(',')
+            .map(|part| {
+                let path = PathBuf::from(part.trim());
+                if path.file_name().and_then(|n| n.to_str()) == Some("projects") {
+                    path
+                } else {
+                    path.join("projects")
+                }
+            })
+            .collect()
+    } else {
+        vec![
+            home().join(".claude/projects"),
+            home().join(".config/claude/projects"),
+        ]
+    };
+    for path in jsonl_files(roots) {
+        let source_path = path.to_string_lossy().to_string();
+        let fallback_session = path
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        for (index, value) in lines(&path)? {
+            if value.get("type").and_then(Value::as_str) != Some("assistant") {
+                continue;
+            }
+            let Some(message) = value.get("message") else {
+                continue;
+            };
+            let Some(usage) = message.get("usage") else {
+                continue;
+            };
+            let cache_write = u64_at(
+                usage,
+                &["cache_creation_input_tokens", "cacheCreationInputTokens"],
+            );
+            let mut tokens = TokenBuckets::disjoint(
+                u64_at(usage, &["input_tokens", "inputTokens"]),
+                u64_at(usage, &["cache_read_input_tokens", "cacheReadInputTokens"]),
+                cache_write,
+                u64_at(usage, &["output_tokens", "outputTokens"]),
+            );
+            tokens.cache_write_1h = usage
+                .pointer("/cache_creation/ephemeral_1h_input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+                .min(tokens.cache_write);
+            if tokens.additive_total() == 0 {
+                continue;
+            }
+            out.push(UsageEvent {
+                source: "claude".into(),
+                source_path: source_path.clone(),
+                source_record_id: Some(format!("line:{index}")),
+                session_id: str_at(&value, &["sessionId", "session_id"])
+                    .or_else(|| fallback_session.clone()),
+                request_id: str_at(&value, &["requestId", "request_id"]),
+                message_id: str_at(message, &["id"]),
+                timestamp_ms: value.get("timestamp").map(timestamp_ms).unwrap_or(0),
+                project: str_at(&value, &["cwd"]),
+                provider: Some("anthropic".into()),
+                model: str_at(message, &["model"]),
+                tokens,
+                source_cost_usd: value.get("costUSD").and_then(Value::as_f64),
+                dedupe_confidence: if message.get("id").is_some()
+                    && value.get("requestId").is_some()
+                {
+                    "exact"
+                } else {
+                    "heuristic"
+                },
+                conservative_undercount: false,
+                sidechain: value
+                    .get("isSidechain")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                source_order: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn reconcile_claude(events: &mut Vec<UsageEvent>) {
+    let mut best_exact: HashMap<(String, String), usize> = HashMap::new();
+    let mut keep = vec![true; events.len()];
+    for index in 0..events.len() {
+        if events[index].source != "claude" {
+            continue;
+        }
+        let (Some(message), Some(request)) = (
+            events[index].message_id.clone(),
+            events[index].request_id.clone(),
+        ) else {
+            continue;
+        };
+        let key = (message, request);
+        if let Some(previous) = best_exact.get(&key).copied() {
+            let winner = choose_claude(&events[previous], &events[index]);
+            if winner {
+                keep[index] = false;
+            } else {
+                keep[previous] = false;
+                best_exact.insert(key, index);
+            }
+        } else {
+            best_exact.insert(key, index);
+        }
+    }
+    let mut by_message: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, event) in events.iter().enumerate() {
+        if keep[index]
+            && event.source == "claude"
+            && let Some(message) = &event.message_id
+        {
+            by_message.entry(message.clone()).or_default().push(index);
+        }
+    }
+    for indices in by_message.into_values() {
+        if indices.len() < 2 || !indices.iter().any(|index| !events[*index].sidechain) {
+            continue;
+        }
+        // Message-only matching is a sidechain replay fallback. Keep every distinct parent
+        // request; suppress only sidechain copies of a message present in a parent transcript.
+        for index in indices {
+            if events[index].sidechain {
+                keep[index] = false;
+            }
+        }
+    }
+    let mut index = 0usize;
+    events.retain(|_| {
+        let retain = keep[index];
+        index += 1;
+        retain
+    });
+}
+
+/// True means `a` wins. Prefer parent/non-sidechain, then completeness, then source order.
+fn choose_claude(a: &UsageEvent, b: &UsageEvent) -> bool {
+    if a.sidechain != b.sidechain {
+        return !a.sidechain;
+    }
+    let a_parent = !a.source_path.contains("/subagents/");
+    let b_parent = !b.source_path.contains("/subagents/");
+    if a_parent != b_parent {
+        return a_parent;
+    }
+    let a_total = a.tokens.additive_total();
+    let b_total = b.tokens.additive_total();
+    if a_total != b_total {
+        return a_total > b_total;
+    }
+    a.source_order >= b.source_order
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+struct CodexTokens {
+    input: u64,
+    cached: u64,
+    output: u64,
+    reasoning: u64,
+}
+
+impl CodexTokens {
+    fn from(value: &Value) -> Self {
+        Self {
+            input: u64_at(value, &["input_tokens", "inputTokens", "prompt_tokens"]),
+            cached: u64_at(
+                value,
+                &[
+                    "cached_input_tokens",
+                    "cachedInputTokens",
+                    "cache_read_input_tokens",
+                ],
+            ),
+            output: u64_at(
+                value,
+                &["output_tokens", "outputTokens", "completion_tokens"],
+            ),
+            reasoning: u64_at(
+                value,
+                &[
+                    "reasoning_output_tokens",
+                    "reasoningTokens",
+                    "reasoning_tokens",
+                ],
+            ),
+        }
+    }
+    fn zero(self) -> bool {
+        self.input == 0 && self.cached == 0 && self.output == 0 && self.reasoning == 0
+    }
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.saturating_add(rhs.input),
+            cached: self.cached.saturating_add(rhs.cached),
+            output: self.output.saturating_add(rhs.output),
+            reasoning: self.reasoning.saturating_add(rhs.reasoning),
+        }
+    }
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.saturating_sub(rhs.input),
+            cached: self.cached.saturating_sub(rhs.cached),
+            output: self.output.saturating_sub(rhs.output),
+            reasoning: self.reasoning.saturating_sub(rhs.reasoning),
+        }
+    }
+    fn min(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.min(rhs.input),
+            cached: self.cached.min(rhs.cached),
+            output: self.output.min(rhs.output),
+            reasoning: self.reasoning.min(rhs.reasoning),
+        }
+    }
+    fn max(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.max(rhs.input),
+            cached: self.cached.max(rhs.cached),
+            output: self.output.max(rhs.output),
+            reasoning: self.reasoning.max(rhs.reasoning),
+        }
+    }
+    fn at_least(self, rhs: Self) -> bool {
+        self.input >= rhs.input
+            && self.cached >= rhs.cached
+            && self.output >= rhs.output
+            && self.reasoning >= rhs.reasoning
+    }
+    fn at_most(self, rhs: Self) -> bool {
+        self.input <= rhs.input
+            && self.cached <= rhs.cached
+            && self.output <= rhs.output
+            && self.reasoning <= rhs.reasoning
+    }
+}
+
+#[derive(Default)]
+struct CodexCounter {
+    counted: CodexTokens,
+    raw_baseline: CodexTokens,
+    watermark: CodexTokens,
+    seen: Vec<CodexTokens>,
+    divergent: bool,
+    interleaved: bool,
+}
+
+impl CodexCounter {
+    fn establish_unresolved_fork_baseline(&mut self, total: CodexTokens) {
+        self.raw_baseline = total;
+        self.watermark = self.watermark.max(total);
+        if self.seen.last() != Some(&total) {
+            self.seen.push(total);
+            if self.seen.len() > 64 {
+                self.seen.remove(0);
+            }
+        }
+    }
+
+    fn account(&mut self, last: Option<CodexTokens>, total: Option<CodexTokens>) -> CodexTokens {
+        if let Some(total) = total {
+            if self.seen.contains(&total) {
+                return CodexTokens::default();
+            }
+            if !total.at_least(self.watermark) {
+                self.interleaved = true;
+            }
+        }
+        let baseline = self.watermark.max(self.raw_baseline);
+        let delta = match (last, total) {
+            (Some(last), Some(total)) if self.interleaved => {
+                last.min(contained(total, baseline, self.counted))
+            }
+            (None, Some(total)) if self.interleaved => contained(total, baseline, self.counted),
+            (Some(last), Some(total)) => {
+                let total_delta = total.sub(baseline);
+                if !self.divergent && total.at_least(baseline) && total_delta.at_most(last) {
+                    total_delta
+                } else {
+                    last
+                }
+            }
+            (None, Some(total)) if self.divergent => contained(total, baseline, self.counted),
+            (None, Some(total)) => total.sub(baseline),
+            (Some(last), None) => last,
+            (None, None) => return CodexTokens::default(),
+        };
+        self.counted = self.counted.add(delta);
+        if let Some(total) = total {
+            self.raw_baseline = total;
+            self.divergent |= total != self.counted;
+            self.watermark = self.watermark.max(total);
+            if self.seen.last() != Some(&total) {
+                self.seen.push(total);
+                if self.seen.len() > 64 {
+                    self.seen.remove(0);
+                }
+            }
+        } else {
+            self.raw_baseline = self.counted;
+            self.watermark = self.watermark.max(self.counted);
+        }
+        delta
+    }
+}
+
+fn contained(current: CodexTokens, watermark: CodexTokens, counted: CodexTokens) -> CodexTokens {
+    fn one(current: u64, watermark: u64, counted: u64) -> u64 {
+        if current >= watermark {
+            current.saturating_sub(watermark.max(counted))
+        } else {
+            current.saturating_sub(counted)
+        }
+    }
+    CodexTokens {
+        input: one(current.input, watermark.input, counted.input),
+        cached: one(current.cached, watermark.cached, counted.cached),
+        output: one(current.output, watermark.output, counted.output),
+        reasoning: one(current.reasoning, watermark.reasoning, counted.reasoning),
+    }
+}
+
+fn scan_codex(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
+    let homes: Vec<PathBuf> = std::env::var_os("CODEX_HOME")
+        .map(|v| {
+            v.to_string_lossy()
+                .split(',')
+                .map(|s| PathBuf::from(s.trim()))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![home().join(".codex")]);
+    let mut files = Vec::new();
+    for root in homes {
+        let active = root.join("sessions");
+        let archived = root.join("archived_sessions");
+        if active.exists() || archived.exists() {
+            files.extend(jsonl_files([active, archived]));
+        } else {
+            files.extend(jsonl_files([root]));
+        }
+    }
+    for path in files {
+        scan_codex_file(&path, out)?;
+    }
+    Ok(())
+}
+
+fn scan_codex_file(path: &Path, out: &mut Vec<UsageEvent>) -> Result<()> {
+    let source_path = path.to_string_lossy().to_string();
+    let mut session = path
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .map(str::to_string);
+    let mut parent = None;
+    let mut fork_timestamp_ms = None;
+    let mut project = None;
+    let mut model = None;
+    let mut turn = None;
+    let mut counter = CodexCounter::default();
+    let mut event_index = 0u64;
+    let mut unresolved_fork_baseline_seen = false;
+    for (line_index, value) in lines(path)? {
+        let kind = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let payload = value.get("payload").unwrap_or(&Value::Null);
+        match kind {
+            "session_meta" => {
+                session = str_at(payload, &["id", "session_id"]).or(session);
+                parent = str_at(
+                    payload,
+                    &["forked_from_id", "parent_session_id", "parentSessionId"],
+                );
+                if parent.is_some() {
+                    fork_timestamp_ms = value.get("timestamp").map(timestamp_ms);
+                }
+                project = str_at(payload, &["cwd"]);
+            }
+            "turn_context" => model = str_at(payload, &["model", "model_name"]),
+            "event_msg" if payload.get("type").and_then(Value::as_str) == Some("task_started") => {
+                turn = str_at(payload, &["turn_id", "turnId"])
+            }
+            "event_msg" if payload.get("type").and_then(Value::as_str) == Some("token_count") => {
+                let info = payload.get("info").unwrap_or(payload);
+                let last = info
+                    .get("last_token_usage")
+                    .map(CodexTokens::from)
+                    .filter(|v| !v.zero());
+                let total = info
+                    .get("total_token_usage")
+                    .map(CodexTokens::from)
+                    .filter(|v| !v.zero());
+                let event_timestamp_ms = value.get("timestamp").map(timestamp_ms).unwrap_or(0);
+                if parent.is_some()
+                    && fork_timestamp_ms.is_some_and(|fork| event_timestamp_ms <= fork)
+                {
+                    if let Some(total) = total {
+                        counter.establish_unresolved_fork_baseline(total);
+                        unresolved_fork_baseline_seen = true;
+                    }
+                    continue;
+                }
+                if parent.is_some()
+                    && !unresolved_fork_baseline_seen
+                    && let Some(total) = total
+                {
+                    counter.establish_unresolved_fork_baseline(total);
+                    unresolved_fork_baseline_seen = true;
+                    continue;
+                }
+                let delta = counter.account(last, total);
+                if delta.zero() {
+                    continue;
+                }
+                out.push(UsageEvent {
+                    source: "codex".into(),
+                    source_path: source_path.clone(),
+                    source_record_id: Some(format!("event:{event_index}")),
+                    session_id: session.clone(),
+                    request_id: turn.clone(),
+                    message_id: None,
+                    timestamp_ms: event_timestamp_ms,
+                    project: project.clone(),
+                    provider: Some("openai".into()),
+                    model: model
+                        .clone()
+                        .or_else(|| str_at(info, &["model", "model_name"])),
+                    tokens: TokenBuckets::codex(
+                        delta.input,
+                        delta.cached,
+                        delta.output,
+                        delta.reasoning,
+                    ),
+                    source_cost_usd: None,
+                    dedupe_confidence: "strong",
+                    conservative_undercount: counter.interleaved || parent.is_some(),
+                    sidechain: false,
+                    source_order: line_index,
+                });
+                event_index += 1;
+            }
+            _ => {
+                if let Some(usage) = value
+                    .get("usage")
+                    .or_else(|| value.pointer("/data/usage"))
+                    .or_else(|| value.pointer("/result/usage"))
+                    .or_else(|| value.pointer("/response/usage"))
+                {
+                    let tokens = CodexTokens::from(usage);
+                    if tokens.zero() {
+                        continue;
+                    }
+                    out.push(UsageEvent {
+                        source: "codex".into(),
+                        source_path: source_path.clone(),
+                        source_record_id: Some(format!("line:{line_index}")),
+                        session_id: session.clone(),
+                        request_id: None,
+                        message_id: None,
+                        timestamp_ms: value
+                            .get("timestamp")
+                            .or_else(|| value.get("created_at"))
+                            .map(timestamp_ms)
+                            .unwrap_or(0),
+                        project: project.clone(),
+                        provider: Some("openai".into()),
+                        model: model
+                            .clone()
+                            .or_else(|| str_at(&value, &["model", "model_name"])),
+                        tokens: TokenBuckets::codex(
+                            tokens.input,
+                            tokens.cached,
+                            tokens.output,
+                            tokens.reasoning,
+                        ),
+                        source_cost_usd: None,
+                        dedupe_confidence: "strong",
+                        conservative_undercount: false,
+                        sidechain: false,
+                        source_order: line_index,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reconcile_codex_copies(events: &mut Vec<UsageEvent>) {
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        if event.source != "codex" {
+            return true;
+        }
+        let Some(session) = &event.session_id else {
+            return true;
+        };
+        let Some(record) = &event.source_record_id else {
+            return true;
+        };
+        seen.insert((session.clone(), record.clone(), event.tokens.clone()))
+    });
+}
+
+fn scan_pi(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
+    let roots = if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
+        vec![PathBuf::from(root)]
+    } else if let Some(root) = std::env::var_os("PI_CODING_AGENT_DIR") {
+        vec![PathBuf::from(root).join("sessions")]
+    } else {
+        vec![home().join(".pi/agent/sessions")]
+    };
+    for path in jsonl_files(roots) {
+        let source_path = path.to_string_lossy().to_string();
+        let session = path
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        let project = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        let mut current_model = None;
+        let mut current_provider = None;
+        for (index, value) in lines(&path)? {
+            if value.get("type").and_then(Value::as_str) == Some("model_change") {
+                current_model = str_at(&value, &["modelId", "model", "model_id"]);
+                current_provider = str_at(&value, &["provider", "providerId", "provider_id"]);
+                continue;
+            }
+            if value.get("type").and_then(Value::as_str) != Some("message") {
+                continue;
+            }
+            let Some(message) = value.get("message") else {
+                continue;
+            };
+            if message.get("role").and_then(Value::as_str) != Some("assistant") {
+                continue;
+            }
+            let Some(usage) = message.get("usage") else {
+                continue;
+            };
+            let tokens = TokenBuckets::disjoint(
+                u64_at(
+                    usage,
+                    &[
+                        "input",
+                        "inputTokens",
+                        "input_tokens",
+                        "promptTokens",
+                        "prompt_tokens",
+                    ],
+                ),
+                u64_at(
+                    usage,
+                    &[
+                        "cacheRead",
+                        "cacheReadTokens",
+                        "cache_read",
+                        "cache_read_tokens",
+                        "cacheReadInputTokens",
+                        "cache_read_input_tokens",
+                    ],
+                ),
+                u64_at(
+                    usage,
+                    &[
+                        "cacheWrite",
+                        "cacheWriteTokens",
+                        "cache_write",
+                        "cache_write_tokens",
+                        "cacheCreationTokens",
+                        "cache_creation_tokens",
+                        "cacheCreationInputTokens",
+                        "cache_creation_input_tokens",
+                    ],
+                ),
+                u64_at(
+                    usage,
+                    &[
+                        "output",
+                        "outputTokens",
+                        "output_tokens",
+                        "completionTokens",
+                        "completion_tokens",
+                    ],
+                ),
+            );
+            if tokens.additive_total() == 0 {
+                continue;
+            }
+            out.push(UsageEvent {
+                source: "pi".into(),
+                source_path: source_path.clone(),
+                source_record_id: Some(format!("line:{index}")),
+                session_id: session.clone(),
+                request_id: None,
+                message_id: str_at(&value, &["id"]),
+                timestamp_ms: value.get("timestamp").map(timestamp_ms).unwrap_or(0),
+                project: project.clone(),
+                provider: str_at(message, &["provider"])
+                    .or_else(|| str_at(&value, &["provider"]))
+                    .or_else(|| current_provider.clone()),
+                model: str_at(message, &["model", "modelId"])
+                    .or_else(|| str_at(&value, &["model", "modelId"]))
+                    .or_else(|| current_model.clone()),
+                tokens,
+                source_cost_usd: usage.pointer("/cost/total").and_then(Value::as_f64),
+                dedupe_confidence: "exact",
+                conservative_undercount: false,
+                sidechain: false,
+                source_order: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn scan_opencode(out: &mut Vec<UsageEvent>, warnings: &mut Vec<String>) -> Result<()> {
+    let roots: Vec<PathBuf> = std::env::var_os("OPENCODE_DATA_DIR")
+        .map(|v| {
+            v.to_string_lossy()
+                .split(',')
+                .map(|s| PathBuf::from(s.trim()))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![home().join(".local/share/opencode")]);
+    for root in roots {
+        let mut database_ids = HashSet::new();
+        let mut databases = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&root) {
+            databases.extend(entries.flatten().map(|entry| entry.path()).filter(|path| {
+                path.extension().and_then(|v| v.to_str()) == Some("db")
+                    && path
+                        .file_name()
+                        .and_then(|v| v.to_str())
+                        .is_some_and(|n| n.starts_with("opencode"))
+            }));
+        }
+        for database in databases {
+            if let Err(error) = scan_opencode_db(&database, out, &mut database_ids) {
+                warnings.push(format!("{}: {error:#}", database.display()));
+            }
+        }
+        let message_root = root.join("storage/message");
+        if message_root.exists() {
+            for entry in WalkDir::new(message_root)
+                .into_iter()
+                .flatten()
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && e.path().extension().and_then(|v| v.to_str()) == Some("json")
+                })
+            {
+                let value: Value = match File::open(entry.path())
+                    .ok()
+                    .and_then(|file| serde_json::from_reader(file).ok())
+                {
+                    Some(value) => value,
+                    None => continue,
+                };
+                let id = str_at(&value, &["id"]).or_else(|| {
+                    entry
+                        .path()
+                        .file_stem()
+                        .and_then(|n| n.to_str())
+                        .map(str::to_string)
+                });
+                if id.as_ref().is_some_and(|id| database_ids.contains(id)) {
+                    continue;
+                }
+                push_opencode_event(&value, entry.path(), id, out);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn scan_opencode_db(
+    path: &Path,
+    out: &mut Vec<UsageEvent>,
+    ids: &mut HashSet<String>,
+) -> Result<()> {
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.busy_timeout(std::time::Duration::from_secs(1))?;
+    let mut stmt = conn.prepare("SELECT id, session_id, data FROM message")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (id, session, data) = row?;
+        let Ok(mut value) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+        if value.get("sessionID").is_none()
+            && let Some(object) = value.as_object_mut()
+        {
+            object.insert(
+                "sessionID".into(),
+                session.map(Value::String).unwrap_or(Value::Null),
+            );
+        }
+        let before = out.len();
+        if !ids.contains(&id) {
+            push_opencode_event(&value, path, Some(id.clone()), out);
+        }
+        if out.len() > before {
+            ids.insert(id);
+        }
+    }
+    Ok(())
+}
+
+fn push_opencode_event(value: &Value, path: &Path, id: Option<String>, out: &mut Vec<UsageEvent>) {
+    let Some(usage) = value.get("tokens") else {
+        return;
+    };
+    let tokens = TokenBuckets::disjoint(
+        u64_at(usage, &["input"]),
+        usage
+            .pointer("/cache/read")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        usage
+            .pointer("/cache/write")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        u64_at(usage, &["output"]),
+    );
+    if tokens.additive_total() == 0 {
+        return;
+    }
+    out.push(UsageEvent {
+        source: "opencode".into(),
+        source_path: path.to_string_lossy().to_string(),
+        source_record_id: id.clone(),
+        session_id: str_at(value, &["sessionID", "session_id"]),
+        request_id: None,
+        message_id: id,
+        timestamp_ms: value
+            .pointer("/time/created")
+            .map(timestamp_ms)
+            .unwrap_or(0),
+        project: str_at(value, &["directory", "cwd"]),
+        provider: str_at(value, &["providerID", "provider"]),
+        model: str_at(value, &["modelID", "model"]),
+        tokens,
+        source_cost_usd: value.get("cost").and_then(Value::as_f64),
+        dedupe_confidence: "exact",
+        conservative_undercount: false,
+        sidechain: false,
+        source_order: 0,
+    });
+}
+
+fn scan_cursor(out: &mut Vec<UsageEvent>, warnings: &mut Vec<String>) -> Result<()> {
+    let user = if cfg!(target_os = "macos") {
+        home().join("Library/Application Support/Cursor/User")
+    } else {
+        home().join(".config/Cursor/User")
+    };
+    let mut databases = vec![user.join("globalStorage/state.vscdb")];
+    databases.extend(
+        WalkDir::new(user.join("workspaceStorage"))
+            .max_depth(3)
+            .into_iter()
+            .flatten()
+            .filter(|e| e.file_type().is_file() && e.file_name() == "state.vscdb")
+            .map(|e| e.path().to_path_buf()),
+    );
+    let mut seen = HashSet::new();
+    for path in databases.into_iter().filter(|path| path.exists()) {
+        if let Err(error) = scan_cursor_db(&path, out, &mut seen) {
+            warnings.push(format!("{}: {error:#}", path.display()));
+        }
+    }
+    Ok(())
+}
+
+fn scan_cursor_db(
+    path: &Path,
+    out: &mut Vec<UsageEvent>,
+    seen: &mut HashSet<String>,
+) -> Result<()> {
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.busy_timeout(std::time::Duration::from_secs(1))?;
+    for (table, query) in [
+        (
+            "cursorDiskKV",
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'",
+        ),
+        (
+            "ItemTable",
+            "SELECT key, value FROM ItemTable WHERE key IN ('aiService.generations', 'workbench.panel.aichat.view.aichat.chatdata')",
+        ),
+    ] {
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+            [table],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            continue;
+        }
+        let mut stmt = conn.prepare(query)?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (key, raw) = row?;
+            let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+                continue;
+            };
+            extract_cursor_objects(&value, &key, table, path, out, seen);
+        }
+    }
+    Ok(())
+}
+
+fn extract_cursor_objects(
+    value: &Value,
+    fallback_id: &str,
+    table: &str,
+    path: &Path,
+    out: &mut Vec<UsageEvent>,
+    seen: &mut HashSet<String>,
+) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                extract_cursor_objects(value, fallback_id, table, path, out, seen);
+            }
+        }
+        Value::Object(object) => {
+            let input = nested_u64(object, &["inputTokens", "input_tokens"]);
+            let output = nested_u64(object, &["outputTokens", "output_tokens"]);
+            if input > 0 || output > 0 {
+                let id = object_string(
+                    object,
+                    &["generationUUID", "generationId", "bubbleId", "id"],
+                )
+                .unwrap_or_else(|| {
+                    format!(
+                        "{fallback_id}:{}:{}",
+                        object.get("createdAt").unwrap_or(&Value::Null),
+                        input + output
+                    )
+                });
+                let dedupe = format!("{id}:{input}:{output}");
+                if seen.insert(dedupe) {
+                    out.push(UsageEvent {
+                        source: "cursor".into(),
+                        source_path: path.to_string_lossy().to_string(),
+                        source_record_id: Some(id),
+                        session_id: object_string(object, &["sessionId", "composerId"]),
+                        request_id: None,
+                        message_id: None,
+                        timestamp_ms: object
+                            .get("createdAt")
+                            .or_else(|| object.get("timestamp"))
+                            .map(timestamp_ms)
+                            .unwrap_or(0),
+                        project: None,
+                        provider: None,
+                        model: object_string(object, &["model", "modelName"])
+                            .or_else(|| {
+                                object
+                                    .get("modelInfo")
+                                    .and_then(|v| str_at(v, &["modelName"]))
+                            })
+                            .or_else(|| {
+                                object
+                                    .get("modelConfig")
+                                    .and_then(|v| str_at(v, &["modelName"]))
+                            }),
+                        tokens: TokenBuckets::disjoint(input, 0, 0, output),
+                        source_cost_usd: None,
+                        dedupe_confidence: if table == "cursorDiskKV" {
+                            "exact"
+                        } else {
+                            "strong"
+                        },
+                        conservative_undercount: false,
+                        sidechain: false,
+                        source_order: 0,
+                    });
+                }
+            }
+            for child in object.values() {
+                if child.is_array() || child.is_object() {
+                    extract_cursor_objects(child, fallback_id, table, path, out, seen);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn nested_u64(object: &Map<String, Value>, aliases: &[&str]) -> u64 {
+    aliases
+        .iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_u64))
+        .or_else(|| {
+            object.get("tokenCount").and_then(|v| {
+                aliases
+                    .iter()
+                    .find_map(|key| v.get(*key).and_then(Value::as_u64))
+            })
+        })
+        .or_else(|| {
+            object.get("usage").and_then(|v| {
+                aliases
+                    .iter()
+                    .find_map(|key| v.get(*key).and_then(Value::as_u64))
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn object_string(object: &Map<String, Value>, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn scan_copilot(out: &mut Vec<UsageEvent>, _warnings: &mut Vec<String>) -> Result<()> {
+    let mut roots = vec![home().join(".copilot/otel")];
+    if let Some(path) = std::env::var_os("COPILOT_OTEL_FILE_EXPORTER_PATH") {
+        roots.push(PathBuf::from(path));
+    }
+    let files = roots
+        .into_iter()
+        .flat_map(|root| {
+            if root.is_file() {
+                vec![root]
+            } else {
+                jsonl_files([root])
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut seen = HashSet::new();
+    for path in files {
+        for (index, value) in lines(&path)? {
+            extract_otel(&value, &path, index, out, &mut seen);
+        }
+    }
+    Ok(())
+}
+
+fn extract_otel(
+    value: &Value,
+    path: &Path,
+    index: u64,
+    out: &mut Vec<UsageEvent>,
+    seen: &mut HashSet<String>,
+) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                extract_otel(value, path, index, out, seen);
+            }
+        }
+        Value::Object(object) => {
+            let attrs = otel_attributes(object.get("attributes").unwrap_or(value));
+            let operation = attrs
+                .get("gen_ai.operation.name")
+                .and_then(Value::as_str)
+                .or_else(|| object.get("name").and_then(Value::as_str));
+            let input = attrs
+                .get("gen_ai.usage.input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let output = attrs
+                .get("gen_ai.usage.output_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            if operation == Some("chat") && (input > 0 || output > 0) {
+                let trace = object
+                    .get("traceId")
+                    .or_else(|| object.get("trace_id"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let span = object
+                    .get("spanId")
+                    .or_else(|| object.get("span_id"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let response = attrs
+                    .get("gen_ai.response.id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let id = if !trace.is_empty() || !span.is_empty() {
+                    format!("{trace}:{span}")
+                } else if !response.is_empty() {
+                    format!("response:{response}")
+                } else {
+                    format!("{}:{index}:{input}:{output}", path.display())
+                };
+                if seen.insert(id.clone()) {
+                    let cache = attrs
+                        .get("gen_ai.usage.cache_read.input_tokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0)
+                        .min(input);
+                    out.push(UsageEvent {
+                        source: "copilot".into(),
+                        source_path: path.to_string_lossy().to_string(),
+                        source_record_id: Some(id),
+                        session_id: attrs
+                            .get("gen_ai.conversation.id")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        request_id: attrs
+                            .get("gen_ai.response.id")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        message_id: None,
+                        timestamp_ms: object
+                            .get("startTimeUnixNano")
+                            .and_then(Value::as_str)
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .map(|v| v / 1_000_000)
+                            .or_else(|| object.get("timestamp").map(timestamp_ms))
+                            .unwrap_or(0),
+                        project: attrs
+                            .get("copilot_chat.repo.remote_url")
+                            .or_else(|| attrs.get("github.copilot.git.repository"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        provider: Some("github-copilot".into()),
+                        model: attrs
+                            .get("gen_ai.response.model")
+                            .or_else(|| attrs.get("gen_ai.request.model"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        tokens: TokenBuckets::codex(
+                            input,
+                            cache,
+                            output,
+                            attrs
+                                .get("gen_ai.usage.reasoning.output_tokens")
+                                .or_else(|| attrs.get("gen_ai.usage.reasoning_tokens"))
+                                .and_then(Value::as_u64)
+                                .unwrap_or(0),
+                        ),
+                        source_cost_usd: None,
+                        dedupe_confidence: "exact",
+                        conservative_undercount: false,
+                        sidechain: false,
+                        source_order: index,
+                    });
+                }
+            }
+            for child in object.values() {
+                if child.is_array() || child.is_object() {
+                    extract_otel(child, path, index, out, seen);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn otel_attributes(value: &Value) -> HashMap<String, Value> {
+    if let Some(object) = value.as_object() {
+        return object
+            .iter()
+            .map(|(k, v)| (k.clone(), unwrap_otel_value(v)))
+            .collect();
+    }
+    let mut out = HashMap::new();
+    if let Some(array) = value.as_array() {
+        for item in array {
+            if let (Some(key), Some(value)) =
+                (item.get("key").and_then(Value::as_str), item.get("value"))
+            {
+                out.insert(key.to_string(), unwrap_otel_value(value));
+            }
+        }
+    }
+    out
+}
+
+fn unwrap_otel_value(value: &Value) -> Value {
+    for key in ["stringValue", "intValue", "doubleValue", "boolValue"] {
+        if let Some(inner) = value.get(key) {
+            if key == "intValue"
+                && let Some(text) = inner.as_str()
+            {
+                return text
+                    .parse::<u64>()
+                    .map(Value::from)
+                    .unwrap_or_else(|_| inner.clone());
+            }
+            return inner.clone();
+        }
+    }
+    value.clone()
+}
+
+// Rates are nano-USD per million tokens. The catalog is deliberately small and versioned:
+// unknown models remain unpriced instead of silently inheriting a guessed family rate.
+const PRICE_CATALOG_ID: &str = "official-api-prices-2026-07-15";
+
+#[derive(Clone, Copy)]
+struct Rates {
+    input: u64,
+    cache_read: u64,
+    cache_write_5m: u64,
+    cache_write_1h: u64,
+    output: u64,
+}
+
+const fn usd_per_million(value_milli_usd: u64) -> u64 {
+    value_milli_usd * 1_000_000
+}
+
+fn event_cost_nanos(event: &UsageEvent, mode: CostMode) -> Option<u64> {
+    let source = event
+        .source_cost_usd
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .and_then(|value| {
+            let nanos = value * 1_000_000_000.0;
+            (nanos <= u64::MAX as f64).then_some(nanos.round() as u64)
+        });
+    match mode {
+        CostMode::Source => source,
+        CostMode::Auto => source.or_else(|| calculated_cost_nanos(event)),
+        CostMode::Reprice => calculated_cost_nanos(event),
+    }
+}
+
+fn calculated_cost_nanos(event: &UsageEvent) -> Option<u64> {
+    let rates = rates_for(event.provider.as_deref(), event.model.as_deref()?)?;
+    let cache_write_1h = event.tokens.cache_write_1h.min(event.tokens.cache_write);
+    let cache_write_5m = event.tokens.cache_write.saturating_sub(cache_write_1h);
+    let total = (event.tokens.uncached_input as u128) * (rates.input as u128)
+        + (event.tokens.cache_read as u128) * (rates.cache_read as u128)
+        + (cache_write_5m as u128) * (rates.cache_write_5m as u128)
+        + (cache_write_1h as u128) * (rates.cache_write_1h as u128)
+        + (event.tokens.output as u128) * (rates.output as u128);
+    // Rates are per million tokens. Reasoning is retained as an output subset and is not charged
+    // a second time.
+    u64::try_from(total / 1_000_000).ok()
+}
+
+fn rates_for(provider: Option<&str>, model: &str) -> Option<Rates> {
+    let model = model.trim().to_ascii_lowercase();
+    let provider = provider.unwrap_or("").trim().to_ascii_lowercase();
+    let exact_or_snapshot = |base: &str| {
+        model == base
+            || model.strip_prefix(base).is_some_and(|suffix| {
+                suffix.starts_with("-20")
+                    && suffix[1..].chars().all(|c| c.is_ascii_digit() || c == '-')
+            })
+    };
+
+    let openai = provider.is_empty()
+        || provider.contains("openai")
+        || provider.contains("codex")
+        || provider.contains("github-copilot");
+    if openai {
+        if exact_or_snapshot("gpt-5.5") {
+            return Some(openai_rates(5_000, 500, 30_000));
+        }
+        if exact_or_snapshot("gpt-5.4") {
+            return Some(openai_rates(2_500, 250, 15_000));
+        }
+        if exact_or_snapshot("gpt-5.4-mini") {
+            return Some(openai_rates(750, 75, 4_500));
+        }
+        if exact_or_snapshot("gpt-5.3-codex") || exact_or_snapshot("gpt-5.2-codex") {
+            return Some(openai_rates(1_750, 175, 14_000));
+        }
+        if exact_or_snapshot("gpt-5-codex") || exact_or_snapshot("gpt-5") {
+            return Some(openai_rates(1_250, 125, 10_000));
+        }
+        if exact_or_snapshot("gpt-4o") {
+            return Some(openai_rates(2_500, 1_250, 10_000));
+        }
+        if exact_or_snapshot("gpt-4o-mini") {
+            return Some(openai_rates(150, 75, 600));
+        }
+    }
+
+    let anthropic = provider.is_empty() || provider.contains("anthropic");
+    if anthropic {
+        if [
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+        ]
+        .iter()
+        .any(|base| exact_or_snapshot(base))
+        {
+            return Some(claude_rates(5_000, 6_250, 10_000, 500, 25_000));
+        }
+        if exact_or_snapshot("claude-opus-4-1") || exact_or_snapshot("claude-opus-4") {
+            return Some(claude_rates(15_000, 18_750, 30_000, 1_500, 75_000));
+        }
+        if exact_or_snapshot("claude-sonnet-5") {
+            // Promotional rate valid on the catalog's 2026-07-15 effective date.
+            return Some(claude_rates(2_000, 2_500, 4_000, 200, 10_000));
+        }
+        if ["claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4"]
+            .iter()
+            .any(|base| exact_or_snapshot(base))
+        {
+            return Some(claude_rates(3_000, 3_750, 6_000, 300, 15_000));
+        }
+        if exact_or_snapshot("claude-haiku-4-5") {
+            return Some(claude_rates(1_000, 1_250, 2_000, 100, 5_000));
+        }
+    }
+    None
+}
+
+fn openai_rates(input: u64, cached: u64, output: u64) -> Rates {
+    Rates {
+        input: usd_per_million(input),
+        cache_read: usd_per_million(cached),
+        cache_write_5m: usd_per_million(input),
+        cache_write_1h: usd_per_million(input),
+        output: usd_per_million(output),
+    }
+}
+
+fn claude_rates(input: u64, write_5m: u64, write_1h: u64, read: u64, output: u64) -> Rates {
+    Rates {
+        input: usd_per_million(input),
+        cache_read: usd_per_million(read),
+        cache_write_5m: usd_per_million(write_5m),
+        cache_write_1h: usd_per_million(write_1h),
+        output: usd_per_million(output),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(input: u64, cached: u64, output: u64) -> CodexTokens {
+        CodexTokens {
+            input,
+            cached,
+            output,
+            reasoning: 0,
+        }
+    }
+
+    #[test]
+    fn codex_repeated_total_does_not_repeat_last() {
+        let mut counter = CodexCounter::default();
+        assert_eq!(
+            counter.account(Some(c(100, 20, 10)), Some(c(100, 20, 10))),
+            c(100, 20, 10)
+        );
+        assert_eq!(
+            counter.account(Some(c(100, 20, 10)), Some(c(100, 20, 10))),
+            c(0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn codex_interleaved_stream_never_recounts_high_water_gap() {
+        let mut counter = CodexCounter::default();
+        assert_eq!(counter.account(None, Some(c(1000, 0, 0))), c(1000, 0, 0));
+        assert_eq!(
+            counter.account(Some(c(200, 0, 0)), Some(c(200, 0, 0))),
+            c(0, 0, 0)
+        );
+        assert_eq!(
+            counter.account(Some(c(900, 0, 0)), Some(c(1100, 0, 0))),
+            c(100, 0, 0)
+        );
+        assert_eq!(counter.counted.input, 1100);
+    }
+
+    #[test]
+    fn openai_cached_input_is_a_subset() {
+        let tokens = TokenBuckets::codex(100, 80, 10, 4);
+        assert_eq!(tokens.uncached_input, 20);
+        assert_eq!(tokens.cache_read, 80);
+        assert_eq!(tokens.additive_total(), 110);
+    }
+
+    #[test]
+    fn claude_cache_write_durations_get_distinct_rates() {
+        let mut tokens = TokenBuckets::disjoint(100, 40, 30, 20);
+        tokens.cache_write_1h = 10;
+        let event = UsageEvent {
+            source: "claude".into(),
+            source_path: "x".into(),
+            source_record_id: None,
+            session_id: None,
+            request_id: None,
+            message_id: None,
+            timestamp_ms: 0,
+            project: None,
+            provider: Some("anthropic".into()),
+            model: Some("claude-sonnet-4-6".into()),
+            tokens,
+            source_cost_usd: None,
+            dedupe_confidence: "exact",
+            conservative_undercount: false,
+            sidechain: false,
+            source_order: 0,
+        };
+        // 100*3 + 40*.3 + 20*3.75 + 10*6 + 20*15 = $0.000747
+        assert_eq!(calculated_cost_nanos(&event), Some(747_000));
+    }
+
+    #[test]
+    fn auto_cost_honors_explicit_zero_source_cost() {
+        let event = UsageEvent {
+            source: "claude".into(),
+            source_path: "x".into(),
+            source_record_id: None,
+            session_id: None,
+            request_id: None,
+            message_id: None,
+            timestamp_ms: 0,
+            project: None,
+            provider: Some("anthropic".into()),
+            model: Some("claude-sonnet-4-6".into()),
+            tokens: TokenBuckets::disjoint(100, 0, 0, 0),
+            source_cost_usd: Some(0.0),
+            dedupe_confidence: "exact",
+            conservative_undercount: false,
+            sidechain: false,
+            source_order: 0,
+        };
+        assert_eq!(event_cost_nanos(&event, CostMode::Auto), Some(0));
+        assert_eq!(event_cost_nanos(&event, CostMode::Reprice), Some(300_000));
+    }
+}

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -44,7 +44,9 @@ pub struct TokenBuckets {
     pub cache_write: u64,
     /// One-hour cache writes, a subset of `cache_write`.
     pub cache_write_1h: u64,
+    /// Billable output, including reasoning when a provider reports it separately.
     pub output: u64,
+    /// Reasoning output, retained as a subset of `output` for reporting.
     pub reasoning: u64,
 }
 
@@ -1025,7 +1027,8 @@ fn push_opencode_event(value: &Value, path: &Path, id: Option<String>, out: &mut
     let Some(usage) = value.get("tokens") else {
         return;
     };
-    let tokens = TokenBuckets::disjoint(
+    let reasoning = u64_at(usage, &["reasoning"]);
+    let mut tokens = TokenBuckets::disjoint(
         u64_at(usage, &["input"]),
         usage
             .pointer("/cache/read")
@@ -1035,8 +1038,11 @@ fn push_opencode_event(value: &Value, path: &Path, id: Option<String>, out: &mut
             .pointer("/cache/write")
             .and_then(Value::as_u64)
             .unwrap_or(0),
-        u64_at(usage, &["output"]),
+        u64_at(usage, &["output"]).saturating_add(reasoning),
     );
+    // OpenCode persists reasoning separately from output. Fold it into the
+    // additive output bucket while retaining the detail field for reporting.
+    tokens.reasoning = reasoning;
     if tokens.additive_total() == 0 {
         return;
     }
@@ -1597,6 +1603,31 @@ mod tests {
         assert_eq!(tokens.uncached_input, 20);
         assert_eq!(tokens.cache_read, 80);
         assert_eq!(tokens.additive_total(), 110);
+    }
+
+    #[test]
+    fn opencode_reasoning_is_included_in_output_and_total() {
+        let value = serde_json::json!({
+            "tokens": {
+                "input": 100,
+                "output": 20,
+                "reasoning": 30,
+                "cache": { "read": 40, "write": 10 }
+            }
+        });
+        let mut events = Vec::new();
+
+        push_opencode_event(
+            &value,
+            Path::new("message.json"),
+            Some("message".into()),
+            &mut events,
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tokens.reasoning, 30);
+        assert_eq!(events[0].tokens.output, 50);
+        assert_eq!(events[0].tokens.total(), 200);
     }
 
     #[test]


### PR DESCRIPTION
Adds historical token reconstruction and API-equivalent cost estimates from local coding-agent logs.

- adds a usage CLI with source, date, JSON, event, and cost controls
- normalizes provider-specific cache and output token fields without double counting
- adds a Ctrl+T home-chart toggle between sessions and token volume
- preserves live session filtering and selected chart ranges
- keeps reconstructed usage separate from provider quota data

Checks: cargo fmt --check; cargo clippy -- -D warnings