### PR TITLE
Track prompt cache misses and estimate re-billed cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ memex usage --json --events
 
 `--cost auto` prefers a provider-stored request cost and otherwise applies the versioned built-in API price catalog. `--cost source` uses only stored costs; `--cost reprice` always applies the catalog. Calculated costs are API-equivalent estimates, not subscription charges. Events with unknown models or prices remain in token totals and are reported as unpriced.
 
+Each source also reports prompt-cache efficiency: the cache hit rate, plus an estimate of cache waste — prompt tokens that were in the previous request's prompt but were re-billed at input rates instead of read from cache, priced at catalog rates and attributed to idle gaps past the cache TTL or model switches where those apply. Waste is estimated per transcript file chain and errs toward undercounting: subagent sidechains, ambiguous dedupe deltas, and prompts that shrink past compaction are not counted.
+
 Local token history is reconstructed usage. It is deliberately kept separate from authoritative subscription quota percentages and reset windows.
 
 When token tracking is enabled, press `Ctrl+T` on the TUI home screen to toggle the 30-day activity chart between session count and token volume. Token activity is loaded lazily and cached when first shown.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ use crate::vector::VectorIndex;
 use anyhow::{Result, anyhow};
 use chrono::SecondsFormat;
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use regex::RegexBuilder;
 use serde::Serialize;
 use serde_json::Value;
@@ -1439,24 +1440,51 @@ fn run_usage(
         memo_ttl_ms: 0,
     };
     // A cold usage cache re-parses whole log corpora, which can take minutes; narrate the
