### PR TITLE
Make cold usage scans resumable and show backfill progress

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1438,7 +1438,34 @@ fn run_usage(
         cache_path: Some(paths.state.join("usage-cache.sqlite3")),
         memo_ttl_ms: 0,
     };
-    let report = scan_usage(&query)?;
+    // A cold usage cache re-parses whole log corpora, which can take minutes; narrate the
+    // parse phase on stderr so the scan doesn't read as a hang.
+    let scan_finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let reporter = std::io::IsTerminal::is_terminal(&std::io::stderr()).then(|| {
+        let scan_finished = scan_finished.clone();
+        std::thread::spawn(move || {
+            let mut printed = false;
+            while !scan_finished.load(std::sync::atomic::Ordering::Relaxed) {
+                if let Some(progress) = crate::usage::usage_scan_progress() {
+                    eprint!(
+                        "\rscanning {} logs {}/{}…   ",
+                        progress.source, progress.done, progress.total
+                    );
+                    printed = true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+            if printed {
+                eprint!("\r{:<60}\r", "");
+            }
+        })
+    });
+    let report = scan_usage(&query);
+    scan_finished.store(true, std::sync::atomic::Ordering::Relaxed);
+    if let Some(reporter) = reporter {
+        let _ = reporter.join();
+    }
+    let report = report?;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2777,10 +2777,21 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         let groups = home_chart_groups(chart_activity, bounds);
         let mut spans: Vec<Span> = Vec::new();
         match app.home_chart_state() {
-            LoadState::Loading => spans.push(Span::styled(
-                format!("{} loading {}…", app.spinner(), app.home_chart_mode.label()),
-                theme.muted,
-            )),
+            LoadState::Loading => {
+                // A cold usage cache re-parses whole log corpora, which can take minutes;
+                // show which source is being backfilled so the scan doesn't read as a hang.
+                let label = match crate::usage::usage_scan_progress() {
+                    Some(progress) if app.home_chart_mode == HomeChartMode::Tokens => format!(
+                        "{} scanning {} logs {}/{}…",
+                        app.spinner(),
+                        progress.source,
+                        progress.done,
+                        progress.total
+                    ),
+                    _ => format!("{} loading {}…", app.spinner(), app.home_chart_mode.label()),
+                };
+                spans.push(Span::styled(label, theme.muted));
+            }
             LoadState::Loaded | LoadState::Empty => {
                 let metric = match app.home_chart_mode {
                     HomeChartMode::Sessions if filtered_chart => {

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -266,8 +266,10 @@ fn memoized_usage_events(query: &UsageQuery) -> (Arc<Vec<UsageEvent>>, Arc<Vec<S
     {
         return (memo.events.clone(), memo.warnings.clone());
     }
-    let built = Instant::now();
     let (events, warnings) = assemble_usage_events(query.source, query.cache_path.as_deref());
+    // Stamp the memo after assembly: an assembly slower than the TTL would otherwise be
+    // expired the moment it finishes, and queued follow-up queries would reassemble.
+    let built = Instant::now();
     let events = Arc::new(events);
     let warnings = Arc::new(warnings);
     if !ttl.is_zero() {
@@ -313,6 +315,7 @@ fn assemble_usage_events(
             warnings.push(format!("{} scanner: {error:#}", filter.as_str()));
         }
     }
+    publish_scan_progress(None);
 
     reconcile_claude(&mut events);
     reconcile_codex_copies(&mut events);
@@ -571,7 +574,44 @@ const OPENCODE_PARSER_VERSION: i64 = 2;
 /// running Cursor rewrites its (potentially multi-GB) databases continuously, and
 /// re-reading them on every scan makes live scans unusable.
 const VOLATILE_DB_REUSE_MS: i64 = 60_000;
+/// Cache rows are persisted after every chunk of parsed files, not once per source, so an
+/// interrupted cold scan resumes from the last completed chunk instead of starting over.
+const PARSE_SAVE_CHUNK: usize = 128;
 static USAGE_SCAN_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+/// Parse-phase progress of the usage scan currently holding `USAGE_SCAN_LOCK`. Cache hits
+/// are not counted: progress is only published while files are being (re)parsed, which is
+/// the phase that can take minutes on a cold cache.
+#[derive(Clone, Copy, Debug)]
+pub struct UsageScanProgress {
+    pub source: &'static str,
+    pub done: usize,
+    pub total: usize,
+}
+
+static USAGE_SCAN_PROGRESS: Lazy<Mutex<Option<UsageScanProgress>>> = Lazy::new(|| Mutex::new(None));
+
+pub fn usage_scan_progress() -> Option<UsageScanProgress> {
+    *USAGE_SCAN_PROGRESS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn publish_scan_progress(progress: Option<UsageScanProgress>) {
+    *USAGE_SCAN_PROGRESS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = progress;
+}
+
+fn bump_scan_progress() {
+    if let Some(progress) = USAGE_SCAN_PROGRESS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .as_mut()
+    {
+        progress.done += 1;
+    }
+}
 
 #[derive(Serialize, Deserialize)]
 struct CachedUsageEvent {
@@ -748,13 +788,24 @@ impl UsageCache {
             .map_err(Into::into)
     }
 
+    fn delete_stale(&mut self, source: &str, stale_paths: &[String]) -> Result<()> {
+        let transaction = self.connection.transaction()?;
+        for path in stale_paths {
+            transaction.execute(
+                "DELETE FROM usage_file_cache WHERE source = ?1 AND path = ?2",
+                params![source, path],
+            )?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
+
     fn save_batch(
         &mut self,
         source: &str,
         parser_version: i64,
         scanned_at_ms: i64,
         parsed: &[ParsedUsageFile],
-        stale_paths: &[String],
     ) -> Result<()> {
         let prepared = parsed
             .iter()
@@ -797,12 +848,6 @@ impl UsageCache {
                     events_blob,
                     deps_blob
                 ],
-            )?;
-        }
-        for path in stale_paths {
-            transaction.execute(
-                "DELETE FROM usage_file_cache WHERE source = ?1 AND path = ?2",
-                params![source, path],
             )?;
         }
         transaction.commit()?;
@@ -935,19 +980,40 @@ fn scan_files_cached_with(
             }
         }
     }
-    let parsed = parse_missing_usage_files(source, &missing, warnings, &parse);
+    let mut cache = cache;
     let stale_paths: Vec<String> = rows.into_keys().collect();
-    // Unresolved-fork parses (cacheable == false) are excluded from persistence so a later
-    // scan re-runs them once their fork parent is available; they still populate `out`.
-    let has_persistable = parsed.iter().any(|file| file.cacheable) || !stale_paths.is_empty();
-    if let Some(cache) = cache
-        && has_persistable
-        && let Err(error) = cache.save_batch(source, parser_version, now_ms, &parsed, &stale_paths)
+    if let Some(cache) = cache.as_deref_mut()
+        && !stale_paths.is_empty()
+        && let Err(error) = cache.delete_stale(source, &stale_paths)
     {
         warnings.push(format!("{source} usage cache write failed: {error:#}"));
     }
-    for file in parsed {
-        slots[file.index] = Some(file.events);
+    if !missing.is_empty() {
+        publish_scan_progress(Some(UsageScanProgress {
+            source,
+            done: 0,
+            total: missing.len(),
+        }));
+    }
+    // Parse and persist in chunks so an interrupted cold scan keeps the chunks it finished;
+    // the next scan resumes from there instead of re-parsing the whole source.
+    let mut save_warned = false;
+    for chunk in missing.chunks(PARSE_SAVE_CHUNK) {
+        let parsed = parse_missing_usage_files(source, chunk, warnings, &parse);
+        // Unresolved-fork parses (cacheable == false) are excluded from persistence so a
+        // later scan re-runs them once their fork parent is available; they still populate
+        // `out`.
+        if let Some(cache) = cache.as_deref_mut()
+            && parsed.iter().any(|file| file.cacheable)
+            && let Err(error) = cache.save_batch(source, parser_version, now_ms, &parsed)
+            && !save_warned
+        {
+            save_warned = true;
+            warnings.push(format!("{source} usage cache write failed: {error:#}"));
+        }
+        for file in parsed {
+            slots[file.index] = Some(file.events);
+        }
     }
     for events in slots.into_iter().flatten() {
         out.extend(events);
@@ -1014,7 +1080,7 @@ fn parse_missing_usage_files(
     let outcomes = missing
         .par_iter()
         .map(|(index, path, metadata)| {
-            parse(path).map(|parsed| ParsedUsageFile {
+            let outcome = parse(path).map(|parsed| ParsedUsageFile {
                 index: *index,
                 path: path.clone(),
                 size: metadata.0,
@@ -1022,7 +1088,9 @@ fn parse_missing_usage_files(
                 events: parsed.events,
                 cacheable: parsed.cacheable,
                 deps: parsed.deps,
-            })
+            });
+            bump_scan_progress();
+            outcome
         })
         .collect::<Vec<_>>();
     let mut parsed = Vec::with_capacity(outcomes.len());


### PR DESCRIPTION
## Why

Token stats appeared to "load forever" on every launch. The per-file usage cache was correct, but every recent PR invalidated it wholesale (#63 schema change dropped the table, #65 bumped the claude parser version, #66 bumped codex), so each new build's first scan was a full cold re-parse of the entire log corpus (~2 minutes for ~22GB). Worse, persistence was all-or-nothing per source: quitting memex mid-backfill saved nothing, so the next launch started cold again. And the TUI showed only a bare spinner, making the one-time backfill indistinguishable from a hang.

## What

- Persist parsed cache rows in chunks of 128 files instead of once per source after all files finish. An interrupted cold scan resumes from the last completed chunk. Stale-row cleanup moved to its own upfront transaction.
- Publish parse-phase progress from the scanner (`usage_scan_progress()`); the TUI token chart caption shows `scanning codex logs 1204/4243…` while backfilling, and `memex usage` prints the same on stderr when it is a TTY. Warm (cache-hit-only) scans never publish progress.
- Stamp the in-process scan memo after assembly instead of before: an assembly slower than the 15s TTL was already expired when it finished, forcing queued queries (range/source toggles made while waiting) to reassemble from scratch.

## Not addressed (follow-ups)

- Warm-path floor: each fresh process still decodes ~200MB of cached blobs and reconciles/sorts ~1M events (single-digit seconds on a large corpus).
- Cursor's 1GB `state.vscdb` is fully re-parsed whenever Cursor is running and the 60s volatile window has lapsed.

`cargo fmt --check` and `cargo clippy -- -D warnings` pass.