-    // parse phase on stderr so the scan doesn't read as a hang.
+    // parse phase on stderr so the scan doesn't read as a hang. Rendered with the same
+    // spinner grammar as `memex index`: one persistent line per source as it completes.
     let scan_finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let reporter = std::io::IsTerminal::is_terminal(&std::io::stderr()).then(|| {
         let scan_finished = scan_finished.clone();
         std::thread::spawn(move || {
-            let mut printed = false;
-            while !scan_finished.load(std::sync::atomic::Ordering::Relaxed) {
+            let style = ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+                .expect("static template")
+                .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+            let multi = MultiProgress::new();
+            let mut active: Option<(&'static str, usize, ProgressBar)> = None;
+            loop {
                 if let Some(progress) = crate::usage::usage_scan_progress() {
-                    eprint!(
-                        "\rscanning {} logs {}/{}…   ",
-                        progress.source, progress.done, progress.total
-                    );
-                    printed = true;
+                    if active
+                        .as_ref()
+                        .is_none_or(|(source, ..)| *source != progress.source)
+                    {
+                        if let Some((source, total, bar)) = active.take() {
+                            finish_scan_bar(&bar, source, total);
+                        }
+                        let bar = multi.add(ProgressBar::new_spinner());
+                        bar.set_style(style.clone());
+                        bar.enable_steady_tick(Duration::from_millis(80));
+                        active = Some((progress.source, progress.total, bar));
+                    }
+                    if let Some((source, total, bar)) = &mut active {
+                        *total = progress.total;
+                        bar.set_message(format!(
+                            "{} parsed {}/{} files",
+                            source,
+                            crate::progress::format_count(progress.done as u64),
+                            crate::progress::format_count(progress.total as u64),
+                        ));
+                    }
                 }
-                std::thread::sleep(std::time::Duration::from_millis(200));
+                if scan_finished.load(std::sync::atomic::Ordering::Relaxed) {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
             }
-            if printed {
-                eprint!("\r{:<60}\r", "");
+            if let Some((source, total, bar)) = active {
+                finish_scan_bar(&bar, source, total);
+                // Leave the draw region on a fresh line so the report doesn't append to
+                // the frozen spinner line.
+                eprintln!();
             }
         })
     });
@@ -1470,61 +1498,27 @@ fn run_usage(
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         println!("local reconstructed usage (not subscription quota)");
-        for row in &report.by_source {
-            println!(
-                "{:<10} {:>12} tokens  {:>9} input  {:>9} cache read  {:>9} cache write  {:>9} output  {:>5} events",
-                row.source,
-                row.total_tokens,
-                row.uncached_input,
-                row.cache_read,
-                row.cache_write,
-                row.output,
-                row.events,
-            );
-            if row.priced_events > 0 {
-                println!(
-                    "             ${:.4} API-equivalent cost ({} priced, {} unpriced)",
-                    row.known_cost_usd, row.priced_events, row.unpriced_events
-                );
-            }
-            let prompt_tokens = row.uncached_input + row.cache_read + row.cache_write;
-            if prompt_tokens > 0 && row.cache_read + row.cache_write > 0 {
-                let hit_rate = row.cache_read as f64 / prompt_tokens as f64 * 100.0;
-                if row.cache_waste.miss_count > 0 {
-                    println!(
-                        "             cache: {:.1}% hit rate; ${:.4} re-billed across {}",
-                        hit_rate,
-                        row.cache_waste.missed_cost_usd,
-                        format_cache_misses(&row.cache_waste),
-                    );
-                } else {
-                    println!("             cache: {hit_rate:.1}% hit rate");
-                }
-            }
-        }
+        print_usage_table(&report);
         println!(
-            "total      {:>12} tokens  {} events",
-            report.total_tokens, report.events
-        );
-        println!(
-            "cost       ${:.4} known API-equivalent ({} priced, {} unpriced; {:?}, {})",
-            report.known_cost_usd,
-            report.priced_events,
-            report.unpriced_events,
-            report.cost_mode,
-            report.price_catalog
+            "cost: API-equivalent at {} pricing, catalog {} ({} priced, {} unpriced events)",
+            format!("{:?}", report.cost_mode).to_lowercase(),
+            report.price_catalog,
+            format_count(report.priced_events),
+            format_count(report.unpriced_events),
         );
         if report.cache_waste.miss_count > 0 {
             println!(
-                "cache      ${:.4} re-billed across {}",
-                report.cache_waste.missed_cost_usd,
-                format_cache_misses(&report.cache_waste),
+                "cache: re-billed estimates prompt tokens lost to cache misses, at catalog rates ({} misses: {} idle, {} model-switch)",
+                format_count(report.cache_waste.miss_count),
+                format_count(report.cache_waste.idle_misses),
+                format_count(report.cache_waste.model_switch_misses),
             );
         }
         if report.unknown_model_events > 0 || report.conservative_events > 0 {
             println!(
                 "quality: {} unknown-model events, {} conservatively undercounted events",
-                report.unknown_model_events, report.conservative_events
+                format_count(report.unknown_model_events),
+                format_count(report.conservative_events),
             );
         }
         for warning in &report.warnings {
@@ -1534,25 +1528,131 @@ fn run_usage(
     Ok(())
 }
 
-fn format_cache_misses(waste: &crate::usage::CacheWaste) -> String {
-    let misses = if waste.miss_count == 1 {
-        "1 miss".to_string()
-    } else {
-        format!("{} misses", waste.miss_count)
+fn print_usage_table(report: &crate::usage::UsageReport) {
+    const HEADERS: [&str; 10] = [
+        "source",
+        "events",
+        "input",
+        "cache read",
+        "cache write",
+        "output",
+        "total",
+        "cost",
+        "hit",
+        "re-billed",
+    ];
+    let mut totals = crate::usage::UsageSummary {
+        source: "total".to_string(),
+        events: report.events,
+        total_tokens: report.total_tokens,
+        known_cost_usd: report.known_cost_usd,
+        priced_events: report.priced_events,
+        unpriced_events: report.unpriced_events,
+        cache_waste: report.cache_waste.clone(),
+        ..Default::default()
     };
-    let mut causes = Vec::new();
-    if waste.idle_misses > 0 {
-        causes.push(format!("{} idle", waste.idle_misses));
+    for row in &report.by_source {
+        totals.uncached_input += row.uncached_input;
+        totals.cache_read += row.cache_read;
+        totals.cache_write += row.cache_write;
+        totals.output += row.output;
     }
-    if waste.model_switch_misses > 0 {
-        causes.push(format!("{} model-switch", waste.model_switch_misses));
-    }
-    let causes = if causes.is_empty() {
-        String::new()
-    } else {
-        format!("; {}", causes.join(", "))
+    let cells = |row: &crate::usage::UsageSummary| -> [String; 10] {
+        let prompt_tokens = row.uncached_input + row.cache_read + row.cache_write;
+        let cache_active = row.cache_read > 0 || row.cache_write > 0;
+        [
+            row.source.clone(),
+            format_count(row.events),
+            format_count(row.uncached_input),
+            format_count(row.cache_read),
+            format_count(row.cache_write),
+            format_count(row.output),
+            format_count(row.total_tokens),
+            if row.priced_events > 0 {
+                format_usd(row.known_cost_usd)
+            } else {
+                "-".to_string()
+            },
+            if cache_active && prompt_tokens > 0 {
+                format!(
+                    "{:.1}%",
+                    row.cache_read as f64 / prompt_tokens as f64 * 100.0
+                )
+            } else {
+                "-".to_string()
+            },
+            if row.cache_waste.miss_count > 0 {
+                format_usd(row.cache_waste.missed_cost_usd)
+            } else if cache_active {
+                "$0.00".to_string()
+            } else {
+                "-".to_string()
+            },
+        ]
     };
-    format!("{misses} ({} tokens{causes})", waste.missed_tokens)
+    let mut table: Vec<[String; 10]> = vec![HEADERS.map(str::to_string)];
+    table.extend(report.by_source.iter().map(cells));
+    table.push(cells(&totals));
+    let mut widths = [0usize; 10];
+    for row in &table {
+        for (width, cell) in widths.iter_mut().zip(row) {
+            *width = (*width).max(cell.len());
+        }
+    }
+    for row in &table {
+        let mut line = String::new();
+        for (index, (cell, width)) in row.iter().zip(&widths).enumerate() {
+            if index > 0 {
+                line.push_str("  ");
+            }
+            if index == 0 {
+                line.push_str(&format!("{cell:<width$}"));
+            } else {
+                line.push_str(&format!("{cell:>width$}"));
+            }
+        }
+        println!("{}", line.trim_end());
+    }
+}
+
+/// Freeze a scan spinner line in place, mirroring the `memex index` finish style. A source
+/// only leaves the active slot once its scan completed, so the frozen line reports the
+/// file total rather than the last polled position.
+fn finish_scan_bar(bar: &ProgressBar, source: &str, total: usize) {
+    bar.finish_with_message(format!(
+        "{source} parsed {} files done",
+        crate::progress::format_count(total as u64)
+    ));
+}
+
+/// Humanized count with three significant digits; small values stay exact.
+fn format_count(value: u64) -> String {
+    const UNITS: [(f64, &str); 4] = [(1e12, "T"), (1e9, "B"), (1e6, "M"), (1e3, "k")];
+    if value < 10_000 {
+        return value.to_string();
+    }
+    let value = value as f64;
+    for (scale, suffix) in UNITS {
+        if value >= scale {
+            let scaled = value / scale;
+            return if scaled >= 100.0 {
+                format!("{scaled:.0}{suffix}")
+            } else if scaled >= 10.0 {
+                format!("{scaled:.1}{suffix}")
+            } else {
+                format!("{scaled:.2}{suffix}")
+            };
+        }
+    }
+    unreachable!("values below 10k return early")
+}
+
+fn format_usd(value: f64) -> String {
+    if value > 0.0 && value < 0.01 {
+        format!("${value:.4}")
+    } else {
+        format!("${value:.2}")
+    }
 }
 
 fn run_analytics_backfill(root: Option<PathBuf>) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1487,6 +1487,20 @@ fn run_usage(
                     row.known_cost_usd, row.priced_events, row.unpriced_events
                 );
             }
+            let prompt_tokens = row.uncached_input + row.cache_read + row.cache_write;
+            if prompt_tokens > 0 && row.cache_read + row.cache_write > 0 {
+                let hit_rate = row.cache_read as f64 / prompt_tokens as f64 * 100.0;
+                if row.cache_waste.miss_count > 0 {
+                    println!(
+                        "             cache: {:.1}% hit rate; ${:.4} re-billed across {}",
+                        hit_rate,
+                        row.cache_waste.missed_cost_usd,
+                        format_cache_misses(&row.cache_waste),
+                    );
+                } else {
+                    println!("             cache: {hit_rate:.1}% hit rate");
+                }
+            }
         }
         println!(
             "total      {:>12} tokens  {} events",
@@ -1500,6 +1514,13 @@ fn run_usage(
             report.cost_mode,
             report.price_catalog
         );
+        if report.cache_waste.miss_count > 0 {
+            println!(
+                "cache      ${:.4} re-billed across {}",
+                report.cache_waste.missed_cost_usd,
+                format_cache_misses(&report.cache_waste),
+            );
+        }
         if report.unknown_model_events > 0 || report.conservative_events > 0 {
             println!(
                 "quality: {} unknown-model events, {} conservatively undercounted events",
@@ -1511,6 +1532,27 @@ fn run_usage(
         }
     }
     Ok(())
+}
+
+fn format_cache_misses(waste: &crate::usage::CacheWaste) -> String {
+    let misses = if waste.miss_count == 1 {
+        "1 miss".to_string()
+    } else {
+        format!("{} misses", waste.miss_count)
+    };
+    let mut causes = Vec::new();
+    if waste.idle_misses > 0 {
+        causes.push(format!("{} idle", waste.idle_misses));
+    }
+    if waste.model_switch_misses > 0 {
+        causes.push(format!("{} model-switch", waste.model_switch_misses));
+    }
+    let causes = if causes.is_empty() {
+        String::new()
+    } else {
+        format!("; {}", causes.join(", "))
+    };
+    format!("{misses} ({} tokens{causes})", waste.missed_tokens)
 }
 
 fn run_analytics_backfill(root: Option<PathBuf>) -> Result<()> {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -248,7 +248,7 @@ fn progress_label(source: SourceKind) -> &'static str {
     }
 }
 
-fn format_count(value: u64) -> String {
+pub(crate) fn format_count(value: u64) -> String {
     if value < 1000 {
         return value.to_string();
     }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -381,7 +381,11 @@ fn compute_cache_waste<'a>(
         let mut reported_cache = cached > 0;
         if let Some(prev) = chains.get(&key) {
             reported_cache |= prev.reported_cache;
-            if (cached > 0 || prev.reported_cache)
+            // A current cache write alone doesn't qualify: the chain's first write creates
+            // the cache, so the previous prompt could not have been served from it. A read
+            // proves a cache already existed (OpenAI-style writes are unreported), as does
+            // earlier reported activity.
+            if (tokens.cache_read > 0 || prev.reported_cache)
                 && prompt_tokens.saturating_mul(2) >= prev.prompt_tokens
             {
                 let missed = prev
@@ -3182,6 +3186,21 @@ mod tests {
             cache_event("s", 60_000, "claude-sonnet-4-6", 0, 9_500, 1_000),
         ];
         assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_first_write_after_uncached_prompts_is_not_a_miss() {
+        // The chain's first cache write creates the cache; the earlier uncached prompt
+        // could not have been served from it. Once the chain has reported cache activity,
+        // a later write-only turn is a genuine full miss.
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 50_000, 0, 0),
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 0, 52_000),
+            cache_event("s", 120_000, "claude-sonnet-4-6", 0, 0, 53_000),
+        ];
+        let waste = waste_for(&events).expect("post-write miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.missed_tokens, 52_000);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -139,6 +139,34 @@ pub struct UsageSummary {
     pub known_cost_usd: f64,
     pub priced_events: u64,
     pub unpriced_events: u64,
+    pub cache_waste: CacheWaste,
+}
+
+/// Estimated prompt-cache waste: prompt tokens that were in the previous request's prompt
+/// (so a warm cache would have served them as cache reads) but were re-billed at
+/// input/cache-write rates instead.
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+pub struct CacheWaste {
+    pub missed_tokens: u64,
+    /// Extra USD paid vs. a full cache hit, at catalog rates; misses on unpriced models
+    /// contribute tokens but no cost.
+    pub missed_cost_usd: f64,
+    /// Misses above the per-request noise floor.
+    pub miss_count: u64,
+    /// Misses following an idle gap of at least the cache TTL (same model).
+    pub idle_misses: u64,
+    /// Misses where the model changed relative to the previous request.
+    pub model_switch_misses: u64,
+}
+
+impl CacheWaste {
+    fn absorb(&mut self, other: &CacheWaste) {
+        self.missed_tokens = self.missed_tokens.saturating_add(other.missed_tokens);
+        self.missed_cost_usd += other.missed_cost_usd;
+        self.miss_count += other.miss_count;
+        self.idle_misses += other.idle_misses;
+        self.model_switch_misses += other.model_switch_misses;
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -153,6 +181,7 @@ pub struct UsageReport {
     pub known_cost_usd: f64,
     pub priced_events: u64,
     pub unpriced_events: u64,
+    pub cache_waste: CacheWaste,
     pub by_source: Vec<UsageSummary>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub details: Vec<UsageEvent>,
@@ -266,12 +295,152 @@ pub fn scan_usage(query: &UsageQuery) -> Result<UsageReport> {
             row.unpriced_events += 1;
         }
     }
+    for (source, waste) in compute_cache_waste(events.iter().copied()) {
+        report.cache_waste.absorb(&waste);
+        if let Some(row) = by_source.get_mut(&source) {
+            row.cache_waste = waste;
+        }
+    }
     report.by_source = by_source.into_values().collect();
     report.by_source.sort_by(|a, b| a.source.cmp(&b.source));
     if query.include_events {
         report.details = events.into_iter().cloned().collect();
     }
     Ok(report)
+}
+
+/// Prompt-cache TTL: misses after idle gaps at least this long are attributed to expiry.
+/// Anthropic's default cache TTL is 5 minutes.
+const CACHE_TTL_MS: u64 = 5 * 60 * 1000;
+
+/// Per-request misses at or below this are cache breakpoint granularity noise.
+const CACHE_MISS_NOISE_FLOOR_TOKENS: u64 = 1024;
+
+/// The last request seen in a session chain; everything in its prompt should be cached.
+struct CacheChainState<'a> {
+    prompt_tokens: u64,
+    /// (provider, model); a change re-bills the full prompt and is counted as a miss.
+    model: (&'a str, &'a str),
+    timestamp_ms: u64,
+    /// Sticky: some earlier request in this chain reported cache activity. Distinguishes a
+    /// total miss on a read-only-reporting provider (OpenAI-style, writes unreported) from
+    /// a provider that never reports caching at all.
+    reported_cache: bool,
+}
+
+/// Estimate per-source cache waste by chaining each session's requests in order and
+/// comparing every request's cache reads against the previous request's prompt.
+///
+/// This follows pi's cache-stats algorithm (earendil-works/pi, core/cache-stats.ts) with
+/// adaptations for reconstructed logs: sidechain requests are excluded (subagents have
+/// their own prompt caches), conservatively undercounted events break the chain (their
+/// buckets are clamped dedupe deltas, not a real request's shape), and a prompt shrinking
+/// below half of its predecessor stands in for the compaction/clear markers the logs don't
+/// carry — the context legitimately changed, so the re-billing is not counted as waste.
+/// Chains start at the first event a caller passes in, so window filters only undercount at
+/// their leading edge.
+fn compute_cache_waste<'a>(
+    events: impl IntoIterator<Item = &'a UsageEvent>,
+) -> HashMap<&'static str, CacheWaste> {
+    let mut chains: HashMap<(&'a str, &'a str, &'a str), CacheChainState<'a>> = HashMap::new();
+    let mut by_source: HashMap<&'static str, CacheWaste> = HashMap::new();
+    for event in events {
+        if event.sidechain {
+            continue;
+        }
+        let Some(session_id) = event.session_id.as_deref() else {
+            continue;
+        };
+        // A chain is one process's linear request stream, which is the transcript file, not
+        // the session: codex spawned/resumed threads share a session id across rollout
+        // files, and interleaving them fabricates misses. OpenCode is the exception — it
+        // persists one file per message, so there the session is the stream.
+        let thread = if event.source == "opencode" {
+            ""
+        } else {
+            event.source_path.as_ref()
+        };
+        let key = (event.source, session_id, thread);
+        if event.conservative_undercount {
+            chains.remove(&key);
+            continue;
+        }
+        let tokens = &event.tokens;
+        let prompt_tokens = tokens
+            .uncached_input
+            .saturating_add(tokens.cache_read)
+            .saturating_add(tokens.cache_write);
+        if prompt_tokens == 0 {
+            continue;
+        }
+        let cached = tokens.cache_read.saturating_add(tokens.cache_write);
+        let model = (
+            event.provider.as_deref().unwrap_or(""),
+            event.model.as_deref().unwrap_or(""),
+        );
+        let mut reported_cache = cached > 0;
+        if let Some(prev) = chains.get(&key) {
+            reported_cache |= prev.reported_cache;
+            if (cached > 0 || prev.reported_cache)
+                && prompt_tokens.saturating_mul(2) >= prev.prompt_tokens
+            {
+                let missed = prev
+                    .prompt_tokens
+                    .min(prompt_tokens)
+                    .saturating_sub(tokens.cache_read);
+                if missed > CACHE_MISS_NOISE_FLOOR_TOKENS {
+                    let waste = by_source.entry(event.source).or_default();
+                    waste.miss_count += 1;
+                    waste.missed_tokens = waste.missed_tokens.saturating_add(missed);
+                    waste.missed_cost_usd += cache_miss_cost_usd(event, missed);
+                    if model != prev.model {
+                        waste.model_switch_misses += 1;
+                    } else if event.timestamp_ms.saturating_sub(prev.timestamp_ms) >= CACHE_TTL_MS {
+                        waste.idle_misses += 1;
+                    }
+                }
+            }
+        }
+        chains.insert(
+            key,
+            CacheChainState {
+                prompt_tokens,
+                model,
+                timestamp_ms: event.timestamp_ms,
+                reported_cache,
+            },
+        );
+    }
+    by_source
+}
+
+/// Extra USD paid for `missed_tokens` vs. reading them from cache. Missed tokens can only
+/// land in the uncached-input or cache-write buckets, so the paid rate is the blend of this
+/// event's own paid buckets at catalog rates; 0 when the model is unpriced.
+fn cache_miss_cost_usd(event: &UsageEvent, missed_tokens: u64) -> f64 {
+    let Some(model) = event.model.as_deref() else {
+        return 0.0;
+    };
+    let Some(rates) = rates_for(event.provider.as_deref(), model) else {
+        return 0.0;
+    };
+    let cache_write_1h = event.tokens.cache_write_1h.min(event.tokens.cache_write);
+    let cache_write_5m = event.tokens.cache_write - cache_write_1h;
+    let paid_tokens = event
+        .tokens
+        .uncached_input
+        .saturating_add(event.tokens.cache_write);
+    if paid_tokens == 0 {
+        return 0.0;
+    }
+    // Rates are nano-USD per million tokens; dividing by a million yields nano-USD per token.
+    let paid_nanos = ((event.tokens.uncached_input as u128) * (rates.input as u128)
+        + (cache_write_5m as u128) * (rates.cache_write_5m as u128)
+        + (cache_write_1h as u128) * (rates.cache_write_1h as u128)) as f64
+        / 1_000_000.0;
+    let paid_per_token = paid_nanos / paid_tokens as f64;
+    let read_per_token = rates.cache_read as f64 / 1_000_000.0;
+    missed_tokens as f64 * (paid_per_token - read_per_token).max(0.0) / 1_000_000_000.0
 }
 
 struct UsageMemo {
@@ -2914,6 +3083,193 @@ mod tests {
         assert_eq!(tokens.uncached_input, 20);
         assert_eq!(tokens.cache_read, 80);
         assert_eq!(tokens.additive_total(), 110);
+    }
+
+    fn cache_event(
+        session: &str,
+        timestamp_ms: u64,
+        model: &str,
+        uncached: u64,
+        read: u64,
+        write: u64,
+    ) -> UsageEvent {
+        UsageEvent {
+            source: "claude",
+            source_path: Arc::from("log.jsonl"),
+            source_record_id: None,
+            session_id: Some(session.to_string()),
+            request_id: None,
+            message_id: None,
+            timestamp_ms,
+            project: None,
+            provider: Some("anthropic".to_string()),
+            model: Some(model.to_string()),
+            tokens: TokenBuckets {
+                raw_input: uncached,
+                uncached_input: uncached,
+                cache_read: read,
+                cache_write: write,
+                cache_write_1h: 0,
+                output: 10,
+                reasoning: 0,
+            },
+            source_cost_usd: None,
+            dedupe_confidence: "exact",
+            conservative_undercount: false,
+            sidechain: false,
+            source_order: 0,
+        }
+    }
+
+    fn waste_for(events: &[UsageEvent]) -> Option<CacheWaste> {
+        compute_cache_waste(events.iter()).remove("claude")
+    }
+
+    #[test]
+    fn cache_idle_gap_miss_is_counted_and_attributed() {
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            cache_event("s", 10 * 60 * 1000, "claude-sonnet-4-6", 0, 0, 100_500),
+        ];
+        let waste = waste_for(&events).expect("miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.missed_tokens, 100_000);
+        assert_eq!(waste.idle_misses, 1);
+        assert_eq!(waste.model_switch_misses, 0);
+        // 100k tokens re-billed at the 5m cache-write rate ($3.75/M) vs read ($0.30/M).
+        assert!((waste.missed_cost_usd - 0.345).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cache_warm_hit_is_not_a_miss() {
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 100_000, 500),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_model_switch_miss_is_attributed_to_the_switch() {
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            cache_event("s", 60_000, "claude-opus-4-8", 0, 0, 100_000),
+        ];
+        let waste = waste_for(&events).expect("miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.model_switch_misses, 1);
+        assert_eq!(waste.idle_misses, 0);
+    }
+
+    #[test]
+    fn cache_prompt_shrink_is_treated_as_context_reset() {
+        // A prompt below half of its predecessor stands in for compaction/clear: the first
+        // post-shrink request is exempt, and the chain rebases onto the shrunk prompt.
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 0, 20_000),
+            cache_event("s", 120_000, "claude-sonnet-4-6", 0, 0, 20_500),
+        ];
+        let waste = waste_for(&events).expect("post-reset miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.missed_tokens, 20_000);
+    }
+
+    #[test]
+    fn cache_miss_below_noise_floor_is_ignored() {
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 10_000),
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 9_500, 1_000),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_never_reported_provider_is_not_counted() {
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 50_000, 0, 0),
+            cache_event("s", 60_000, "claude-sonnet-4-6", 50_500, 0, 0),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_read_only_provider_total_miss_counts_after_reported_cache() {
+        // OpenAI-style: reads reported, writes not. Once cache activity has been seen, a
+        // zero-cache request is a total miss.
+        let mut first = cache_event("s", 0, "gpt-5.4", 10_000, 40_000, 0);
+        first.provider = Some("openai".to_string());
+        let mut second = cache_event("s", 60_000, "gpt-5.4", 50_500, 0, 0);
+        second.provider = Some("openai".to_string());
+        let waste = waste_for(&[first, second]).expect("total miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.missed_tokens, 50_000);
+        // 50k tokens at gpt-5.4 input ($2.50/M) vs cached ($0.25/M).
+        assert!((waste.missed_cost_usd - 0.1125).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cache_sidechain_events_are_excluded_from_chains() {
+        let mut sidechain = cache_event("s", 30_000, "claude-sonnet-4-6", 0, 0, 5_000);
+        sidechain.sidechain = true;
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            sidechain,
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 100_000, 500),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_conservative_events_break_the_chain() {
+        // Clamped dedupe deltas do not describe a real request's prompt; neither the
+        // conservative event nor its successor may be counted against the chain.
+        let mut clamped = cache_event("s", 30_000, "claude-sonnet-4-6", 0, 0, 40_000);
+        clamped.conservative_undercount = true;
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            clamped,
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 0, 100_500),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_sessions_chain_independently() {
+        let events = vec![
+            cache_event("a", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            cache_event("b", 60_000, "claude-sonnet-4-6", 0, 0, 100_000),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_parallel_threads_sharing_a_session_chain_per_file() {
+        // Codex spawned/resumed threads share a session id across rollout files; comparing
+        // across files fabricates misses.
+        let mut thread = cache_event("s", 30_000, "claude-sonnet-4-6", 0, 0, 90_000);
+        thread.source_path = Arc::from("thread.jsonl");
+        let events = vec![
+            cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000),
+            thread,
+            cache_event("s", 60_000, "claude-sonnet-4-6", 0, 100_000, 500),
+        ];
+        assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn cache_opencode_chains_across_per_message_files() {
+        let mut first = cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000);
+        first.source = "opencode";
+        first.source_path = Arc::from("msg-1.json");
+        let mut second = cache_event("s", 10 * 60 * 1000, "claude-sonnet-4-6", 0, 0, 100_500);
+        second.source = "opencode";
+        second.source_path = Arc::from("msg-2.json");
+        let waste = compute_cache_waste([&first, &second])
+            .remove("opencode")
+            .expect("miss counted");
+        assert_eq!(waste.miss_count, 1);
+        assert_eq!(waste.idle_misses, 1);
     }
 
     #[test]


### PR DESCRIPTION
Adds pi-style prompt cache miss tracking to `memex usage` (following earendil-works/pi `core/cache-stats.ts`), and overhauls the command's output.

## Cache miss tracking

Chains each transcript file's requests in order and compares every request's cache reads against the previous request's prompt: tokens that were in the previous prompt but not read from cache were re-billed at input/cache-write rates. Misses above a 1024-token noise floor are priced at catalog rates (blended paid rate minus cache-read rate) and attributed to idle gaps past the 5-minute cache TTL or model switches.

Adaptations for reconstructed logs, all erring toward undercounting:

- Sidechain requests are excluded (subagents have their own prompt caches).
- Conservatively undercounted events break the chain: their buckets are clamped dedupe deltas, not a real request's shape.
- Chains key on the transcript file rather than the session: codex spawned/resumed threads share one session id across dozens of rollout files, and chaining across them fabricates misses. OpenCode is the exception (one file per message), where the session is the stream.
- A prompt shrinking below half of its predecessor stands in for the compaction/clear markers the logs don't carry.

The report gains `cache_waste` totals (missed tokens, cost, miss count, idle/model-switch attribution) per source and overall, available in `--json`.

## Output overhaul

Replaces the wide raw-integer listing with an aligned table: humanized counts, adaptive dollar formatting, per-source cache hit rate and re-billed columns, a totals row, and short footer lines for cost basis, miss attribution, and quality. Illustrative output:

```
source    events  input  cache read  cache write  output  total     cost    hit  re-billed
claude      1234  12.3M       1.23B        45.6M   5.67M  1.29B  $987.65  95.4%    $123.45
codex       2345  56.7M       2.34B            0   8.90M  2.41B  $876.54  97.1%     $98.76
opencode      99   1.2M       34.5M         2.3M    456k  38.5M    $1.23  91.2%      $0.42
total       3678  70.2M       3.60B        47.9M  15.0M   3.74B $1865.42  96.3%    $222.63
```

Cold-scan progress now renders with the same indicatif spinner grammar as `memex index` (one persistent line per source under a MultiProgress) instead of a hand-rolled carriage-return status line; warm scans stay silent.