### PR TITLE
Unify source parsing and incremental tool attribution

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -58,6 +58,7 @@ struct FileTask {
     size: u64,
     mtime: i64,
     delete_first: bool,
+    parser_version_invalidated: bool,
     pending_tool_calls: HashMap<String, PendingToolCall>,
     identity: FileIdentity,
     parser_version: u32,
@@ -146,6 +147,8 @@ fn prepare_file_task(
         .min(size) as usize;
     let identity = file_identity(&path, metadata, prefix_bytes);
     let parser_version = crate::sources::index_state_version(source);
+    let parser_version_invalidated =
+        previous.is_some_and(|previous| previous.parser_version != parser_version);
     let (offset, turn_id, delete_first, pending_tool_calls, skip) = match previous {
         None => (0, 0, false, HashMap::new(), false),
         Some(previous)
@@ -188,6 +191,7 @@ fn prepare_file_task(
             size,
             mtime,
             delete_first,
+            parser_version_invalidated,
             pending_tool_calls,
             identity,
             parser_version,
@@ -234,12 +238,41 @@ impl RecordSender {
 struct WriterContext {
     embeddings: bool,
     do_backfill_embeddings: bool,
+    reset_vector_store: bool,
     vector_dir: PathBuf,
     analytics_path: PathBuf,
     progress: Arc<Progress>,
     model: ModelChoice,
     embed_runtime: EmbedRuntimeConfig,
     tool_content_limits: IndexedToolContentLimits,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VectorMigration {
+    rebuild: bool,
+    model: ModelChoice,
+}
+
+fn vector_migration(
+    vector_dir: &Path,
+    tasks: &[FileTask],
+    configured_model: ModelChoice,
+) -> VectorMigration {
+    let rebuild = tasks.iter().any(|task| task.parser_version_invalidated)
+        && vector_dir.join("usearch.index").exists();
+    let model = if rebuild {
+        crate::vector::VectorIndex::open(vector_dir)
+            .ok()
+            .and_then(|index| {
+                index
+                    .model()
+                    .and_then(|model| ModelChoice::parse(model).ok())
+            })
+            .unwrap_or(configured_model)
+    } else {
+        configured_model
+    };
+    VectorMigration { rebuild, model }
 }
 
 fn record_channel() -> (Sender<Record>, Receiver<Record>) {
@@ -445,7 +478,9 @@ pub fn ingest_all(
         });
     }
 
-    let progress = Arc::new(Progress::new(totals, file_totals, options.embeddings));
+    let vector_migration = vector_migration(&paths.vectors, &tasks, options.model);
+    let embeddings = options.embeddings || vector_migration.rebuild;
+    let progress = Arc::new(Progress::new(totals, file_totals, embeddings));
 
     let (raw_tx_record, rx_record) = record_channel();
     let tx_record = RecordSender::new(raw_tx_record, options.tool_content_limits);
@@ -456,15 +491,15 @@ pub fn ingest_all(
         .filter(|t| t.delete_first)
         .map(|t| t.path.to_string_lossy().to_string())
         .collect();
-
     let writer_index = index.clone();
     let writer_ctx = WriterContext {
-        embeddings: options.embeddings,
-        do_backfill_embeddings: options.backfill_embeddings,
+        embeddings,
+        do_backfill_embeddings: options.backfill_embeddings || vector_migration.rebuild,
+        reset_vector_store: vector_migration.rebuild,
         vector_dir: paths.vectors.clone(),
         analytics_path: analytics_db.clone(),
         progress: progress.clone(),
-        model: options.model,
+        model: vector_migration.model,
         embed_runtime: options.embed_runtime.clone(),
         tool_content_limits: options.tool_content_limits,
     };
@@ -620,6 +655,7 @@ fn writer_loop(
     let WriterContext {
         embeddings,
         do_backfill_embeddings,
+        reset_vector_store,
         vector_dir,
         analytics_path,
         progress,
@@ -643,6 +679,9 @@ fn writer_loop(
     if embeddings {
         let handle = EmbedderHandle::with_model_and_runtime(model, &embed_runtime)?;
         let dims = handle.dims;
+        if reset_vector_store {
+            crate::vector::VectorIndex::reset(&vector_dir)?;
+        }
         vector_index = Some(crate::vector::VectorIndex::open_or_create(
             &vector_dir,
             dims,
@@ -663,7 +702,11 @@ fn writer_loop(
             progress.add_indexed(record.source, index_pending[source_idx]);
             index_pending[source_idx] = 0;
         }
-        if embeddings && is_embedding_role(&record.role) && !record.text.is_empty() {
+        if embeddings
+            && !reset_vector_store
+            && is_embedding_role(&record.role)
+            && !record.text.is_empty()
+        {
             let text = truncate_for_embedding(std::mem::take(&mut record.text));
             if let Some(vindex) = vector_index.as_ref()
                 && !vindex.contains(record.doc_id)
@@ -1223,6 +1266,7 @@ mod tests {
                 .map(|duration| duration.as_secs() as i64)
                 .unwrap_or(0),
             delete_first: false,
+            parser_version_invalidated: false,
             pending_tool_calls,
             identity: file_identity(
                 path,
@@ -1821,8 +1865,40 @@ mod tests {
         let (task, skip) = prepare_file_task(path, SourceKind::Claude, &metadata, Some(&previous));
         assert!(!skip);
         assert!(task.delete_first);
+        assert!(task.parser_version_invalidated);
         assert_eq!(task.offset, 0);
         assert!(task.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn parser_version_migration_rebuilds_vectors_with_the_existing_model() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(&transcript, "{}\n").expect("transcript");
+        let mut task = incremental_task(&transcript, SourceKind::Claude, 0, 0, HashMap::new());
+        task.parser_version_invalidated = true;
+
+        let migration = vector_migration(&paths.vectors, &[task], ModelChoice::Gemma);
+
+        assert!(migration.rebuild);
+        assert_eq!(migration.model, ModelChoice::BGESmall);
+    }
+
+    #[test]
+    fn ordinary_file_replacement_does_not_rebuild_the_vector_store() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        save_vector_store(&paths, "bge", 384);
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(&transcript, "{}\n").expect("transcript");
+        let task = incremental_task(&transcript, SourceKind::Claude, 0, 0, HashMap::new());
+
+        let migration = vector_migration(&paths.vectors, &[task], ModelChoice::Gemma);
+
+        assert!(!migration.rebuild);
+        assert_eq!(migration.model, ModelChoice::Gemma);
     }
 
     #[test]
@@ -2343,6 +2419,7 @@ mod tests {
             size: (existing.len() + appended.len()) as u64,
             mtime: 0,
             delete_first: false,
+            parser_version_invalidated: false,
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity::default(),
             parser_version: crate::sources::index_state_version(SourceKind::Pi),
@@ -2413,6 +2490,7 @@ mod tests {
             size: meta.len(),
             mtime: 0,
             delete_first: false,
+            parser_version_invalidated: false,
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity::default(),
             parser_version: crate::sources::index_state_version(SourceKind::Copilot),
@@ -2504,6 +2582,7 @@ mod tests {
         let ctx = WriterContext {
             embeddings: false,
             do_backfill_embeddings: false,
+            reset_vector_store: false,
             vector_dir,
             analytics_path: tmp.path().join("state").join("analytics.sqlite"),
             progress,

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -3,22 +3,20 @@ use crate::config::{IndexedToolContentLimits, Paths};
 use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::SearchIndex;
 use crate::progress::{Progress, SOURCE_COUNT};
-use crate::state::{FileState, IngestState, ScanCache};
-use crate::types::{Record, RecordLinks, SourceKind};
+use crate::state::{FileIdentity, FileState, IngestState, PendingToolCall, ScanCache};
+#[cfg(test)]
+use crate::types::RecordLinks;
+use crate::types::{Record, SourceKind};
 use anyhow::{Result, anyhow};
-use chrono::{DateTime, Utc};
 use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
-use memchr::memchr;
-use memmap2::Mmap;
 use rayon::prelude::*;
-use simd_json::BorrowedValue;
-use simd_json::prelude::*;
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use walkdir::WalkDir;
 
 const EMBED_BATCH_SIZE: usize = 64;
 const EMBED_MAX_CHARS: usize = 8192;
@@ -26,9 +24,6 @@ const RETAINED_HEAD_PERCENT: usize = 75;
 const INDEX_PROGRESS_BATCH: u64 = 1;
 // Keep a small amount of parser/writer overlap without retaining an unbounded transcript backlog.
 const RECORD_CHANNEL_CAPACITY: usize = 8;
-const CURSOR_SUBAGENT_TURN_BASE: u32 = 1_000_000_000;
-const CURSOR_SUBAGENT_TURN_STRIDE: u32 = 50_000;
-const CURSOR_SUBAGENT_TURN_BUCKETS: u32 = 65_536;
 
 #[derive(Debug, Clone)]
 pub struct IngestOptions {
@@ -63,6 +58,9 @@ struct FileTask {
     size: u64,
     mtime: i64,
     delete_first: bool,
+    pending_tool_calls: HashMap<String, PendingToolCall>,
+    identity: FileIdentity,
+    parser_version: u32,
 }
 
 #[derive(Debug)]
@@ -70,6 +68,149 @@ struct FileUpdate {
     path: String,
     state: FileState,
     session_id: Option<String>,
+}
+
+const FILE_IDENTITY_PREFIX_BYTES: usize = 4096;
+
+fn file_identity(path: &Path, metadata: &std::fs::Metadata, prefix_bytes: usize) -> FileIdentity {
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+
+    let prefix_sha256 = if metadata.is_file() {
+        File::open(path).ok().and_then(|mut file| {
+            let mut bytes = vec![0; prefix_bytes];
+            let read = file.read(&mut bytes).ok()?;
+            bytes.truncate(read);
+            Some(format!("{:x}", Sha256::digest(&bytes)))
+        })
+    } else {
+        None
+    };
+
+    FileIdentity {
+        #[cfg(unix)]
+        device: Some(metadata.dev()),
+        #[cfg(not(unix))]
+        device: None,
+        #[cfg(unix)]
+        inode: Some(metadata.ino()),
+        #[cfg(not(unix))]
+        inode: None,
+        prefix_sha256,
+        prefix_bytes: prefix_bytes as u64,
+        modified_ns: metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64),
+    }
+}
+
+fn file_was_replaced(previous: &FileIdentity, current: &FileIdentity) -> bool {
+    previous
+        .device
+        .zip(previous.inode)
+        .zip(current.device.zip(current.inode))
+        .is_some_and(|((old_device, old_inode), (new_device, new_inode))| {
+            old_device != new_device || old_inode != new_inode
+        })
+        || previous
+            .prefix_sha256
+            .as_ref()
+            .zip(current.prefix_sha256.as_ref())
+            .is_some_and(|(old, new)| previous.prefix_bytes == current.prefix_bytes && old != new)
+}
+
+fn prepare_file_task(
+    path: PathBuf,
+    source: SourceKind,
+    metadata: &std::fs::Metadata,
+    previous: Option<&FileState>,
+) -> (FileTask, bool) {
+    let size = metadata.len();
+    let mtime = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    let prefix_bytes = previous
+        .map(|state| {
+            if state.identity.prefix_bytes > 0 {
+                state.identity.prefix_bytes
+            } else {
+                state.size.min(FILE_IDENTITY_PREFIX_BYTES as u64)
+            }
+        })
+        .unwrap_or_else(|| size.min(FILE_IDENTITY_PREFIX_BYTES as u64))
+        .min(size) as usize;
+    let identity = file_identity(&path, metadata, prefix_bytes);
+    let parser_version = crate::sources::index_state_version(source);
+    let (offset, turn_id, delete_first, pending_tool_calls, skip) = match previous {
+        None => (0, 0, false, HashMap::new(), false),
+        Some(previous)
+            if size < previous.size
+                || mtime < previous.mtime
+                || previous.parser_version != parser_version
+                || file_was_replaced(&previous.identity, &identity)
+                || (size == previous.size
+                    && previous
+                        .identity
+                        .modified_ns
+                        .zip(identity.modified_ns)
+                        .is_some_and(|(old, new)| old != new))
+                || (size == previous.size && mtime != previous.mtime) =>
+        {
+            (0, 0, true, HashMap::new(), false)
+        }
+        Some(previous) if size == previous.size && mtime == previous.mtime => (
+            previous.offset,
+            previous.turn_id,
+            false,
+            previous.pending_tool_calls.clone(),
+            true,
+        ),
+        Some(previous) => (
+            previous.offset,
+            previous.turn_id,
+            false,
+            previous.pending_tool_calls.clone(),
+            false,
+        ),
+    };
+
+    (
+        FileTask {
+            path,
+            source,
+            offset,
+            turn_id,
+            size,
+            mtime,
+            delete_first,
+            pending_tool_calls,
+            identity,
+            parser_version,
+        },
+        skip,
+    )
+}
+
+fn completed_file_state(
+    task: &FileTask,
+    offset: u64,
+    turn_id: u32,
+    pending_tool_calls: HashMap<String, PendingToolCall>,
+) -> FileState {
+    FileState {
+        size: task.size,
+        mtime: task.mtime,
+        offset,
+        turn_id,
+        parser_version: task.parser_version,
+        pending_tool_calls,
+        identity: task.identity.clone(),
+    }
 }
 
 #[derive(Clone)]
@@ -148,312 +289,140 @@ pub fn ingest_all(
     let mut total_bytes = 0u64;
 
     if options.claude_source.exists() {
-        let claude_files = collect_claude_files(&options.claude_source, options.include_agents)?;
-        for path in claude_files {
+        let claude_files =
+            crate::sources::claude::discover(&options.claude_source, options.include_agents)?;
+        for source_file in claude_files {
+            let path = source_file.path;
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::Claude, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::Claude,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     let mut session_ids = HashSet::new();
     if options.include_codex {
-        let codex_files = collect_codex_session_files()?;
-        for path in codex_files {
-            if let Some(id) = session_id_from_filename(&path) {
+        let codex_files = crate::sources::codex::discover_rollouts();
+        for source_file in codex_files {
+            let path = source_file.path;
+            if let Some(id) = crate::sources::codex::session_id_from_path(&path) {
                 session_ids.insert(id);
             }
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::CodexSession, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::CodexSession,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     if options.include_codex {
-        let history_path = codex_history_path();
-        if history_path.exists() {
+        for history_path in crate::sources::codex::history_paths() {
             let meta = history_path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = history_path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) = prepare_file_task(
+                history_path,
+                SourceKind::CodexHistory,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
             } else {
-                tasks.push(FileTask {
-                    path: history_path,
-                    source: SourceKind::CodexHistory,
-                    offset,
-                    turn_id,
-                    size,
-                    mtime,
-                    delete_first,
-                });
+                tasks.push(task);
             }
         }
     }
 
     if options.include_opencode {
-        let opencode_files = collect_opencode_files()?;
-        for path in opencode_files {
+        let opencode_files = crate::sources::opencode::discover_sessions()?;
+        for source_file in opencode_files {
+            let path = source_file.path;
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::Opencode, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::Opencode,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     if options.include_cursor {
-        let cursor_files = collect_cursor_files()?;
-        for path in cursor_files {
+        let cursor_files = crate::sources::cursor::discover_transcripts();
+        for source_file in cursor_files {
+            let path = source_file.path;
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::Cursor, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::Cursor,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     if options.include_pi {
-        let pi_files = collect_pi_files()?;
-        for path in pi_files {
+        let pi_files = crate::sources::pi::discover();
+        for source_file in pi_files {
+            let path = source_file.path;
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::Pi, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::Pi,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     if options.include_copilot {
-        let copilot_files = collect_copilot_files()?;
-        for path in copilot_files {
+        let copilot_files = crate::sources::copilot::discover_sessions();
+        for source_file in copilot_files {
+            let path = source_file.path;
             let meta = path.metadata()?;
-            let size = meta.len();
-            let mtime = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
             files_scanned += 1;
-            total_bytes += size;
+            total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let prev = state.files.get(&key);
-            let (offset, turn_id, delete_first, skip) = match prev {
-                None => (0, 0, false, false),
-                Some(prev) => {
-                    if size < prev.size || mtime < prev.mtime {
-                        (0, 0, true, false)
-                    } else if size == prev.size && mtime == prev.mtime {
-                        (prev.offset, prev.turn_id, false, true)
-                    } else {
-                        (prev.offset, prev.turn_id, false, false)
-                    }
-                }
-            };
+            let (task, skip) =
+                prepare_file_task(path, SourceKind::Copilot, &meta, state.files.get(&key));
             if skip {
                 files_skipped += 1;
                 continue;
             }
-            tasks.push(FileTask {
-                path,
-                source: SourceKind::Copilot,
-                offset,
-                turn_id,
-                size,
-                mtime,
-                delete_first,
-            });
+            tasks.push(task);
         }
     }
 
     let opencode_session_links = if tasks.iter().any(|task| task.source == SourceKind::Opencode) {
-        opencode_session_links_by_id()
+        crate::sources::opencode::session_links_by_id()
     } else {
         HashMap::new()
     };
@@ -798,458 +767,6 @@ fn backfill_embeddings(
     Ok(embedded_count.get())
 }
 
-fn collect_claude_files(source: &Path, include_agents: bool) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for entry in WalkDir::new(source).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        if !include_agents
-            && let Some(name) = path.file_name().and_then(|n| n.to_str())
-            && name.starts_with("agent-")
-        {
-            continue;
-        }
-        files.push(path.to_path_buf());
-    }
-    Ok(files)
-}
-
-fn collect_codex_session_files() -> Result<Vec<PathBuf>> {
-    collect_codex_session_files_from_roots(&codex_session_roots())
-}
-
-fn collect_codex_session_files_from_roots(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for root in roots {
-        if !root.exists() {
-            continue;
-        }
-        for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                continue;
-            }
-            files.push(path.to_path_buf());
-        }
-    }
-    Ok(files)
-}
-
-fn collect_opencode_files() -> Result<Vec<PathBuf>> {
-    let root = opencode_root();
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    // In opencode, "sessions" are directories inside storage/message/
-    // e.g. storage/message/ses_.../
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
-        let path = entry.path();
-        if entry.file_type()?.is_dir()
-            && let Some(name) = path.file_name().and_then(|n| n.to_str())
-            && name.starts_with("ses_")
-        {
-            files.push(path);
-        }
-    }
-    Ok(files)
-}
-
-fn collect_cursor_files() -> Result<Vec<PathBuf>> {
-    let root = cursor_projects_root();
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Some(path_str) = path.to_str() else {
-            continue;
-        };
-        if path_str.contains("/agent-transcripts/") || path_str.contains("\\agent-transcripts\\") {
-            files.push(path.to_path_buf());
-        }
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn collect_pi_files() -> Result<Vec<PathBuf>> {
-    collect_pi_files_from_root(&pi_sessions_root())
-}
-
-fn collect_pi_files_from_root(root: &Path) -> Result<Vec<PathBuf>> {
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        files.push(path.to_path_buf());
-    }
-    Ok(files)
-}
-
-fn collect_copilot_files() -> Result<Vec<PathBuf>> {
-    collect_copilot_files_from_root(&copilot_session_root())
-}
-
-fn collect_copilot_files_from_root(root: &Path) -> Result<Vec<PathBuf>> {
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.file_name().and_then(|n| n.to_str()) == Some("events.jsonl") {
-            files.push(path.to_path_buf());
-        }
-    }
-    Ok(files)
-}
-
-fn codex_root() -> PathBuf {
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".codex")
-}
-
-fn codex_session_roots() -> Vec<PathBuf> {
-    let codex_root = codex_root();
-    vec![
-        codex_root.join("sessions"),
-        codex_root.join("archived_sessions"),
-    ]
-}
-
-fn opencode_root() -> PathBuf {
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".local")
-        .join("share")
-        .join("opencode")
-        .join("storage")
-        .join("message")
-}
-
-fn copilot_root() -> PathBuf {
-    if let Some(path) = std::env::var_os("COPILOT_HOME") {
-        return PathBuf::from(path);
-    }
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".copilot")
-}
-
-fn copilot_session_root() -> PathBuf {
-    copilot_root().join("session-state")
-}
-
-fn opencode_parts_root() -> PathBuf {
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".local")
-        .join("share")
-        .join("opencode")
-        .join("storage")
-        .join("part")
-}
-
-fn opencode_default_session_links() -> SessionLinks {
-    SessionLinks {
-        conversation_kind: Some("main".to_string()),
-        ..SessionLinks::default()
-    }
-}
-
-fn opencode_session_links_by_id() -> HashMap<String, SessionLinks> {
-    opencode_session_links_by_id_from_root(&opencode_storage_root().join("session"))
-}
-
-fn opencode_session_links_by_id_from_root(root: &Path) -> HashMap<String, SessionLinks> {
-    let mut links_by_id = HashMap::new();
-    if !root.exists() {
-        return links_by_id;
-    }
-
-    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        if entry.path().extension().and_then(|e| e.to_str()) != Some("json") {
-            continue;
-        }
-        let Some(session_id) = entry
-            .path()
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-        else {
-            continue;
-        };
-        let Ok(file) = File::open(entry.path()) else {
-            continue;
-        };
-        let reader = std::io::BufReader::new(file);
-        let Ok(value) = serde_json::from_reader::<_, serde_json::Value>(reader) else {
-            continue;
-        };
-
-        links_by_id.insert(session_id, opencode_session_links_from_value(&value));
-    }
-
-    links_by_id
-}
-
-#[cfg(test)]
-fn opencode_session_links_from_root(root: &Path, session_id: &str) -> SessionLinks {
-    opencode_session_links_by_id_from_root(root)
-        .remove(session_id)
-        .unwrap_or_else(opencode_default_session_links)
-}
-
-fn opencode_session_links_from_value(value: &serde_json::Value) -> SessionLinks {
-    let parent_session_id = value
-        .get("parentID")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    SessionLinks {
-        conversation_kind: Some(if parent_session_id.is_some() {
-            "fork".to_string()
-        } else {
-            "main".to_string()
-        }),
-        thread_source: parent_session_id.as_ref().map(|_| "fork".to_string()),
-        parent_session_id,
-    }
-}
-
-fn opencode_storage_root() -> PathBuf {
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".local")
-        .join("share")
-        .join("opencode")
-        .join("storage")
-}
-
-fn codex_history_path() -> PathBuf {
-    codex_root().join("history.jsonl")
-}
-
-pub(crate) fn cursor_projects_root() -> PathBuf {
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".cursor").join("projects")
-}
-
-fn pi_agent_root() -> PathBuf {
-    if let Some(root) = std::env::var_os("PI_CODING_AGENT_DIR") {
-        return PathBuf::from(root);
-    }
-    let home = directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"));
-    home.join(".pi").join("agent")
-}
-
-pub(crate) fn pi_sessions_root() -> PathBuf {
-    if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
-        return PathBuf::from(root);
-    }
-    let agent_root = pi_agent_root();
-    if let Some(root) = pi_configured_session_root(&agent_root) {
-        return root;
-    }
-    agent_root.join("sessions")
-}
-
-fn pi_configured_session_root(agent_root: &Path) -> Option<PathBuf> {
-    let settings_path = agent_root.join("settings.json");
-    let contents = std::fs::read_to_string(settings_path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
-    let session_dir = value.get("sessionDir")?.as_str()?.trim();
-    if session_dir.is_empty() {
-        return None;
-    }
-    Some(resolve_pi_settings_path(session_dir, agent_root))
-}
-
-fn resolve_pi_settings_path(raw: &str, base: &Path) -> PathBuf {
-    if raw == "~" {
-        return directories::BaseDirs::new()
-            .map(|b| b.home_dir().to_path_buf())
-            .unwrap_or_else(|| PathBuf::from(raw));
-    }
-    if let Some(rest) = raw.strip_prefix("~/") {
-        return directories::BaseDirs::new()
-            .map(|b| b.home_dir().join(rest))
-            .unwrap_or_else(|| PathBuf::from(raw));
-    }
-    let path = PathBuf::from(raw);
-    if path.is_absolute() {
-        path
-    } else {
-        base.join(path)
-    }
-}
-
-#[derive(Clone, Default)]
-struct SessionLinks {
-    parent_session_id: Option<String>,
-    thread_source: Option<String>,
-    conversation_kind: Option<String>,
-}
-
-impl SessionLinks {
-    fn record_links(&self) -> RecordLinks {
-        RecordLinks {
-            parent_session_id: self.parent_session_id.clone(),
-            thread_source: self.thread_source.clone(),
-            conversation_kind: self.conversation_kind.clone(),
-            ..RecordLinks::default()
-        }
-    }
-}
-
-#[derive(Clone)]
-struct CodexSessionMeta {
-    session_id: String,
-    project: String,
-    links: SessionLinks,
-}
-
-fn codex_session_meta_from_path(path: &Path) -> CodexSessionMeta {
-    CodexSessionMeta {
-        session_id: session_id_from_filename(path).unwrap_or_else(|| "unknown".to_string()),
-        project: "codex".to_string(),
-        links: SessionLinks {
-            conversation_kind: Some("main".to_string()),
-            ..SessionLinks::default()
-        },
-    }
-}
-
-fn read_codex_session_meta_until(path: &Path, limit: u64) -> Result<CodexSessionMeta> {
-    let mut meta = codex_session_meta_from_path(path);
-    if limit == 0 {
-        return Ok(meta);
-    }
-    let file = File::open(path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = 0usize;
-    let limit = (limit as usize).min(mmap.len());
-    let mut buf = Vec::new();
-    while start < limit {
-        let slice = &mmap[start..limit];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        start += rel + 1;
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if value.get("type").and_then(|v| v.as_str()) == Some("session_meta")
-            && let Some(payload) = value.get("payload").and_then(|v| v.as_object())
-        {
-            apply_codex_session_meta(payload, &mut meta);
-        }
-    }
-    Ok(meta)
-}
-
-fn apply_codex_session_meta(payload: &simd_json::borrowed::Object, meta: &mut CodexSessionMeta) {
-    if let Some(id) = payload.get("id").and_then(|v| v.as_str()) {
-        meta.session_id = id.to_string();
-    }
-    if let Some(cwd) = payload.get("cwd").and_then(|v| v.as_str()) {
-        meta.project = project_from_path(cwd);
-    }
-
-    let forked_from_id = payload
-        .get("forked_from_id")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
-    let parent_thread_id = payload
-        .get("source")
-        .and_then(|v| v.as_object())
-        .and_then(|source| source.get("subagent"))
-        .and_then(|v| v.as_object())
-        .and_then(|subagent| subagent.get("thread_spawn"))
-        .and_then(|v| v.as_object())
-        .and_then(|spawn| spawn.get("parent_thread_id"))
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
-    let thread_source = payload
-        .get("thread_source")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .or_else(|| parent_thread_id.as_ref().map(|_| "subagent".to_string()))
-        .or_else(|| forked_from_id.as_ref().map(|_| "fork".to_string()));
-
-    meta.links.parent_session_id = forked_from_id.clone().or(parent_thread_id);
-    meta.links.thread_source = thread_source.clone();
-    meta.links.conversation_kind = Some(if thread_source.as_deref() == Some("subagent") {
-        "subagent".to_string()
-    } else if forked_from_id.is_some() {
-        "fork".to_string()
-    } else {
-        "main".to_string()
-    });
-}
-
-fn opt_str(obj: &simd_json::borrowed::Object, key: &str) -> Option<String> {
-    obj.get(key).and_then(|v| v.as_str()).map(str::to_string)
-}
-
-fn pi_base_links(obj: &simd_json::borrowed::Object, conversation_kind: &str) -> RecordLinks {
-    RecordLinks {
-        event_id: opt_str(obj, "id"),
-        parent_event_id: opt_str(obj, "parentId"),
-        logical_parent_event_id: opt_str(obj, "fromId"),
-        thread_source: (conversation_kind != "main").then(|| conversation_kind.to_string()),
-        conversation_kind: Some(conversation_kind.to_string()),
-        ..RecordLinks::default()
-    }
-}
-
 fn parse_claude_file(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -1257,248 +774,28 @@ fn parse_claude_file(
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = task.turn_id;
-
-    let project = project_from_claude_path(&task.path);
-    let session_id = task
-        .path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-    let is_agent_file = session_id.starts_with("agent-")
-        || task
-            .path
-            .components()
-            .any(|component| component.as_os_str().to_str() == Some("subagents"));
     let source_path = task.path.to_string_lossy().to_string();
-    let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
-
-    let mut buf = Vec::new();
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::Claude, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let obj = match value.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        if entry_type != "user" && entry_type != "assistant" {
-            continue;
-        }
-        let entry_uuid = opt_str(obj, "uuid");
-        let entry_parent_uuid = opt_str(obj, "parentUuid");
-        let is_sidechain = obj
-            .get("isSidechain")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        let conversation_kind = if is_agent_file {
-            "subagent"
-        } else if is_sidechain {
-            "sidechain"
-        } else {
-            "main"
-        };
-        let thread_source = if is_agent_file {
-            Some("subagent".to_string())
-        } else if is_sidechain {
-            Some("sidechain".to_string())
-        } else {
-            None
-        };
-        let entry_links = RecordLinks {
-            event_id: entry_uuid.clone(),
-            parent_event_id: entry_parent_uuid,
-            logical_parent_event_id: opt_str(obj, "logicalParentUuid"),
-            parent_session_id: is_agent_file.then(|| opt_str(obj, "sessionId")).flatten(),
-            thread_source,
-            conversation_kind: Some(conversation_kind.to_string()),
-            parent_tool_use_id: opt_str(obj, "parentToolUseID"),
-            source_tool_use_id: opt_str(obj, "sourceToolUseID"),
-            source_tool_assistant_uuid: opt_str(obj, "sourceToolAssistantUUID"),
-        };
-        let timestamp = obj
-            .get("timestamp")
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_millis)
-            .unwrap_or(0);
-        let message = match obj.get("message").and_then(|v| v.as_object()) {
-            Some(m) => m,
-            None => continue,
-        };
-        let content = message.get("content");
-        let mut text_parts = Vec::new();
-        if let Some(content) = content {
-            if let Some(text) = content.as_str() {
-                text_parts.push(text);
-            } else if let Some(arr) = content.as_array() {
-                for block in arr {
-                    let block_obj = match block.as_object() {
-                        Some(b) => b,
-                        None => continue,
-                    };
-                    let block_type = block_obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                    if block_type == "text" {
-                        if let Some(text) = block_obj.get("text").and_then(|v| v.as_str()) {
-                            text_parts.push(text);
-                        }
-                    } else if block_type == "tool_use" {
-                        let tool_name = block_obj
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        if let (Some(id), Some(name)) = (
-                            block_obj.get("id").and_then(|v| v.as_str()),
-                            tool_name.clone(),
-                        ) {
-                            tool_id_to_name.insert(id.to_string(), name);
-                        }
-                        let tool_input = block_obj.get("input").map(|v| v.to_string());
-                        let text = tool_input.clone().unwrap_or_default();
-                        let mut links = entry_links.clone();
-                        if let Some(tool_id) = block_obj.get("id").and_then(|v| v.as_str()) {
-                            links.event_id = Some(tool_id.to_string());
-                            links.parent_event_id = entry_uuid.clone();
-                        }
-                        let record = Record {
-                            source: SourceKind::Claude,
-                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                            ts: timestamp,
-                            project: project.clone(),
-                            session_id: session_id.clone(),
-                            turn_id,
-                            role: "tool_use".to_string(),
-                            text,
-                            tool_name,
-                            tool_input,
-                            tool_output: None,
-                            links,
-                            source_path: source_path.clone(),
-                        };
-                        progress.add_produced(SourceKind::Claude, 1);
-                        tx_record.send(record)?;
-                        turn_id += 1;
-                    }
-                }
-            }
-        }
-
-        if entry_type == "user"
-            && let Some(content) = content
-            && let Some(arr) = content.as_array()
-        {
-            for block in arr {
-                let block_obj = match block.as_object() {
-                    Some(b) => b,
-                    None => continue,
-                };
-                if block_obj.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
-                    let tool_output = block_obj.get("content").map(|v| v.to_string());
-                    let mut text = extract_text_from_tool_result(block).unwrap_or_default();
-                    if text.is_empty()
-                        && let Some(content) = block_obj.get("content")
-                    {
-                        text = content.to_string();
-                    }
-                    let tool_name = block_obj
-                        .get("tool_use_id")
-                        .and_then(|v| v.as_str())
-                        .and_then(|id| tool_id_to_name.get(id))
-                        .cloned();
-                    let tool_use_id = block_obj
-                        .get("tool_use_id")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string);
-                    let mut links = entry_links.clone();
-                    if let Some(tool_use_id) = &tool_use_id {
-                        links.event_id = entry_uuid
-                            .as_ref()
-                            .map(|uuid| format!("{uuid}:tool_result:{tool_use_id}"));
-                        links.parent_event_id = Some(tool_use_id.clone());
-                        links.parent_tool_use_id = Some(tool_use_id.clone());
-                    }
-                    let record = Record {
-                        source: SourceKind::Claude,
-                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                        ts: timestamp,
-                        project: project.clone(),
-                        session_id: session_id.clone(),
-                        turn_id,
-                        role: "tool_result".to_string(),
-                        text,
-                        tool_name,
-                        tool_input: None,
-                        tool_output,
-                        links,
-                        source_path: source_path.clone(),
-                    };
-                    progress.add_produced(SourceKind::Claude, 1);
-                    tx_record.send(record)?;
-                    turn_id += 1;
-                }
-            }
-        }
-
-        let text = text_parts.join(" ").trim().to_string();
-        if !text.is_empty() {
-            let record = Record {
-                source: SourceKind::Claude,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
-                turn_id,
-                role: entry_type.to_string(),
-                text,
-                tool_name: None,
-                tool_input: None,
-                tool_output: None,
-                links: entry_links,
-                source_path: source_path.clone(),
-            };
+    let parsed = crate::sources::claude::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        next_doc_id,
+        |record| {
             progress.add_produced(SourceKind::Claude, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-        }
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::Claude, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::Claude, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: source_path,
-        state,
-        session_id: Some(session_id),
-    })?;
-    Ok(())
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Claude,
+        source_path,
+        parsed,
+    )
 }
 
 fn parse_codex_session(
@@ -1508,198 +805,28 @@ fn parse_codex_session(
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = task.turn_id;
-
     let source_path = task.path.to_string_lossy().to_string();
-    let mut meta = read_codex_session_meta_until(&task.path, task.offset)?;
-    let mut call_id_to_name: HashMap<String, String> = HashMap::new();
-
-    let mut buf = Vec::new();
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::CodexSession, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let obj = match value.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let timestamp = obj
-            .get("timestamp")
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_millis)
-            .unwrap_or(0);
-        if entry_type == "session_meta" {
-            if let Some(payload) = obj.get("payload").and_then(|v| v.as_object()) {
-                apply_codex_session_meta(payload, &mut meta);
-            }
-            continue;
-        }
-        if entry_type != "response_item" {
-            continue;
-        }
-        let payload = match obj.get("payload").and_then(|v| v.as_object()) {
-            Some(p) => p,
-            None => continue,
-        };
-        let payload_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let mut base_links = meta.links.record_links();
-        base_links.event_id = opt_str(payload, "id");
-        if payload_type == "message" {
-            let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("");
-            let content = payload.get("content");
-            let mut text_parts = Vec::new();
-            if let Some(content) = content {
-                if let Some(text) = content.as_str() {
-                    text_parts.push(text);
-                } else if let Some(arr) = content.as_array() {
-                    for block in arr {
-                        if let Some(block_obj) = block.as_object()
-                            && let Some(text) = block_obj.get("text").and_then(|v| v.as_str())
-                        {
-                            text_parts.push(text);
-                        }
-                    }
-                }
-            }
-            let text = text_parts.join("\n").trim().to_string();
-            if text.is_empty() {
-                continue;
-            }
-            if is_system_instruction(&text) {
-                continue;
-            }
-            let record = Record {
-                source: SourceKind::CodexSession,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: meta.project.clone(),
-                session_id: meta.session_id.clone(),
-                turn_id,
-                role: role.to_string(),
-                text,
-                tool_name: None,
-                tool_input: None,
-                tool_output: None,
-                links: base_links,
-                source_path: source_path.clone(),
-            };
+    let parsed = crate::sources::codex::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        next_doc_id,
+        |record| {
             progress.add_produced(SourceKind::CodexSession, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-        } else if payload_type == "function_call" {
-            let tool_name = payload
-                .get("name")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let tool_input = payload
-                .get("arguments")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            if let Some(call_id) = payload.get("call_id").and_then(|v| v.as_str())
-                && let Some(name) = tool_name.clone()
-            {
-                call_id_to_name.insert(call_id.to_string(), name);
-            }
-            let text = tool_input.clone().unwrap_or_default();
-            let mut links = base_links;
-            if let Some(call_id) = payload.get("call_id").and_then(|v| v.as_str()) {
-                links.event_id = Some(call_id.to_string());
-            }
-            let record = Record {
-                source: SourceKind::CodexSession,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: meta.project.clone(),
-                session_id: meta.session_id.clone(),
-                turn_id,
-                role: "tool_use".to_string(),
-                text,
-                tool_name,
-                tool_input,
-                tool_output: None,
-                links,
-                source_path: source_path.clone(),
-            };
-            progress.add_produced(SourceKind::CodexSession, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-        } else if payload_type == "function_call_output" {
-            let call_id = payload
-                .get("call_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let tool_name = call_id_to_name.get(call_id).cloned();
-            let tool_output = payload
-                .get("output")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let text = tool_output.clone().unwrap_or_default();
-            if text.is_empty() {
-                continue;
-            }
-            let mut links = base_links;
-            if !call_id.is_empty() {
-                links.parent_event_id = Some(call_id.to_string());
-                links.parent_tool_use_id = Some(call_id.to_string());
-            }
-            let record = Record {
-                source: SourceKind::CodexSession,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: meta.project.clone(),
-                session_id: meta.session_id.clone(),
-                turn_id,
-                role: "tool_result".to_string(),
-                text,
-                tool_name,
-                tool_input: None,
-                tool_output,
-                links,
-                source_path: source_path.clone(),
-            };
-            progress.add_produced(SourceKind::CodexSession, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-        }
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::CodexSession, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::CodexSession, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: source_path,
-        state,
-        session_id: Some(meta.session_id),
-    })?;
-    Ok(())
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::CodexSession,
+        source_path,
+        parsed,
+    )
 }
 
 fn parse_codex_history(
@@ -1710,216 +837,85 @@ fn parse_codex_history(
     session_ids: &HashSet<String>,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = task.turn_id;
     let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::codex::parse_history_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        session_ids,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::CodexHistory, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::CodexHistory,
+        source_path,
+        parsed,
+    )
+}
 
-    let mut buf = Vec::new();
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::CodexHistory, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let obj = match value.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let session_id = obj.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
-        if session_id.is_empty() || session_ids.contains(session_id) {
-            continue;
-        }
-        let ts = obj.get("ts").and_then(|v| v.as_i64()).unwrap_or(0);
-        let ts_ms = (ts.max(0) as u64) * 1000;
-        let text = obj
-            .get("text")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if text.is_empty() {
-            continue;
-        }
-        let record = Record {
-            source: SourceKind::CodexHistory,
-            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-            ts: ts_ms,
-            project: "codex".to_string(),
-            session_id: session_id.to_string(),
-            turn_id,
-            role: "user".to_string(),
-            text,
-            tool_name: None,
-            tool_input: None,
-            tool_output: None,
-            links: RecordLinks {
-                conversation_kind: Some("main".to_string()),
-                ..RecordLinks::default()
-            },
-            source_path: source_path.clone(),
-        };
-        progress.add_produced(SourceKind::CodexHistory, 1);
-        tx_record.send(record)?;
-        turn_id += 1;
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::CodexHistory, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::CodexHistory, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
+fn finish_source_parse(
+    task: &FileTask,
+    tx_update: &Sender<FileUpdate>,
+    progress: &Arc<Progress>,
+    source: SourceKind,
+    source_path: String,
+    parsed: crate::sources::IndexParseOutput,
+) -> Result<()> {
+    progress.add_parsed_bytes(source, parsed.offset.saturating_sub(task.offset));
+    progress.add_files_done(source, 1);
+    let state = completed_file_state(
+        task,
+        parsed.offset,
+        parsed.turn_id,
+        parsed.pending_tool_calls,
+    );
     tx_update.send(FileUpdate {
         path: source_path,
         state,
-        session_id: None,
+        session_id: parsed.session_id,
     })?;
     Ok(())
 }
-
 fn parse_opencode_file(
     task: &FileTask,
     tx_record: &RecordSender,
     tx_update: &Sender<FileUpdate>,
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
-    opencode_session_links: &HashMap<String, SessionLinks>,
+    opencode_session_links: &HashMap<String, crate::sources::opencode::SessionLinks>,
 ) -> Result<()> {
-    let session_dir = &task.path;
-    let session_id = session_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-    let project = SourceKind::Opencode.label().to_string();
-    let session_links = opencode_session_links
-        .get(&session_id)
-        .cloned()
-        .unwrap_or_else(opencode_default_session_links);
-
-    let mut messages = Vec::new();
-    for entry in std::fs::read_dir(session_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
-            continue;
-        }
-        let file = File::open(&path)?;
-        let reader = std::io::BufReader::new(file);
-        let msg: serde_json::Value = match serde_json::from_reader(reader) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-
-        let msg_id = msg.get("id").and_then(|v| v.as_str()).unwrap_or_default();
-        if msg_id.is_empty() {
-            continue;
-        }
-        let timestamp = msg
-            .get("time")
-            .and_then(|t| t.get("created"))
-            .and_then(|c| c.as_u64())
-            .unwrap_or(0);
-        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-
-        messages.push((msg_id.to_string(), timestamp, role.to_string()));
-    }
-
-    messages.sort_by_key(|k| k.1);
-
-    let parts_root = opencode_parts_root();
-    let mut turn_id = task.turn_id;
-
-    for (msg_id, timestamp, role) in messages {
-        let part_dir = parts_root.join(&msg_id);
-        if !part_dir.exists() {
-            continue;
-        }
-
-        let mut part_files: Vec<_> = std::fs::read_dir(&part_dir)?
-            .flatten()
-            .map(|e| e.path())
-            .collect();
-        // Ensure deterministic order for message parts
-        part_files.sort();
-
-        let mut text_parts = Vec::new();
-        for path in part_files {
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            let file = File::open(&path)?;
-            let reader = std::io::BufReader::new(file);
-            let part: serde_json::Value = match serde_json::from_reader(reader) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-
-            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-                text_parts.push(text.to_string());
-            }
-        }
-
-        if text_parts.is_empty() {
-            continue;
-        }
-
-        let text = text_parts.join("\n");
-        let mut links = session_links.record_links();
-        links.event_id = Some(msg_id.clone());
-        let record = Record {
-            source: SourceKind::Opencode,
-            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-            ts: timestamp,
-            project: project.clone(),
-            session_id: session_id.clone(),
-            turn_id,
-            role: role.clone(),
-            text,
-            tool_name: None,
-            tool_input: None,
-            tool_output: None,
-            links,
-            source_path: session_dir.to_string_lossy().to_string(),
-        };
-        progress.add_produced(SourceKind::Opencode, 1);
-        tx_record.send(record)?;
-        turn_id += 1;
-    }
-
-    progress.add_files_done(SourceKind::Opencode, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: 0,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: session_dir.to_string_lossy().to_string(),
-        state,
-        session_id: Some(session_id),
-    })?;
-    Ok(())
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::opencode::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        opencode_session_links,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Opencode, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Opencode,
+        source_path,
+        parsed,
+    )
 }
 
 fn parse_cursor_file(
@@ -1929,164 +925,30 @@ fn parse_cursor_file(
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = cursor_initial_turn_id(&task.path, task.turn_id);
-
     let source_path = task.path.to_string_lossy().to_string();
-    let session_id = cursor_session_id_from_path(&task.path);
-    let project = project_from_cursor_path(&task.path);
-    let timestamp = task.mtime.max(0) as u64 * 1000;
-
-    let mut buf = Vec::new();
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::Cursor, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let obj = match value.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let role = obj.get("role").and_then(|v| v.as_str()).unwrap_or("");
-        if role != "user" && role != "assistant" {
-            continue;
-        }
-        let message = match obj.get("message").and_then(|v| v.as_object()) {
-            Some(m) => m,
-            None => continue,
-        };
-        let mut text_parts = Vec::new();
-        if let Some(content) = message.get("content") {
-            if let Some(text) = content.as_str() {
-                text_parts.push(text);
-            } else if let Some(arr) = content.as_array() {
-                for block in arr {
-                    let Some(block_obj) = block.as_object() else {
-                        continue;
-                    };
-                    let block_type = block_obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                    if block_type == "text" {
-                        if let Some(text) = block_obj.get("text").and_then(|v| v.as_str()) {
-                            text_parts.push(text);
-                        }
-                    } else if block_type == "tool_use" {
-                        let tool_name = block_obj
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        let tool_input = block_obj.get("input").map(|v| v.to_string());
-                        let text = tool_input.clone().unwrap_or_default();
-                        let record = Record {
-                            source: SourceKind::Cursor,
-                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                            ts: timestamp,
-                            project: project.clone(),
-                            session_id: session_id.clone(),
-                            turn_id,
-                            role: "tool_use".to_string(),
-                            text,
-                            tool_name,
-                            tool_input,
-                            tool_output: None,
-                            links: cursor_record_links(&task.path, &session_id, turn_id),
-                            source_path: source_path.clone(),
-                        };
-                        progress.add_produced(SourceKind::Cursor, 1);
-                        tx_record.send(record)?;
-                        turn_id += 1;
-                    } else if block_type == "tool_result" {
-                        let tool_output = block_obj.get("content").map(|v| v.to_string());
-                        let mut text = extract_text_from_tool_result(block).unwrap_or_default();
-                        if text.is_empty()
-                            && let Some(content) = block_obj.get("content")
-                        {
-                            text = content.to_string();
-                        }
-                        if text.is_empty() {
-                            continue;
-                        }
-                        let record = Record {
-                            source: SourceKind::Cursor,
-                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                            ts: timestamp,
-                            project: project.clone(),
-                            session_id: session_id.clone(),
-                            turn_id,
-                            role: "tool_result".to_string(),
-                            text,
-                            tool_name: None,
-                            tool_input: None,
-                            tool_output,
-                            links: cursor_record_links(&task.path, &session_id, turn_id),
-                            source_path: source_path.clone(),
-                        };
-                        progress.add_produced(SourceKind::Cursor, 1);
-                        tx_record.send(record)?;
-                        turn_id += 1;
-                    }
-                }
-            }
-        }
-
-        let text = text_parts.join("\n").trim().to_string();
-        if !text.is_empty() {
-            let record = Record {
-                source: SourceKind::Cursor,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
-                turn_id,
-                role: role.to_string(),
-                text,
-                tool_name: None,
-                tool_input: None,
-                tool_output: None,
-                links: cursor_record_links(&task.path, &session_id, turn_id),
-                source_path: source_path.clone(),
-            };
+    let parsed = crate::sources::cursor::parse_index_records(
+        &task.path,
+        task.mtime,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        next_doc_id,
+        |record| {
             progress.add_produced(SourceKind::Cursor, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-        }
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::Cursor, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::Cursor, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: source_path,
-        state,
-        session_id: Some(session_id),
-    })?;
-    Ok(())
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Cursor,
+        source_path,
+        parsed,
+    )
 }
-
 fn parse_pi_file(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -2094,434 +956,29 @@ fn parse_pi_file(
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = task.turn_id;
-
     let source_path = task.path.to_string_lossy().to_string();
-    let mut session_id = pi_session_id_from_path(&task.path);
-    let mut project = project_from_pi_session_path(&task.path);
-    let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
-
-    let mut buf = Vec::new();
-    if start > 0 && !mmap.is_empty() {
-        let rel = memchr(b'\n', &mmap).unwrap_or(mmap.len());
-        let line = &mmap[..rel];
-        if !line.is_empty() {
-            buf.extend_from_slice(line);
-            if let Ok(value) = simd_json::to_borrowed_value(&mut buf)
-                && let Some(obj) = value.as_object()
-                && obj.get("type").and_then(|v| v.as_str()) == Some("session")
-            {
-                apply_pi_session_header(obj, &mut session_id, &mut project);
-            }
-            buf.clear();
-        }
-    }
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::Pi, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        buf.clear();
-        buf.extend_from_slice(line);
-        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let obj = match value.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let timestamp = obj
-            .get("timestamp")
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_millis)
-            .unwrap_or(0);
-        let conversation_kind = match entry_type {
-            "branch_summary" => "branch",
-            "compaction" => "compaction",
-            _ => "main",
-        };
-        let mut base_links = pi_base_links(obj, conversation_kind);
-
-        if entry_type == "session" {
-            apply_pi_session_header(obj, &mut session_id, &mut project);
-            continue;
-        }
-
-        if entry_type == "compaction" || entry_type == "branch_summary" {
-            let summary = obj
-                .get("summary")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .trim();
-            if summary.is_empty() {
-                continue;
-            }
-            let record = Record {
-                source: SourceKind::Pi,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
-                turn_id,
-                role: "assistant".to_string(),
-                text: format!("{entry_type}: {summary}"),
-                tool_name: None,
-                tool_input: None,
-                tool_output: None,
-                links: base_links,
-                source_path: source_path.clone(),
-            };
+    let parsed = crate::sources::pi::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        next_doc_id,
+        |record| {
             progress.add_produced(SourceKind::Pi, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-            continue;
-        }
-
-        if entry_type == "custom_message" {
-            let text = pi_content_text(obj.get("content")).trim().to_string();
-            if text.is_empty() {
-                continue;
-            }
-            let custom_type = obj.get("customType").and_then(|v| v.as_str()).unwrap_or("");
-            let prefix = if custom_type.is_empty() {
-                "custom_message".to_string()
-            } else {
-                format!("custom_message({custom_type})")
-            };
-            let record = Record {
-                source: SourceKind::Pi,
-                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                ts: timestamp,
-                project: project.clone(),
-                session_id: session_id.clone(),
-                turn_id,
-                role: "assistant".to_string(),
-                text: format!("{prefix}: {text}"),
-                tool_name: None,
-                tool_input: None,
-                tool_output: None,
-                links: base_links,
-                source_path: source_path.clone(),
-            };
-            progress.add_produced(SourceKind::Pi, 1);
-            tx_record.send(record)?;
-            turn_id += 1;
-            continue;
-        }
-
-        if entry_type != "message" {
-            continue;
-        }
-        let message = match obj.get("message").and_then(|v| v.as_object()) {
-            Some(m) => m,
-            None => continue,
-        };
-        let timestamp = if timestamp == 0 {
-            message
-                .get("timestamp")
-                .and_then(|v| v.as_str())
-                .and_then(parse_iso_millis)
-                .unwrap_or(0)
-        } else {
-            timestamp
-        };
-        let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
-        if conversation_kind == "main" {
-            match role {
-                "branchSummary" => {
-                    base_links.thread_source = Some("branch".to_string());
-                    base_links.conversation_kind = Some("branch".to_string());
-                }
-                "compactionSummary" => {
-                    base_links.thread_source = Some("compaction".to_string());
-                    base_links.conversation_kind = Some("compaction".to_string());
-                }
-                _ => {}
-            }
-        }
-
-        match role {
-            "user" | "assistant" => {
-                let content = message.get("content");
-                if role == "assistant"
-                    && let Some(arr) = content.and_then(|v| v.as_array())
-                {
-                    for block in arr {
-                        let Some(block_obj) = block.as_object() else {
-                            continue;
-                        };
-                        if block_obj.get("type").and_then(|v| v.as_str()) != Some("toolCall") {
-                            continue;
-                        }
-                        let tool_name = block_obj
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        if let (Some(id), Some(name)) = (
-                            block_obj.get("id").and_then(|v| v.as_str()),
-                            tool_name.clone(),
-                        ) {
-                            tool_id_to_name.insert(id.to_string(), name);
-                        }
-                        let tool_input = block_obj.get("arguments").map(|v| v.to_string());
-                        let mut links = base_links.clone();
-                        if let Some(tool_call_id) = block_obj.get("id").and_then(|v| v.as_str()) {
-                            links.event_id = Some(tool_call_id.to_string());
-                            links.parent_event_id = base_links.event_id.clone();
-                        }
-                        let record = Record {
-                            source: SourceKind::Pi,
-                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                            ts: timestamp,
-                            project: project.clone(),
-                            session_id: session_id.clone(),
-                            turn_id,
-                            role: "tool_use".to_string(),
-                            text: tool_input.clone().unwrap_or_default(),
-                            tool_name,
-                            tool_input,
-                            tool_output: None,
-                            links,
-                            source_path: source_path.clone(),
-                        };
-                        progress.add_produced(SourceKind::Pi, 1);
-                        tx_record.send(record)?;
-                        turn_id += 1;
-                    }
-                }
-
-                let text = pi_content_text(content).trim().to_string();
-                if text.is_empty() {
-                    continue;
-                }
-                let record = Record {
-                    source: SourceKind::Pi,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: role.to_string(),
-                    text,
-                    tool_name: None,
-                    tool_input: None,
-                    tool_output: None,
-                    links: base_links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Pi, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "toolResult" => {
-                let tool_call_id = message
-                    .get("toolCallId")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let tool_name = message
-                    .get("toolName")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-                    .or_else(|| tool_id_to_name.get(tool_call_id).cloned());
-                let tool_output = Some(pi_content_text(message.get("content")));
-                let text = tool_output.clone().unwrap_or_default();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let mut links = base_links;
-                if !tool_call_id.is_empty() {
-                    links.parent_tool_use_id = Some(tool_call_id.to_string());
-                }
-                let record = Record {
-                    source: SourceKind::Pi,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "tool_result".to_string(),
-                    text,
-                    tool_name,
-                    tool_input: None,
-                    tool_output,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Pi, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "bashExecution" => {
-                if message
-                    .get("excludeFromContext")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false)
-                {
-                    continue;
-                }
-                let command = message
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let output = message
-                    .get("output")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let exit_code = message.get("exitCode").and_then(|v| v.as_i64());
-                let text = pi_bash_text(&command, &output, exit_code);
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let record = Record {
-                    source: SourceKind::Pi,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "tool_result".to_string(),
-                    text,
-                    tool_name: Some("Bash".to_string()),
-                    tool_input: if command.is_empty() {
-                        None
-                    } else {
-                        Some(command)
-                    },
-                    tool_output: if output.is_empty() {
-                        None
-                    } else {
-                        Some(output)
-                    },
-                    links: base_links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Pi, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "custom" | "branchSummary" | "compactionSummary" => {
-                let text = pi_summary_message_text(message, role);
-                if text.is_empty() {
-                    continue;
-                }
-                let record = Record {
-                    source: SourceKind::Pi,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "assistant".to_string(),
-                    text: format!("{role}: {text}"),
-                    tool_name: None,
-                    tool_input: None,
-                    tool_output: None,
-                    links: base_links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Pi, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            _ => {}
-        }
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::Pi, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::Pi, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: source_path,
-        state,
-        session_id: Some(session_id),
-    })?;
-    Ok(())
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Pi,
+        source_path,
+        parsed,
+    )
 }
-
-fn parse_iso_millis(input: &str) -> Option<u64> {
-    DateTime::parse_from_rfc3339(input)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc).timestamp_millis() as u64)
-}
-
-fn project_from_claude_path(path: &Path) -> String {
-    let Some(parent) = path
-        .parent()
-        .and_then(|p| p.file_name())
-        .and_then(|s| s.to_str())
-    else {
-        return "unknown".to_string();
-    };
-    decode_project_name(parent)
-}
-
-fn project_from_path(path: &str) -> String {
-    let p = Path::new(path);
-    if let Some(name) = p.file_name().and_then(|s| s.to_str()) {
-        return name.to_string();
-    }
-    "codex".to_string()
-}
-
-fn apply_pi_session_header(
-    obj: &simd_json::borrowed::Object,
-    session_id: &mut String,
-    project: &mut String,
-) {
-    apply_pi_session_identity(
-        obj.get("id").and_then(|v| v.as_str()),
-        obj.get("cwd").and_then(|v| v.as_str()),
-        session_id,
-        project,
-    );
-}
-
-pub(crate) fn apply_pi_session_identity(
-    id: Option<&str>,
-    cwd: Option<&str>,
-    session_id: &mut String,
-    project: &mut String,
-) {
-    if let Some(id) = id.filter(|id| !id.is_empty()) {
-        *session_id = id.to_string();
-    }
-    if let Some(cwd) = cwd.filter(|cwd| !cwd.is_empty()) {
-        *project = project_from_path(cwd);
-    }
-}
-
-#[derive(Debug, Default)]
-struct CopilotWorkspace {
-    cwd: Option<String>,
-    git_root: Option<String>,
-    repository: Option<String>,
-    branch: Option<String>,
-}
-
 fn parse_copilot_session(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -2529,790 +986,29 @@ fn parse_copilot_session(
     next_doc_id: &AtomicU64,
     progress: &Arc<Progress>,
 ) -> Result<()> {
-    let file = File::open(&task.path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    let mut start = task.offset as usize;
-    let mut turn_id = task.turn_id;
-
     let source_path = task.path.to_string_lossy().to_string();
-    let mut session_id =
-        session_id_from_copilot_path(&task.path).unwrap_or_else(|| "unknown".to_string());
-    let mut workspace = read_copilot_workspace(&task.path);
-    let mut project = copilot_project(&workspace);
-    let mut call_id_to_name: HashMap<String, String> = HashMap::new();
-
-    let mut parsed_bytes = 0u64;
-    while start < mmap.len() {
-        let slice = &mmap[start..];
-        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
-        let line = &slice[..rel];
-        let advanced = rel + 1;
-        start += advanced;
-        parsed_bytes += advanced as u64;
-        if parsed_bytes >= 64 * 1024 {
-            progress.add_parsed_bytes(SourceKind::Copilot, parsed_bytes);
-            parsed_bytes = 0;
-        }
-        if line.is_empty() {
-            continue;
-        }
-        let value: serde_json::Value = match serde_json::from_slice(line) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let Some(obj) = value.as_object() else {
-            continue;
-        };
-        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let data = obj
-            .get("data")
-            .or_else(|| obj.get("payload"))
-            .unwrap_or(&serde_json::Value::Null);
-        let timestamp = obj
-            .get("timestamp")
-            .and_then(json_timestamp_millis)
-            .or_else(|| data.get("timestamp").and_then(json_timestamp_millis))
-            .unwrap_or(0);
-
-        match entry_type {
-            "session.start" | "session.resume" => {
-                if let Some(id) = data
-                    .get("sessionId")
-                    .or_else(|| data.get("session_id"))
-                    .and_then(|v| v.as_str())
-                {
-                    session_id = id.to_string();
-                }
-                merge_copilot_workspace(&mut workspace, data.get("context").unwrap_or(data));
-                project = copilot_project(&workspace);
-            }
-            "session.context_changed" => {
-                merge_copilot_workspace(&mut workspace, data);
-                project = copilot_project(&workspace);
-            }
-            "user.message" => {
-                let text = data
-                    .get("content")
-                    .or_else(|| data.get("message"))
-                    .or_else(|| data.get("prompt"))
-                    .and_then(text_from_json)
-                    .unwrap_or_default();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let links = copilot_record_links(obj, data, &session_id, turn_id);
-                let record = Record {
-                    source: SourceKind::Copilot,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "user".to_string(),
-                    text,
-                    tool_name: None,
-                    tool_input: None,
-                    tool_output: None,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Copilot, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "assistant.message" => {
-                let text = data
-                    .get("content")
-                    .and_then(text_from_json)
-                    .unwrap_or_default();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let links = copilot_record_links(obj, data, &session_id, turn_id);
-                let record = Record {
-                    source: SourceKind::Copilot,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "assistant".to_string(),
-                    text,
-                    tool_name: None,
-                    tool_input: None,
-                    tool_output: None,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Copilot, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "tool.execution_start" | "tool.user_requested" => {
-                let tool_name = data
-                    .get("toolName")
-                    .or_else(|| data.get("name"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                if let Some(call_id) = data.get("toolCallId").and_then(|v| v.as_str())
-                    && let Some(name) = tool_name.clone()
-                {
-                    call_id_to_name.insert(call_id.to_string(), name);
-                }
-                let tool_input = data
-                    .get("arguments")
-                    .map(json_to_text)
-                    .filter(|s| !s.is_empty());
-                let text = tool_input.clone().unwrap_or_default();
-                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
-                if let Some(call_id) = data.get("toolCallId").and_then(|v| v.as_str()) {
-                    links.event_id = Some(call_id.to_string());
-                }
-                let record = Record {
-                    source: SourceKind::Copilot,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "tool_use".to_string(),
-                    text,
-                    tool_name,
-                    tool_input,
-                    tool_output: None,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Copilot, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "tool.execution_complete" => {
-                let call_id = data
-                    .get("toolCallId")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let tool_name = data
-                    .get("toolName")
-                    .or_else(|| data.get("name"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-                    .or_else(|| call_id_to_name.get(call_id).cloned());
-                let tool_output = copilot_tool_output(data);
-                let text = tool_output.clone().unwrap_or_default();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
-                if !call_id.is_empty() {
-                    links.parent_event_id = Some(call_id.to_string());
-                    links.parent_tool_use_id = Some(call_id.to_string());
-                }
-                let record = Record {
-                    source: SourceKind::Copilot,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "tool_result".to_string(),
-                    text,
-                    tool_name,
-                    tool_input: None,
-                    tool_output,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Copilot, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            "session.task_complete" => {
-                let text = data
-                    .get("summary")
-                    .and_then(text_from_json)
-                    .unwrap_or_default();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                let links = copilot_record_links(obj, data, &session_id, turn_id);
-                let record = Record {
-                    source: SourceKind::Copilot,
-                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
-                    ts: timestamp,
-                    project: project.clone(),
-                    session_id: session_id.clone(),
-                    turn_id,
-                    role: "assistant".to_string(),
-                    text,
-                    tool_name: None,
-                    tool_input: None,
-                    tool_output: None,
-                    links,
-                    source_path: source_path.clone(),
-                };
-                progress.add_produced(SourceKind::Copilot, 1);
-                tx_record.send(record)?;
-                turn_id += 1;
-            }
-            _ => {}
-        }
-    }
-
-    if parsed_bytes > 0 {
-        progress.add_parsed_bytes(SourceKind::Copilot, parsed_bytes);
-    }
-    progress.add_files_done(SourceKind::Copilot, 1);
-    let state = FileState {
-        size: task.size,
-        mtime: task.mtime,
-        offset: mmap.len() as u64,
-        turn_id,
-    };
-    tx_update.send(FileUpdate {
-        path: source_path,
-        state,
-        session_id: Some(session_id),
-    })?;
-    Ok(())
+    let parsed = crate::sources::copilot::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Copilot, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Copilot,
+        source_path,
+        parsed,
+    )
 }
-
-fn read_copilot_workspace(events_path: &Path) -> CopilotWorkspace {
-    let Some(dir) = events_path.parent() else {
-        return CopilotWorkspace::default();
-    };
-    let path = dir.join("workspace.yaml");
-    let Ok(contents) = std::fs::read_to_string(path) else {
-        return CopilotWorkspace::default();
-    };
-    parse_copilot_workspace_yaml(&contents)
-}
-
-fn parse_copilot_workspace_yaml(contents: &str) -> CopilotWorkspace {
-    let mut workspace = CopilotWorkspace::default();
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with('#')
-            || line.chars().next().is_some_and(|c| c.is_whitespace())
-        {
-            continue;
-        }
-        let Some((key, value)) = trimmed.split_once(':') else {
-            continue;
-        };
-        let value = value
-            .trim()
-            .trim_matches('"')
-            .trim_matches('\'')
-            .to_string();
-        if value.is_empty() {
-            continue;
-        }
-        match key.trim() {
-            "cwd" => workspace.cwd = Some(value),
-            "gitRoot" | "git_root" => workspace.git_root = Some(value),
-            "repository" => workspace.repository = Some(value),
-            "branch" => workspace.branch = Some(value),
-            _ => {}
-        }
-    }
-    workspace
-}
-
-fn merge_copilot_workspace(workspace: &mut CopilotWorkspace, value: &serde_json::Value) {
-    if let Some(cwd) = value.get("cwd").and_then(|v| v.as_str()) {
-        workspace.cwd = Some(cwd.to_string());
-    }
-    if let Some(git_root) = value
-        .get("gitRoot")
-        .or_else(|| value.get("git_root"))
-        .and_then(|v| v.as_str())
-    {
-        workspace.git_root = Some(git_root.to_string());
-    }
-    if let Some(repository) = value.get("repository").and_then(|v| v.as_str()) {
-        workspace.repository = Some(repository.to_string());
-    }
-    if let Some(branch) = value.get("branch").and_then(|v| v.as_str()) {
-        workspace.branch = Some(branch.to_string());
-    }
-}
-
-fn copilot_project(workspace: &CopilotWorkspace) -> String {
-    if let Some(repo) = workspace.repository.as_deref() {
-        if let Some((_, name)) = repo.rsplit_once('/')
-            && !name.is_empty()
-        {
-            return name.to_string();
-        }
-        if !repo.is_empty() {
-            return repo.to_string();
-        }
-    }
-    if let Some(git_root) = workspace.git_root.as_deref() {
-        return project_from_path(git_root);
-    }
-    if let Some(cwd) = workspace.cwd.as_deref() {
-        return project_from_path(cwd);
-    }
-    "copilot".to_string()
-}
-
-fn session_id_from_copilot_path(path: &Path) -> Option<String> {
-    path.parent()
-        .and_then(|p| p.file_name())
-        .and_then(|s| s.to_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-}
-
-fn copilot_record_links(
-    obj: &serde_json::Map<String, serde_json::Value>,
-    data: &serde_json::Value,
-    session_id: &str,
-    turn_id: u32,
-) -> RecordLinks {
-    let parent_session_id = copilot_string_field(data, obj, COPILOT_PARENT_SESSION_KEYS);
-    let explicit_thread_source =
-        copilot_string_field(data, obj, &["threadSource", "thread_source", "source"]);
-    let thread_source = explicit_thread_source.or_else(|| {
-        parent_session_id
-            .as_ref()
-            .filter(|parent| parent.as_str() != session_id)
-            .map(|_| "fork".to_string())
-    });
-    let conversation_kind = match thread_source.as_deref() {
-        Some("subagent") => "subagent",
-        Some("sidechain") => "sidechain",
-        Some("branch") => "branch",
-        Some("fork") => "fork",
-        _ => "main",
-    };
-
-    RecordLinks {
-        event_id: copilot_string_field(data, obj, COPILOT_EVENT_KEYS)
-            .or_else(|| Some(format!("{session_id}:{turn_id}"))),
-        parent_event_id: copilot_string_field(data, obj, COPILOT_PARENT_EVENT_KEYS),
-        logical_parent_event_id: copilot_string_field(data, obj, COPILOT_LOGICAL_PARENT_KEYS),
-        parent_session_id,
-        thread_source,
-        conversation_kind: Some(conversation_kind.to_string()),
-        ..RecordLinks::default()
-    }
-}
-
-const COPILOT_EVENT_KEYS: &[&str] = &[
-    "id",
-    "eventId",
-    "event_id",
-    "messageId",
-    "message_id",
-    "requestId",
-    "request_id",
-    "responseId",
-    "response_id",
-];
-const COPILOT_PARENT_EVENT_KEYS: &[&str] = &[
-    "parentId",
-    "parent_id",
-    "parentMessageId",
-    "parent_message_id",
-    "parentEventId",
-    "parent_event_id",
-];
-const COPILOT_LOGICAL_PARENT_KEYS: &[&str] = &["fromId", "from_id", "rootId", "root_id"];
-const COPILOT_PARENT_SESSION_KEYS: &[&str] = &[
-    "parentSessionId",
-    "parent_session_id",
-    "forkedFromSessionId",
-    "forked_from_session_id",
-];
-
-fn copilot_string_field(
-    data: &serde_json::Value,
-    obj: &serde_json::Map<String, serde_json::Value>,
-    keys: &[&str],
-) -> Option<String> {
-    for key in keys {
-        if let Some(value) = data
-            .get(*key)
-            .or_else(|| obj.get(*key))
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-        {
-            return Some(value.to_string());
-        }
-    }
-    None
-}
-
-fn json_timestamp_millis(value: &serde_json::Value) -> Option<u64> {
-    if let Some(text) = value.as_str() {
-        if let Some(ts) = parse_iso_millis(text) {
-            return Some(ts);
-        }
-        return text.parse::<u64>().ok();
-    }
-    if let Some(n) = value.as_u64() {
-        return Some(if n < 10_000_000_000 { n * 1000 } else { n });
-    }
-    None
-}
-
-fn text_from_json(value: &serde_json::Value) -> Option<String> {
-    if let Some(text) = value.as_str() {
-        return Some(text.trim().to_string());
-    }
-    if let Some(arr) = value.as_array() {
-        let mut parts = Vec::new();
-        for item in arr {
-            if let Some(text) = item.as_str() {
-                parts.push(text);
-                continue;
-            }
-            if let Some(obj) = item.as_object()
-                && let Some(text) = obj
-                    .get("text")
-                    .or_else(|| obj.get("content"))
-                    .and_then(|v| v.as_str())
-            {
-                parts.push(text);
-            }
-        }
-        if !parts.is_empty() {
-            return Some(parts.join("\n").trim().to_string());
-        }
-    }
-    None
-}
-
-fn json_to_text(value: &serde_json::Value) -> String {
-    if let Some(text) = text_from_json(value) {
-        return text;
-    }
-    serde_json::to_string(value).unwrap_or_default()
-}
-
-fn copilot_tool_output(data: &serde_json::Value) -> Option<String> {
-    if let Some(result) = data.get("result") {
-        for key in ["detailedContent", "content"] {
-            if let Some(text) = result.get(key).and_then(text_from_json)
-                && !text.trim().is_empty()
-            {
-                return Some(text);
-            }
-        }
-        if let Some(contents) = result.get("contents").and_then(|v| v.as_array()) {
-            let mut parts = Vec::new();
-            for item in contents {
-                if let Some(text) = text_from_json(item) {
-                    parts.push(text);
-                }
-            }
-            if !parts.is_empty() {
-                return Some(parts.join("\n"));
-            }
-        }
-    }
-    if let Some(error) = data.get("error") {
-        if let Some(message) = error.get("message").and_then(|v| v.as_str()) {
-            return Some(message.to_string());
-        }
-        return Some(json_to_text(error));
-    }
-    None
-}
-
-pub(crate) fn project_from_cursor_path(path: &Path) -> String {
-    let root = cursor_projects_root();
-    let Ok(relative) = path.strip_prefix(root) else {
-        return "cursor".to_string();
-    };
-    let Some(project_folder) = relative
-        .components()
-        .next()
-        .and_then(|c| c.as_os_str().to_str())
-    else {
-        return "cursor".to_string();
-    };
-    if project_folder == "empty-window" {
-        return project_folder.to_string();
-    }
-    decode_project_name(project_folder)
-}
-
-pub(crate) fn cursor_session_id_from_path(path: &Path) -> String {
-    let components: Vec<_> = path.components().collect();
-    for (idx, component) in components.iter().enumerate() {
-        if component.as_os_str().to_str() == Some("agent-transcripts")
-            && let Some(session_id) = components
-                .get(idx + 1)
-                .and_then(|c| Path::new(c.as_os_str()).file_stem())
-                .and_then(|s| s.to_str())
-                .filter(|s| !s.is_empty())
-        {
-            return session_id.to_string();
-        }
-    }
-
-    session_id_from_filename(path).unwrap_or_else(|| {
-        path.file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown")
-            .to_string()
-    })
-}
-
-fn cursor_initial_turn_id(path: &Path, cached_turn_id: u32) -> u32 {
-    if cached_turn_id != 0 {
-        return cached_turn_id;
-    }
-    cursor_subagent_turn_base(path).unwrap_or(cached_turn_id)
-}
-
-fn cursor_subagent_turn_base(path: &Path) -> Option<u32> {
-    if !path
-        .components()
-        .any(|component| component.as_os_str().to_str() == Some("subagents"))
-    {
-        return None;
-    }
-
-    let agent_id = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .filter(|s| !s.is_empty())?;
-    let bucket = stable_cursor_turn_bucket(agent_id);
-    Some(CURSOR_SUBAGENT_TURN_BASE + bucket.saturating_mul(CURSOR_SUBAGENT_TURN_STRIDE))
-}
-
-fn cursor_is_subagent_transcript(path: &Path) -> bool {
-    path.components()
-        .any(|component| component.as_os_str().to_str() == Some("subagents"))
-}
-
-pub(crate) fn cursor_transcript_id(path: &Path) -> String {
-    path.file_stem()
-        .and_then(|s| s.to_str())
-        .filter(|s| !s.is_empty())
-        .unwrap_or("unknown")
-        .to_string()
-}
-
-fn cursor_record_links(path: &Path, session_id: &str, turn_id: u32) -> RecordLinks {
-    let is_subagent = cursor_is_subagent_transcript(path);
-    RecordLinks {
-        event_id: Some(format!("{}:{turn_id}", cursor_transcript_id(path))),
-        parent_session_id: is_subagent.then(|| session_id.to_string()),
-        thread_source: is_subagent.then(|| "subagent".to_string()),
-        conversation_kind: Some(if is_subagent { "subagent" } else { "main" }.to_string()),
-        ..RecordLinks::default()
-    }
-}
-
-fn stable_cursor_turn_bucket(value: &str) -> u32 {
-    let mut hash = 2_166_136_261u32;
-    for byte in value.as_bytes() {
-        hash ^= *byte as u32;
-        hash = hash.wrapping_mul(16_777_619);
-    }
-    hash % CURSOR_SUBAGENT_TURN_BUCKETS
-}
-
-pub(crate) fn project_from_pi_session_path(path: &Path) -> String {
-    path.parent()
-        .and_then(|p| p.file_name())
-        .and_then(|s| s.to_str())
-        .map(|name| decode_pi_project_name(pi_session_dir_project_key(name)))
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| "pi".to_string())
-}
-
-fn pi_session_dir_project_key(name: &str) -> &str {
-    if name.starts_with("--") && name.ends_with("--") && name.len() > 4 {
-        &name[1..name.len() - 1]
-    } else {
-        name
-    }
-}
-
-fn pi_content_text(content: Option<&BorrowedValue>) -> String {
-    let Some(content) = content else {
-        return String::new();
-    };
-    if let Some(text) = content.as_str() {
-        return text.to_string();
-    }
-    if let Some(arr) = content.as_array() {
-        let mut parts = Vec::new();
-        for item in arr {
-            if let Some(text) = item.as_str() {
-                parts.push(text.to_string());
-                continue;
-            }
-            let Some(obj) = item.as_object() else {
-                continue;
-            };
-            match obj.get("type").and_then(|v| v.as_str()).unwrap_or("") {
-                "text" => {
-                    if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
-                        parts.push(text.to_string());
-                    }
-                }
-                "thinking" => {
-                    if let Some(text) = obj.get("thinking").and_then(|v| v.as_str()) {
-                        parts.push(format!("Thinking:\n{text}"));
-                    }
-                }
-                "toolCall" => {}
-                _ => {
-                    if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
-                        parts.push(text.to_string());
-                    } else if let Some(text) = obj.get("content").and_then(|v| v.as_str()) {
-                        parts.push(text.to_string());
-                    }
-                }
-            }
-        }
-        return parts.join("\n");
-    }
-    content.to_string()
-}
-
-fn pi_summary_message_text(message: &simd_json::borrowed::Object, role: &str) -> String {
-    let summary = if role == "branchSummary" || role == "compactionSummary" {
-        message.get("summary").and_then(|v| v.as_str())
-    } else {
-        None
-    };
-    summary
-        .map(str::to_string)
-        .unwrap_or_else(|| pi_content_text(message.get("content")))
-        .trim()
-        .to_string()
-}
-
-fn pi_bash_text(command: &str, output: &str, exit_code: Option<i64>) -> String {
-    let mut parts = Vec::new();
-    if !command.is_empty() {
-        parts.push(format!("$ {command}"));
-    }
-    if !output.is_empty() {
-        parts.push(output.to_string());
-    }
-    if let Some(code) = exit_code {
-        parts.push(format!("exit code: {code}"));
-    }
-    parts.join("\n")
-}
-
-fn decode_pi_project_name(folder_name: &str) -> String {
-    let decoded = decode_project_name(folder_name);
-    decoded
-        .rsplit('-')
-        .find(|part| !part.is_empty())
-        .unwrap_or(&decoded)
-        .to_string()
-}
-
-fn decode_project_name(folder_name: &str) -> String {
-    let prefixes_to_strip = ["-home-", "-mnt-c-Users-", "-mnt-c-users-", "-Users-"];
-    let mut name = folder_name;
-    if name.len() > 10 {
-        let bytes = name.as_bytes();
-        if bytes[0] == b'-'
-            && bytes[2] == b'-'
-            && bytes[3] == b'-'
-            && bytes[1].is_ascii_alphabetic()
-            && name[4..].to_lowercase().starts_with("users-")
-        {
-            name = &name[10..];
-        }
-    }
-    for prefix in prefixes_to_strip {
-        if name.to_lowercase().starts_with(&prefix.to_lowercase()) {
-            name = &name[prefix.len()..];
-            break;
-        }
-    }
-    let parts: Vec<&str> = name.split('-').filter(|p| !p.is_empty()).collect();
-    let skip_dirs = [
-        "projects",
-        "code",
-        "repos",
-        "src",
-        "dev",
-        "work",
-        "documents",
-    ];
-    let mut meaningful = Vec::new();
-    let mut found_project = false;
-
-    for (i, part) in parts.iter().enumerate() {
-        if i == 0 && !found_project {
-            let remaining: Vec<String> = parts[i + 1..].iter().map(|p| p.to_lowercase()).collect();
-            if remaining.iter().any(|d| skip_dirs.contains(&d.as_str())) {
-                continue;
-            }
-        }
-        if skip_dirs.contains(&part.to_lowercase().as_str()) {
-            found_project = true;
-            continue;
-        }
-        meaningful.push(*part);
-        found_project = true;
-    }
-    if meaningful.is_empty() {
-        return folder_name.to_string();
-    }
-    meaningful.join("-")
-}
-
-fn extract_text_from_tool_result(block: &simd_json::BorrowedValue) -> Option<String> {
-    let obj = block.as_object()?;
-    let content = obj.get("content")?;
-    if let Some(text) = content.as_str() {
-        return Some(text.to_string());
-    }
-    if let Some(arr) = content.as_array() {
-        let mut parts = Vec::new();
-        for item in arr {
-            if let Some(obj) = item.as_object()
-                && obj.get("type").and_then(|v| v.as_str()) == Some("text")
-                && let Some(text) = obj.get("text").and_then(|v| v.as_str())
-            {
-                parts.push(text);
-            }
-        }
-        if !parts.is_empty() {
-            return Some(parts.join(" "));
-        }
-    }
-    None
-}
-
-fn session_id_from_filename(path: &Path) -> Option<String> {
-    static UUID_RE: once_cell::sync::Lazy<regex::Regex> = once_cell::sync::Lazy::new(|| {
-        regex::Regex::new(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
-            .expect("uuid regex")
-    });
-    let name = path.file_stem()?.to_string_lossy();
-    UUID_RE
-        .captures(&name)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
-}
-
-pub(crate) fn pi_session_id_from_path(path: &Path) -> String {
-    session_id_from_filename(path).unwrap_or_else(|| path.to_string_lossy().into_owned())
-}
-
-fn is_system_instruction(text: &str) -> bool {
-    let t = text.trim_start();
-    t.starts_with("<system_instruction>") || t.starts_with("<system-instruction>")
-}
-
 fn flush_embeddings(
     buffer: &mut Vec<(u64, String, SourceKind)>,
     embedder: &mut EmbedderHandle,
@@ -3506,6 +1202,53 @@ mod tests {
             .expect("mark analytics complete");
     }
 
+    fn incremental_task(
+        path: &Path,
+        source: SourceKind,
+        offset: u64,
+        turn_id: u32,
+        pending_tool_calls: HashMap<String, PendingToolCall>,
+    ) -> FileTask {
+        let metadata = path.metadata().expect("transcript metadata");
+        FileTask {
+            path: path.to_path_buf(),
+            source,
+            offset,
+            turn_id,
+            size: metadata.len(),
+            mtime: metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0),
+            delete_first: false,
+            pending_tool_calls,
+            identity: file_identity(
+                path,
+                &metadata,
+                metadata.len().min(FILE_IDENTITY_PREFIX_BYTES as u64) as usize,
+            ),
+            parser_version: crate::sources::index_state_version(source),
+        }
+    }
+
+    fn parser_channels() -> (
+        RecordSender,
+        Receiver<Record>,
+        Sender<FileUpdate>,
+        Receiver<FileUpdate>,
+    ) {
+        let (raw_tx_record, rx_record) = unbounded();
+        let (tx_update, rx_update) = unbounded();
+        (
+            RecordSender::new(raw_tx_record, IndexedToolContentLimits::default()),
+            rx_record,
+            tx_update,
+            rx_update,
+        )
+    }
+
     fn record(doc_id: u64, role: &str, text: &str) -> Record {
         Record {
             source: SourceKind::Claude,
@@ -3639,7 +1382,7 @@ mod tests {
         );
 
         assert_eq!(
-            cursor_session_id_from_path(path),
+            crate::sources::cursor::session_id_from_path(path),
             "11111111-1111-1111-1111-111111111111"
         );
     }
@@ -3652,7 +1395,7 @@ mod tests {
         );
 
         assert_eq!(
-            cursor_session_id_from_path(path),
+            crate::sources::cursor::session_id_from_path(path),
             "11111111-1111-1111-1111-111111111111"
         );
     }
@@ -3666,7 +1409,7 @@ mod tests {
         );
 
         assert_eq!(
-            cursor_session_id_from_path(path),
+            crate::sources::cursor::session_id_from_path(path),
             "11111111-1111-1111-1111-111111111111"
         );
     }
@@ -3679,8 +1422,8 @@ mod tests {
              11111111-1111-1111-1111-111111111111.jsonl",
         );
 
-        assert_eq!(cursor_initial_turn_id(path, 0), 0);
-        assert_eq!(cursor_initial_turn_id(path, 42), 42);
+        assert_eq!(crate::sources::cursor::initial_turn_id(path, 0), 0);
+        assert_eq!(crate::sources::cursor::initial_turn_id(path, 42), 42);
     }
 
     #[test]
@@ -3691,9 +1434,12 @@ mod tests {
              22222222-2222-2222-2222-222222222222.jsonl",
         );
 
-        let initial = cursor_initial_turn_id(path, 0);
-        assert!(initial >= CURSOR_SUBAGENT_TURN_BASE);
-        assert_eq!(cursor_initial_turn_id(path, initial + 3), initial + 3);
+        let initial = crate::sources::cursor::initial_turn_id(path, 0);
+        assert!(initial >= 1_000_000_000);
+        assert_eq!(
+            crate::sources::cursor::initial_turn_id(path, initial + 3),
+            initial + 3
+        );
     }
 
     #[test]
@@ -3704,7 +1450,8 @@ mod tests {
              22222222-2222-2222-2222-222222222222.jsonl",
         );
 
-        let links = cursor_record_links(path, "11111111-1111-1111-1111-111111111111", 42);
+        let links =
+            crate::sources::cursor::record_links(path, "11111111-1111-1111-1111-111111111111", 42);
 
         assert_eq!(
             links.event_id.as_deref(),
@@ -3729,7 +1476,9 @@ mod tests {
         )
         .expect("write opencode session");
 
-        let links = opencode_session_links_from_root(tmp.path(), "ses_child");
+        let links = crate::sources::opencode::session_links_by_id_from_root(tmp.path())
+            .remove("ses_child")
+            .expect("child links");
 
         assert_eq!(links.parent_session_id.as_deref(), Some("ses_parent"));
         assert_eq!(links.thread_source.as_deref(), Some("fork"));
@@ -3752,7 +1501,7 @@ mod tests {
         )
         .expect("write main session");
 
-        let links_by_id = opencode_session_links_by_id_from_root(tmp.path());
+        let links_by_id = crate::sources::opencode::session_links_by_id_from_root(tmp.path());
         let child_links = links_by_id.get("ses_child").expect("child links");
         let main_links = links_by_id.get("ses_main").expect("main links");
 
@@ -3779,17 +1528,301 @@ mod tests {
         )
         .expect("write codex session");
 
-        let meta = read_codex_session_meta_until(&path, fs::metadata(&path).unwrap().len())
-            .expect("read codex meta");
+        let meta = crate::sources::codex::probe(&path).expect("read codex meta");
 
-        assert_eq!(meta.session_id, "019e5155-b507-7d83-8c3d-9ecee5f93f12");
-        assert_eq!(meta.project, "project");
         assert_eq!(
-            meta.links.parent_session_id.as_deref(),
+            meta.session.session_id,
+            "019e5155-b507-7d83-8c3d-9ecee5f93f12"
+        );
+        assert_eq!(meta.project.as_deref(), Some("project"));
+        assert_eq!(
+            meta.session.parent_session_id.as_deref(),
             Some("019e5117-c673-7660-b218-af0489416e0f")
         );
-        assert_eq!(meta.links.thread_source.as_deref(), Some("subagent"));
-        assert_eq!(meta.links.conversation_kind.as_deref(), Some("subagent"));
+        assert_eq!(
+            meta.session.conversation_kind,
+            crate::sources::ConversationKind::Subagent
+        );
+    }
+
+    #[test]
+    fn claude_incremental_results_use_persisted_calls_out_of_order() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("-Users-nico-Code-memex");
+        fs::create_dir_all(&project).expect("project dir");
+        let path = project.join("claude-incremental.jsonl");
+        let calls = concat!(
+            "{\"type\":\"assistant\",\"uuid\":\"assistant-1\",\"sessionId\":\"claude-incremental\",\"timestamp\":\"2026-07-20T10:00:00Z\",\"message\":{\"content\":[",
+            "{\"type\":\"tool_use\",\"id\":\"call-a\",\"name\":\"Read\",\"input\":{\"path\":\"a\"}},",
+            "{\"type\":\"tool_use\",\"id\":\"call-b\",\"name\":\"Grep\",\"input\":{\"pattern\":\"b\"}}]}}\n"
+        );
+        let results = concat!(
+            "{\"type\":\"user\",\"uuid\":\"result-b\",\"parentUuid\":\"assistant-1\",\"sessionId\":\"claude-incremental\",\"timestamp\":\"2026-07-20T10:00:01Z\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"call-b\",\"content\":\"B\"}]}}\n",
+            "{\"type\":\"user\",\"uuid\":\"result-a\",\"parentUuid\":\"result-b\",\"sessionId\":\"claude-incremental\",\"timestamp\":\"2026-07-20T10:00:02Z\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"call-a\",\"content\":\"A\"}]}}\n"
+        );
+        fs::write(&path, calls).expect("write calls");
+
+        let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
+        let next_doc_id = AtomicU64::new(1);
+        let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
+        let first = incremental_task(&path, SourceKind::Claude, 0, 0, HashMap::new());
+        parse_claude_file(&first, &tx_record, &tx_update, &next_doc_id, &progress)
+            .expect("parse calls");
+        let first_records: Vec<_> = rx_record.try_iter().collect();
+        let first_state = rx_update.try_recv().expect("first state").state;
+        assert_eq!(first_records.len(), 2);
+        assert_eq!(first_state.pending_tool_calls.len(), 2);
+        let pending_a = first_state
+            .pending_tool_calls
+            .get("call-a")
+            .expect("pending call a");
+        assert_eq!(pending_a.tool_name.as_deref(), Some("Read"));
+        assert_eq!(pending_a.tool_use_event_id.as_deref(), Some("call-a"));
+        assert_eq!(pending_a.tool_use_doc_id, Some(first_records[0].doc_id));
+        assert!(pending_a.argument_sha256.is_some());
+        assert!(pending_a.argument_bytes.is_some_and(|bytes| bytes > 0));
+
+        use std::io::Write;
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(results.as_bytes())
+            .expect("append results");
+        let second = incremental_task(
+            &path,
+            SourceKind::Claude,
+            first_state.offset,
+            first_state.turn_id,
+            first_state.pending_tool_calls,
+        );
+        parse_claude_file(&second, &tx_record, &tx_update, &next_doc_id, &progress)
+            .expect("parse results");
+        let second_records: Vec<_> = rx_record.try_iter().collect();
+        let second_state = rx_update.try_recv().expect("second state").state;
+
+        assert_eq!(second_records.len(), 2);
+        assert_eq!(second_records[0].tool_name.as_deref(), Some("Grep"));
+        assert_eq!(
+            second_records[0].links.parent_tool_use_id.as_deref(),
+            Some("call-b")
+        );
+        assert_eq!(second_records[1].tool_name.as_deref(), Some("Read"));
+        assert_eq!(
+            second_records[1].links.parent_event_id.as_deref(),
+            Some("call-a")
+        );
+        assert!(
+            second_records
+                .iter()
+                .all(|record| record.session_id == "claude-incremental"
+                    && record.source == SourceKind::Claude
+                    && record.source_path == path.to_string_lossy())
+        );
+        assert!(second_state.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn codex_incremental_result_uses_persisted_call_metadata() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp
+            .path()
+            .join("rollout-2026-07-20T10-00-00-11111111-1111-4111-8111-111111111111.jsonl");
+        let call = concat!(
+            "{\"timestamp\":\"2026-07-20T10:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"11111111-1111-4111-8111-111111111111\",\"cwd\":\"/Users/nico/Code/memex\"}}\n",
+            "{\"timestamp\":\"2026-07-20T10:00:01Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"id\":\"fc-item\",\"call_id\":\"call-1\",\"name\":\"shell\",\"arguments\":\"{\\\"cmd\\\":\\\"pwd\\\"}\"}}\n"
+        );
+        let result = "{\"timestamp\":\"2026-07-20T10:00:02Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"function_call_output\",\"call_id\":\"call-1\",\"output\":\"/Users/nico/Code/memex\"}}\n";
+        fs::write(&path, call).expect("write call");
+
+        let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
+        let next_doc_id = AtomicU64::new(10);
+        let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
+        let first = incremental_task(&path, SourceKind::CodexSession, 0, 0, HashMap::new());
+        parse_codex_session(&first, &tx_record, &tx_update, &next_doc_id, &progress)
+            .expect("parse call");
+        let call_record = rx_record.try_recv().expect("call record");
+        let first_state = rx_update.try_recv().expect("first state").state;
+        assert_eq!(call_record.tool_name.as_deref(), Some("shell"));
+        assert_eq!(
+            first_state
+                .pending_tool_calls
+                .get("call-1")
+                .and_then(|call| call.tool_use_doc_id),
+            Some(call_record.doc_id)
+        );
+
+        use std::io::Write;
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(result.as_bytes())
+            .expect("append result");
+        let second = incremental_task(
+            &path,
+            SourceKind::CodexSession,
+            first_state.offset,
+            first_state.turn_id,
+            first_state.pending_tool_calls,
+        );
+        parse_codex_session(&second, &tx_record, &tx_update, &next_doc_id, &progress)
+            .expect("parse result");
+        let result_record = rx_record.try_recv().expect("result record");
+        let second_state = rx_update.try_recv().expect("second state").state;
+
+        assert_eq!(result_record.tool_name.as_deref(), Some("shell"));
+        assert_eq!(
+            result_record.links.parent_tool_use_id.as_deref(),
+            Some("call-1")
+        );
+        assert_eq!(
+            result_record.links.parent_event_id.as_deref(),
+            Some("call-1")
+        );
+        assert_eq!(
+            result_record.session_id,
+            "11111111-1111-4111-8111-111111111111"
+        );
+        assert_eq!(result_record.project, "memex");
+        assert_eq!(result_record.source, SourceKind::CodexSession);
+        assert_eq!(result_record.source_path, path.to_string_lossy());
+        assert!(second_state.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn truncation_and_replacement_clear_stale_pending_calls() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("session.jsonl");
+        fs::write(&path, "original transcript with a pending call\n").expect("write original");
+        let metadata = path.metadata().expect("original metadata");
+        let (mut original, _) =
+            prepare_file_task(path.clone(), SourceKind::Claude, &metadata, None);
+        original.pending_tool_calls.insert(
+            "stale".to_string(),
+            PendingToolCall {
+                tool_name: Some("StaleTool".to_string()),
+                ..PendingToolCall::default()
+            },
+        );
+        let prior = completed_file_state(
+            &original,
+            metadata.len(),
+            1,
+            original.pending_tool_calls.clone(),
+        );
+
+        fs::write(&path, "short\n").expect("truncate");
+        let truncated_meta = path.metadata().expect("truncated metadata");
+        let (truncated, skip) = prepare_file_task(
+            path.clone(),
+            SourceKind::Claude,
+            &truncated_meta,
+            Some(&prior),
+        );
+        assert!(!skip);
+        assert!(truncated.delete_first);
+        assert_eq!(truncated.offset, 0);
+        assert!(truncated.pending_tool_calls.is_empty());
+
+        let replacement = tmp.path().join("replacement.jsonl");
+        fs::write(
+            &replacement,
+            "replacement transcript that is longer than the original\n",
+        )
+        .expect("write replacement");
+        fs::rename(&replacement, &path).expect("replace path");
+        let replacement_meta = path.metadata().expect("replacement metadata");
+        let (replaced, skip) =
+            prepare_file_task(path, SourceKind::Claude, &replacement_meta, Some(&prior));
+        assert!(!skip);
+        assert!(replaced.delete_first);
+        assert_eq!(replaced.offset, 0);
+        assert!(replaced.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn short_file_append_preserves_pending_calls_and_offset() {
+        use std::io::Write;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        fs::write(&path, "tool call\n").expect("write call");
+        let metadata = path.metadata().expect("call metadata");
+        let (mut first, _) = prepare_file_task(path.clone(), SourceKind::Claude, &metadata, None);
+        first.pending_tool_calls.insert(
+            "call-1".to_string(),
+            PendingToolCall {
+                tool_name: Some("Read".to_string()),
+                ..PendingToolCall::default()
+            },
+        );
+        let previous =
+            completed_file_state(&first, metadata.len(), 1, first.pending_tool_calls.clone());
+
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(b"tool result\n")
+            .expect("append result");
+        let appended_metadata = path.metadata().expect("appended metadata");
+        let (appended, skip) = prepare_file_task(
+            path,
+            SourceKind::Claude,
+            &appended_metadata,
+            Some(&previous),
+        );
+
+        assert!(!skip);
+        assert!(!appended.delete_first);
+        assert_eq!(appended.offset, metadata.len());
+        assert_eq!(
+            appended
+                .pending_tool_calls
+                .get("call-1")
+                .and_then(|call| call.tool_name.as_deref()),
+            Some("Read")
+        );
+    }
+
+    #[test]
+    fn index_parser_version_change_rebuilds_and_clears_pending_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        fs::write(&path, "{}\n").expect("transcript");
+        let metadata = path.metadata().expect("metadata");
+        let identity = file_identity(
+            &path,
+            &metadata,
+            metadata.len().min(FILE_IDENTITY_PREFIX_BYTES as u64) as usize,
+        );
+        let previous = FileState {
+            size: metadata.len(),
+            mtime: metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0),
+            offset: metadata.len(),
+            turn_id: 1,
+            parser_version: crate::sources::index_state_version(SourceKind::Claude)
+                .saturating_sub(1),
+            pending_tool_calls: HashMap::from([(
+                "stale".to_string(),
+                PendingToolCall {
+                    tool_name: Some("Old".to_string()),
+                    ..PendingToolCall::default()
+                },
+            )]),
+            identity,
+        };
+        let (task, skip) = prepare_file_task(path, SourceKind::Claude, &metadata, Some(&previous));
+        assert!(!skip);
+        assert!(task.delete_first);
+        assert_eq!(task.offset, 0);
+        assert!(task.pending_tool_calls.is_empty());
     }
 
     #[test]
@@ -3879,6 +1912,7 @@ mod tests {
             records[3].links.parent_tool_use_id.as_deref(),
             Some("tool-claude")
         );
+        assert_eq!(records[3].tool_name.as_deref(), Some("Read"));
     }
 
     #[test]
@@ -3899,9 +1933,7 @@ mod tests {
         fs::write(&archived, "{}\n").expect("write archived");
         fs::write(&ignored, "{}\n").expect("write ignored");
 
-        let mut files = collect_codex_session_files_from_roots(&[sessions_root, archived_root])
-            .expect("collect codex sessions");
-        files.sort();
+        let files = crate::sources::common::jsonl_files([sessions_root, archived_root]);
 
         assert_eq!(files, vec![archived, live]);
     }
@@ -4080,7 +2112,7 @@ mod tests {
         fs::write(&session, "{}\n").expect("write pi session");
         fs::write(&ignored, "{}\n").expect("write ignored");
 
-        let files = collect_pi_files_from_root(&sessions_root).expect("collect pi files");
+        let files = crate::sources::common::jsonl_files([sessions_root]);
 
         assert_eq!(files, vec![session]);
     }
@@ -4098,7 +2130,7 @@ mod tests {
             ("PI_CODING_AGENT_DIR", None),
         ]);
 
-        assert_eq!(pi_sessions_root(), custom_sessions);
+        assert_eq!(crate::sources::pi::sessions_root(), custom_sessions);
     }
 
     #[test]
@@ -4117,7 +2149,10 @@ mod tests {
             ("PI_CODING_AGENT_DIR", Some(pi_root.as_os_str())),
         ]);
 
-        assert_eq!(pi_sessions_root(), pi_root.join(".pi/sessions"));
+        assert_eq!(
+            crate::sources::pi::sessions_root(),
+            pi_root.join(".pi/sessions")
+        );
     }
 
     #[test]
@@ -4144,10 +2179,13 @@ mod tests {
             .join("--home-alice-code-acme-memex--")
             .join("20260703T010203Z_11111111-1111-1111-1111-111111111111.jsonl");
 
-        assert_eq!(project_from_pi_session_path(&home_path), "memex");
-        assert_eq!(project_from_pi_session_path(&users_path), "memex");
-        assert_eq!(project_from_pi_session_path(&windows_path), "memex");
-        assert_eq!(project_from_pi_session_path(&nested_path), "memex");
+        assert_eq!(crate::sources::pi::project_from_path(&home_path), "memex");
+        assert_eq!(crate::sources::pi::project_from_path(&users_path), "memex");
+        assert_eq!(
+            crate::sources::pi::project_from_path(&windows_path),
+            "memex"
+        );
+        assert_eq!(crate::sources::pi::project_from_path(&nested_path), "memex");
     }
 
     #[test]
@@ -4305,6 +2343,9 @@ mod tests {
             size: (existing.len() + appended.len()) as u64,
             mtime: 0,
             delete_first: false,
+            pending_tool_calls: HashMap::new(),
+            identity: FileIdentity::default(),
+            parser_version: crate::sources::index_state_version(SourceKind::Pi),
         };
         let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
         let next_doc_id = AtomicU64::new(1);
@@ -4331,8 +2372,11 @@ mod tests {
         fs::write(&events, "{}\n").expect("write events");
         fs::write(&ignored, "cwd: /tmp/project\n").expect("write workspace");
 
-        let files = collect_copilot_files_from_root(&tmp.path().join("session-state"))
-            .expect("collect copilot sessions");
+        let files =
+            crate::sources::copilot::discover_sessions_from_root(&tmp.path().join("session-state"))
+                .into_iter()
+                .map(|file| file.path)
+                .collect::<Vec<_>>();
 
         assert_eq!(files, vec![events]);
     }
@@ -4369,6 +2413,9 @@ mod tests {
             size: meta.len(),
             mtime: 0,
             delete_first: false,
+            pending_tool_calls: HashMap::new(),
+            identity: FileIdentity::default(),
+            parser_version: crate::sources::index_state_version(SourceKind::Copilot),
         };
         let (raw_tx_record, rx_record) = unbounded();
         let tx_record = RecordSender::new(raw_tx_record, IndexedToolContentLimits::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod embed;
 pub mod index;
 pub mod ingest;
 pub mod progress;
+pub mod sources;
 pub mod state;
 pub mod transfer;
 pub mod tui;

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -1,0 +1,682 @@
+use super::{
+    ConversationKind, IndexParseOutput, IndexParseState, ParserVersions, SessionIdentity,
+    SourceFile, SourceMetadata,
+};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::{Context, Result};
+use memchr::memmem;
+use once_cell::sync::Lazy;
+use serde_json::Value;
+use simd_json::prelude::*;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    index: 2,
+    usage: 4,
+};
+
+pub fn discover(root: &Path, include_agents: bool) -> Result<Vec<SourceFile>> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file()
+            || entry.path().extension().and_then(|ext| ext.to_str()) != Some("jsonl")
+        {
+            continue;
+        }
+        if !include_agents
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("agent-"))
+        {
+            continue;
+        }
+        files.push(SourceFile {
+            source: SourceKind::Claude,
+            path: entry.path().to_path_buf(),
+        });
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(files)
+}
+
+pub fn default_usage_roots() -> Vec<PathBuf> {
+    vec![
+        super::common::home().join(".claude/projects"),
+        super::common::home().join(".config/claude/projects"),
+    ]
+}
+
+pub fn usage_files() -> Vec<PathBuf> {
+    let roots = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .map(|root| {
+            root.to_string_lossy()
+                .split(',')
+                .map(|path| PathBuf::from(path.trim()).join("projects"))
+                .collect()
+        })
+        .unwrap_or_else(default_usage_roots);
+    super::common::jsonl_files(roots)
+}
+
+pub fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn project_from_path(path: &Path) -> String {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .map(decode_project_name)
+        .unwrap_or_else(|| SourceKind::Claude.label().to_string())
+}
+
+fn decode_project_name(folder_name: &str) -> String {
+    let prefixes_to_strip = ["-home-", "-mnt-c-Users-", "-mnt-c-users-", "-Users-"];
+    let mut name = folder_name;
+    if name.len() > 10 {
+        let bytes = name.as_bytes();
+        if bytes[0] == b'-'
+            && bytes[2] == b'-'
+            && bytes[3] == b'-'
+            && bytes[1].is_ascii_alphabetic()
+            && name[4..].to_lowercase().starts_with("users-")
+        {
+            name = &name[10..];
+        }
+    }
+    for prefix in prefixes_to_strip {
+        if name.to_lowercase().starts_with(&prefix.to_lowercase()) {
+            name = &name[prefix.len()..];
+            break;
+        }
+    }
+    let parts: Vec<&str> = name.split('-').filter(|part| !part.is_empty()).collect();
+    let skip_dirs = [
+        "projects",
+        "code",
+        "repos",
+        "src",
+        "dev",
+        "work",
+        "documents",
+    ];
+    let mut meaningful = Vec::new();
+    let mut found_project = false;
+    for (index, part) in parts.iter().enumerate() {
+        if index == 0 && !found_project {
+            let remaining: Vec<String> = parts[index + 1..]
+                .iter()
+                .map(|part| part.to_lowercase())
+                .collect();
+            if remaining
+                .iter()
+                .any(|directory| skip_dirs.contains(&directory.as_str()))
+            {
+                continue;
+            }
+        }
+        if skip_dirs.contains(&part.to_lowercase().as_str()) {
+            found_project = true;
+            continue;
+        }
+        meaningful.push(*part);
+        found_project = true;
+    }
+    if meaningful.is_empty() {
+        folder_name.to_string()
+    } else {
+        meaningful.join("-")
+    }
+}
+
+pub fn is_subagent_path(path: &Path) -> bool {
+    session_id_from_path(path).starts_with("agent-")
+        || path
+            .components()
+            .any(|component| component.as_os_str().to_str() == Some("subagents"))
+}
+
+pub fn classify(path: &Path, is_sidechain: bool) -> ConversationKind {
+    if is_subagent_path(path) {
+        ConversationKind::Subagent
+    } else if is_sidechain {
+        ConversationKind::Sidechain
+    } else {
+        ConversationKind::Main
+    }
+}
+
+pub fn probe(path: &Path) -> Result<SourceMetadata> {
+    let fallback_id = session_id_from_path(path);
+    let mut session_id = fallback_id;
+    let mut parent_session_id = None;
+    let mut cwd = None;
+    let mut project = Some(project_from_path(path));
+    let mut conversation_kind = classify(path, false);
+
+    let reader = BufReader::new(File::open(path)?);
+    for line in reader.lines().take(64) {
+        let Ok(line) = line else { continue };
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if let Some(id) = value.get("sessionId").and_then(Value::as_str) {
+            session_id = id.to_string();
+        }
+        if let Some(value_cwd) = value.get("cwd").and_then(Value::as_str) {
+            cwd = Some(PathBuf::from(value_cwd));
+            project = Some(super::common::project_from_path(value_cwd));
+        }
+        let sidechain = value
+            .get("isSidechain")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        conversation_kind = classify(path, sidechain);
+        if conversation_kind == ConversationKind::Subagent {
+            parent_session_id = value
+                .get("sessionId")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if cwd.is_some() && value.get("sessionId").is_some() {
+            break;
+        }
+    }
+
+    Ok(SourceMetadata {
+        session: SessionIdentity {
+            source: SourceKind::Claude,
+            session_id,
+            parent_session_id,
+            conversation_kind,
+            source_path: path.to_path_buf(),
+        },
+        cwd,
+        project,
+        git_branch: None,
+    })
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    use memchr::memchr;
+    use memmap2::Mmap;
+    use simd_json::prelude::*;
+
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+    let mut pending_tool_calls = state.pending_tool_calls;
+    let project = project_from_path(path);
+    let session_id = session_id_from_path(path);
+    let is_agent_file = is_subagent_path(path);
+    let source_path = path.to_string_lossy().to_string();
+    let mut buffer = Vec::new();
+
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + 1;
+        if line.is_empty() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        let entry_type = object
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if entry_type != "user" && entry_type != "assistant" {
+            continue;
+        }
+        let entry_uuid = super::common::borrowed_string(object, "uuid");
+        let entry_parent_uuid = super::common::borrowed_string(object, "parentUuid");
+        let sidechain = object
+            .get("isSidechain")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let kind = classify(path, sidechain);
+        let thread_source = match kind {
+            ConversationKind::Subagent => Some("subagent".to_string()),
+            ConversationKind::Sidechain => Some("sidechain".to_string()),
+            _ => None,
+        };
+        let entry_links = RecordLinks {
+            event_id: entry_uuid.clone(),
+            parent_event_id: entry_parent_uuid,
+            logical_parent_event_id: super::common::borrowed_string(object, "logicalParentUuid"),
+            parent_session_id: is_agent_file
+                .then(|| super::common::borrowed_string(object, "sessionId"))
+                .flatten(),
+            thread_source,
+            conversation_kind: Some(kind.as_str().to_string()),
+            parent_tool_use_id: super::common::borrowed_string(object, "parentToolUseID"),
+            source_tool_use_id: super::common::borrowed_string(object, "sourceToolUseID"),
+            source_tool_assistant_uuid: super::common::borrowed_string(
+                object,
+                "sourceToolAssistantUUID",
+            ),
+        };
+        let timestamp = object
+            .get("timestamp")
+            .and_then(|value| value.as_str())
+            .and_then(super::common::parse_iso_millis)
+            .unwrap_or(0);
+        let Some(message) = object.get("message").and_then(|value| value.as_object()) else {
+            continue;
+        };
+        let content = message.get("content");
+        let mut text_parts = Vec::new();
+        if let Some(content) = content {
+            if let Some(text) = content.as_str() {
+                text_parts.push(text);
+            } else if let Some(array) = content.as_array() {
+                for block in array {
+                    let Some(block_object) = block.as_object() else {
+                        continue;
+                    };
+                    match block_object
+                        .get("type")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("")
+                    {
+                        "text" => {
+                            if let Some(text) =
+                                block_object.get("text").and_then(|value| value.as_str())
+                            {
+                                text_parts.push(text);
+                            }
+                        }
+                        "tool_use" => {
+                            let tool_name = block_object
+                                .get("name")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string);
+                            let tool_input =
+                                block_object.get("input").map(|value| value.to_string());
+                            let text = tool_input.clone().unwrap_or_default();
+                            let tool_id = block_object
+                                .get("id")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string);
+                            let mut links = entry_links.clone();
+                            if let Some(tool_id) = &tool_id {
+                                links.event_id = Some(tool_id.clone());
+                                links.parent_event_id = entry_uuid.clone();
+                            }
+                            let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                            if let Some(tool_id) = tool_id {
+                                pending_tool_calls.insert(
+                                    tool_id.clone(),
+                                    super::common::pending_tool_call(
+                                        tool_name.clone(),
+                                        Some(tool_id),
+                                        doc_id,
+                                        timestamp,
+                                        tool_input.as_deref(),
+                                        &links,
+                                        &session_id,
+                                    ),
+                                );
+                            }
+                            emit(Record {
+                                source: SourceKind::Claude,
+                                doc_id,
+                                ts: timestamp,
+                                project: project.clone(),
+                                session_id: session_id.clone(),
+                                turn_id,
+                                role: "tool_use".to_string(),
+                                text,
+                                tool_name,
+                                tool_input,
+                                tool_output: None,
+                                links,
+                                source_path: source_path.clone(),
+                            })?;
+                            turn_id += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        if entry_type == "user"
+            && let Some(array) = content.and_then(|value| value.as_array())
+        {
+            for block in array {
+                let Some(block_object) = block.as_object() else {
+                    continue;
+                };
+                if block_object.get("type").and_then(|value| value.as_str()) != Some("tool_result")
+                {
+                    continue;
+                }
+                let tool_output = block_object.get("content").map(|value| value.to_string());
+                let mut text = super::common::tool_result_text(block).unwrap_or_default();
+                if text.is_empty()
+                    && let Some(content) = block_object.get("content")
+                {
+                    text = content.to_string();
+                }
+                let tool_use_id = block_object
+                    .get("tool_use_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let tool_name = tool_use_id
+                    .as_ref()
+                    .and_then(|id| pending_tool_calls.remove(id))
+                    .and_then(|call| call.tool_name);
+                let mut links = entry_links.clone();
+                if let Some(tool_use_id) = &tool_use_id {
+                    links.event_id = entry_uuid
+                        .as_ref()
+                        .map(|uuid| format!("{uuid}:tool_result:{tool_use_id}"));
+                    links.parent_event_id = Some(tool_use_id.clone());
+                    links.parent_tool_use_id = Some(tool_use_id.clone());
+                }
+                emit(Record {
+                    source: SourceKind::Claude,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+        }
+
+        let text = text_parts.join(" ").trim().to_string();
+        if !text.is_empty() {
+            emit(Record {
+                source: SourceKind::Claude,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: entry_type.to_string(),
+                text,
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                links: entry_links,
+                source_path: source_path.clone(),
+            })?;
+            turn_id += 1;
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+    })
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    static USAGE_NEEDLE: Lazy<memmem::Finder<'static>> =
+        Lazy::new(|| memmem::Finder::new(b"\"usage\""));
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let fallback_session = Some(session_id_from_path(path));
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut reader = BufReader::with_capacity(256 * 1024, file);
+    let mut line = Vec::with_capacity(16 * 1024);
+    let mut index = 0u64;
+    let mut events = Vec::new();
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line)? == 0 {
+            break;
+        }
+        if line.last() == Some(&b'\n') {
+            line.pop();
+        }
+        if USAGE_NEEDLE.find(&line).is_some()
+            && let Ok(value) = simd_json::to_borrowed_value(&mut line)
+            && value.get("type").and_then(|value| value.as_str()) == Some("assistant")
+            && let Some(message) = value.get("message")
+            && let Some(usage) = message.get("usage")
+        {
+            let number = |value: &simd_json::BorrowedValue, names: &[&str]| {
+                names
+                    .iter()
+                    .find_map(|name| value.get(*name).and_then(|value| value.as_u64()))
+                    .unwrap_or(0)
+            };
+            let cache_write = number(
+                usage,
+                &["cache_creation_input_tokens", "cacheCreationInputTokens"],
+            );
+            let mut tokens = TokenBuckets::disjoint(
+                number(usage, &["input_tokens", "inputTokens"]),
+                number(usage, &["cache_read_input_tokens", "cacheReadInputTokens"]),
+                cache_write,
+                number(usage, &["output_tokens", "outputTokens"]),
+            );
+            tokens.cache_write_1h = usage
+                .get("cache_creation")
+                .and_then(|cache| cache.get("ephemeral_1h_input_tokens"))
+                .and_then(|value| value.as_u64())
+                .unwrap_or_default()
+                .min(tokens.cache_write);
+            if tokens.additive_total() > 0 {
+                let string = |names: &[&str]| {
+                    names
+                        .iter()
+                        .find_map(|name| value.get(*name).and_then(|value| value.as_str()))
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string)
+                };
+                let session_id = string(&["sessionId", "session_id"]);
+                let request_id = string(&["requestId", "request_id"]);
+                let message_id = message
+                    .get("id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+                let exact_dedupe = message_id.is_some() && request_id.is_some();
+                let project = value
+                    .get("cwd")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let timestamp_ms = value
+                    .get("timestamp")
+                    .and_then(|timestamp| {
+                        timestamp
+                            .as_str()
+                            .and_then(super::common::parse_iso_millis)
+                            .or_else(|| timestamp.as_u64())
+                            .or_else(|| timestamp.as_i64().map(|value| value.max(0) as u64))
+                    })
+                    .unwrap_or(0);
+                events.push(UsageEvent {
+                    source: "claude",
+                    source_path: source_path.clone(),
+                    source_record_id: Some(format!("line:{index}")),
+                    session_id: session_id.or_else(|| fallback_session.clone()),
+                    request_id,
+                    message_id,
+                    timestamp_ms,
+                    project,
+                    provider: Some("anthropic".into()),
+                    model: message
+                        .get("model")
+                        .and_then(|value| value.as_str())
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string),
+                    tokens,
+                    source_cost_usd: value.get("costUSD").and_then(|value| value.as_f64()),
+                    dedupe_confidence: if exact_dedupe { "exact" } else { "heuristic" },
+                    conservative_undercount: false,
+                    sidechain: value
+                        .get("isSidechain")
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false),
+                    source_order: index,
+                });
+            }
+        }
+        index += 1;
+    }
+    Ok(events)
+}
+
+pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
+    use std::collections::HashMap;
+
+    let mut best_exact: HashMap<(&str, &str), usize> = HashMap::new();
+    let mut keep = vec![true; events.len()];
+    for (index, event) in events.iter().enumerate() {
+        if event.source != "claude" {
+            continue;
+        }
+        let (Some(message), Some(request)) =
+            (event.message_id.as_deref(), event.request_id.as_deref())
+        else {
+            continue;
+        };
+        let key = (message, request);
+        if let Some(previous) = best_exact.get(&key).copied() {
+            if choose_usage(&events[previous], event) {
+                keep[index] = false;
+            } else {
+                keep[previous] = false;
+                best_exact.insert(key, index);
+            }
+        } else {
+            best_exact.insert(key, index);
+        }
+    }
+    let mut by_message: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (index, event) in events.iter().enumerate() {
+        if keep[index]
+            && event.source == "claude"
+            && let Some(message) = event.message_id.as_deref()
+        {
+            by_message.entry(message).or_default().push(index);
+        }
+    }
+    for indices in by_message.into_values() {
+        if indices.len() < 2 || !indices.iter().any(|index| !events[*index].sidechain) {
+            continue;
+        }
+        for index in indices {
+            if events[index].sidechain {
+                keep[index] = false;
+            }
+        }
+    }
+    let mut index = 0usize;
+    events.retain(|_| {
+        let retain = keep[index];
+        index += 1;
+        retain
+    });
+}
+
+fn choose_usage(left: &UsageEvent, right: &UsageEvent) -> bool {
+    if left.sidechain != right.sidechain {
+        return !left.sidechain;
+    }
+    let left_parent = !left.source_path.contains("/subagents/");
+    let right_parent = !right.source_path.contains("/subagents/");
+    if left_parent != right_parent {
+        return left_parent;
+    }
+    let left_total = left.tokens.additive_total();
+    let right_total = right.tokens.additive_total();
+    if left_total != right_total {
+        return left_total > right_total;
+    }
+    left.source_order >= right.source_order
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn discovery_includes_subagents_only_when_requested() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("main.jsonl"), "{}\n").unwrap();
+        fs::write(temp.path().join("agent-child.jsonl"), "{}\n").unwrap();
+        assert_eq!(discover(temp.path(), false).unwrap().len(), 1);
+        assert_eq!(discover(temp.path(), true).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn probe_shares_sidechain_session_and_project_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("-Users-nico-Code-memex");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("fallback.jsonl");
+        fs::write(
+            &path,
+            "{\"type\":\"assistant\",\"sessionId\":\"session-1\",\"cwd\":\"/Users/nico/Code/memex\",\"isSidechain\":true}\n",
+        )
+        .unwrap();
+        let metadata = probe(&path).unwrap();
+        assert_eq!(metadata.session.session_id, "session-1");
+        assert_eq!(
+            metadata.session.conversation_kind,
+            ConversationKind::Sidechain
+        );
+        assert_eq!(metadata.project.as_deref(), Some("memex"));
+    }
+
+    #[test]
+    fn usage_preserves_the_full_cwd_and_does_not_invent_a_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"assistant\",\"cwd\":\"/Users/nico/Code/memex\",",
+                "\"message\":{\"id\":\"one\",\"usage\":{\"input_tokens\":1}}}\n",
+                "{\"type\":\"assistant\",",
+                "\"message\":{\"id\":\"two\",\"usage\":{\"input_tokens\":1}}}\n"
+            ),
+        )
+        .unwrap();
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events[0].project.as_deref(), Some("/Users/nico/Code/memex"));
+        assert_eq!(events[1].project, None);
+    }
+}

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -59,11 +59,20 @@ pub fn usage_files() -> Vec<PathBuf> {
         .map(|root| {
             root.to_string_lossy()
                 .split(',')
-                .map(|path| PathBuf::from(path.trim()).join("projects"))
+                .map(expand_usage_root)
                 .collect()
         })
         .unwrap_or_else(default_usage_roots);
     super::common::jsonl_files(roots)
+}
+
+fn expand_usage_root(path: &str) -> PathBuf {
+    let path = PathBuf::from(path.trim());
+    if path.file_name().and_then(|name| name.to_str()) == Some("projects") {
+        path
+    } else {
+        path.join("projects")
+    }
 }
 
 pub fn session_id_from_path(path: &Path) -> String {
@@ -516,13 +525,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
                     .map(str::to_string);
                 let timestamp_ms = value
                     .get("timestamp")
-                    .and_then(|timestamp| {
-                        timestamp
-                            .as_str()
-                            .and_then(super::common::parse_iso_millis)
-                            .or_else(|| timestamp.as_u64())
-                            .or_else(|| timestamp.as_i64().map(|value| value.max(0) as u64))
-                    })
+                    .map(usage_timestamp_millis)
                     .unwrap_or(0);
                 events.push(UsageEvent {
                     source: "claude",
@@ -554,6 +557,26 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
         index += 1;
     }
     Ok(events)
+}
+
+fn usage_timestamp_millis(timestamp: &simd_json::BorrowedValue<'_>) -> u64 {
+    timestamp
+        .as_u64()
+        .map(|value| {
+            if value < 10_000_000_000 {
+                value.saturating_mul(1_000)
+            } else {
+                value
+            }
+        })
+        .or_else(|| {
+            timestamp
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| value as u64)
+        })
+        .or_else(|| timestamp.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
 }
 
 pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
@@ -678,5 +701,37 @@ mod tests {
         let events = parse_usage_file(&path).unwrap();
         assert_eq!(events[0].project.as_deref(), Some("/Users/nico/Code/memex"));
         assert_eq!(events[1].project, None);
+    }
+
+    #[test]
+    fn usage_root_accepts_config_and_already_expanded_projects_paths() {
+        assert_eq!(
+            expand_usage_root("/tmp/claude"),
+            PathBuf::from("/tmp/claude/projects")
+        );
+        assert_eq!(
+            expand_usage_root("/tmp/claude/projects"),
+            PathBuf::from("/tmp/claude/projects")
+        );
+    }
+
+    #[test]
+    fn usage_converts_numeric_second_timestamps_to_milliseconds() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"assistant\",\"timestamp\":1776386452,",
+                "\"message\":{\"id\":\"seconds\",\"usage\":{\"input_tokens\":1}}}\n",
+                "{\"type\":\"assistant\",\"timestamp\":1776386452437,",
+                "\"message\":{\"id\":\"milliseconds\",\"usage\":{\"input_tokens\":1}}}\n"
+            ),
+        )
+        .unwrap();
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events[0].timestamp_ms, 1_776_386_452_000);
+        assert_eq!(events[1].timestamp_ms, 1_776_386_452_437);
     }
 }

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -1,0 +1,1171 @@
+use super::{
+    ConversationKind, IndexParseOutput, IndexParseState, ParserVersions, SessionIdentity,
+    SourceFile, SourceMetadata, UsageDependency, UsageParseOutput,
+};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use memchr::{memchr, memmem};
+use memmap2::Mmap;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 2,
+    index: 2,
+    usage: 4,
+};
+
+pub fn classify_path(path: &str) -> Option<SourceKind> {
+    if path.contains(".codex/sessions")
+        || path.contains(".codex\\sessions")
+        || path.contains(".codex/archived_sessions")
+        || path.contains(".codex\\archived_sessions")
+    {
+        Some(SourceKind::CodexSession)
+    } else if path.contains(".codex/history.jsonl") || path.contains(".codex\\history.jsonl") {
+        Some(SourceKind::CodexHistory)
+    } else {
+        None
+    }
+}
+
+pub fn homes() -> Vec<PathBuf> {
+    std::env::var_os("CODEX_HOME")
+        .map(|roots| {
+            roots
+                .to_string_lossy()
+                .split(',')
+                .map(|root| PathBuf::from(root.trim()))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![super::common::home().join(".codex")])
+}
+
+pub fn rollout_roots() -> Vec<PathBuf> {
+    homes()
+        .into_iter()
+        .flat_map(|home| {
+            let active = home.join("sessions");
+            let archived = home.join("archived_sessions");
+            if active.exists() || archived.exists() {
+                vec![active, archived]
+            } else {
+                vec![home]
+            }
+        })
+        .collect()
+}
+
+pub fn discover_rollouts() -> Vec<SourceFile> {
+    super::common::jsonl_files(rollout_roots())
+        .into_iter()
+        .map(|path| SourceFile {
+            source: SourceKind::CodexSession,
+            path,
+        })
+        .collect()
+}
+
+pub fn history_paths() -> Vec<PathBuf> {
+    homes()
+        .into_iter()
+        .map(|home| home.join("history.jsonl"))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+pub fn session_id_from_path(path: &Path) -> Option<String> {
+    static UUID: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(|| {
+        Regex::new(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
+            .expect("uuid regex")
+    });
+    let stem = path.file_stem()?.to_string_lossy();
+    UUID.captures(&stem)
+        .and_then(|captures| captures.get(1))
+        .map(|value| value.as_str().to_string())
+}
+
+#[derive(Clone, Default)]
+struct SessionLinks {
+    parent_session_id: Option<String>,
+    thread_source: Option<String>,
+    conversation_kind: Option<String>,
+}
+
+impl SessionLinks {
+    fn record_links(&self) -> RecordLinks {
+        RecordLinks {
+            parent_session_id: self.parent_session_id.clone(),
+            thread_source: self.thread_source.clone(),
+            conversation_kind: self.conversation_kind.clone(),
+            ..RecordLinks::default()
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SessionMeta {
+    session_id: String,
+    project: String,
+    cwd: Option<PathBuf>,
+    links: SessionLinks,
+}
+
+fn fallback_meta(path: &Path) -> SessionMeta {
+    SessionMeta {
+        session_id: session_id_from_path(path).unwrap_or_else(|| "unknown".to_string()),
+        project: SourceKind::CodexSession.label().to_string(),
+        cwd: None,
+        links: SessionLinks {
+            conversation_kind: Some(ConversationKind::Main.as_str().to_string()),
+            ..SessionLinks::default()
+        },
+    }
+}
+
+fn apply_meta(payload: &simd_json::borrowed::Object<'_>, metadata: &mut SessionMeta) {
+    if let Some(id) = payload.get("id").and_then(|value| value.as_str()) {
+        metadata.session_id = id.to_string();
+    }
+    if let Some(cwd) = payload.get("cwd").and_then(|value| value.as_str()) {
+        metadata.project = super::common::project_from_path(cwd);
+        metadata.cwd = Some(PathBuf::from(cwd));
+    }
+    let forked_from_id = payload
+        .get("forked_from_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let parent_thread_id = payload
+        .get("source")
+        .and_then(|value| value.as_object())
+        .and_then(|source| source.get("subagent"))
+        .and_then(|value| value.as_object())
+        .and_then(|subagent| subagent.get("thread_spawn"))
+        .and_then(|value| value.as_object())
+        .and_then(|spawn| spawn.get("parent_thread_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let thread_source = payload
+        .get("thread_source")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or_else(|| parent_thread_id.as_ref().map(|_| "subagent".to_string()))
+        .or_else(|| forked_from_id.as_ref().map(|_| "fork".to_string()));
+    metadata.links.parent_session_id = forked_from_id.clone().or(parent_thread_id);
+    metadata.links.thread_source = thread_source.clone();
+    metadata.links.conversation_kind = Some(
+        if thread_source.as_deref() == Some("subagent") {
+            ConversationKind::Subagent
+        } else if forked_from_id.is_some() {
+            ConversationKind::Fork
+        } else {
+            ConversationKind::Main
+        }
+        .as_str()
+        .to_string(),
+    );
+}
+
+fn read_meta_until(path: &Path, limit: u64) -> Result<SessionMeta> {
+    let mut metadata = fallback_meta(path);
+    if limit == 0 {
+        return Ok(metadata);
+    }
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let limit = (limit as usize).min(mmap.len());
+    let mut start = 0usize;
+    let mut buffer = Vec::new();
+    while start < limit {
+        let slice = &mmap[start..limit];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + 1;
+        if line.is_empty() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        if let Ok(value) = simd_json::to_borrowed_value(&mut buffer)
+            && value.get("type").and_then(|value| value.as_str()) == Some("session_meta")
+            && let Some(payload) = value.get("payload").and_then(|value| value.as_object())
+        {
+            apply_meta(payload, &mut metadata);
+        }
+    }
+    Ok(metadata)
+}
+
+pub fn probe(path: &Path) -> Result<SourceMetadata> {
+    let limit = path.metadata()?.len();
+    let metadata = read_meta_until(path, limit)?;
+    let kind = match metadata.links.conversation_kind.as_deref() {
+        Some("subagent") => ConversationKind::Subagent,
+        Some("fork") => ConversationKind::Fork,
+        _ => ConversationKind::Main,
+    };
+    Ok(SourceMetadata {
+        session: SessionIdentity {
+            source: SourceKind::CodexSession,
+            session_id: metadata.session_id,
+            parent_session_id: metadata.links.parent_session_id,
+            conversation_kind: kind,
+            source_path: path.to_path_buf(),
+        },
+        cwd: metadata.cwd,
+        project: Some(metadata.project),
+        git_branch: None,
+    })
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+    let mut pending_tool_calls = state.pending_tool_calls;
+    let source_path = path.to_string_lossy().to_string();
+    let mut metadata = read_meta_until(path, state.offset)?;
+    let mut buffer = Vec::new();
+
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + 1;
+        if line.is_empty() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        let entry_type = object
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let timestamp = object
+            .get("timestamp")
+            .and_then(|value| value.as_str())
+            .and_then(super::common::parse_iso_millis)
+            .unwrap_or(0);
+        if entry_type == "session_meta" {
+            if let Some(payload) = object.get("payload").and_then(|value| value.as_object()) {
+                apply_meta(payload, &mut metadata);
+            }
+            continue;
+        }
+        if entry_type != "response_item" {
+            continue;
+        }
+        let Some(payload) = object.get("payload").and_then(|value| value.as_object()) else {
+            continue;
+        };
+        let payload_type = payload
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let mut links = metadata.links.record_links();
+        links.event_id = super::common::borrowed_string(payload, "id");
+        match payload_type {
+            "message" => {
+                let role = payload
+                    .get("role")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let mut text_parts = Vec::new();
+                if let Some(content) = payload.get("content") {
+                    if let Some(text) = content.as_str() {
+                        text_parts.push(text);
+                    } else if let Some(array) = content.as_array() {
+                        for block in array {
+                            if let Some(text) = block
+                                .as_object()
+                                .and_then(|object| object.get("text"))
+                                .and_then(|value| value.as_str())
+                            {
+                                text_parts.push(text);
+                            }
+                        }
+                    }
+                }
+                let text = text_parts.join("\n").trim().to_string();
+                if text.is_empty() || is_system_instruction(&text) {
+                    continue;
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: role.to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            "function_call" => {
+                let tool_name = payload
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let tool_input = payload
+                    .get("arguments")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let call_id = payload
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                if let Some(call_id) = &call_id {
+                    links.event_id = Some(call_id.clone());
+                }
+                let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                if let Some(call_id) = call_id {
+                    pending_tool_calls.insert(
+                        call_id.clone(),
+                        super::common::pending_tool_call(
+                            tool_name.clone(),
+                            Some(call_id),
+                            doc_id,
+                            timestamp,
+                            tool_input.as_deref(),
+                            &links,
+                            &metadata.session_id,
+                        ),
+                    );
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id,
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "tool_use".to_string(),
+                    text: tool_input.clone().unwrap_or_default(),
+                    tool_name,
+                    tool_input,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            "function_call_output" => {
+                let call_id = payload
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let tool_name = (!call_id.is_empty())
+                    .then(|| pending_tool_calls.remove(call_id))
+                    .flatten()
+                    .and_then(|call| call.tool_name);
+                let tool_output = payload
+                    .get("output")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let text = tool_output.clone().unwrap_or_default();
+                if text.is_empty() {
+                    continue;
+                }
+                if !call_id.is_empty() {
+                    links.parent_event_id = Some(call_id.to_string());
+                    links.parent_tool_use_id = Some(call_id.to_string());
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(metadata.session_id),
+    })
+}
+
+pub(crate) fn parse_history_records(
+    path: &Path,
+    state: IndexParseState,
+    session_ids: &HashSet<String>,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+    let source_path = path.to_string_lossy().to_string();
+    let mut buffer = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + 1;
+        if line.is_empty() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value): Result<BorrowedValue<'_>, _> = simd_json::to_borrowed_value(&mut buffer)
+        else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        let session_id = object
+            .get("session_id")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if session_id.is_empty() || session_ids.contains(session_id) {
+            continue;
+        }
+        let text = object
+            .get("text")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if text.is_empty() {
+            continue;
+        }
+        let timestamp = object
+            .get("ts")
+            .and_then(|value| value.as_i64())
+            .unwrap_or(0)
+            .max(0) as u64
+            * 1000;
+        emit(Record {
+            source: SourceKind::CodexHistory,
+            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+            ts: timestamp,
+            project: SourceKind::CodexSession.label().to_string(),
+            session_id: session_id.to_string(),
+            turn_id,
+            role: "user".to_string(),
+            text: text.to_string(),
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            links: RecordLinks {
+                conversation_kind: Some(ConversationKind::Main.as_str().to_string()),
+                ..RecordLinks::default()
+            },
+            source_path: source_path.clone(),
+        })?;
+        turn_id += 1;
+    }
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls: state.pending_tool_calls,
+        session_id: None,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+struct UsageTokens {
+    input: u64,
+    cached: u64,
+    output: u64,
+    reasoning: u64,
+}
+
+impl UsageTokens {
+    fn from(value: &BorrowedValue<'_>) -> Self {
+        let number = |aliases: &[&str]| {
+            aliases
+                .iter()
+                .find_map(|key| value.get(*key).and_then(|value| value.as_u64()))
+                .unwrap_or(0)
+        };
+        Self {
+            input: number(&["input_tokens", "inputTokens", "prompt_tokens"]),
+            cached: number(&[
+                "cached_input_tokens",
+                "cachedInputTokens",
+                "cache_read_input_tokens",
+            ]),
+            output: number(&["output_tokens", "outputTokens", "completion_tokens"]),
+            reasoning: number(&[
+                "reasoning_output_tokens",
+                "reasoningTokens",
+                "reasoning_tokens",
+            ]),
+        }
+    }
+
+    fn zero(self) -> bool {
+        self.input == 0 && self.cached == 0 && self.output == 0 && self.reasoning == 0
+    }
+
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.saturating_add(rhs.input),
+            cached: self.cached.saturating_add(rhs.cached),
+            output: self.output.saturating_add(rhs.output),
+            reasoning: self.reasoning.saturating_add(rhs.reasoning),
+        }
+    }
+
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.saturating_sub(rhs.input),
+            cached: self.cached.saturating_sub(rhs.cached),
+            output: self.output.saturating_sub(rhs.output),
+            reasoning: self.reasoning.saturating_sub(rhs.reasoning),
+        }
+    }
+
+    fn min(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.min(rhs.input),
+            cached: self.cached.min(rhs.cached),
+            output: self.output.min(rhs.output),
+            reasoning: self.reasoning.min(rhs.reasoning),
+        }
+    }
+
+    fn max(self, rhs: Self) -> Self {
+        Self {
+            input: self.input.max(rhs.input),
+            cached: self.cached.max(rhs.cached),
+            output: self.output.max(rhs.output),
+            reasoning: self.reasoning.max(rhs.reasoning),
+        }
+    }
+
+    fn at_least(self, rhs: Self) -> bool {
+        self.input >= rhs.input
+            && self.cached >= rhs.cached
+            && self.output >= rhs.output
+            && self.reasoning >= rhs.reasoning
+    }
+
+    fn at_most(self, rhs: Self) -> bool {
+        self.input <= rhs.input
+            && self.cached <= rhs.cached
+            && self.output <= rhs.output
+            && self.reasoning <= rhs.reasoning
+    }
+}
+
+#[derive(Default)]
+struct UsageCounter {
+    counted: UsageTokens,
+    raw_baseline: UsageTokens,
+    watermark: UsageTokens,
+    seen: Vec<UsageTokens>,
+    inherited_seen: HashSet<UsageTokens>,
+    divergent: bool,
+    interleaved: bool,
+}
+
+impl UsageCounter {
+    fn establish_unresolved_fork_baseline(&mut self, total: UsageTokens) {
+        self.raw_baseline = total;
+        self.watermark = self.watermark.max(total);
+        if self.seen.last() != Some(&total) {
+            self.seen.push(total);
+            if self.seen.len() > 64 {
+                self.seen.remove(0);
+            }
+        }
+    }
+
+    fn seed_inherited(&mut self, snapshots: &[UsageTokens]) {
+        let Some(baseline) = snapshots.iter().copied().reduce(UsageTokens::max) else {
+            return;
+        };
+        self.inherited_seen.extend(snapshots.iter().copied());
+        self.raw_baseline = baseline;
+        self.watermark = self.watermark.max(baseline);
+    }
+
+    fn account(&mut self, last: Option<UsageTokens>, total: Option<UsageTokens>) -> UsageTokens {
+        if let Some(total) = total {
+            if self.seen.contains(&total) || self.inherited_seen.contains(&total) {
+                return UsageTokens::default();
+            }
+            if !total.at_least(self.watermark) {
+                self.interleaved = true;
+            }
+        }
+        let baseline = self.watermark.max(self.raw_baseline);
+        let delta = match (last, total) {
+            (Some(last), Some(total)) if self.interleaved => {
+                last.min(contained_usage(total, baseline, self.counted))
+            }
+            (None, Some(total)) if self.interleaved => {
+                contained_usage(total, baseline, self.counted)
+            }
+            (Some(last), Some(total)) => {
+                let total_delta = total.sub(baseline);
+                if !self.divergent && total.at_least(baseline) && total_delta.at_most(last) {
+                    total_delta
+                } else {
+                    last
+                }
+            }
+            (None, Some(total)) if self.divergent => contained_usage(total, baseline, self.counted),
+            (None, Some(total)) => total.sub(baseline),
+            (Some(last), None) => last,
+            (None, None) => return UsageTokens::default(),
+        };
+        self.counted = self.counted.add(delta);
+        if let Some(total) = total {
+            self.raw_baseline = total;
+            self.divergent |= total != self.counted;
+            self.watermark = self.watermark.max(total);
+            if self.seen.last() != Some(&total) {
+                self.seen.push(total);
+                if self.seen.len() > 64 {
+                    self.seen.remove(0);
+                }
+            }
+        } else {
+            self.raw_baseline = self.counted;
+            self.watermark = self.watermark.max(self.counted);
+        }
+        delta
+    }
+}
+
+fn contained_usage(
+    current: UsageTokens,
+    watermark: UsageTokens,
+    counted: UsageTokens,
+) -> UsageTokens {
+    fn one(current: u64, watermark: u64, counted: u64) -> u64 {
+        if current >= watermark {
+            current.saturating_sub(watermark.max(counted))
+        } else {
+            current.saturating_sub(counted)
+        }
+    }
+    UsageTokens {
+        input: one(current.input, watermark.input, counted.input),
+        cached: one(current.cached, watermark.cached, counted.cached),
+        output: one(current.output, watermark.output, counted.output),
+        reasoning: one(current.reasoning, watermark.reasoning, counted.reasoning),
+    }
+}
+
+struct ParentData {
+    deps: Vec<UsageDependency>,
+    snapshots: Vec<(u64, UsageTokens)>,
+}
+
+type ParentSlot = Option<Arc<ParentData>>;
+
+/// Source-owned fork resolver. The usage cache asks this object whether its recorded
+/// dependency set is still complete, but does not interpret Codex hierarchy itself.
+pub(crate) struct UsageParentIndex {
+    by_session: HashMap<String, Vec<PathBuf>>,
+    parents: Mutex<HashMap<String, ParentSlot>>,
+}
+
+impl UsageParentIndex {
+    pub fn new(files: &[PathBuf]) -> Self {
+        let mut by_session: HashMap<String, Vec<PathBuf>> = HashMap::new();
+        for path in files {
+            if let Some(session) = session_id_from_path(path) {
+                by_session.entry(session).or_default().push(path.clone());
+            }
+        }
+        Self {
+            by_session,
+            parents: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn load(&self, parent: &str) -> ParentSlot {
+        if let Some(slot) = self.parents.lock().unwrap().get(parent) {
+            return slot.clone();
+        }
+        let loaded = self.by_session.get(parent).and_then(|paths| {
+            let mut deps = Vec::new();
+            let mut snapshots = Vec::new();
+            for path in paths {
+                let Ok(dependency) = UsageDependency::from_path(path) else {
+                    continue;
+                };
+                let Ok(file_snapshots) = total_usage_snapshots(path) else {
+                    continue;
+                };
+                deps.push(dependency);
+                snapshots.extend(file_snapshots);
+            }
+            (!deps.is_empty()).then(|| Arc::new(ParentData { deps, snapshots }))
+        });
+        self.parents
+            .lock()
+            .unwrap()
+            .entry(parent.to_string())
+            .or_insert(loaded)
+            .clone()
+    }
+
+    pub fn deps_match_current_candidates(&self, deps: &[UsageDependency]) -> bool {
+        let Some(first) = deps.first() else {
+            return true;
+        };
+        let Some(session) = session_id_from_path(Path::new(&first.path)) else {
+            return true;
+        };
+        let current: HashSet<&str> = self
+            .by_session
+            .get(&session)
+            .map(|paths| paths.iter().filter_map(|path| path.to_str()).collect())
+            .unwrap_or_default();
+        let recorded: HashSet<&str> = deps.iter().map(|dep| dep.path.as_str()).collect();
+        current == recorded
+    }
+
+    fn resolve(
+        &self,
+        parent: &str,
+        cutoff_ms: u64,
+    ) -> Option<(Vec<UsageDependency>, Vec<UsageTokens>)> {
+        let data = self.load(parent)?;
+        let totals = data
+            .snapshots
+            .iter()
+            .filter(|(timestamp, _)| *timestamp <= cutoff_ms)
+            .map(|(_, totals)| *totals)
+            .collect::<Vec<_>>();
+        (!totals.is_empty()).then(|| (data.deps.clone(), totals))
+    }
+}
+
+static USAGE_LINE_NEEDLES: Lazy<Vec<memmem::Finder<'static>>> = Lazy::new(|| {
+    [
+        &b"token_count"[..],
+        b"turn_context",
+        b"session_meta",
+        b"task_started",
+        b"\"usage\"",
+    ]
+    .into_iter()
+    .map(memmem::Finder::new)
+    .collect()
+});
+
+fn usage_timestamp(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|number| *number >= 0)
+                .map(|number| number as u64)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+fn borrowed_string(value: &BorrowedValue<'_>, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_str()))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn usage_parent_session_id(payload: &BorrowedValue<'_>) -> Option<String> {
+    borrowed_string(
+        payload,
+        &["forked_from_id", "parent_session_id", "parentSessionId"],
+    )
+    .or_else(|| {
+        payload
+            .get("source")
+            .and_then(|value| value.get("subagent"))
+            .and_then(|value| value.get("thread_spawn"))
+            .and_then(|value| value.get("parent_thread_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+    })
+}
+
+fn total_usage_snapshots(path: &Path) -> Result<Vec<(u64, UsageTokens)>> {
+    static TOKEN_COUNT_NEEDLE: Lazy<memmem::Finder<'static>> =
+        Lazy::new(|| memmem::Finder::new(b"token_count"));
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = 0usize;
+    let mut buffer = Vec::new();
+    let mut snapshots = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + usize::from(relative < slice.len());
+        if TOKEN_COUNT_NEEDLE.find(line).is_none() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            continue;
+        };
+        if value.get("type").and_then(|value| value.as_str()) != Some("event_msg") {
+            continue;
+        }
+        let Some(payload) = value.get("payload") else {
+            continue;
+        };
+        if payload.get("type").and_then(|value| value.as_str()) != Some("token_count") {
+            continue;
+        }
+        let info = payload.get("info").unwrap_or(payload);
+        let Some(total) = info
+            .get("total_token_usage")
+            .map(UsageTokens::from)
+            .filter(|total| !total.zero())
+        else {
+            continue;
+        };
+        snapshots.push((
+            value.get("timestamp").map(usage_timestamp).unwrap_or(0),
+            total,
+        ));
+    }
+    Ok(snapshots)
+}
+
+pub(crate) fn parse_usage_file(
+    path: &Path,
+    parents: &UsageParentIndex,
+) -> Result<UsageParseOutput> {
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut session = session_id_from_path(path);
+    let mut parent = None;
+    let mut fork_timestamp_ms = None;
+    let mut fork_resolved = false;
+    let mut parent_deps = Vec::new();
+    let mut project = None;
+    let mut model = None;
+    let mut turn = None;
+    let mut counter = UsageCounter::default();
+    let mut event_index = 0u64;
+    let mut unresolved_fork_baseline_seen = false;
+    let mut events = Vec::new();
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = 0usize;
+    let mut line_index = 0u64;
+    let mut buffer = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + usize::from(relative < slice.len());
+        let source_order = line_index;
+        line_index += 1;
+        if !USAGE_LINE_NEEDLES
+            .iter()
+            .any(|needle| needle.find(line).is_some())
+        {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            continue;
+        };
+        let kind = value
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let payload = value.get("payload");
+        match (kind, payload) {
+            ("session_meta", Some(payload)) => {
+                session = borrowed_string(payload, &["id", "session_id"]).or(session);
+                parent = usage_parent_session_id(payload);
+                if parent.is_some() {
+                    fork_timestamp_ms = value.get("timestamp").map(usage_timestamp);
+                }
+                if let (Some(parent_id), Some(fork_ms)) = (&parent, fork_timestamp_ms)
+                    && let Some((deps, inherited)) = parents.resolve(parent_id, fork_ms)
+                {
+                    counter.seed_inherited(&inherited);
+                    unresolved_fork_baseline_seen = true;
+                    fork_resolved = true;
+                    parent_deps = deps;
+                }
+                // Usage reports historically expose Codex's full cwd. Keep that projection
+                // stable even though the search index uses the leaf project label.
+                project = borrowed_string(payload, &["cwd"]);
+            }
+            ("turn_context", Some(payload)) => {
+                model = borrowed_string(payload, &["model", "model_name"]);
+            }
+            ("event_msg", Some(payload))
+                if payload.get("type").and_then(|value| value.as_str()) == Some("task_started") =>
+            {
+                turn = borrowed_string(payload, &["turn_id", "turnId"]);
+            }
+            ("event_msg", Some(payload))
+                if payload.get("type").and_then(|value| value.as_str()) == Some("token_count") =>
+            {
+                let info = payload.get("info").unwrap_or(payload);
+                let last = info
+                    .get("last_token_usage")
+                    .map(UsageTokens::from)
+                    .filter(|tokens| !tokens.zero());
+                let total = info
+                    .get("total_token_usage")
+                    .map(UsageTokens::from)
+                    .filter(|tokens| !tokens.zero());
+                let event_timestamp_ms = value.get("timestamp").map(usage_timestamp).unwrap_or(0);
+                if parent.is_some()
+                    && fork_timestamp_ms.is_some_and(|fork| event_timestamp_ms <= fork)
+                {
+                    if let Some(total) = total {
+                        counter.establish_unresolved_fork_baseline(total);
+                        unresolved_fork_baseline_seen = true;
+                    }
+                    continue;
+                }
+                if parent.is_some()
+                    && !unresolved_fork_baseline_seen
+                    && let Some(total) = total
+                {
+                    counter.establish_unresolved_fork_baseline(total);
+                    unresolved_fork_baseline_seen = true;
+                    continue;
+                }
+                let delta = counter.account(last, total);
+                if delta.zero() {
+                    continue;
+                }
+                events.push(UsageEvent {
+                    source: "codex",
+                    source_path: source_path.clone(),
+                    source_record_id: Some(format!("event:{event_index}")),
+                    session_id: session.clone(),
+                    request_id: turn.clone(),
+                    message_id: None,
+                    timestamp_ms: event_timestamp_ms,
+                    project: project.clone(),
+                    provider: Some("openai".into()),
+                    model: model
+                        .clone()
+                        .or_else(|| borrowed_string(info, &["model", "model_name"])),
+                    tokens: TokenBuckets::codex(
+                        delta.input,
+                        delta.cached,
+                        delta.output,
+                        delta.reasoning,
+                    ),
+                    source_cost_usd: None,
+                    dedupe_confidence: "strong",
+                    conservative_undercount: counter.interleaved
+                        || (parent.is_some() && !fork_resolved),
+                    sidechain: false,
+                    source_order,
+                });
+                event_index += 1;
+            }
+            _ => {
+                let usage = value
+                    .get("usage")
+                    .or_else(|| value.get("data").and_then(|value| value.get("usage")))
+                    .or_else(|| value.get("result").and_then(|value| value.get("usage")))
+                    .or_else(|| value.get("response").and_then(|value| value.get("usage")));
+                let Some(usage) = usage else {
+                    continue;
+                };
+                let tokens = UsageTokens::from(usage);
+                if tokens.zero() {
+                    continue;
+                }
+                events.push(UsageEvent {
+                    source: "codex",
+                    source_path: source_path.clone(),
+                    source_record_id: Some(format!("line:{source_order}")),
+                    session_id: session.clone(),
+                    request_id: None,
+                    message_id: None,
+                    timestamp_ms: value
+                        .get("timestamp")
+                        .or_else(|| value.get("created_at"))
+                        .map(usage_timestamp)
+                        .unwrap_or(0),
+                    project: project.clone(),
+                    provider: Some("openai".into()),
+                    model: model
+                        .clone()
+                        .or_else(|| borrowed_string(&value, &["model", "model_name"])),
+                    tokens: TokenBuckets::codex(
+                        tokens.input,
+                        tokens.cached,
+                        tokens.output,
+                        tokens.reasoning,
+                    ),
+                    source_cost_usd: None,
+                    dedupe_confidence: "strong",
+                    conservative_undercount: false,
+                    sidechain: false,
+                    source_order,
+                });
+            }
+        }
+    }
+    Ok(UsageParseOutput {
+        events,
+        cacheable: parent.is_none() || fork_resolved,
+        deps: parent_deps,
+    })
+}
+
+pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        if event.source != "codex" {
+            return true;
+        }
+        let Some(session) = &event.session_id else {
+            return true;
+        };
+        let Some(record) = &event.source_record_id else {
+            return true;
+        };
+        seen.insert((session.clone(), record.clone(), event.tokens.clone()))
+    });
+}
+
+fn is_system_instruction(text: &str) -> bool {
+    let text = text.trim_start();
+    text.starts_with("<system_instruction>") || text.starts_with("<system-instruction>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn usage(input: u64, cached: u64, output: u64) -> UsageTokens {
+        UsageTokens {
+            input,
+            cached,
+            output,
+            reasoning: 0,
+        }
+    }
+
+    #[test]
+    fn repeated_total_does_not_repeat_last() {
+        let mut counter = UsageCounter::default();
+        assert_eq!(
+            counter.account(Some(usage(100, 20, 10)), Some(usage(100, 20, 10))),
+            usage(100, 20, 10)
+        );
+        assert_eq!(
+            counter.account(Some(usage(100, 20, 10)), Some(usage(100, 20, 10))),
+            usage(0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn interleaved_stream_never_recounts_high_water_gap() {
+        let mut counter = UsageCounter::default();
+        assert_eq!(
+            counter.account(None, Some(usage(1000, 0, 0))),
+            usage(1000, 0, 0)
+        );
+        assert_eq!(
+            counter.account(Some(usage(200, 0, 0)), Some(usage(200, 0, 0))),
+            usage(0, 0, 0)
+        );
+        assert_eq!(
+            counter.account(Some(usage(900, 0, 0)), Some(usage(1100, 0, 0))),
+            usage(100, 0, 0)
+        );
+        assert_eq!(counter.counted.input, 1100);
+    }
+
+    #[test]
+    fn discovers_active_and_archived_rollouts() {
+        let temp = tempfile::tempdir().unwrap();
+        let active = temp.path().join("sessions");
+        let archived = temp.path().join("archived_sessions");
+        fs::create_dir_all(&active).unwrap();
+        fs::create_dir_all(&archived).unwrap();
+        fs::write(active.join("active.jsonl"), "{}\n").unwrap();
+        fs::write(archived.join("archived.jsonl"), "{}\n").unwrap();
+        let files = super::super::common::jsonl_files([active, archived]);
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn probe_resolves_nested_subagent_parent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp
+            .path()
+            .join("rollout-2026-07-20T00-00-00-11111111-1111-4111-8111-111111111111.jsonl");
+        fs::write(
+            &path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"11111111-1111-4111-8111-111111111111\",\"cwd\":\"/repo/memex\",\"source\":{\"subagent\":{\"thread_spawn\":{\"parent_thread_id\":\"22222222-2222-4222-8222-222222222222\"}}}}}\n",
+        )
+        .unwrap();
+        let metadata = probe(&path).unwrap();
+        assert_eq!(
+            metadata.session.parent_session_id.as_deref(),
+            Some("22222222-2222-4222-8222-222222222222")
+        );
+        assert_eq!(
+            metadata.session.conversation_kind,
+            ConversationKind::Subagent
+        );
+        assert_eq!(metadata.project.as_deref(), Some("memex"));
+    }
+}

--- a/src/sources/common.rs
+++ b/src/sources/common.rs
@@ -1,0 +1,111 @@
+use crate::state::PendingToolCall;
+use crate::types::RecordLinks;
+use chrono::{DateTime, Utc};
+use directories::BaseDirs;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub fn home() -> PathBuf {
+    BaseDirs::new()
+        .map(|dirs| dirs.home_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+pub fn parse_iso_millis(input: &str) -> Option<u64> {
+    DateTime::parse_from_rfc3339(input)
+        .ok()
+        .map(|date| date.with_timezone(&Utc).timestamp_millis().max(0) as u64)
+}
+
+pub fn timestamp_millis(value: &Value) -> u64 {
+    value
+        .as_u64()
+        .or_else(|| value.as_i64().map(|value| value.max(0) as u64))
+        .or_else(|| value.as_str().and_then(parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub fn jsonl_files(roots: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut files = roots
+        .into_iter()
+        .filter(|root| root.exists())
+        .flat_map(|root| {
+            WalkDir::new(root)
+                .into_iter()
+                .flatten()
+                .filter(|entry| {
+                    entry.file_type().is_file()
+                        && entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                })
+                .map(|entry| entry.path().to_path_buf())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+    files
+}
+
+pub fn project_from_path(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(path)
+        .to_string()
+}
+
+pub(crate) fn pending_tool_call(
+    tool_name: Option<String>,
+    event_id: Option<String>,
+    doc_id: u64,
+    timestamp: u64,
+    arguments: Option<&str>,
+    links: &RecordLinks,
+    session_id: &str,
+) -> PendingToolCall {
+    PendingToolCall {
+        tool_name,
+        tool_use_event_id: event_id,
+        tool_use_doc_id: Some(doc_id),
+        timestamp,
+        argument_sha256: arguments.map(|value| format!("{:x}", Sha256::digest(value.as_bytes()))),
+        argument_bytes: arguments.map(|value| value.len() as u64),
+        parent_event_id: links.parent_event_id.clone(),
+        session_id: Some(session_id.to_string()),
+        source_tool_use_id: links.source_tool_use_id.clone(),
+        source_tool_assistant_uuid: links.source_tool_assistant_uuid.clone(),
+    }
+}
+
+pub(crate) fn borrowed_string(
+    object: &simd_json::borrowed::Object<'_>,
+    key: &str,
+) -> Option<String> {
+    use simd_json::prelude::*;
+    object
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+pub(crate) fn tool_result_text(block: &simd_json::BorrowedValue<'_>) -> Option<String> {
+    use simd_json::prelude::*;
+    let object = block.as_object()?;
+    let content = object.get("content")?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let array = content.as_array()?;
+    let parts = array
+        .iter()
+        .filter_map(|item| {
+            item.as_object()
+                .and_then(|object| object.get("text"))
+                .and_then(|value| value.as_str())
+        })
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}

--- a/src/sources/copilot.rs
+++ b/src/sources/copilot.rs
@@ -1,0 +1,771 @@
+use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use memchr::memchr;
+use memmap2::Mmap;
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::collections::HashSet;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 2,
+    index: 2,
+    usage: 3,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    path.contains(".copilot/session-state")
+        || path.contains(".copilot\\session-state")
+        || path.contains("/session-state/")
+        || path.contains("\\session-state\\")
+}
+
+pub fn root() -> PathBuf {
+    std::env::var_os("COPILOT_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::common::home().join(".copilot"))
+}
+
+pub fn session_root() -> PathBuf {
+    root().join("session-state")
+}
+
+pub fn discover_sessions() -> Vec<SourceFile> {
+    discover_sessions_from_root(&session_root())
+}
+
+pub fn discover_sessions_from_root(root: &Path) -> Vec<SourceFile> {
+    let mut files = WalkDir::new(root)
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().file_name().and_then(|name| name.to_str()) == Some("events.jsonl")
+        })
+        .map(|entry| SourceFile {
+            source: SourceKind::Copilot,
+            path: entry.path().to_path_buf(),
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files
+}
+
+pub fn session_id_from_path(path: &Path) -> Option<String> {
+    path.parent()?
+        .file_name()?
+        .to_str()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub fn usage_files() -> Vec<PathBuf> {
+    let mut roots = vec![root().join("otel")];
+    if let Some(path) = std::env::var_os("COPILOT_OTEL_FILE_EXPORTER_PATH") {
+        roots.push(PathBuf::from(path));
+    }
+    roots
+        .into_iter()
+        .flat_map(|root| {
+            if root.is_file() {
+                vec![root]
+            } else {
+                super::common::jsonl_files([root])
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Default)]
+struct CopilotWorkspace {
+    cwd: Option<String>,
+    git_root: Option<String>,
+    repository: Option<String>,
+    branch: Option<String>,
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+
+    let source_path = path.to_string_lossy().to_string();
+    let mut session_id = crate::sources::copilot::session_id_from_path(path)
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut workspace = read_copilot_workspace(path);
+    let mut project = copilot_project(&workspace);
+    let mut pending_tool_calls = state.pending_tool_calls;
+
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + usize::from(rel < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_slice(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let Some(obj) = value.as_object() else {
+            continue;
+        };
+        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let data = obj
+            .get("data")
+            .or_else(|| obj.get("payload"))
+            .unwrap_or(&serde_json::Value::Null);
+        let timestamp = obj
+            .get("timestamp")
+            .and_then(json_timestamp_millis)
+            .or_else(|| data.get("timestamp").and_then(json_timestamp_millis))
+            .unwrap_or(0);
+
+        match entry_type {
+            "session.start" | "session.resume" => {
+                if let Some(id) = data
+                    .get("sessionId")
+                    .or_else(|| data.get("session_id"))
+                    .and_then(|v| v.as_str())
+                {
+                    session_id = id.to_string();
+                }
+                merge_copilot_workspace(&mut workspace, data.get("context").unwrap_or(data));
+                project = copilot_project(&workspace);
+            }
+            "session.context_changed" => {
+                merge_copilot_workspace(&mut workspace, data);
+                project = copilot_project(&workspace);
+            }
+            "user.message" => {
+                let text = data
+                    .get("content")
+                    .or_else(|| data.get("message"))
+                    .or_else(|| data.get("prompt"))
+                    .and_then(text_from_json)
+                    .unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
+                let record = Record {
+                    source: SourceKind::Copilot,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "user".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "assistant.message" => {
+                let text = data
+                    .get("content")
+                    .and_then(text_from_json)
+                    .unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
+                let record = Record {
+                    source: SourceKind::Copilot,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "tool.execution_start" | "tool.user_requested" => {
+                let tool_name = data
+                    .get("toolName")
+                    .or_else(|| data.get("name"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let tool_input = data
+                    .get("arguments")
+                    .map(json_to_text)
+                    .filter(|s| !s.is_empty());
+                let text = tool_input.clone().unwrap_or_default();
+                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
+                let call_id = data
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                if let Some(call_id) = &call_id {
+                    links.event_id = Some(call_id.clone());
+                }
+                let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                if let Some(call_id) = call_id {
+                    pending_tool_calls.insert(
+                        call_id.clone(),
+                        super::common::pending_tool_call(
+                            tool_name.clone(),
+                            Some(call_id),
+                            doc_id,
+                            timestamp,
+                            tool_input.as_deref(),
+                            &links,
+                            &session_id,
+                        ),
+                    );
+                }
+                let record = Record {
+                    source: SourceKind::Copilot,
+                    doc_id,
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_use".to_string(),
+                    text,
+                    tool_name,
+                    tool_input,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "tool.execution_complete" => {
+                let call_id = data
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let tool_name = data
+                    .get("toolName")
+                    .or_else(|| data.get("name"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        (!call_id.is_empty())
+                            .then(|| pending_tool_calls.get(call_id))
+                            .flatten()
+                            .and_then(|call| call.tool_name.clone())
+                    });
+                if !call_id.is_empty() {
+                    pending_tool_calls.remove(call_id);
+                }
+                let tool_output = copilot_tool_output(data);
+                let text = tool_output.clone().unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let mut links = copilot_record_links(obj, data, &session_id, turn_id);
+                if !call_id.is_empty() {
+                    links.parent_event_id = Some(call_id.to_string());
+                    links.parent_tool_use_id = Some(call_id.to_string());
+                }
+                let record = Record {
+                    source: SourceKind::Copilot,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "session.task_complete" => {
+                let text = data
+                    .get("summary")
+                    .and_then(text_from_json)
+                    .unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let links = copilot_record_links(obj, data, &session_id, turn_id);
+                let record = Record {
+                    source: SourceKind::Copilot,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+    })
+}
+
+fn read_copilot_workspace(events_path: &Path) -> CopilotWorkspace {
+    let Some(dir) = events_path.parent() else {
+        return CopilotWorkspace::default();
+    };
+    let path = dir.join("workspace.yaml");
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return CopilotWorkspace::default();
+    };
+    parse_copilot_workspace_yaml(&contents)
+}
+
+fn parse_copilot_workspace_yaml(contents: &str) -> CopilotWorkspace {
+    let mut workspace = CopilotWorkspace::default();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('#')
+            || line.chars().next().is_some_and(|c| c.is_whitespace())
+        {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let value = value
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
+        if value.is_empty() {
+            continue;
+        }
+        match key.trim() {
+            "cwd" => workspace.cwd = Some(value),
+            "gitRoot" | "git_root" => workspace.git_root = Some(value),
+            "repository" => workspace.repository = Some(value),
+            "branch" => workspace.branch = Some(value),
+            _ => {}
+        }
+    }
+    workspace
+}
+
+fn merge_copilot_workspace(workspace: &mut CopilotWorkspace, value: &serde_json::Value) {
+    if let Some(cwd) = value.get("cwd").and_then(|v| v.as_str()) {
+        workspace.cwd = Some(cwd.to_string());
+    }
+    if let Some(git_root) = value
+        .get("gitRoot")
+        .or_else(|| value.get("git_root"))
+        .and_then(|v| v.as_str())
+    {
+        workspace.git_root = Some(git_root.to_string());
+    }
+    if let Some(repository) = value.get("repository").and_then(|v| v.as_str()) {
+        workspace.repository = Some(repository.to_string());
+    }
+    if let Some(branch) = value.get("branch").and_then(|v| v.as_str()) {
+        workspace.branch = Some(branch.to_string());
+    }
+}
+
+fn copilot_project(workspace: &CopilotWorkspace) -> String {
+    if let Some(repo) = workspace.repository.as_deref() {
+        if let Some((_, name)) = repo.rsplit_once('/')
+            && !name.is_empty()
+        {
+            return name.to_string();
+        }
+        if !repo.is_empty() {
+            return repo.to_string();
+        }
+    }
+    if let Some(git_root) = workspace.git_root.as_deref() {
+        return super::common::project_from_path(git_root);
+    }
+    if let Some(cwd) = workspace.cwd.as_deref() {
+        return super::common::project_from_path(cwd);
+    }
+    "copilot".to_string()
+}
+
+fn copilot_record_links(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    data: &serde_json::Value,
+    session_id: &str,
+    turn_id: u32,
+) -> RecordLinks {
+    let parent_session_id = copilot_string_field(data, obj, COPILOT_PARENT_SESSION_KEYS);
+    let explicit_thread_source =
+        copilot_string_field(data, obj, &["threadSource", "thread_source", "source"]);
+    let thread_source = explicit_thread_source.or_else(|| {
+        parent_session_id
+            .as_ref()
+            .filter(|parent| parent.as_str() != session_id)
+            .map(|_| "fork".to_string())
+    });
+    let conversation_kind = match thread_source.as_deref() {
+        Some("subagent") => "subagent",
+        Some("sidechain") => "sidechain",
+        Some("branch") => "branch",
+        Some("fork") => "fork",
+        _ => "main",
+    };
+
+    RecordLinks {
+        event_id: copilot_string_field(data, obj, COPILOT_EVENT_KEYS)
+            .or_else(|| Some(format!("{session_id}:{turn_id}"))),
+        parent_event_id: copilot_string_field(data, obj, COPILOT_PARENT_EVENT_KEYS),
+        logical_parent_event_id: copilot_string_field(data, obj, COPILOT_LOGICAL_PARENT_KEYS),
+        parent_session_id,
+        thread_source,
+        conversation_kind: Some(conversation_kind.to_string()),
+        ..RecordLinks::default()
+    }
+}
+
+const COPILOT_EVENT_KEYS: &[&str] = &[
+    "id",
+    "eventId",
+    "event_id",
+    "messageId",
+    "message_id",
+    "requestId",
+    "request_id",
+    "responseId",
+    "response_id",
+];
+const COPILOT_PARENT_EVENT_KEYS: &[&str] = &[
+    "parentId",
+    "parent_id",
+    "parentMessageId",
+    "parent_message_id",
+    "parentEventId",
+    "parent_event_id",
+];
+const COPILOT_LOGICAL_PARENT_KEYS: &[&str] = &["fromId", "from_id", "rootId", "root_id"];
+const COPILOT_PARENT_SESSION_KEYS: &[&str] = &[
+    "parentSessionId",
+    "parent_session_id",
+    "forkedFromSessionId",
+    "forked_from_session_id",
+];
+
+fn copilot_string_field(
+    data: &serde_json::Value,
+    obj: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    for key in keys {
+        if let Some(value) = data
+            .get(*key)
+            .or_else(|| obj.get(*key))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn json_timestamp_millis(value: &serde_json::Value) -> Option<u64> {
+    if let Some(text) = value.as_str() {
+        if let Some(ts) = super::common::parse_iso_millis(text) {
+            return Some(ts);
+        }
+        return text.parse::<u64>().ok();
+    }
+    if let Some(n) = value.as_u64() {
+        return Some(if n < 10_000_000_000 { n * 1000 } else { n });
+    }
+    None
+}
+
+fn text_from_json(value: &serde_json::Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.trim().to_string());
+    }
+    if let Some(arr) = value.as_array() {
+        let mut parts = Vec::new();
+        for item in arr {
+            if let Some(text) = item.as_str() {
+                parts.push(text);
+                continue;
+            }
+            if let Some(obj) = item.as_object()
+                && let Some(text) = obj
+                    .get("text")
+                    .or_else(|| obj.get("content"))
+                    .and_then(|v| v.as_str())
+            {
+                parts.push(text);
+            }
+        }
+        if !parts.is_empty() {
+            return Some(parts.join("\n").trim().to_string());
+        }
+    }
+    None
+}
+
+fn json_to_text(value: &serde_json::Value) -> String {
+    if let Some(text) = text_from_json(value) {
+        return text;
+    }
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+fn copilot_tool_output(data: &serde_json::Value) -> Option<String> {
+    if let Some(result) = data.get("result") {
+        for key in ["detailedContent", "content"] {
+            if let Some(text) = result.get(key).and_then(text_from_json)
+                && !text.trim().is_empty()
+            {
+                return Some(text);
+            }
+        }
+        if let Some(contents) = result.get("contents").and_then(|v| v.as_array()) {
+            let mut parts = Vec::new();
+            for item in contents {
+                if let Some(text) = text_from_json(item) {
+                    parts.push(text);
+                }
+            }
+            if !parts.is_empty() {
+                return Some(parts.join("\n"));
+            }
+        }
+    }
+    if let Some(error) = data.get("error") {
+        if let Some(message) = error.get("message").and_then(|v| v.as_str()) {
+            return Some(message.to_string());
+        }
+        return Some(json_to_text(error));
+    }
+    None
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut start = 0usize;
+    let mut index = 0u64;
+    let mut buffer = Vec::new();
+    let mut events = Vec::new();
+    let mut seen = HashSet::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + usize::from(relative < slice.len());
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        if let Ok(value) = simd_json::to_borrowed_value(&mut buffer) {
+            extract_usage(&value, &source_path, path, index, &mut events, &mut seen);
+        }
+        index += 1;
+    }
+    Ok(events)
+}
+
+fn extract_usage(
+    value: &BorrowedValue<'_>,
+    source_path: &Arc<str>,
+    path: &Path,
+    index: u64,
+    events: &mut Vec<UsageEvent>,
+    seen: &mut HashSet<String>,
+) {
+    if let Some(array) = value.as_array() {
+        for child in array {
+            extract_usage(child, source_path, path, index, events, seen);
+        }
+        return;
+    }
+    let Some(object) = value.as_object() else {
+        return;
+    };
+    let attributes = object.get("attributes").unwrap_or(value);
+    let operation = attribute_str(attributes, "gen_ai.operation.name")
+        .or_else(|| object.get("name").and_then(|value| value.as_str()));
+    let input = attribute_u64(attributes, "gen_ai.usage.input_tokens");
+    let output = attribute_u64(attributes, "gen_ai.usage.output_tokens");
+    if operation == Some("chat") && (input > 0 || output > 0) {
+        let trace = object
+            .get("traceId")
+            .or_else(|| object.get("trace_id"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let span = object
+            .get("spanId")
+            .or_else(|| object.get("span_id"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        let response = attribute_str(attributes, "gen_ai.response.id").unwrap_or("");
+        let id = if !trace.is_empty() || !span.is_empty() {
+            format!("{trace}:{span}")
+        } else if !response.is_empty() {
+            format!("response:{response}")
+        } else {
+            format!("{}:{index}:{input}:{output}", path.display())
+        };
+        if seen.insert(id.clone()) {
+            let cache =
+                attribute_u64(attributes, "gen_ai.usage.cache_read.input_tokens").min(input);
+            events.push(UsageEvent {
+                source: "copilot",
+                source_path: source_path.clone(),
+                source_record_id: Some(id),
+                session_id: attribute_str(attributes, "gen_ai.conversation.id").map(str::to_string),
+                request_id: attribute_str(attributes, "gen_ai.response.id").map(str::to_string),
+                message_id: None,
+                timestamp_ms: object
+                    .get("startTimeUnixNano")
+                    .and_then(value_u64)
+                    .map(|value| value / 1_000_000)
+                    .or_else(|| object.get("timestamp").map(timestamp_millis))
+                    .unwrap_or(0),
+                project: attribute_str(attributes, "copilot_chat.repo.remote_url")
+                    .or_else(|| attribute_str(attributes, "github.copilot.git.repository"))
+                    .map(str::to_string),
+                provider: Some("github-copilot".into()),
+                model: attribute_str(attributes, "gen_ai.response.model")
+                    .or_else(|| attribute_str(attributes, "gen_ai.request.model"))
+                    .map(str::to_string),
+                tokens: TokenBuckets::codex(
+                    input,
+                    cache,
+                    output,
+                    attribute_u64(attributes, "gen_ai.usage.reasoning.output_tokens")
+                        .max(attribute_u64(attributes, "gen_ai.usage.reasoning_tokens")),
+                ),
+                source_cost_usd: None,
+                dedupe_confidence: "exact",
+                conservative_undercount: false,
+                sidechain: false,
+                source_order: index,
+            });
+        }
+    }
+    for child in object.values() {
+        if child.is_array() || child.is_object() {
+            extract_usage(child, source_path, path, index, events, seen);
+        }
+    }
+}
+
+fn attribute<'a>(attributes: &'a BorrowedValue<'a>, key: &str) -> Option<&'a BorrowedValue<'a>> {
+    if let Some(object) = attributes.as_object() {
+        return object.get(key).map(unwrap_attribute);
+    }
+    attributes.as_array()?.iter().find_map(|item| {
+        (item.get("key").and_then(|value| value.as_str()) == Some(key))
+            .then(|| item.get("value").map(unwrap_attribute))
+            .flatten()
+    })
+}
+
+fn unwrap_attribute<'a>(value: &'a BorrowedValue<'a>) -> &'a BorrowedValue<'a> {
+    ["stringValue", "intValue", "doubleValue", "boolValue"]
+        .iter()
+        .find_map(|key| value.get(*key))
+        .unwrap_or(value)
+}
+
+fn value_u64(value: &BorrowedValue<'_>) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_i64().and_then(|value| u64::try_from(value).ok()))
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+}
+
+fn attribute_u64(attributes: &BorrowedValue<'_>, key: &str) -> u64 {
+    attribute(attributes, key).and_then(value_u64).unwrap_or(0)
+}
+
+fn attribute_str<'a>(attributes: &'a BorrowedValue<'a>, key: &str) -> Option<&'a str> {
+    attribute(attributes, key)?.as_str()
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value_u64(value)
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        event.source != "copilot"
+            || event
+                .source_record_id
+                .as_ref()
+                .is_none_or(|record| seen.insert(record.clone()))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_decoder_reads_wrapped_otel_attributes() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("usage.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"resourceSpans":[{"scopeSpans":[{"spans":[{"name":"chat","traceId":"trace","spanId":"span","startTimeUnixNano":"1750000000000000000","attributes":[{"key":"gen_ai.operation.name","value":{"stringValue":"chat"}},{"key":"gen_ai.usage.input_tokens","value":{"intValue":"100"}},{"key":"gen_ai.usage.cache_read.input_tokens","value":{"intValue":"40"}},{"key":"gen_ai.usage.output_tokens","value":{"intValue":"20"}},{"key":"gen_ai.conversation.id","value":{"stringValue":"session"}},{"key":"gen_ai.response.id","value":{"stringValue":"response"}},{"key":"gen_ai.response.model","value":{"stringValue":"gpt-5"}}]}]}]}]}"#,
+        )
+        .unwrap();
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source_record_id.as_deref(), Some("trace:span"));
+        assert_eq!(events[0].session_id.as_deref(), Some("session"));
+        assert_eq!(events[0].request_id.as_deref(), Some("response"));
+        assert_eq!(events[0].model.as_deref(), Some("gpt-5"));
+        assert_eq!(events[0].tokens.uncached_input, 60);
+        assert_eq!(events[0].tokens.cache_read, 40);
+        assert_eq!(events[0].tokens.output, 20);
+        assert_eq!(events[0].timestamp_ms, 1_750_000_000_000);
+    }
+}

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -1,0 +1,610 @@
+use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use memchr::memchr;
+use memmap2::Mmap;
+use rusqlite::{Connection, OpenFlags};
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 2,
+    index: 2,
+    usage: 3,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    path.contains(".cursor/projects")
+        || path.contains(".cursor\\projects")
+        || path.contains("agent-transcripts")
+}
+
+pub fn projects_root() -> PathBuf {
+    super::common::home().join(".cursor/projects")
+}
+
+pub fn discover_transcripts() -> Vec<SourceFile> {
+    let mut files = WalkDir::new(projects_root())
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                && entry.path().to_str().is_some_and(|path| {
+                    path.contains("/agent-transcripts/") || path.contains("\\agent-transcripts\\")
+                })
+        })
+        .map(|entry| SourceFile {
+            source: SourceKind::Cursor,
+            path: entry.path().to_path_buf(),
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files
+}
+
+pub fn transcript_id(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn session_id_from_path(path: &Path) -> String {
+    let components = path.components().collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        if component.as_os_str().to_str() == Some("agent-transcripts")
+            && let Some(session) = components
+                .get(index + 1)
+                .and_then(|component| Path::new(component.as_os_str()).file_stem())
+                .and_then(|stem| stem.to_str())
+                .filter(|stem| !stem.is_empty())
+        {
+            return session.to_string();
+        }
+    }
+    crate::sources::codex::session_id_from_path(path).unwrap_or_else(|| transcript_id(path))
+}
+
+pub fn project_from_path(path: &Path) -> String {
+    let Ok(relative) = path.strip_prefix(projects_root()) else {
+        return SourceKind::Cursor.label().to_string();
+    };
+    relative
+        .components()
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+        .map(|folder| {
+            if folder == "empty-window" {
+                folder.to_string()
+            } else {
+                folder
+                    .trim_matches('-')
+                    .rsplit('-')
+                    .find(|part| !part.is_empty())
+                    .unwrap_or(folder)
+                    .to_string()
+            }
+        })
+        .unwrap_or_else(|| SourceKind::Cursor.label().to_string())
+}
+
+const SUBAGENT_TURN_BASE: u32 = 1_000_000_000;
+const SUBAGENT_TURN_STRIDE: u32 = 50_000;
+const SUBAGENT_TURN_BUCKETS: u32 = 65_536;
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    mtime: i64,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = initial_turn_id(path, state.turn_id);
+    let mut pending_tool_calls = state.pending_tool_calls;
+    let source_path = path.to_string_lossy().to_string();
+    let session_id = session_id_from_path(path);
+    let project = project_from_path(path);
+    let timestamp = mtime.max(0) as u64 * 1000;
+    let mut buffer = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + usize::from(relative < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        let role = object
+            .get("role")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if role != "user" && role != "assistant" {
+            continue;
+        }
+        let Some(message) = object.get("message").and_then(|value| value.as_object()) else {
+            continue;
+        };
+        let mut text_parts = Vec::new();
+        if let Some(content) = message.get("content") {
+            if let Some(text) = content.as_str() {
+                text_parts.push(text);
+            } else if let Some(array) = content.as_array() {
+                for block in array {
+                    let Some(block_object) = block.as_object() else {
+                        continue;
+                    };
+                    match block_object
+                        .get("type")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("")
+                    {
+                        "text" => {
+                            if let Some(text) =
+                                block_object.get("text").and_then(|value| value.as_str())
+                            {
+                                text_parts.push(text);
+                            }
+                        }
+                        "tool_use" => {
+                            let tool_name = super::common::borrowed_string(block_object, "name");
+                            let tool_input = block_object.get("input").map(ToString::to_string);
+                            let tool_id = ["id", "tool_use_id", "toolCallId"]
+                                .iter()
+                                .find_map(|key| {
+                                    block_object.get(*key).and_then(|value| value.as_str())
+                                })
+                                .map(str::to_string);
+                            let mut links = record_links(path, &session_id, turn_id);
+                            links.event_id = tool_id.clone();
+                            let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                            if let Some(tool_id) = tool_id {
+                                pending_tool_calls.insert(
+                                    tool_id.clone(),
+                                    super::common::pending_tool_call(
+                                        tool_name.clone(),
+                                        Some(tool_id),
+                                        doc_id,
+                                        timestamp,
+                                        tool_input.as_deref(),
+                                        &links,
+                                        &session_id,
+                                    ),
+                                );
+                            }
+                            emit(Record {
+                                source: SourceKind::Cursor,
+                                doc_id,
+                                ts: timestamp,
+                                project: project.clone(),
+                                session_id: session_id.clone(),
+                                turn_id,
+                                role: "tool_use".to_string(),
+                                text: tool_input.clone().unwrap_or_default(),
+                                tool_name,
+                                tool_input,
+                                tool_output: None,
+                                links,
+                                source_path: source_path.clone(),
+                            })?;
+                            turn_id += 1;
+                        }
+                        "tool_result" => {
+                            let tool_output = block_object.get("content").map(ToString::to_string);
+                            let mut text =
+                                super::common::tool_result_text(block).unwrap_or_default();
+                            if text.is_empty() {
+                                text = tool_output.clone().unwrap_or_default();
+                            }
+                            if text.is_empty() {
+                                continue;
+                            }
+                            let tool_use_id = ["tool_use_id", "toolCallId"]
+                                .iter()
+                                .find_map(|key| {
+                                    block_object.get(*key).and_then(|value| value.as_str())
+                                })
+                                .map(str::to_string);
+                            let pending = tool_use_id
+                                .as_ref()
+                                .and_then(|id| pending_tool_calls.remove(id));
+                            let tool_name = super::common::borrowed_string(block_object, "name")
+                                .or_else(|| pending.and_then(|call| call.tool_name));
+                            let mut links = record_links(path, &session_id, turn_id);
+                            if let Some(tool_use_id) = tool_use_id {
+                                links.parent_event_id = Some(tool_use_id.clone());
+                                links.parent_tool_use_id = Some(tool_use_id);
+                            }
+                            emit(Record {
+                                source: SourceKind::Cursor,
+                                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                ts: timestamp,
+                                project: project.clone(),
+                                session_id: session_id.clone(),
+                                turn_id,
+                                role: "tool_result".to_string(),
+                                text,
+                                tool_name,
+                                tool_input: None,
+                                tool_output,
+                                links,
+                                source_path: source_path.clone(),
+                            })?;
+                            turn_id += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let text = text_parts.join("\n").trim().to_string();
+        if !text.is_empty() {
+            emit(Record {
+                source: SourceKind::Cursor,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: role.to_string(),
+                text,
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                links: record_links(path, &session_id, turn_id),
+                source_path: source_path.clone(),
+            })?;
+            turn_id += 1;
+        }
+    }
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+    })
+}
+
+pub(crate) fn initial_turn_id(path: &Path, cached_turn_id: u32) -> u32 {
+    if cached_turn_id != 0 {
+        return cached_turn_id;
+    }
+    subagent_turn_base(path).unwrap_or(cached_turn_id)
+}
+
+fn subagent_turn_base(path: &Path) -> Option<u32> {
+    if !is_subagent_transcript(path) {
+        return None;
+    }
+    let agent_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|id| !id.is_empty())?;
+    Some(SUBAGENT_TURN_BASE + stable_turn_bucket(agent_id).saturating_mul(SUBAGENT_TURN_STRIDE))
+}
+
+fn is_subagent_transcript(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str().to_str() == Some("subagents"))
+}
+
+pub(crate) fn record_links(path: &Path, session_id: &str, turn_id: u32) -> RecordLinks {
+    let is_subagent = is_subagent_transcript(path);
+    RecordLinks {
+        event_id: Some(format!("{}:{turn_id}", transcript_id(path))),
+        parent_session_id: is_subagent.then(|| session_id.to_string()),
+        thread_source: is_subagent.then(|| "subagent".to_string()),
+        conversation_kind: Some(if is_subagent { "subagent" } else { "main" }.to_string()),
+        ..RecordLinks::default()
+    }
+}
+
+fn stable_turn_bucket(value: &str) -> u32 {
+    let mut hash = 2_166_136_261u32;
+    for byte in value.as_bytes() {
+        hash ^= *byte as u32;
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    hash % SUBAGENT_TURN_BUCKETS
+}
+
+pub fn usage_databases() -> Vec<PathBuf> {
+    let user = if cfg!(target_os = "macos") {
+        super::common::home().join("Library/Application Support/Cursor/User")
+    } else {
+        super::common::home().join(".config/Cursor/User")
+    };
+    let mut databases = vec![user.join("globalStorage/state.vscdb")];
+    databases.extend(
+        WalkDir::new(user.join("workspaceStorage"))
+            .max_depth(3)
+            .into_iter()
+            .flatten()
+            .filter(|entry| entry.file_type().is_file() && entry.file_name() == "state.vscdb")
+            .map(|entry| entry.path().to_path_buf()),
+    );
+    databases.retain(|path| path.exists());
+    databases
+}
+
+pub(crate) fn project_by_session() -> HashMap<String, String> {
+    let mut projects = HashMap::new();
+    for entry in WalkDir::new(projects_root())
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+        })
+    {
+        let path = entry.path();
+        let project = project_from_path(path);
+        projects.insert(session_id_from_path(path), project.clone());
+        projects.insert(transcript_id(path), project);
+    }
+    projects
+}
+
+pub(crate) fn apply_projects(
+    events: &mut [UsageEvent],
+    project_by_session: &HashMap<String, String>,
+) {
+    for event in events {
+        event.project = event
+            .session_id
+            .as_deref()
+            .and_then(|session| project_by_session.get(session))
+            .cloned();
+    }
+}
+
+pub(crate) fn parse_usage_database(path: &Path) -> Result<Vec<UsageEvent>> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    connection.busy_timeout(Duration::from_secs(1))?;
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut events = Vec::new();
+    let mut seen = HashSet::new();
+    for (table, query) in [
+        (
+            "cursorDiskKV",
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'",
+        ),
+        (
+            "ItemTable",
+            "SELECT key, value FROM ItemTable WHERE key IN ('aiService.generations', 'workbench.panel.aichat.view.aichat.chatdata')",
+        ),
+    ] {
+        let exists: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+            [table],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            continue;
+        }
+        let mut statement = connection.prepare(query)?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })?;
+        for row in rows {
+            let (key, Some(raw)) = row? else {
+                continue;
+            };
+            let mut bytes = raw.into_bytes();
+            let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+                continue;
+            };
+            extract_usage(&value, &key, table, &source_path, &mut events, &mut seen);
+        }
+    }
+    Ok(events)
+}
+
+fn extract_usage(
+    value: &BorrowedValue<'_>,
+    fallback_id: &str,
+    table: &str,
+    source_path: &Arc<str>,
+    events: &mut Vec<UsageEvent>,
+    seen: &mut HashSet<String>,
+) {
+    if let Some(array) = value.as_array() {
+        for child in array {
+            extract_usage(child, fallback_id, table, source_path, events, seen);
+        }
+        return;
+    }
+    let Some(object) = value.as_object() else {
+        return;
+    };
+    let input = nested_u64(value, &["inputTokens", "input_tokens"]);
+    let output = nested_u64(value, &["outputTokens", "output_tokens"]);
+    let session_id = borrowed_string(value, &["sessionId", "composerId"]).or_else(|| {
+        fallback_id
+            .strip_prefix("composerData:")
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+    });
+    let counted = input > 0 || output > 0;
+    if counted {
+        let id = borrowed_string(value, &["generationUUID", "generationId", "bubbleId", "id"])
+            .unwrap_or_else(|| {
+                let created = object
+                    .get("createdAt")
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| "null".to_string());
+                format!("{fallback_id}:{created}:{}", input + output)
+            });
+        let dedupe = format!("{id}:{input}:{output}");
+        if seen.insert(dedupe) {
+            events.push(UsageEvent {
+                source: "cursor",
+                source_path: source_path.clone(),
+                source_record_id: Some(id),
+                session_id,
+                request_id: None,
+                message_id: None,
+                timestamp_ms: object
+                    .get("createdAt")
+                    .or_else(|| object.get("timestamp"))
+                    .map(timestamp_millis)
+                    .unwrap_or(0),
+                project: None,
+                provider: None,
+                model: borrowed_string(value, &["model", "modelName"])
+                    .or_else(|| {
+                        object
+                            .get("modelInfo")
+                            .and_then(|value| borrowed_string(value, &["modelName"]))
+                    })
+                    .or_else(|| {
+                        object
+                            .get("modelConfig")
+                            .and_then(|value| borrowed_string(value, &["modelName"]))
+                    }),
+                tokens: TokenBuckets::disjoint(input, 0, 0, output),
+                source_cost_usd: None,
+                dedupe_confidence: if table == "cursorDiskKV" {
+                    "exact"
+                } else {
+                    "strong"
+                },
+                conservative_undercount: false,
+                sidechain: false,
+                source_order: 0,
+            });
+        }
+    }
+    for (key, child) in object {
+        if counted && matches!(key.as_ref(), "usage" | "tokenCount") {
+            continue;
+        }
+        if child.is_array() || child.is_object() {
+            extract_usage(child, fallback_id, table, source_path, events, seen);
+        }
+    }
+}
+
+fn nested_u64(value: &BorrowedValue<'_>, aliases: &[&str]) -> u64 {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_u64()))
+        .or_else(|| {
+            value.get("tokenCount").and_then(|nested| {
+                aliases
+                    .iter()
+                    .find_map(|key| nested.get(*key).and_then(|value| value.as_u64()))
+            })
+        })
+        .or_else(|| {
+            value.get("usage").and_then(|nested| {
+                aliases
+                    .iter()
+                    .find_map(|key| nested.get(*key).and_then(|value| value.as_u64()))
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn borrowed_string(value: &BorrowedValue<'_>, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_str()))
+        .map(str::to_string)
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| value as u64)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        event.source != "cursor"
+            || event.source_record_id.as_ref().is_none_or(|record| {
+                seen.insert((record.clone(), event.tokens.raw_input, event.tokens.output))
+            })
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_token_containers_are_not_recounted() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.vscdb");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                r#"CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);
+                   INSERT INTO cursorDiskKV VALUES (
+                     'composerData:composer-main',
+                     '[{"generationUUID":"usage-parent","composerId":"composer-main","usage":{"inputTokens":10,"outputTokens":5},"children":[{"generationId":"nested-request","inputTokens":7,"outputTokens":3}]},{"generationUUID":"count-parent","tokenCount":{"input_tokens":20,"output_tokens":8}}]'
+                   );"#,
+            )
+            .unwrap();
+        drop(connection);
+
+        let mut events = parse_usage_database(&path).unwrap();
+        apply_projects(
+            &mut events,
+            &HashMap::from([("composer-main".to_string(), "memex".to_string())]),
+        );
+
+        assert_eq!(events.len(), 3);
+        let ids = events
+            .iter()
+            .filter_map(|event| event.source_record_id.as_deref())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            ids,
+            HashSet::from(["usage-parent", "nested-request", "count-parent"])
+        );
+        assert_eq!(
+            events.iter().map(|event| event.tokens.total()).sum::<u64>(),
+            53
+        );
+        assert_eq!(events[0].project.as_deref(), Some("memex"));
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,0 +1,173 @@
+//! Source-owned transcript discovery, identity, and projection adapters.
+//!
+//! Indexing and usage reconstruction deliberately remain independent projections.  The
+//! adapters in this module make them share source identity, discovery, hierarchy, and
+//! parser-version rules without introducing a persisted normalized transcript store.
+
+pub mod claude;
+pub mod codex;
+pub mod common;
+pub mod copilot;
+pub mod cursor;
+pub mod opencode;
+pub mod pi;
+
+use crate::state::PendingToolCall;
+use crate::types::SourceKind;
+use crate::usage::UsageEvent;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationKind {
+    Main,
+    Subagent,
+    Sidechain,
+    Fork,
+    Branch,
+    Compaction,
+}
+
+impl ConversationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::Subagent => "subagent",
+            Self::Sidechain => "sidechain",
+            Self::Fork => "fork",
+            Self::Branch => "branch",
+            Self::Compaction => "compaction",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceFile {
+    pub source: SourceKind,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionIdentity {
+    pub source: SourceKind,
+    pub session_id: String,
+    pub parent_session_id: Option<String>,
+    pub conversation_kind: ConversationKind,
+    pub source_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceMetadata {
+    pub session: SessionIdentity,
+    pub cwd: Option<PathBuf>,
+    pub project: Option<String>,
+    pub git_branch: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParserVersions {
+    /// Rules shared by both projections: discovery, logical session, hierarchy, and project.
+    pub identity: u32,
+    /// Byte-offset/Tantivy record projection.
+    pub index: u32,
+    /// Request/token projection.
+    pub usage: i64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct IndexParseState {
+    pub offset: u64,
+    pub turn_id: u32,
+    pub pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct IndexParseOutput {
+    pub offset: u64,
+    pub turn_id: u32,
+    pub pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
+    pub session_id: Option<String>,
+}
+
+/// A file whose content a cached usage projection depends on. Sources that reconstruct
+/// cross-file state (currently Codex forks) attach these fingerprints to their parse result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct UsageDependency {
+    pub path: String,
+    pub size: u64,
+    pub mtime_ns: i64,
+}
+
+impl UsageDependency {
+    pub fn from_path(path: &Path) -> std::io::Result<Self> {
+        let metadata = path.metadata()?;
+        let mtime_ns = metadata
+            .modified()?
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+            .min(i64::MAX as u128) as i64;
+        Ok(Self {
+            path: path.to_string_lossy().to_string(),
+            size: metadata.len(),
+            mtime_ns,
+        })
+    }
+
+    pub fn is_current(&self) -> bool {
+        Self::from_path(Path::new(&self.path))
+            .is_ok_and(|current| current.size == self.size && current.mtime_ns == self.mtime_ns)
+    }
+}
+
+/// Source-owned usage parsing output. The shared usage pipeline only caches and assembles it.
+pub(crate) struct UsageParseOutput {
+    pub events: Vec<UsageEvent>,
+    pub cacheable: bool,
+    pub deps: Vec<UsageDependency>,
+}
+
+impl UsageParseOutput {
+    pub fn cacheable(events: Vec<UsageEvent>) -> Self {
+        Self {
+            events,
+            cacheable: true,
+            deps: Vec::new(),
+        }
+    }
+}
+
+pub fn versions(source: SourceKind) -> ParserVersions {
+    match source {
+        SourceKind::Claude => claude::VERSIONS,
+        SourceKind::CodexSession | SourceKind::CodexHistory => codex::VERSIONS,
+        SourceKind::Cursor => cursor::VERSIONS,
+        SourceKind::Opencode => opencode::VERSIONS,
+        SourceKind::Pi => pi::VERSIONS,
+        SourceKind::Copilot => copilot::VERSIONS,
+    }
+}
+
+pub fn index_state_version(source: SourceKind) -> u32 {
+    let versions = versions(source);
+    versions.identity.saturating_mul(10_000) + versions.index
+}
+
+/// Compatibility classification for persisted records that only carry a source path.
+/// Individual path rules stay beside the source discovery code that defines them.
+pub fn classify_path(path: &str) -> SourceKind {
+    if let Some(source) = codex::classify_path(path) {
+        source
+    } else if opencode::matches_path(path) {
+        SourceKind::Opencode
+    } else if cursor::matches_path(path) {
+        SourceKind::Cursor
+    } else if pi::matches_path(path) {
+        SourceKind::Pi
+    } else if copilot::matches_path(path) {
+        SourceKind::Copilot
+    } else {
+        SourceKind::Claude
+    }
+}

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -1,0 +1,479 @@
+use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use rusqlite::{Connection, OpenFlags};
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 2,
+    index: 2,
+    usage: 3,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    path.contains("opencode/storage/message") || path.contains("opencode\\storage\\message")
+}
+
+pub fn data_roots() -> Vec<PathBuf> {
+    std::env::var_os("OPENCODE_DATA_DIR")
+        .map(|roots| {
+            roots
+                .to_string_lossy()
+                .split(',')
+                .map(|root| PathBuf::from(root.trim()))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![super::common::home().join(".local/share/opencode")])
+}
+
+pub fn storage_root() -> PathBuf {
+    data_roots()
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| super::common::home().join(".local/share/opencode"))
+        .join("storage")
+}
+
+pub fn message_root() -> PathBuf {
+    storage_root().join("message")
+}
+
+pub fn parts_root() -> PathBuf {
+    storage_root().join("part")
+}
+
+pub fn discover_sessions() -> anyhow::Result<Vec<SourceFile>> {
+    discover_sessions_from_root(&message_root())
+}
+
+pub fn discover_sessions_from_root(root: &Path) -> anyhow::Result<Vec<SourceFile>> {
+    let mut files = Vec::new();
+    if !root.exists() {
+        return Ok(files);
+    }
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir()
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("ses_"))
+        {
+            files.push(SourceFile {
+                source: SourceKind::Opencode,
+                path: entry.path(),
+            });
+        }
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(files)
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SessionLinks {
+    pub parent_session_id: Option<String>,
+    pub thread_source: Option<String>,
+    pub conversation_kind: Option<String>,
+}
+
+impl SessionLinks {
+    fn record_links(&self) -> RecordLinks {
+        RecordLinks {
+            parent_session_id: self.parent_session_id.clone(),
+            thread_source: self.thread_source.clone(),
+            conversation_kind: self.conversation_kind.clone(),
+            ..RecordLinks::default()
+        }
+    }
+}
+
+fn default_session_links() -> SessionLinks {
+    SessionLinks {
+        conversation_kind: Some("main".to_string()),
+        ..SessionLinks::default()
+    }
+}
+
+pub(crate) fn session_links_by_id() -> HashMap<String, SessionLinks> {
+    session_links_by_id_from_root(&storage_root().join("session"))
+}
+
+pub(crate) fn session_links_by_id_from_root(root: &Path) -> HashMap<String, SessionLinks> {
+    let mut links_by_id = HashMap::new();
+    if !root.exists() {
+        return links_by_id;
+    }
+    for entry in WalkDir::new(root).into_iter().flatten().filter(|entry| {
+        entry.file_type().is_file()
+            && entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+    }) {
+        let Some(session_id) = entry
+            .path()
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let Ok(mut bytes) = std::fs::read(entry.path()) else {
+            continue;
+        };
+        let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+            continue;
+        };
+        links_by_id.insert(session_id, session_links_from_value(&value));
+    }
+    links_by_id
+}
+
+fn session_links_from_value(value: &BorrowedValue<'_>) -> SessionLinks {
+    let parent_session_id = value
+        .get("parentID")
+        .and_then(|value| value.as_str())
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    SessionLinks {
+        conversation_kind: Some(if parent_session_id.is_some() {
+            "fork".to_string()
+        } else {
+            "main".to_string()
+        }),
+        thread_source: parent_session_id.as_ref().map(|_| "fork".to_string()),
+        parent_session_id,
+    }
+}
+
+pub(crate) fn parse_index_records(
+    session_dir: &Path,
+    state: IndexParseState,
+    session_links: &HashMap<String, SessionLinks>,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let session_id = session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let links = session_links
+        .get(&session_id)
+        .cloned()
+        .unwrap_or_else(default_session_links);
+    let mut messages = Vec::new();
+    for entry in std::fs::read_dir(session_dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(mut bytes) = std::fs::read(path) else {
+            continue;
+        };
+        let Ok(message) = simd_json::to_borrowed_value(&mut bytes) else {
+            continue;
+        };
+        let Some(message_id) = message
+            .get("id")
+            .and_then(|value| value.as_str())
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        messages.push((
+            message_id.to_string(),
+            message
+                .get("time")
+                .and_then(|value| value.get("created"))
+                .and_then(|value| value.as_u64())
+                .unwrap_or(0),
+            message
+                .get("role")
+                .and_then(|value| value.as_str())
+                .unwrap_or("user")
+                .to_string(),
+        ));
+    }
+    messages.sort_by_key(|message| message.1);
+    let source_path = session_dir.to_string_lossy().to_string();
+    let project = SourceKind::Opencode.label().to_string();
+    let mut turn_id = state.turn_id;
+    for (message_id, timestamp, role) in messages {
+        let part_dir = parts_root().join(&message_id);
+        if !part_dir.exists() {
+            continue;
+        }
+        let mut part_files = std::fs::read_dir(part_dir)?
+            .flatten()
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>();
+        part_files.sort();
+        let mut text_parts = Vec::new();
+        for path in part_files {
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(mut bytes) = std::fs::read(path) else {
+                continue;
+            };
+            let Ok(part) = simd_json::to_borrowed_value(&mut bytes) else {
+                continue;
+            };
+            if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
+                text_parts.push(text.to_string());
+            }
+        }
+        if text_parts.is_empty() {
+            continue;
+        }
+        let mut record_links = links.record_links();
+        record_links.event_id = Some(message_id);
+        emit(Record {
+            source: SourceKind::Opencode,
+            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+            ts: timestamp,
+            project: project.clone(),
+            session_id: session_id.clone(),
+            turn_id,
+            role,
+            text: text_parts.join("\n"),
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            links: record_links,
+            source_path: source_path.clone(),
+        })?;
+        turn_id += 1;
+    }
+    Ok(IndexParseOutput {
+        offset: 0,
+        turn_id,
+        pending_tool_calls: state.pending_tool_calls,
+        session_id: Some(session_id),
+    })
+}
+
+/// Databases precede message files so duplicate reconciliation retains the database copy,
+/// matching OpenCode's pre-cache scan order.
+pub fn usage_files() -> Vec<PathBuf> {
+    let roots = data_roots();
+    let mut files = Vec::new();
+    for root in &roots {
+        let mut databases = std::fs::read_dir(root)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.extension().and_then(|value| value.to_str()) == Some("db")
+                    && path
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .is_some_and(|name| name.starts_with("opencode"))
+            })
+            .collect::<Vec<_>>();
+        databases.sort();
+        files.extend(databases);
+    }
+    for root in &roots {
+        let message_root = root.join("storage/message");
+        if message_root.exists() {
+            files.extend(
+                WalkDir::new(message_root)
+                    .into_iter()
+                    .flatten()
+                    .filter(|entry| {
+                        entry.file_type().is_file()
+                            && entry.path().extension().and_then(|value| value.to_str())
+                                == Some("json")
+                    })
+                    .map(|entry| entry.path().to_path_buf()),
+            );
+        }
+    }
+    files
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    if path.extension().and_then(|value| value.to_str()) == Some("db") {
+        parse_usage_database(path)
+    } else {
+        parse_usage_message(path)
+    }
+}
+
+fn parse_usage_message(path: &Path) -> Result<Vec<UsageEvent>> {
+    let mut bytes = std::fs::read(path)?;
+    let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+        return Ok(Vec::new());
+    };
+    let id = borrowed_string(&value, &["id"]).or_else(|| {
+        path.file_stem()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+    });
+    Ok(usage_event(&value, path, id, None).into_iter().collect())
+}
+
+fn parse_usage_database(path: &Path) -> Result<Vec<UsageEvent>> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    connection.busy_timeout(Duration::from_secs(1))?;
+    let mut statement = connection.prepare("SELECT id, session_id, data FROM message")?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut ids = HashSet::new();
+    let mut events = Vec::new();
+    for row in rows {
+        let (id, session, data) = row?;
+        if ids.contains(&id) {
+            continue;
+        }
+        let mut bytes = data.into_bytes();
+        let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+            continue;
+        };
+        if let Some(mut event) = usage_event(&value, path, Some(id.clone()), session.as_deref()) {
+            event.source_path = source_path.clone();
+            ids.insert(id);
+            events.push(event);
+        }
+    }
+    Ok(events)
+}
+
+fn usage_event(
+    value: &BorrowedValue<'_>,
+    path: &Path,
+    id: Option<String>,
+    fallback_session: Option<&str>,
+) -> Option<UsageEvent> {
+    let usage = value.get("tokens")?;
+    let number = |key: &str| usage.get(key).and_then(|value| value.as_u64()).unwrap_or(0);
+    let reasoning = number("reasoning");
+    let cache = usage.get("cache");
+    let mut tokens = TokenBuckets::disjoint(
+        number("input"),
+        cache
+            .and_then(|value| value.get("read"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        cache
+            .and_then(|value| value.get("write"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        number("output").saturating_add(reasoning),
+    );
+    tokens.reasoning = reasoning;
+    if tokens.additive_total() == 0 {
+        return None;
+    }
+    Some(UsageEvent {
+        source: "opencode",
+        source_path: Arc::from(path.to_string_lossy()),
+        source_record_id: id.clone(),
+        session_id: borrowed_string(value, &["sessionID", "session_id"])
+            .or_else(|| fallback_session.map(str::to_string)),
+        request_id: None,
+        message_id: id,
+        timestamp_ms: value
+            .get("time")
+            .and_then(|value| value.get("created"))
+            .map(timestamp_millis)
+            .unwrap_or(0),
+        project: Some(SourceKind::Opencode.label().to_string()),
+        provider: borrowed_string(value, &["providerID", "provider"]),
+        model: borrowed_string(value, &["modelID", "model"]),
+        tokens,
+        source_cost_usd: value.get("cost").and_then(|value| value.as_f64()),
+        dedupe_confidence: "exact",
+        conservative_undercount: false,
+        sidechain: false,
+        source_order: 0,
+    })
+}
+
+fn borrowed_string(value: &BorrowedValue<'_>, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_str()))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| value as u64)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        event.source != "opencode"
+            || event
+                .source_record_id
+                .as_ref()
+                .is_none_or(|record| seen.insert(record.clone()))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_is_included_in_output_and_total() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("message.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "id": "message",
+                "tokens": {
+                    "input": 100,
+                    "output": 20,
+                    "reasoning": 30,
+                    "cache": { "read": 40, "write": 10 }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tokens.reasoning, 30);
+        assert_eq!(events[0].tokens.output, 50);
+        assert_eq!(events[0].tokens.total(), 200);
+        assert_eq!(events[0].project.as_deref(), Some("opencode"));
+    }
+}

--- a/src/sources/pi.rs
+++ b/src/sources/pi.rs
@@ -1,0 +1,742 @@
+use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use memchr::memchr;
+use memmap2::Mmap;
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 2,
+    index: 2,
+    usage: 3,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    path.contains(".pi/agent/sessions")
+        || path.contains(".pi\\agent\\sessions")
+        || path.contains("pi/agent/sessions")
+        || path.contains("pi\\agent\\sessions")
+}
+
+pub fn agent_root() -> PathBuf {
+    std::env::var_os("PI_CODING_AGENT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::common::home().join(".pi/agent"))
+}
+
+pub fn sessions_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
+        return PathBuf::from(root);
+    }
+    let agent = agent_root();
+    configured_session_root(&agent).unwrap_or_else(|| agent.join("sessions"))
+}
+
+fn configured_session_root(agent: &Path) -> Option<PathBuf> {
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(agent.join("settings.json")).ok()?).ok()?;
+    let raw = value.get("sessionDir")?.as_str()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if raw == "~" {
+        return Some(super::common::home());
+    }
+    if let Some(relative) = raw.strip_prefix("~/") {
+        return Some(super::common::home().join(relative));
+    }
+    let path = PathBuf::from(raw);
+    Some(if path.is_absolute() {
+        path
+    } else {
+        agent.join(path)
+    })
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    super::common::jsonl_files([sessions_root()])
+        .into_iter()
+        .map(|path| SourceFile {
+            source: SourceKind::Pi,
+            path,
+        })
+        .collect()
+}
+
+pub fn session_id_from_path(path: &Path) -> String {
+    crate::sources::codex::session_id_from_path(path)
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}
+
+pub fn project_from_path(path: &Path) -> String {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            let key = if name.starts_with("--") && name.ends_with("--") && name.len() > 4 {
+                &name[1..name.len() - 1]
+            } else {
+                name
+            };
+            key.trim_matches('-')
+                .rsplit('-')
+                .find(|part| !part.is_empty())
+                .unwrap_or(key)
+                .to_string()
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| SourceKind::Pi.label().to_string())
+}
+
+pub(crate) fn apply_session_identity(
+    id: Option<&str>,
+    cwd: Option<&str>,
+    session_id: &mut String,
+    project: &mut String,
+) {
+    if let Some(id) = id.filter(|id| !id.is_empty()) {
+        *session_id = id.to_string();
+    }
+    if let Some(cwd) = cwd.filter(|cwd| !cwd.is_empty()) {
+        *project = super::common::project_from_path(cwd);
+    }
+}
+
+fn apply_session_header(
+    object: &simd_json::borrowed::Object<'_>,
+    session_id: &mut String,
+    project: &mut String,
+) {
+    apply_session_identity(
+        object.get("id").and_then(|value| value.as_str()),
+        object.get("cwd").and_then(|value| value.as_str()),
+        session_id,
+        project,
+    );
+}
+
+fn optional_string(object: &simd_json::borrowed::Object<'_>, key: &str) -> Option<String> {
+    object
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn base_links(object: &simd_json::borrowed::Object<'_>, conversation_kind: &str) -> RecordLinks {
+    RecordLinks {
+        event_id: optional_string(object, "id"),
+        parent_event_id: optional_string(object, "parentId"),
+        logical_parent_event_id: optional_string(object, "fromId"),
+        thread_source: (conversation_kind != "main").then(|| conversation_kind.to_string()),
+        conversation_kind: Some(conversation_kind.to_string()),
+        ..RecordLinks::default()
+    }
+}
+
+fn content_text(content: Option<&BorrowedValue<'_>>) -> String {
+    let Some(content) = content else {
+        return String::new();
+    };
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    if let Some(array) = content.as_array() {
+        let mut parts = Vec::new();
+        for item in array {
+            if let Some(text) = item.as_str() {
+                parts.push(text.to_string());
+                continue;
+            }
+            let Some(object) = item.as_object() else {
+                continue;
+            };
+            match object
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+            {
+                "text" => {
+                    if let Some(text) = object.get("text").and_then(|value| value.as_str()) {
+                        parts.push(text.to_string());
+                    }
+                }
+                "thinking" => {
+                    if let Some(text) = object.get("thinking").and_then(|value| value.as_str()) {
+                        parts.push(format!("Thinking:\n{text}"));
+                    }
+                }
+                "toolCall" => {}
+                _ => {
+                    if let Some(text) = object.get("text").and_then(|value| value.as_str()) {
+                        parts.push(text.to_string());
+                    } else if let Some(text) =
+                        object.get("content").and_then(|value| value.as_str())
+                    {
+                        parts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        return parts.join("\n");
+    }
+    content.to_string()
+}
+
+fn summary_message_text(message: &simd_json::borrowed::Object<'_>, role: &str) -> String {
+    let summary = if role == "branchSummary" || role == "compactionSummary" {
+        message.get("summary").and_then(|value| value.as_str())
+    } else {
+        None
+    };
+    summary
+        .map(str::to_string)
+        .unwrap_or_else(|| content_text(message.get("content")))
+        .trim()
+        .to_string()
+}
+
+fn bash_text(command: &str, output: &str, exit_code: Option<i64>) -> String {
+    let mut parts = Vec::new();
+    if !command.is_empty() {
+        parts.push(format!("$ {command}"));
+    }
+    if !output.is_empty() {
+        parts.push(output.to_string());
+    }
+    if let Some(code) = exit_code {
+        parts.push(format!("exit code: {code}"));
+    }
+    parts.join("\n")
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+
+    let source_path = path.to_string_lossy().to_string();
+    let mut session_id = crate::sources::pi::session_id_from_path(path);
+    let mut project = crate::sources::pi::project_from_path(path);
+    let mut pending_tool_calls = state.pending_tool_calls;
+
+    let mut buf = Vec::new();
+    if start > 0 && !mmap.is_empty() {
+        let rel = memchr(b'\n', &mmap).unwrap_or(mmap.len());
+        let line = &mmap[..rel];
+        if !line.is_empty() {
+            buf.extend_from_slice(line);
+            if let Ok(value) = simd_json::to_borrowed_value(&mut buf)
+                && let Some(obj) = value.as_object()
+                && obj.get("type").and_then(|v| v.as_str()) == Some("session")
+            {
+                apply_session_header(obj, &mut session_id, &mut project);
+            }
+            buf.clear();
+        }
+    }
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + usize::from(rel < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let timestamp = obj
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(super::common::parse_iso_millis)
+            .unwrap_or(0);
+        let conversation_kind = match entry_type {
+            "branch_summary" => "branch",
+            "compaction" => "compaction",
+            _ => "main",
+        };
+        let mut base_links = base_links(obj, conversation_kind);
+
+        if entry_type == "session" {
+            apply_session_header(obj, &mut session_id, &mut project);
+            continue;
+        }
+
+        if entry_type == "compaction" || entry_type == "branch_summary" {
+            let summary = obj
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            if summary.is_empty() {
+                continue;
+            }
+            let record = Record {
+                source: SourceKind::Pi,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: "assistant".to_string(),
+                text: format!("{entry_type}: {summary}"),
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                links: base_links,
+                source_path: source_path.clone(),
+            };
+            emit(record)?;
+            turn_id += 1;
+            continue;
+        }
+
+        if entry_type == "custom_message" {
+            let text = content_text(obj.get("content")).trim().to_string();
+            if text.is_empty() {
+                continue;
+            }
+            let custom_type = obj.get("customType").and_then(|v| v.as_str()).unwrap_or("");
+            let prefix = if custom_type.is_empty() {
+                "custom_message".to_string()
+            } else {
+                format!("custom_message({custom_type})")
+            };
+            let record = Record {
+                source: SourceKind::Pi,
+                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                ts: timestamp,
+                project: project.clone(),
+                session_id: session_id.clone(),
+                turn_id,
+                role: "assistant".to_string(),
+                text: format!("{prefix}: {text}"),
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                links: base_links,
+                source_path: source_path.clone(),
+            };
+            emit(record)?;
+            turn_id += 1;
+            continue;
+        }
+
+        if entry_type != "message" {
+            continue;
+        }
+        let message = match obj.get("message").and_then(|v| v.as_object()) {
+            Some(m) => m,
+            None => continue,
+        };
+        let timestamp = if timestamp == 0 {
+            message
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .and_then(super::common::parse_iso_millis)
+                .unwrap_or(0)
+        } else {
+            timestamp
+        };
+        let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if conversation_kind == "main" {
+            match role {
+                "branchSummary" => {
+                    base_links.thread_source = Some("branch".to_string());
+                    base_links.conversation_kind = Some("branch".to_string());
+                }
+                "compactionSummary" => {
+                    base_links.thread_source = Some("compaction".to_string());
+                    base_links.conversation_kind = Some("compaction".to_string());
+                }
+                _ => {}
+            }
+        }
+
+        match role {
+            "user" | "assistant" => {
+                let content = message.get("content");
+                if role == "assistant"
+                    && let Some(arr) = content.and_then(|v| v.as_array())
+                {
+                    for block in arr {
+                        let Some(block_obj) = block.as_object() else {
+                            continue;
+                        };
+                        if block_obj.get("type").and_then(|v| v.as_str()) != Some("toolCall") {
+                            continue;
+                        }
+                        let tool_name = block_obj
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let tool_input = block_obj.get("arguments").map(|v| v.to_string());
+                        let mut links = base_links.clone();
+                        let tool_call_id = block_obj
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                        if let Some(tool_call_id) = &tool_call_id {
+                            links.event_id = Some(tool_call_id.clone());
+                            links.parent_event_id = base_links.event_id.clone();
+                        }
+                        let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                        if let Some(tool_call_id) = tool_call_id {
+                            pending_tool_calls.insert(
+                                tool_call_id.clone(),
+                                super::common::pending_tool_call(
+                                    tool_name.clone(),
+                                    Some(tool_call_id),
+                                    doc_id,
+                                    timestamp,
+                                    tool_input.as_deref(),
+                                    &links,
+                                    &session_id,
+                                ),
+                            );
+                        }
+                        let record = Record {
+                            source: SourceKind::Pi,
+                            doc_id,
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "tool_use".to_string(),
+                            text: tool_input.clone().unwrap_or_default(),
+                            tool_name,
+                            tool_input,
+                            tool_output: None,
+                            links,
+                            source_path: source_path.clone(),
+                        };
+                        emit(record)?;
+                        turn_id += 1;
+                    }
+                }
+
+                let text = content_text(content).trim().to_string();
+                if text.is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: role.to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: base_links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "toolResult" => {
+                let tool_call_id = message
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let tool_name = message
+                    .get("toolName")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        (!tool_call_id.is_empty())
+                            .then(|| pending_tool_calls.get(tool_call_id))
+                            .flatten()
+                            .and_then(|call| call.tool_name.clone())
+                    });
+                if !tool_call_id.is_empty() {
+                    pending_tool_calls.remove(tool_call_id);
+                }
+                let tool_output = Some(content_text(message.get("content")));
+                let text = tool_output.clone().unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let mut links = base_links;
+                if !tool_call_id.is_empty() {
+                    links.parent_tool_use_id = Some(tool_call_id.to_string());
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "bashExecution" => {
+                if message
+                    .get("excludeFromContext")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                let command = message
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let output = message
+                    .get("output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let exit_code = message.get("exitCode").and_then(|v| v.as_i64());
+                let text = bash_text(&command, &output, exit_code);
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name: Some("Bash".to_string()),
+                    tool_input: if command.is_empty() {
+                        None
+                    } else {
+                        Some(command)
+                    },
+                    tool_output: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output)
+                    },
+                    links: base_links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            "custom" | "branchSummary" | "compactionSummary" => {
+                let text = summary_message_text(message, role);
+                if text.is_empty() {
+                    continue;
+                }
+                let record = Record {
+                    source: SourceKind::Pi,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: project.clone(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text: format!("{role}: {text}"),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: base_links,
+                    source_path: source_path.clone(),
+                };
+                emit(record)?;
+                turn_id += 1;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+    })
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut session = session_id_from_path(path);
+    let mut project = project_from_path(path);
+    let mut current_model = None;
+    let mut current_provider = None;
+    let mut start = 0usize;
+    let mut index = 0u64;
+    let mut buffer = Vec::new();
+    let mut events = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let relative = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..relative];
+        start += relative + usize::from(relative < slice.len());
+        buffer.clear();
+        buffer.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
+            index += 1;
+            continue;
+        };
+        let kind = value
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if kind == "session" {
+            apply_session_identity(
+                value.get("id").and_then(|value| value.as_str()),
+                value.get("cwd").and_then(|value| value.as_str()),
+                &mut session,
+                &mut project,
+            );
+            index += 1;
+            continue;
+        }
+        if kind == "model_change" {
+            current_model = borrowed_string(&value, &["modelId", "model", "model_id"]);
+            current_provider = borrowed_string(&value, &["provider", "providerId", "provider_id"]);
+            index += 1;
+            continue;
+        }
+        let Some(message) = (kind == "message").then(|| value.get("message")).flatten() else {
+            index += 1;
+            continue;
+        };
+        if message.get("role").and_then(|value| value.as_str()) != Some("assistant") {
+            index += 1;
+            continue;
+        }
+        let Some(usage) = message.get("usage") else {
+            index += 1;
+            continue;
+        };
+        let number = |aliases: &[&str]| {
+            aliases
+                .iter()
+                .find_map(|key| usage.get(*key).and_then(|value| value.as_u64()))
+                .unwrap_or(0)
+        };
+        let tokens = TokenBuckets::disjoint(
+            number(&[
+                "input",
+                "inputTokens",
+                "input_tokens",
+                "promptTokens",
+                "prompt_tokens",
+            ]),
+            number(&[
+                "cacheRead",
+                "cacheReadTokens",
+                "cache_read",
+                "cache_read_tokens",
+                "cacheReadInputTokens",
+                "cache_read_input_tokens",
+            ]),
+            number(&[
+                "cacheWrite",
+                "cacheWriteTokens",
+                "cache_write",
+                "cache_write_tokens",
+                "cacheCreationTokens",
+                "cache_creation_tokens",
+                "cacheCreationInputTokens",
+                "cache_creation_input_tokens",
+            ]),
+            number(&[
+                "output",
+                "outputTokens",
+                "output_tokens",
+                "completionTokens",
+                "completion_tokens",
+            ]),
+        );
+        if tokens.additive_total() > 0 {
+            events.push(UsageEvent {
+                source: "pi",
+                source_path: source_path.clone(),
+                source_record_id: Some(format!("line:{index}")),
+                session_id: Some(session.clone()),
+                request_id: None,
+                message_id: borrowed_string(&value, &["id"]),
+                timestamp_ms: value.get("timestamp").map(timestamp_millis).unwrap_or(0),
+                project: Some(project.clone()),
+                provider: borrowed_string(message, &["provider"])
+                    .or_else(|| borrowed_string(&value, &["provider"]))
+                    .or_else(|| current_provider.clone()),
+                model: borrowed_string(message, &["model", "modelId"])
+                    .or_else(|| borrowed_string(&value, &["model", "modelId"]))
+                    .or_else(|| current_model.clone()),
+                tokens,
+                source_cost_usd: usage
+                    .get("cost")
+                    .and_then(|value| value.get("total"))
+                    .and_then(|value| value.as_f64()),
+                dedupe_confidence: "exact",
+                conservative_undercount: false,
+                sidechain: false,
+                source_order: index,
+            });
+        }
+        index += 1;
+    }
+    Ok(events)
+}
+
+fn borrowed_string(value: &BorrowedValue<'_>, aliases: &[&str]) -> Option<String> {
+    aliases
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_str()))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| value as u64)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,12 +4,62 @@ use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileIdentity {
+    /// Stable filesystem identity when the platform exposes one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inode: Option<u64>,
+    /// Hash of a bounded prefix, used to detect in-place replacement without rescanning a file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix_sha256: Option<String>,
+    /// Number of leading bytes covered by `prefix_sha256`. Keeping this stable across appends
+    /// prevents a short file's fingerprint from changing merely because its prefix grew.
+    #[serde(default)]
+    pub prefix_bytes: u64,
+    /// Nanosecond-resolution modification marker for detecting same-size rewrites.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified_ns: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingToolCall {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_doc_id: Option<u64>,
+    #[serde(default)]
+    pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argument_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argument_bytes: Option<u64>,
+    /// Source-native parent event for formats whose result event does not repeat it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_tool_use_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_tool_assistant_uuid: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileState {
     pub size: u64,
     pub mtime: i64,
     pub offset: u64,
     pub turn_id: u32,
+    #[serde(default)]
+    pub parser_version: u32,
+    #[serde(default)]
+    pub pending_tool_calls: HashMap<String, PendingToolCall>,
+    #[serde(default)]
+    pub identity: FileIdentity,
 }
 
 /// Tracks when we last scanned for changes, allowing us to skip

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,38 +74,7 @@ impl SourceKind {
     }
 
     pub fn from_path(path: &str) -> Self {
-        if path.contains(".codex/sessions")
-            || path.contains(".codex\\sessions")
-            || path.contains(".codex/archived_sessions")
-            || path.contains(".codex\\archived_sessions")
-        {
-            SourceKind::CodexSession
-        } else if path.contains(".codex/history.jsonl") || path.contains(".codex\\history.jsonl") {
-            SourceKind::CodexHistory
-        } else if path.contains("opencode/storage/message")
-            || path.contains("opencode\\storage\\message")
-        {
-            SourceKind::Opencode
-        } else if path.contains(".cursor/projects")
-            || path.contains(".cursor\\projects")
-            || path.contains("agent-transcripts")
-        {
-            SourceKind::Cursor
-        } else if path.contains(".pi/agent/sessions")
-            || path.contains(".pi\\agent\\sessions")
-            || path.contains("pi/agent/sessions")
-            || path.contains("pi\\agent\\sessions")
-        {
-            SourceKind::Pi
-        } else if path.contains(".copilot/session-state")
-            || path.contains(".copilot\\session-state")
-            || path.contains("/session-state/")
-            || path.contains("\\session-state\\")
-        {
-            SourceKind::Copilot
-        } else {
-            SourceKind::Claude
-        }
+        crate::sources::classify_path(path)
     }
 
     pub fn from_label(label: &str) -> Option<Self> {

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -4,23 +4,17 @@
 //! request-level accounting, but they are not authoritative subscription-limit telemetry.
 
 use crate::analytics::ProjectGrouping;
-use crate::types::{SourceFilter, SourceKind};
-use anyhow::{Context, Result};
-use chrono::DateTime;
+use crate::types::SourceFilter;
+use anyhow::Result;
 use clap::ValueEnum;
-use memchr::memmem;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
-use rusqlite::{Connection, OpenFlags, params};
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{Map, Value};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use walkdir::WalkDir;
 
 #[derive(Clone, Debug, Default)]
 pub struct UsageQuery {
@@ -65,7 +59,7 @@ pub struct TokenBuckets {
 }
 
 impl TokenBuckets {
-    fn additive_total(&self) -> u64 {
+    pub(crate) fn additive_total(&self) -> u64 {
         self.uncached_input
             .saturating_add(self.cache_read)
             .saturating_add(self.cache_write)
@@ -76,7 +70,7 @@ impl TokenBuckets {
         self.additive_total()
     }
 
-    fn codex(input: u64, cached: u64, output: u64, reasoning: u64) -> Self {
+    pub(crate) fn codex(input: u64, cached: u64, output: u64, reasoning: u64) -> Self {
         let cache_read = cached.min(input);
         Self {
             raw_input: input,
@@ -89,7 +83,7 @@ impl TokenBuckets {
         }
     }
 
-    fn disjoint(input: u64, cache_read: u64, cache_write: u64, output: u64) -> Self {
+    pub(crate) fn disjoint(input: u64, cache_read: u64, cache_write: u64, output: u64) -> Self {
         Self {
             raw_input: input,
             uncached_input: input,
@@ -121,9 +115,9 @@ pub struct UsageEvent {
     pub dedupe_confidence: &'static str,
     pub conservative_undercount: bool,
     #[serde(skip)]
-    sidechain: bool,
+    pub(crate) sidechain: bool,
     #[serde(skip)]
-    source_order: u64,
+    pub(crate) source_order: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -529,11 +523,11 @@ fn assemble_usage_events(
     publish_scan_progress(None);
 
     let reconcile_start = Instant::now();
-    reconcile_claude(&mut events);
-    reconcile_codex_copies(&mut events);
-    reconcile_cursor_copies(&mut events);
-    reconcile_copilot_copies(&mut events);
-    reconcile_opencode_copies(&mut events);
+    crate::sources::claude::reconcile_usage(&mut events);
+    crate::sources::codex::reconcile_usage(&mut events);
+    crate::sources::cursor::reconcile_usage(&mut events);
+    crate::sources::copilot::reconcile_usage(&mut events);
+    crate::sources::opencode::reconcile_usage(&mut events);
     usage_timing(reconcile_start, || {
         format!("reconcile ({} events kept)", events.len())
     });
@@ -562,74 +556,6 @@ fn usage_timing(start: Instant, message: impl FnOnce() -> String) {
             start.elapsed().as_millis()
         );
     }
-}
-
-fn home() -> PathBuf {
-    directories::BaseDirs::new()
-        .map(|dirs| dirs.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"))
-}
-
-fn jsonl_files(roots: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for root in roots {
-        if !root.exists() {
-            continue;
-        }
-        for entry in WalkDir::new(root).follow_links(false).into_iter().flatten() {
-            let path = entry.path();
-            if entry.file_type().is_file()
-                && path.extension().and_then(|v| v.to_str()) == Some("jsonl")
-            {
-                files.push(path.to_path_buf());
-            }
-        }
-    }
-    files.sort();
-    files.dedup();
-    files
-}
-
-fn lines(path: &Path) -> Result<impl Iterator<Item = (u64, Value)>> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    Ok(BufReader::new(file)
-        .lines()
-        .enumerate()
-        .filter_map(|(index, line)| {
-            let line = line.ok()?;
-            serde_json::from_str(&line)
-                .ok()
-                .map(|value| (index as u64, value))
-        }))
-}
-
-fn timestamp_ms(value: &Value) -> u64 {
-    value
-        .as_u64()
-        .map(|n| if n < 10_000_000_000 { n * 1000 } else { n })
-        .or_else(|| value.as_i64().filter(|n| *n >= 0).map(|n| n as u64))
-        .or_else(|| {
-            value
-                .as_str()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|d| d.timestamp_millis().max(0) as u64)
-        })
-        .unwrap_or(0)
-}
-
-fn u64_at(value: &Value, aliases: &[&str]) -> u64 {
-    aliases
-        .iter()
-        .find_map(|key| value.get(*key).and_then(Value::as_u64))
-        .unwrap_or(0)
-}
-
-fn str_at(value: &Value, aliases: &[&str]) -> Option<String> {
-    aliases
-        .iter()
-        .find_map(|key| value.get(*key).and_then(Value::as_str))
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
 }
 
 fn usage_project_matches(
@@ -670,138 +596,6 @@ fn usage_project_key(value: &str) -> String {
     tail.to_string()
 }
 
-#[derive(Deserialize)]
-struct ClaudeUsageLine {
-    #[serde(
-        rename = "type",
-        default,
-        deserialize_with = "deserialize_optional_string"
-    )]
-    kind: Option<String>,
-    message: Option<ClaudeUsageMessage>,
-    // Claude Code 2.1.210+ writes BOTH spellings on one line; a serde `alias` would
-    // reject that as a duplicate field and silently drop the event, so each spelling
-    // gets its own field and they are merged at use sites.
-    #[serde(
-        rename = "sessionId",
-        default,
-        deserialize_with = "deserialize_optional_string"
-    )]
-    session_id_camel: Option<String>,
-    #[serde(
-        rename = "session_id",
-        default,
-        deserialize_with = "deserialize_optional_string"
-    )]
-    session_id_snake: Option<String>,
-    #[serde(
-        rename = "requestId",
-        default,
-        deserialize_with = "deserialize_optional_string"
-    )]
-    request_id_camel: Option<String>,
-    #[serde(
-        rename = "request_id",
-        default,
-        deserialize_with = "deserialize_optional_string"
-    )]
-    request_id_snake: Option<String>,
-    timestamp: Option<Value>,
-    #[serde(default, deserialize_with = "deserialize_optional_string")]
-    cwd: Option<String>,
-    #[serde(
-        rename = "costUSD",
-        default,
-        deserialize_with = "deserialize_optional_f64"
-    )]
-    cost_usd: Option<f64>,
-    #[serde(
-        rename = "isSidechain",
-        default,
-        deserialize_with = "deserialize_bool_or_false"
-    )]
-    is_sidechain: bool,
-}
-
-#[derive(Deserialize)]
-struct ClaudeUsageMessage {
-    #[serde(default, deserialize_with = "deserialize_optional_string")]
-    id: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_optional_string")]
-    model: Option<String>,
-    usage: Option<ClaudeTokenUsage>,
-}
-
-#[derive(Deserialize)]
-struct ClaudeTokenUsage {
-    #[serde(
-        default,
-        alias = "inputTokens",
-        deserialize_with = "deserialize_u64_or_zero"
-    )]
-    input_tokens: u64,
-    #[serde(
-        default,
-        alias = "cacheReadInputTokens",
-        deserialize_with = "deserialize_u64_or_zero"
-    )]
-    cache_read_input_tokens: u64,
-    #[serde(
-        default,
-        alias = "cacheCreationInputTokens",
-        deserialize_with = "deserialize_u64_or_zero"
-    )]
-    cache_creation_input_tokens: u64,
-    #[serde(
-        default,
-        alias = "outputTokens",
-        deserialize_with = "deserialize_u64_or_zero"
-    )]
-    output_tokens: u64,
-    cache_creation: Option<Value>,
-}
-
-fn deserialize_optional_string<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(Value::deserialize(deserializer)?
-        .as_str()
-        .filter(|value| !value.is_empty())
-        .map(str::to_string))
-}
-
-fn deserialize_optional_f64<'de, D>(deserializer: D) -> std::result::Result<Option<f64>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(Value::deserialize(deserializer)?.as_f64())
-}
-
-fn deserialize_bool_or_false<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(Value::deserialize(deserializer)?.as_bool().unwrap_or(false))
-}
-
-fn deserialize_u64_or_zero<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(Value::deserialize(deserializer)?.as_u64().unwrap_or(0))
-}
-
-// Parser versions also cover the cached blob encoding (postcard); bump them when either
-// the per-source parsing or `CachedUsageEvent` changes shape.
-const CLAUDE_PARSER_VERSION: i64 = 4;
-const CODEX_PARSER_VERSION: i64 = 4;
-const PI_PARSER_VERSION: i64 = 2;
-const CURSOR_PARSER_VERSION: i64 = 2;
-const COPILOT_PARSER_VERSION: i64 = 2;
-const OPENCODE_PARSER_VERSION: i64 = 2;
 /// Reuse cached Cursor state databases this long even when their metadata changed: a
 /// running Cursor rewrites its (potentially multi-GB) databases continuously, and
 /// re-reading them on every scan makes live scans unusable.
@@ -921,26 +715,8 @@ struct CachedFileRow {
     deps: Vec<UsageFileDep>,
 }
 
-/// A parse closure's output: the file's events plus whether the result may be persisted.
-/// `cacheable` is false when parsing depended on state outside the file that can change
-/// while the file itself does not — e.g. a codex fork whose parent rollout was not yet on
-/// disk, so its baseline was guessed and must be recomputed once the parent appears.
-struct FileParse {
-    events: Vec<UsageEvent>,
-    cacheable: bool,
-    /// Other files this parse's result depends on; a change to any invalidates the cache.
-    deps: Vec<UsageFileDep>,
-}
-
-impl FileParse {
-    fn cacheable(events: Vec<UsageEvent>) -> Self {
-        Self {
-            events,
-            cacheable: true,
-            deps: Vec::new(),
-        }
-    }
-}
+type FileParse = crate::sources::UsageParseOutput;
+type UsageFileDep = crate::sources::UsageDependency;
 
 struct ParsedUsageFile {
     index: usize,
@@ -1311,37 +1087,18 @@ fn scan_claude(
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let roots = if let Some(config) = std::env::var_os("CLAUDE_CONFIG_DIR") {
-        config
-            .to_string_lossy()
-            .split(',')
-            .map(|part| {
-                let path = PathBuf::from(part.trim());
-                if path.file_name().and_then(|n| n.to_str()) == Some("projects") {
-                    path
-                } else {
-                    path.join("projects")
-                }
-            })
-            .collect()
-    } else {
-        vec![
-            home().join(".claude/projects"),
-            home().join(".config/claude/projects"),
-        ]
-    };
-    let files = jsonl_files(roots);
+    let files = crate::sources::claude::usage_files();
     scan_files_cached(
         SourceScan {
             source: "claude",
-            parser_version: CLAUDE_PARSER_VERSION,
+            parser_version: crate::sources::claude::VERSIONS.usage,
             volatile_reuse_ms: |_| None,
         },
         &files,
         cache,
         warnings,
         out,
-        |path| scan_claude_file(path).map(FileParse::cacheable),
+        |path| crate::sources::claude::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
 }
@@ -1381,789 +1138,30 @@ fn parse_missing_usage_files(
     parsed
 }
 
-/// Stream a file line by line as raw bytes, reusing one buffer. Line indices count every
-/// line in the file so record ids stay stable across parser changes.
-fn for_each_line(path: &Path, mut visit: impl FnMut(u64, &[u8])) -> Result<()> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    let mut reader = BufReader::with_capacity(256 * 1024, file);
-    let mut line = Vec::with_capacity(16 * 1024);
-    let mut index = 0u64;
-    loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line)? == 0 {
-            return Ok(());
-        }
-        if line.last() == Some(&b'\n') {
-            line.pop();
-        }
-        visit(index, &line);
-        index += 1;
-    }
-}
-
-fn scan_claude_file(path: &Path) -> Result<Vec<UsageEvent>> {
-    static USAGE_NEEDLE: Lazy<memmem::Finder<'static>> =
-        Lazy::new(|| memmem::Finder::new(b"\"usage\""));
-    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
-    let fallback_session = path
-        .file_stem()
-        .and_then(|n| n.to_str())
-        .map(str::to_string);
-    let mut events = Vec::new();
-    for_each_line(path, |index, line| {
-        if USAGE_NEEDLE.find(line).is_none() {
-            return;
-        }
-        let Ok(value) = serde_json::from_slice::<ClaudeUsageLine>(line) else {
-            return;
-        };
-        if value.kind.as_deref() != Some("assistant") {
-            return;
-        }
-        let Some(message) = value.message else {
-            return;
-        };
-        let Some(usage) = message.usage else {
-            return;
-        };
-        let cache_write = usage.cache_creation_input_tokens;
-        let mut tokens = TokenBuckets::disjoint(
-            usage.input_tokens,
-            usage.cache_read_input_tokens,
-            cache_write,
-            usage.output_tokens,
-        );
-        tokens.cache_write_1h = usage
-            .cache_creation
-            .as_ref()
-            .and_then(|cache| cache.get("ephemeral_1h_input_tokens"))
-            .and_then(Value::as_u64)
-            .unwrap_or_default()
-            .min(tokens.cache_write);
-        if tokens.additive_total() == 0 {
-            return;
-        }
-        let session_id = value.session_id_camel.or(value.session_id_snake);
-        let request_id = value.request_id_camel.or(value.request_id_snake);
-        let exact_dedupe = message.id.is_some() && request_id.is_some();
-        events.push(UsageEvent {
-            source: "claude",
-            source_path: source_path.clone(),
-            source_record_id: Some(format!("line:{index}")),
-            session_id: session_id.or_else(|| fallback_session.clone()),
-            request_id,
-            message_id: message.id,
-            timestamp_ms: value.timestamp.as_ref().map(timestamp_ms).unwrap_or(0),
-            project: value.cwd,
-            provider: Some("anthropic".into()),
-            model: message.model,
-            tokens,
-            source_cost_usd: value.cost_usd,
-            dedupe_confidence: if exact_dedupe { "exact" } else { "heuristic" },
-            conservative_undercount: false,
-            sidechain: value.is_sidechain,
-            source_order: index,
-        });
-    })?;
-    Ok(events)
-}
-
-fn reconcile_claude(events: &mut Vec<UsageEvent>) {
-    // Map keys borrow from `events`: both passes only read events and write `keep`, and
-    // assembled scans hold millions of events, so per-event key clones matter.
-    let mut best_exact: HashMap<(&str, &str), usize> = HashMap::new();
-    let mut keep = vec![true; events.len()];
-    for (index, event) in events.iter().enumerate() {
-        if event.source != "claude" {
-            continue;
-        }
-        let (Some(message), Some(request)) =
-            (event.message_id.as_deref(), event.request_id.as_deref())
-        else {
-            continue;
-        };
-        let key = (message, request);
-        if let Some(previous) = best_exact.get(&key).copied() {
-            let winner = choose_claude(&events[previous], event);
-            if winner {
-                keep[index] = false;
-            } else {
-                keep[previous] = false;
-                best_exact.insert(key, index);
-            }
-        } else {
-            best_exact.insert(key, index);
-        }
-    }
-    let mut by_message: HashMap<&str, Vec<usize>> = HashMap::new();
-    for (index, event) in events.iter().enumerate() {
-        if keep[index]
-            && event.source == "claude"
-            && let Some(message) = event.message_id.as_deref()
-        {
-            by_message.entry(message).or_default().push(index);
-        }
-    }
-    for indices in by_message.into_values() {
-        if indices.len() < 2 || !indices.iter().any(|index| !events[*index].sidechain) {
-            continue;
-        }
-        // Message-only matching is a sidechain replay fallback. Keep every distinct parent
-        // request; suppress only sidechain copies of a message present in a parent transcript.
-        for index in indices {
-            if events[index].sidechain {
-                keep[index] = false;
-            }
-        }
-    }
-    let mut index = 0usize;
-    events.retain(|_| {
-        let retain = keep[index];
-        index += 1;
-        retain
-    });
-}
-
-/// True means `a` wins. Prefer parent/non-sidechain, then completeness, then source order.
-fn choose_claude(a: &UsageEvent, b: &UsageEvent) -> bool {
-    if a.sidechain != b.sidechain {
-        return !a.sidechain;
-    }
-    let a_parent = !a.source_path.contains("/subagents/");
-    let b_parent = !b.source_path.contains("/subagents/");
-    if a_parent != b_parent {
-        return a_parent;
-    }
-    let a_total = a.tokens.additive_total();
-    let b_total = b.tokens.additive_total();
-    if a_total != b_total {
-        return a_total > b_total;
-    }
-    a.source_order >= b.source_order
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-struct CodexTokens {
-    input: u64,
-    cached: u64,
-    output: u64,
-    reasoning: u64,
-}
-
-impl CodexTokens {
-    fn from(value: &Value) -> Self {
-        Self {
-            input: u64_at(value, &["input_tokens", "inputTokens", "prompt_tokens"]),
-            cached: u64_at(
-                value,
-                &[
-                    "cached_input_tokens",
-                    "cachedInputTokens",
-                    "cache_read_input_tokens",
-                ],
-            ),
-            output: u64_at(
-                value,
-                &["output_tokens", "outputTokens", "completion_tokens"],
-            ),
-            reasoning: u64_at(
-                value,
-                &[
-                    "reasoning_output_tokens",
-                    "reasoningTokens",
-                    "reasoning_tokens",
-                ],
-            ),
-        }
-    }
-    fn zero(self) -> bool {
-        self.input == 0 && self.cached == 0 && self.output == 0 && self.reasoning == 0
-    }
-    fn add(self, rhs: Self) -> Self {
-        Self {
-            input: self.input.saturating_add(rhs.input),
-            cached: self.cached.saturating_add(rhs.cached),
-            output: self.output.saturating_add(rhs.output),
-            reasoning: self.reasoning.saturating_add(rhs.reasoning),
-        }
-    }
-    fn sub(self, rhs: Self) -> Self {
-        Self {
-            input: self.input.saturating_sub(rhs.input),
-            cached: self.cached.saturating_sub(rhs.cached),
-            output: self.output.saturating_sub(rhs.output),
-            reasoning: self.reasoning.saturating_sub(rhs.reasoning),
-        }
-    }
-    fn min(self, rhs: Self) -> Self {
-        Self {
-            input: self.input.min(rhs.input),
-            cached: self.cached.min(rhs.cached),
-            output: self.output.min(rhs.output),
-            reasoning: self.reasoning.min(rhs.reasoning),
-        }
-    }
-    fn max(self, rhs: Self) -> Self {
-        Self {
-            input: self.input.max(rhs.input),
-            cached: self.cached.max(rhs.cached),
-            output: self.output.max(rhs.output),
-            reasoning: self.reasoning.max(rhs.reasoning),
-        }
-    }
-    fn at_least(self, rhs: Self) -> bool {
-        self.input >= rhs.input
-            && self.cached >= rhs.cached
-            && self.output >= rhs.output
-            && self.reasoning >= rhs.reasoning
-    }
-    fn at_most(self, rhs: Self) -> bool {
-        self.input <= rhs.input
-            && self.cached <= rhs.cached
-            && self.output <= rhs.output
-            && self.reasoning <= rhs.reasoning
-    }
-}
-
-#[derive(Default)]
-struct CodexCounter {
-    counted: CodexTokens,
-    raw_baseline: CodexTokens,
-    watermark: CodexTokens,
-    seen: Vec<CodexTokens>,
-    /// Cumulative totals the fork parent reached before the fork point. Fork files replay
-    /// the parent's history with re-stamped timestamps; any total in this set is a replayed
-    /// snapshot, not new usage, regardless of event order or replay truncation.
-    inherited_seen: HashSet<CodexTokens>,
-    divergent: bool,
-    interleaved: bool,
-}
-
-impl CodexCounter {
-    fn establish_unresolved_fork_baseline(&mut self, total: CodexTokens) {
-        self.raw_baseline = total;
-        self.watermark = self.watermark.max(total);
-        if self.seen.last() != Some(&total) {
-            self.seen.push(total);
-            if self.seen.len() > 64 {
-                self.seen.remove(0);
-            }
-        }
-    }
-
-    /// Seeds the counter from the fork parent's snapshots at-or-before the fork timestamp
-    /// (the CodexBar inherited-baseline policy): new usage counts as growth beyond the
-    /// parent's final pre-fork totals, and every replayed parent snapshot is suppressed.
-    /// `snapshots` may be merged from several parent copies and so need not be ordered; the
-    /// baseline is the component-wise maximum rather than the last element.
-    fn seed_inherited(&mut self, snapshots: &[CodexTokens]) {
-        let Some(baseline) = snapshots.iter().copied().reduce(CodexTokens::max) else {
-            return;
-        };
-        self.inherited_seen.extend(snapshots.iter().copied());
-        self.raw_baseline = baseline;
-        self.watermark = self.watermark.max(baseline);
-    }
-
-    fn account(&mut self, last: Option<CodexTokens>, total: Option<CodexTokens>) -> CodexTokens {
-        if let Some(total) = total {
-            if self.seen.contains(&total) || self.inherited_seen.contains(&total) {
-                return CodexTokens::default();
-            }
-            if !total.at_least(self.watermark) {
-                self.interleaved = true;
-            }
-        }
-        let baseline = self.watermark.max(self.raw_baseline);
-        let delta = match (last, total) {
-            (Some(last), Some(total)) if self.interleaved => {
-                last.min(contained(total, baseline, self.counted))
-            }
-            (None, Some(total)) if self.interleaved => contained(total, baseline, self.counted),
-            (Some(last), Some(total)) => {
-                let total_delta = total.sub(baseline);
-                if !self.divergent && total.at_least(baseline) && total_delta.at_most(last) {
-                    total_delta
-                } else {
-                    last
-                }
-            }
-            (None, Some(total)) if self.divergent => contained(total, baseline, self.counted),
-            (None, Some(total)) => total.sub(baseline),
-            (Some(last), None) => last,
-            (None, None) => return CodexTokens::default(),
-        };
-        self.counted = self.counted.add(delta);
-        if let Some(total) = total {
-            self.raw_baseline = total;
-            self.divergent |= total != self.counted;
-            self.watermark = self.watermark.max(total);
-            if self.seen.last() != Some(&total) {
-                self.seen.push(total);
-                if self.seen.len() > 64 {
-                    self.seen.remove(0);
-                }
-            }
-        } else {
-            self.raw_baseline = self.counted;
-            self.watermark = self.watermark.max(self.counted);
-        }
-        delta
-    }
-}
-
-fn contained(current: CodexTokens, watermark: CodexTokens, counted: CodexTokens) -> CodexTokens {
-    fn one(current: u64, watermark: u64, counted: u64) -> u64 {
-        if current >= watermark {
-            current.saturating_sub(watermark.max(counted))
-        } else {
-            current.saturating_sub(counted)
-        }
-    }
-    CodexTokens {
-        input: one(current.input, watermark.input, counted.input),
-        cached: one(current.cached, watermark.cached, counted.cached),
-        output: one(current.output, watermark.output, counted.output),
-        reasoning: one(current.reasoning, watermark.reasoning, counted.reasoning),
-    }
-}
-
-/// A file whose content a cached parse depended on, recorded so the cached result can be
-/// invalidated when that file changes. Used for codex fork children, whose baseline comes
-/// from a separate parent rollout that can change (be synced, extended) without the child
-/// file changing.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
-struct UsageFileDep {
-    path: String,
-    size: u64,
-    mtime_ns: i64,
-}
-
-impl UsageFileDep {
-    /// True if the file still matches the recorded size and mtime. A vanished or changed
-    /// dependency invalidates the cached parse that depended on it.
-    fn is_current(&self) -> bool {
-        usage_file_metadata(Path::new(&self.path))
-            .map(|(size, mtime_ns)| size == self.size && mtime_ns == self.mtime_ns)
-            .unwrap_or(false)
-    }
-}
-
-struct CodexParentData {
-    /// Every rollout file carrying this session id; a child depends on all of them so a
-    /// change to any copy re-parses it.
-    deps: Vec<UsageFileDep>,
-    /// Snapshots merged across all copies. Order is not meaningful — callers filter by
-    /// timestamp and treat the set as a suppression set plus a component-wise-max baseline.
-    snapshots: Vec<(u64, CodexTokens)>,
-}
-
-/// Resolves a forked session's parent rollout files and the parent's cumulative token
-/// totals, so fork children can inherit a baseline instead of recounting replayed history.
-/// The same session id can appear in more than one file (active plus archived, or across
-/// comma-separated CODEX_HOME roots); snapshots are merged across every copy so a child
-/// never inherits a truncated baseline from an arbitrary one, and every copy's metadata
-/// travels with the resolution so a child re-parses when any of them changes.
-type CodexParentSlot = Option<Arc<CodexParentData>>;
-
-struct CodexParentIndex {
-    by_session: HashMap<String, Vec<PathBuf>>,
-    parents: Mutex<HashMap<String, CodexParentSlot>>,
-}
-
-impl CodexParentIndex {
-    fn new(files: &[PathBuf]) -> Self {
-        let mut by_session: HashMap<String, Vec<PathBuf>> = HashMap::new();
-        for path in files {
-            if let Some(session) = codex_session_uuid_from_stem(path) {
-                by_session.entry(session).or_default().push(path.clone());
-            }
-        }
-        Self {
-            by_session,
-            parents: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn load(&self, parent: &str) -> CodexParentSlot {
-        if let Some(slot) = self.parents.lock().unwrap().get(parent) {
-            return slot.clone();
-        }
-        let loaded = self.by_session.get(parent).and_then(|paths| {
-            let mut deps = Vec::new();
-            let mut snapshots = Vec::new();
-            for path in paths {
-                let Ok((size, mtime_ns)) = usage_file_metadata(path) else {
-                    continue;
-                };
-                let Ok(file_snapshots) = codex_total_snapshots(path) else {
-                    continue;
-                };
-                deps.push(UsageFileDep {
-                    path: path.to_string_lossy().to_string(),
-                    size,
-                    mtime_ns,
-                });
-                snapshots.extend(file_snapshots);
-            }
-            (!deps.is_empty()).then(|| Arc::new(CodexParentData { deps, snapshots }))
-        });
-        self.parents
-            .lock()
-            .unwrap()
-            .entry(parent.to_string())
-            .or_insert(loaded)
-            .clone()
-    }
-
-    /// True if the current set of parent copies still matches the copies recorded when a fork
-    /// child was cached. A child's `deps` are the parent rollout copies present at resolution
-    /// time; if a fuller copy later appears at a new path (an archive lands, another
-    /// CODEX_HOME root syncs), the merged baseline changes even though every recorded copy is
-    /// unchanged, so the child must re-parse. Non-fork rows have no deps and are always valid.
-    fn deps_match_current_candidates(&self, deps: &[UsageFileDep]) -> bool {
-        let Some(first) = deps.first() else {
-            return true;
-        };
-        let Some(session) = codex_session_uuid_from_stem(Path::new(&first.path)) else {
-            return true;
-        };
-        let current: HashSet<&str> = self
-            .by_session
-            .get(&session)
-            .map(|paths| paths.iter().filter_map(|path| path.to_str()).collect())
-            .unwrap_or_default();
-        let recorded: HashSet<&str> = deps.iter().map(|dep| dep.path.as_str()).collect();
-        current == recorded
-    }
-
-    /// Parent snapshots recorded at-or-before `cutoff_ms` paired with the dependency
-    /// fingerprints of every parent copy. `None` means the parent is unknown or had no usage
-    /// before the fork, so the caller falls back to the unresolved-fork baseline and does not
-    /// cache.
-    fn resolve(
-        &self,
-        parent: &str,
-        cutoff_ms: u64,
-    ) -> Option<(Vec<UsageFileDep>, Vec<CodexTokens>)> {
-        let data = self.load(parent)?;
-        let totals: Vec<CodexTokens> = data
-            .snapshots
-            .iter()
-            .filter(|(ts, _)| *ts <= cutoff_ms)
-            .map(|(_, totals)| *totals)
-            .collect();
-        if totals.is_empty() {
-            return None;
-        }
-        Some((data.deps.clone(), totals))
-    }
-}
-
-/// Codex records a fork/subagent parent either as a flat `forked_from_id` or nested under
-/// `source.subagent.thread_spawn.parent_thread_id`. Matches `apply_codex_session_meta` in
-/// `ingest.rs` so both shapes are treated as forks.
-fn codex_parent_session_id(payload: &Value) -> Option<String> {
-    str_at(
-        payload,
-        &["forked_from_id", "parent_session_id", "parentSessionId"],
-    )
-    .or_else(|| {
-        payload
-            .pointer("/source/subagent/thread_spawn/parent_thread_id")
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    })
-}
-
-fn codex_session_uuid_from_stem(path: &Path) -> Option<String> {
-    let stem = path.file_stem()?.to_str()?;
-    if stem.len() < 36 {
-        return None;
-    }
-    let candidate = &stem[stem.len() - 36..];
-    let uuid_shaped = candidate.bytes().enumerate().all(|(i, b)| {
-        if matches!(i, 8 | 13 | 18 | 23) {
-            b == b'-'
-        } else {
-            b.is_ascii_hexdigit()
-        }
-    });
-    uuid_shaped.then(|| candidate.to_string())
-}
-
-/// Extracts every (timestamp, total_token_usage) snapshot from a rollout file.
-fn codex_total_snapshots(path: &Path) -> Result<Vec<(u64, CodexTokens)>> {
-    static TOKEN_COUNT_NEEDLE: Lazy<memmem::Finder<'static>> =
-        Lazy::new(|| memmem::Finder::new(b"token_count"));
-    let mut snapshots = Vec::new();
-    for_each_line(path, |_, line| {
-        if TOKEN_COUNT_NEEDLE.find(line).is_none() {
-            return;
-        }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            return;
-        };
-        if value.get("type").and_then(Value::as_str) != Some("event_msg") {
-            return;
-        }
-        let payload = value.get("payload").unwrap_or(&Value::Null);
-        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
-            return;
-        }
-        let info = payload.get("info").unwrap_or(payload);
-        let Some(total) = info
-            .get("total_token_usage")
-            .map(CodexTokens::from)
-            .filter(|total| !total.zero())
-        else {
-            return;
-        };
-        let ts = value.get("timestamp").map(timestamp_ms).unwrap_or(0);
-        snapshots.push((ts, total));
-    })?;
-    Ok(snapshots)
-}
-
 fn scan_codex(
     out: &mut Vec<UsageEvent>,
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let homes: Vec<PathBuf> = std::env::var_os("CODEX_HOME")
-        .map(|v| {
-            v.to_string_lossy()
-                .split(',')
-                .map(|s| PathBuf::from(s.trim()))
-                .collect()
-        })
-        .unwrap_or_else(|| vec![home().join(".codex")]);
-    let mut files = Vec::new();
-    for root in homes {
-        let active = root.join("sessions");
-        let archived = root.join("archived_sessions");
-        if active.exists() || archived.exists() {
-            files.extend(jsonl_files([active, archived]));
-        } else {
-            files.extend(jsonl_files([root]));
-        }
-    }
-    let parents = CodexParentIndex::new(&files);
+    let files = crate::sources::codex::discover_rollouts()
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<_>>();
+    let parents = crate::sources::codex::UsageParentIndex::new(&files);
     scan_files_cached_with(
         SourceScan {
             source: "codex",
-            parser_version: CODEX_PARSER_VERSION,
+            parser_version: crate::sources::codex::VERSIONS.usage,
             volatile_reuse_ms: |_| None,
         },
         &files,
         cache,
         warnings,
         out,
-        |path| scan_codex_file(path, &parents),
+        |path| crate::sources::codex::parse_usage_file(path, &parents),
         |deps| parents.deps_match_current_candidates(deps),
     );
     Ok(())
-}
-
-/// Matches every line kind `scan_codex_file` can consume; other lines (the vast majority:
-/// prompts, tool output, reasoning) are skipped without a JSON parse.
-static CODEX_LINE_NEEDLES: Lazy<Vec<memmem::Finder<'static>>> = Lazy::new(|| {
-    [
-        &b"token_count"[..],
-        b"turn_context",
-        b"session_meta",
-        b"task_started",
-        b"\"usage\"",
-    ]
-    .into_iter()
-    .map(memmem::Finder::new)
-    .collect()
-});
-
-fn scan_codex_file(path: &Path, parents: &CodexParentIndex) -> Result<FileParse> {
-    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
-    let mut session = path
-        .file_stem()
-        .and_then(|n| n.to_str())
-        .map(str::to_string);
-    let mut parent = None;
-    let mut fork_timestamp_ms = None;
-    let mut fork_resolved = false;
-    let mut parent_deps: Vec<UsageFileDep> = Vec::new();
-    let mut project = None;
-    let mut model = None;
-    let mut turn = None;
-    let mut counter = CodexCounter::default();
-    let mut event_index = 0u64;
-    let mut unresolved_fork_baseline_seen = false;
-    let mut out = Vec::new();
-    for_each_line(path, |line_index, line| {
-        if !CODEX_LINE_NEEDLES
-            .iter()
-            .any(|needle| needle.find(line).is_some())
-        {
-            return;
-        }
-        let Ok(value) = serde_json::from_slice::<Value>(line) else {
-            return;
-        };
-        let kind = value.get("type").and_then(Value::as_str).unwrap_or("");
-        let payload = value.get("payload").unwrap_or(&Value::Null);
-        match kind {
-            "session_meta" => {
-                session = str_at(payload, &["id", "session_id"]).or_else(|| session.take());
-                parent = codex_parent_session_id(payload);
-                if parent.is_some() {
-                    fork_timestamp_ms = value.get("timestamp").map(timestamp_ms);
-                }
-                if let (Some(parent_id), Some(fork_ms)) = (&parent, fork_timestamp_ms)
-                    && let Some((deps, inherited)) = parents.resolve(parent_id, fork_ms)
-                {
-                    counter.seed_inherited(&inherited);
-                    // The parent baseline is resolved; the first post-fork event is a
-                    // real turn and must not be swallowed as a baseline guess.
-                    unresolved_fork_baseline_seen = true;
-                    fork_resolved = true;
-                    parent_deps = deps;
-                }
-                project = str_at(payload, &["cwd"]);
-            }
-            "turn_context" => model = str_at(payload, &["model", "model_name"]),
-            "event_msg" if payload.get("type").and_then(Value::as_str) == Some("task_started") => {
-                turn = str_at(payload, &["turn_id", "turnId"])
-            }
-            "event_msg" if payload.get("type").and_then(Value::as_str) == Some("token_count") => {
-                let info = payload.get("info").unwrap_or(payload);
-                let last = info
-                    .get("last_token_usage")
-                    .map(CodexTokens::from)
-                    .filter(|v| !v.zero());
-                let total = info
-                    .get("total_token_usage")
-                    .map(CodexTokens::from)
-                    .filter(|v| !v.zero());
-                let event_timestamp_ms = value.get("timestamp").map(timestamp_ms).unwrap_or(0);
-                if parent.is_some()
-                    && fork_timestamp_ms.is_some_and(|fork| event_timestamp_ms <= fork)
-                {
-                    if let Some(total) = total {
-                        counter.establish_unresolved_fork_baseline(total);
-                        unresolved_fork_baseline_seen = true;
-                    }
-                    return;
-                }
-                if parent.is_some()
-                    && !unresolved_fork_baseline_seen
-                    && let Some(total) = total
-                {
-                    counter.establish_unresolved_fork_baseline(total);
-                    unresolved_fork_baseline_seen = true;
-                    return;
-                }
-                let delta = counter.account(last, total);
-                if delta.zero() {
-                    return;
-                }
-                out.push(UsageEvent {
-                    source: "codex",
-                    source_path: source_path.clone(),
-                    source_record_id: Some(format!("event:{event_index}")),
-                    session_id: session.clone(),
-                    request_id: turn.clone(),
-                    message_id: None,
-                    timestamp_ms: event_timestamp_ms,
-                    project: project.clone(),
-                    provider: Some("openai".into()),
-                    model: model
-                        .clone()
-                        .or_else(|| str_at(info, &["model", "model_name"])),
-                    tokens: TokenBuckets::codex(
-                        delta.input,
-                        delta.cached,
-                        delta.output,
-                        delta.reasoning,
-                    ),
-                    source_cost_usd: None,
-                    dedupe_confidence: "strong",
-                    conservative_undercount: counter.interleaved
-                        || (parent.is_some() && !fork_resolved),
-                    sidechain: false,
-                    source_order: line_index,
-                });
-                event_index += 1;
-            }
-            _ => {
-                if let Some(usage) = value
-                    .get("usage")
-                    .or_else(|| value.pointer("/data/usage"))
-                    .or_else(|| value.pointer("/result/usage"))
-                    .or_else(|| value.pointer("/response/usage"))
-                {
-                    let tokens = CodexTokens::from(usage);
-                    if tokens.zero() {
-                        return;
-                    }
-                    out.push(UsageEvent {
-                        source: "codex",
-                        source_path: source_path.clone(),
-                        source_record_id: Some(format!("line:{line_index}")),
-                        session_id: session.clone(),
-                        request_id: None,
-                        message_id: None,
-                        timestamp_ms: value
-                            .get("timestamp")
-                            .or_else(|| value.get("created_at"))
-                            .map(timestamp_ms)
-                            .unwrap_or(0),
-                        project: project.clone(),
-                        provider: Some("openai".into()),
-                        model: model
-                            .clone()
-                            .or_else(|| str_at(&value, &["model", "model_name"])),
-                        tokens: TokenBuckets::codex(
-                            tokens.input,
-                            tokens.cached,
-                            tokens.output,
-                            tokens.reasoning,
-                        ),
-                        source_cost_usd: None,
-                        dedupe_confidence: "strong",
-                        conservative_undercount: false,
-                        sidechain: false,
-                        source_order: line_index,
-                    });
-                }
-            }
-        }
-    })?;
-    // A fork whose parent rollout was not on disk this scan was counted with a guessed
-    // baseline; persisting it would freeze that guess even after the parent appears, so the
-    // result is provisional and must be recomputed on the next scan.
-    let cacheable = parent.is_none() || fork_resolved;
-    // A resolved fork depends on the parent rollout's content: if any parent copy is later
-    // synced further or extended, the cached child must be re-parsed so its baseline
-    // reflects the fuller parent instead of a partial prefix.
-    Ok(FileParse {
-        events: out,
-        cacheable,
-        deps: parent_deps,
-    })
-}
-
-fn reconcile_codex_copies(events: &mut Vec<UsageEvent>) {
-    let mut seen = HashSet::new();
-    events.retain(|event| {
-        if event.source != "codex" {
-            return true;
-        }
-        let Some(session) = &event.session_id else {
-            return true;
-        };
-        let Some(record) = &event.source_record_id else {
-            return true;
-        };
-        seen.insert((session.clone(), record.clone(), event.tokens.clone()))
-    });
 }
 
 fn scan_pi(
@@ -2171,131 +1169,23 @@ fn scan_pi(
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let files = jsonl_files([crate::ingest::pi_sessions_root()]);
+    let files = crate::sources::pi::discover()
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<_>>();
     scan_files_cached(
         SourceScan {
             source: "pi",
-            parser_version: PI_PARSER_VERSION,
+            parser_version: crate::sources::pi::VERSIONS.usage,
             volatile_reuse_ms: |_| None,
         },
         &files,
         cache,
         warnings,
         out,
-        |path| scan_pi_file(path).map(FileParse::cacheable),
+        |path| crate::sources::pi::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
-}
-
-fn scan_pi_file(path: &Path) -> Result<Vec<UsageEvent>> {
-    let mut out = Vec::new();
-    {
-        let source_path: Arc<str> = Arc::from(path.to_string_lossy());
-        let mut session = crate::ingest::pi_session_id_from_path(path);
-        let mut project = crate::ingest::project_from_pi_session_path(path);
-        let mut current_model = None;
-        let mut current_provider = None;
-        for (index, value) in lines(path)? {
-            if value.get("type").and_then(Value::as_str) == Some("session") {
-                crate::ingest::apply_pi_session_identity(
-                    value.get("id").and_then(Value::as_str),
-                    value.get("cwd").and_then(Value::as_str),
-                    &mut session,
-                    &mut project,
-                );
-                continue;
-            }
-            if value.get("type").and_then(Value::as_str) == Some("model_change") {
-                current_model = str_at(&value, &["modelId", "model", "model_id"]);
-                current_provider = str_at(&value, &["provider", "providerId", "provider_id"]);
-                continue;
-            }
-            if value.get("type").and_then(Value::as_str) != Some("message") {
-                continue;
-            }
-            let Some(message) = value.get("message") else {
-                continue;
-            };
-            if message.get("role").and_then(Value::as_str) != Some("assistant") {
-                continue;
-            }
-            let Some(usage) = message.get("usage") else {
-                continue;
-            };
-            let tokens = TokenBuckets::disjoint(
-                u64_at(
-                    usage,
-                    &[
-                        "input",
-                        "inputTokens",
-                        "input_tokens",
-                        "promptTokens",
-                        "prompt_tokens",
-                    ],
-                ),
-                u64_at(
-                    usage,
-                    &[
-                        "cacheRead",
-                        "cacheReadTokens",
-                        "cache_read",
-                        "cache_read_tokens",
-                        "cacheReadInputTokens",
-                        "cache_read_input_tokens",
-                    ],
-                ),
-                u64_at(
-                    usage,
-                    &[
-                        "cacheWrite",
-                        "cacheWriteTokens",
-                        "cache_write",
-                        "cache_write_tokens",
-                        "cacheCreationTokens",
-                        "cache_creation_tokens",
-                        "cacheCreationInputTokens",
-                        "cache_creation_input_tokens",
-                    ],
-                ),
-                u64_at(
-                    usage,
-                    &[
-                        "output",
-                        "outputTokens",
-                        "output_tokens",
-                        "completionTokens",
-                        "completion_tokens",
-                    ],
-                ),
-            );
-            if tokens.additive_total() == 0 {
-                continue;
-            }
-            out.push(UsageEvent {
-                source: "pi",
-                source_path: source_path.clone(),
-                source_record_id: Some(format!("line:{index}")),
-                session_id: Some(session.clone()),
-                request_id: None,
-                message_id: str_at(&value, &["id"]),
-                timestamp_ms: value.get("timestamp").map(timestamp_ms).unwrap_or(0),
-                project: Some(project.clone()),
-                provider: str_at(message, &["provider"])
-                    .or_else(|| str_at(&value, &["provider"]))
-                    .or_else(|| current_provider.clone()),
-                model: str_at(message, &["model", "modelId"])
-                    .or_else(|| str_at(&value, &["model", "modelId"]))
-                    .or_else(|| current_model.clone()),
-                tokens,
-                source_cost_usd: usage.pointer("/cost/total").and_then(Value::as_f64),
-                dedupe_confidence: "exact",
-                conservative_undercount: false,
-                sidechain: false,
-                source_order: index,
-            });
-        }
-    }
-    Ok(out)
 }
 
 fn scan_opencode(
@@ -2303,50 +1193,11 @@ fn scan_opencode(
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let roots: Vec<PathBuf> = std::env::var_os("OPENCODE_DATA_DIR")
-        .map(|v| {
-            v.to_string_lossy()
-                .split(',')
-                .map(|s| PathBuf::from(s.trim()))
-                .collect()
-        })
-        .unwrap_or_else(|| vec![home().join(".local/share/opencode")]);
-    // Databases come before message files so `reconcile_opencode_copies` keeps the
-    // database copy of a message, matching the pre-cache suppression order.
-    let mut files = Vec::new();
-    for root in &roots {
-        let mut databases = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(root) {
-            databases.extend(entries.flatten().map(|entry| entry.path()).filter(|path| {
-                path.extension().and_then(|v| v.to_str()) == Some("db")
-                    && path
-                        .file_name()
-                        .and_then(|v| v.to_str())
-                        .is_some_and(|n| n.starts_with("opencode"))
-            }));
-        }
-        databases.sort();
-        files.extend(databases);
-    }
-    for root in &roots {
-        let message_root = root.join("storage/message");
-        if message_root.exists() {
-            files.extend(
-                WalkDir::new(message_root)
-                    .into_iter()
-                    .flatten()
-                    .filter(|e| {
-                        e.file_type().is_file()
-                            && e.path().extension().and_then(|v| v.to_str()) == Some("json")
-                    })
-                    .map(|e| e.path().to_path_buf()),
-            );
-        }
-    }
+    let files = crate::sources::opencode::usage_files();
     scan_files_cached(
         SourceScan {
             source: "opencode",
-            parser_version: OPENCODE_PARSER_VERSION,
+            parser_version: crate::sources::opencode::VERSIONS.usage,
             // Only the databases are volatile; message JSON files are updated in place
             // while a response streams and must re-parse as soon as they change.
             volatile_reuse_ms: |path| {
@@ -2358,138 +1209,9 @@ fn scan_opencode(
         cache,
         warnings,
         out,
-        |path| {
-            if path.extension().and_then(|v| v.to_str()) == Some("db") {
-                scan_opencode_db(path)
-            } else {
-                scan_opencode_message_file(path)
-            }
-            .map(FileParse::cacheable)
-        },
+        |path| crate::sources::opencode::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
-}
-
-/// A message can exist both in an OpenCode database and as a JSON file under
-/// `storage/message` (and in databases from several roots). Keep the first copy in scan
-/// order, which lists databases first.
-fn reconcile_opencode_copies(events: &mut Vec<UsageEvent>) {
-    let mut seen = HashSet::new();
-    events.retain(|event| {
-        if event.source != "opencode" {
-            return true;
-        }
-        let Some(record) = &event.source_record_id else {
-            return true;
-        };
-        seen.insert(record.clone())
-    });
-}
-
-fn scan_opencode_message_file(path: &Path) -> Result<Vec<UsageEvent>> {
-    let mut out = Vec::new();
-    let value: Value = match File::open(path)
-        .ok()
-        .and_then(|file| serde_json::from_reader(file).ok())
-    {
-        Some(value) => value,
-        None => return Ok(out),
-    };
-    let id = str_at(&value, &["id"]).or_else(|| {
-        path.file_stem()
-            .and_then(|n| n.to_str())
-            .map(str::to_string)
-    });
-    push_opencode_event(&value, path, id, &mut out);
-    Ok(out)
-}
-
-fn scan_opencode_db(path: &Path) -> Result<Vec<UsageEvent>> {
-    let mut out = Vec::new();
-    let mut ids = HashSet::new();
-    let conn = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-    conn.busy_timeout(Duration::from_secs(1))?;
-    let mut stmt = conn.prepare("SELECT id, session_id, data FROM message")?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, Option<String>>(1)?,
-            row.get::<_, String>(2)?,
-        ))
-    })?;
-    for row in rows {
-        let (id, session, data) = row?;
-        let Ok(mut value) = serde_json::from_str::<Value>(&data) else {
-            continue;
-        };
-        if value.get("sessionID").is_none()
-            && let Some(object) = value.as_object_mut()
-        {
-            object.insert(
-                "sessionID".into(),
-                session.map(Value::String).unwrap_or(Value::Null),
-            );
-        }
-        let before = out.len();
-        if !ids.contains(&id) {
-            push_opencode_event(&value, path, Some(id.clone()), &mut out);
-        }
-        if out.len() > before {
-            ids.insert(id);
-        }
-    }
-    Ok(out)
-}
-
-fn push_opencode_event(value: &Value, path: &Path, id: Option<String>, out: &mut Vec<UsageEvent>) {
-    let Some(usage) = value.get("tokens") else {
-        return;
-    };
-    let reasoning = u64_at(usage, &["reasoning"]);
-    let mut tokens = TokenBuckets::disjoint(
-        u64_at(usage, &["input"]),
-        usage
-            .pointer("/cache/read")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        usage
-            .pointer("/cache/write")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        u64_at(usage, &["output"]).saturating_add(reasoning),
-    );
-    // OpenCode persists reasoning separately from output. Fold it into the
-    // additive output bucket while retaining the detail field for reporting.
-    tokens.reasoning = reasoning;
-    if tokens.additive_total() == 0 {
-        return;
-    }
-    out.push(UsageEvent {
-        source: "opencode",
-        source_path: Arc::from(path.to_string_lossy()),
-        source_record_id: id.clone(),
-        session_id: str_at(value, &["sessionID", "session_id"]),
-        request_id: None,
-        message_id: id,
-        timestamp_ms: value
-            .pointer("/time/created")
-            .map(timestamp_ms)
-            .unwrap_or(0),
-        // Ingestion currently groups all OpenCode sessions under this
-        // synthetic project, so usage must use the same attribution.
-        project: Some(SourceKind::Opencode.label().to_string()),
-        provider: str_at(value, &["providerID", "provider"]),
-        model: str_at(value, &["modelID", "model"]),
-        tokens,
-        source_cost_usd: value.get("cost").and_then(Value::as_f64),
-        dedupe_confidence: "exact",
-        conservative_undercount: false,
-        sidechain: false,
-        source_order: 0,
-    });
 }
 
 fn scan_cursor(
@@ -2497,246 +1219,25 @@ fn scan_cursor(
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let user = if cfg!(target_os = "macos") {
-        home().join("Library/Application Support/Cursor/User")
-    } else {
-        home().join(".config/Cursor/User")
-    };
-    let mut databases = vec![user.join("globalStorage/state.vscdb")];
-    databases.extend(
-        WalkDir::new(user.join("workspaceStorage"))
-            .max_depth(3)
-            .into_iter()
-            .flatten()
-            .filter(|e| e.file_type().is_file() && e.file_name() == "state.vscdb")
-            .map(|e| e.path().to_path_buf()),
-    );
-    let databases: Vec<PathBuf> = databases.into_iter().filter(|path| path.exists()).collect();
+    let databases = crate::sources::cursor::usage_databases();
     let start = out.len();
     scan_files_cached(
         SourceScan {
             source: "cursor",
-            parser_version: CURSOR_PARSER_VERSION,
+            parser_version: crate::sources::cursor::VERSIONS.usage,
             volatile_reuse_ms: |_| Some(VOLATILE_DB_REUSE_MS),
         },
         &databases,
         cache,
         warnings,
         out,
-        |path| scan_cursor_db(path).map(FileParse::cacheable),
+        |path| crate::sources::cursor::parse_usage_database(path).map(FileParse::cacheable),
     );
-    apply_cursor_projects(&mut out[start..], &cursor_project_by_session());
+    crate::sources::cursor::apply_projects(
+        &mut out[start..],
+        &crate::sources::cursor::project_by_session(),
+    );
     Ok(())
-}
-
-/// Project attribution comes from `.cursor/projects` transcripts, which change independently
-/// of the database files the cache is keyed on. Derive it fresh on every scan (cached rows
-/// included) so a transcript that is indexed or moved after a database was cached still
-/// updates attribution.
-fn apply_cursor_projects(events: &mut [UsageEvent], project_by_session: &HashMap<String, String>) {
-    for event in events {
-        event.project = event
-            .session_id
-            .as_deref()
-            .and_then(|session_id| project_by_session.get(session_id))
-            .cloned();
-    }
-}
-
-/// Cursor generations can appear in both the global and a workspace database. Keep the
-/// first copy in database order, mirroring the shared `seen` set the scanners used before
-/// results were cached per database.
-fn reconcile_cursor_copies(events: &mut Vec<UsageEvent>) {
-    let mut seen = HashSet::new();
-    events.retain(|event| {
-        if event.source != "cursor" {
-            return true;
-        }
-        let Some(record) = &event.source_record_id else {
-            return true;
-        };
-        seen.insert((record.clone(), event.tokens.raw_input, event.tokens.output))
-    });
-}
-
-fn cursor_project_by_session() -> HashMap<String, String> {
-    let root = crate::ingest::cursor_projects_root();
-    let mut projects = HashMap::new();
-    for entry in WalkDir::new(root).into_iter().flatten().filter(|entry| {
-        entry.file_type().is_file()
-            && entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
-    }) {
-        let path = entry.path();
-        let project = crate::ingest::project_from_cursor_path(path);
-        projects.insert(
-            crate::ingest::cursor_session_id_from_path(path),
-            project.clone(),
-        );
-        projects.insert(crate::ingest::cursor_transcript_id(path), project);
-    }
-    projects
-}
-
-fn scan_cursor_db(path: &Path) -> Result<Vec<UsageEvent>> {
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
-    let conn = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-    conn.busy_timeout(Duration::from_secs(1))?;
-    for (table, query) in [
-        (
-            "cursorDiskKV",
-            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'",
-        ),
-        (
-            "ItemTable",
-            "SELECT key, value FROM ItemTable WHERE key IN ('aiService.generations', 'workbench.panel.aichat.view.aichat.chatdata')",
-        ),
-    ] {
-        let exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
-            [table],
-            |row| row.get(0),
-        )?;
-        if !exists {
-            continue;
-        }
-        let mut stmt = conn.prepare(query)?;
-        let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
-        })?;
-        for row in rows {
-            let (key, raw) = row?;
-            let Some(raw) = raw else {
-                continue;
-            };
-            let Ok(value) = serde_json::from_str::<Value>(&raw) else {
-                continue;
-            };
-            extract_cursor_objects(&value, &key, table, path, &mut out, &mut seen);
-        }
-    }
-    Ok(out)
-}
-
-fn extract_cursor_objects(
-    value: &Value,
-    fallback_id: &str,
-    table: &str,
-    path: &Path,
-    out: &mut Vec<UsageEvent>,
-    seen: &mut HashSet<String>,
-) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                extract_cursor_objects(value, fallback_id, table, path, out, seen);
-            }
-        }
-        Value::Object(object) => {
-            let input = nested_u64(object, &["inputTokens", "input_tokens"]);
-            let output = nested_u64(object, &["outputTokens", "output_tokens"]);
-            let session_id = object_string(object, &["sessionId", "composerId"]).or_else(|| {
-                fallback_id
-                    .strip_prefix("composerData:")
-                    .filter(|id| !id.is_empty())
-                    .map(str::to_string)
-            });
-            let counted = input > 0 || output > 0;
-            if counted {
-                let id = object_string(
-                    object,
-                    &["generationUUID", "generationId", "bubbleId", "id"],
-                )
-                .unwrap_or_else(|| {
-                    format!(
-                        "{fallback_id}:{}:{}",
-                        object.get("createdAt").unwrap_or(&Value::Null),
-                        input + output
-                    )
-                });
-                let dedupe = format!("{id}:{input}:{output}");
-                if seen.insert(dedupe) {
-                    out.push(UsageEvent {
-                        source: "cursor",
-                        source_path: Arc::from(path.to_string_lossy()),
-                        source_record_id: Some(id),
-                        session_id,
-                        request_id: None,
-                        message_id: None,
-                        timestamp_ms: object
-                            .get("createdAt")
-                            .or_else(|| object.get("timestamp"))
-                            .map(timestamp_ms)
-                            .unwrap_or(0),
-                        // Derived per scan by `apply_cursor_projects`; never cached.
-                        project: None,
-                        provider: None,
-                        model: object_string(object, &["model", "modelName"])
-                            .or_else(|| {
-                                object
-                                    .get("modelInfo")
-                                    .and_then(|v| str_at(v, &["modelName"]))
-                            })
-                            .or_else(|| {
-                                object
-                                    .get("modelConfig")
-                                    .and_then(|v| str_at(v, &["modelName"]))
-                            }),
-                        tokens: TokenBuckets::disjoint(input, 0, 0, output),
-                        source_cost_usd: None,
-                        dedupe_confidence: if table == "cursorDiskKV" {
-                            "exact"
-                        } else {
-                            "strong"
-                        },
-                        conservative_undercount: false,
-                        sidechain: false,
-                        source_order: 0,
-                    });
-                }
-            }
-            for (key, child) in object {
-                if counted && matches!(key.as_str(), "usage" | "tokenCount") {
-                    continue;
-                }
-                if child.is_array() || child.is_object() {
-                    extract_cursor_objects(child, fallback_id, table, path, out, seen);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn nested_u64(object: &Map<String, Value>, aliases: &[&str]) -> u64 {
-    aliases
-        .iter()
-        .find_map(|key| object.get(*key).and_then(Value::as_u64))
-        .or_else(|| {
-            object.get("tokenCount").and_then(|v| {
-                aliases
-                    .iter()
-                    .find_map(|key| v.get(*key).and_then(Value::as_u64))
-            })
-        })
-        .or_else(|| {
-            object.get("usage").and_then(|v| {
-                aliases
-                    .iter()
-                    .find_map(|key| v.get(*key).and_then(Value::as_u64))
-            })
-        })
-        .unwrap_or(0)
-}
-
-fn object_string(object: &Map<String, Value>, aliases: &[&str]) -> Option<String> {
-    aliases
-        .iter()
-        .find_map(|key| object.get(*key).and_then(Value::as_str))
-        .map(str::to_string)
 }
 
 fn scan_copilot(
@@ -2744,209 +1245,20 @@ fn scan_copilot(
     warnings: &mut Vec<String>,
     cache: Option<&mut UsageCache>,
 ) -> Result<()> {
-    let mut roots = vec![home().join(".copilot/otel")];
-    if let Some(path) = std::env::var_os("COPILOT_OTEL_FILE_EXPORTER_PATH") {
-        roots.push(PathBuf::from(path));
-    }
-    let files = roots
-        .into_iter()
-        .flat_map(|root| {
-            if root.is_file() {
-                vec![root]
-            } else {
-                jsonl_files([root])
-            }
-        })
-        .collect::<Vec<_>>();
+    let files = crate::sources::copilot::usage_files();
     scan_files_cached(
         SourceScan {
             source: "copilot",
-            parser_version: COPILOT_PARSER_VERSION,
+            parser_version: crate::sources::copilot::VERSIONS.usage,
             volatile_reuse_ms: |_| None,
         },
         &files,
         cache,
         warnings,
         out,
-        |path| scan_copilot_file(path).map(FileParse::cacheable),
+        |path| crate::sources::copilot::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
-}
-
-fn scan_copilot_file(path: &Path) -> Result<Vec<UsageEvent>> {
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
-    for (index, value) in lines(path)? {
-        extract_otel(&value, path, index, &mut out, &mut seen);
-    }
-    Ok(out)
-}
-
-/// OTel spans can repeat across exporter files (same trace/span or response id). Keep the
-/// first copy in file order, mirroring the shared `seen` set the scanner used before
-/// results were cached per file.
-fn reconcile_copilot_copies(events: &mut Vec<UsageEvent>) {
-    let mut seen = HashSet::new();
-    events.retain(|event| {
-        if event.source != "copilot" {
-            return true;
-        }
-        let Some(record) = &event.source_record_id else {
-            return true;
-        };
-        seen.insert(record.clone())
-    });
-}
-
-fn extract_otel(
-    value: &Value,
-    path: &Path,
-    index: u64,
-    out: &mut Vec<UsageEvent>,
-    seen: &mut HashSet<String>,
-) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                extract_otel(value, path, index, out, seen);
-            }
-        }
-        Value::Object(object) => {
-            let attrs = otel_attributes(object.get("attributes").unwrap_or(value));
-            let operation = attrs
-                .get("gen_ai.operation.name")
-                .and_then(Value::as_str)
-                .or_else(|| object.get("name").and_then(Value::as_str));
-            let input = attrs
-                .get("gen_ai.usage.input_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(0);
-            let output = attrs
-                .get("gen_ai.usage.output_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(0);
-            if operation == Some("chat") && (input > 0 || output > 0) {
-                let trace = object
-                    .get("traceId")
-                    .or_else(|| object.get("trace_id"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let span = object
-                    .get("spanId")
-                    .or_else(|| object.get("span_id"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let response = attrs
-                    .get("gen_ai.response.id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                let id = if !trace.is_empty() || !span.is_empty() {
-                    format!("{trace}:{span}")
-                } else if !response.is_empty() {
-                    format!("response:{response}")
-                } else {
-                    format!("{}:{index}:{input}:{output}", path.display())
-                };
-                if seen.insert(id.clone()) {
-                    let cache = attrs
-                        .get("gen_ai.usage.cache_read.input_tokens")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0)
-                        .min(input);
-                    out.push(UsageEvent {
-                        source: "copilot",
-                        source_path: Arc::from(path.to_string_lossy()),
-                        source_record_id: Some(id),
-                        session_id: attrs
-                            .get("gen_ai.conversation.id")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        request_id: attrs
-                            .get("gen_ai.response.id")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        message_id: None,
-                        timestamp_ms: object
-                            .get("startTimeUnixNano")
-                            .and_then(Value::as_str)
-                            .and_then(|v| v.parse::<u64>().ok())
-                            .map(|v| v / 1_000_000)
-                            .or_else(|| object.get("timestamp").map(timestamp_ms))
-                            .unwrap_or(0),
-                        project: attrs
-                            .get("copilot_chat.repo.remote_url")
-                            .or_else(|| attrs.get("github.copilot.git.repository"))
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        provider: Some("github-copilot".into()),
-                        model: attrs
-                            .get("gen_ai.response.model")
-                            .or_else(|| attrs.get("gen_ai.request.model"))
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        tokens: TokenBuckets::codex(
-                            input,
-                            cache,
-                            output,
-                            attrs
-                                .get("gen_ai.usage.reasoning.output_tokens")
-                                .or_else(|| attrs.get("gen_ai.usage.reasoning_tokens"))
-                                .and_then(Value::as_u64)
-                                .unwrap_or(0),
-                        ),
-                        source_cost_usd: None,
-                        dedupe_confidence: "exact",
-                        conservative_undercount: false,
-                        sidechain: false,
-                        source_order: index,
-                    });
-                }
-            }
-            for child in object.values() {
-                if child.is_array() || child.is_object() {
-                    extract_otel(child, path, index, out, seen);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn otel_attributes(value: &Value) -> HashMap<String, Value> {
-    if let Some(object) = value.as_object() {
-        return object
-            .iter()
-            .map(|(k, v)| (k.clone(), unwrap_otel_value(v)))
-            .collect();
-    }
-    let mut out = HashMap::new();
-    if let Some(array) = value.as_array() {
-        for item in array {
-            if let (Some(key), Some(value)) =
-                (item.get("key").and_then(Value::as_str), item.get("value"))
-            {
-                out.insert(key.to_string(), unwrap_otel_value(value));
-            }
-        }
-    }
-    out
-}
-
-fn unwrap_otel_value(value: &Value) -> Value {
-    for key in ["stringValue", "intValue", "doubleValue", "boolValue"] {
-        if let Some(inner) = value.get(key) {
-            if key == "intValue"
-                && let Some(text) = inner.as_str()
-            {
-                return text
-                    .parse::<u64>()
-                    .map(Value::from)
-                    .unwrap_or_else(|_| inner.clone());
-            }
-            return inner.clone();
-        }
-    }
-    value.clone()
 }
 
 // Rates are nano-USD per million tokens. The catalog is deliberately small and versioned:
@@ -3091,41 +1403,40 @@ fn claude_rates(input: u64, write_5m: u64, write_1h: u64, read: u64, output: u64
 mod tests {
     use super::*;
 
-    fn c(input: u64, cached: u64, output: u64) -> CodexTokens {
-        CodexTokens {
-            input,
-            cached,
-            output,
-            reasoning: 0,
-        }
-    }
-
     #[test]
-    fn codex_repeated_total_does_not_repeat_last() {
-        let mut counter = CodexCounter::default();
-        assert_eq!(
-            counter.account(Some(c(100, 20, 10)), Some(c(100, 20, 10))),
-            c(100, 20, 10)
-        );
-        assert_eq!(
-            counter.account(Some(c(100, 20, 10)), Some(c(100, 20, 10))),
-            c(0, 0, 0)
-        );
-    }
+    fn usage_parser_version_change_invalidates_cached_rows() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&path).expect("open cache");
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('claude', '/tmp/session.jsonl', 1, 10, 20, 30, ?1, ?2)",
+                params![
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    postcard::to_stdvec(&Vec::<UsageFileDep>::new()).unwrap()
+                ],
+            )
+            .expect("seed stale cache row");
 
-    #[test]
-    fn codex_interleaved_stream_never_recounts_high_water_gap() {
-        let mut counter = CodexCounter::default();
-        assert_eq!(counter.account(None, Some(c(1000, 0, 0))), c(1000, 0, 0));
-        assert_eq!(
-            counter.account(Some(c(200, 0, 0)), Some(c(200, 0, 0))),
-            c(0, 0, 0)
+        assert!(
+            cache
+                .load_source("claude", 2)
+                .expect("load new parser version")
+                .is_empty()
         );
-        assert_eq!(
-            counter.account(Some(c(900, 0, 0)), Some(c(1100, 0, 0))),
-            c(100, 0, 0)
-        );
-        assert_eq!(counter.counted.input, 1100);
+        let rows: i64 = cache
+            .connection
+            .query_row(
+                "SELECT count(*) FROM usage_file_cache WHERE source = 'claude'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 0);
     }
 
     #[test]
@@ -3450,7 +1761,8 @@ mod tests {
         )
         .expect("write transcript");
 
-        let events = scan_claude_file(&transcript).expect("scan transcript");
+        let events =
+            crate::sources::claude::parse_usage_file(&transcript).expect("scan transcript");
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].session_id.as_deref(), Some("ses-1"));
@@ -3484,7 +1796,7 @@ mod tests {
 
         let parsed =
             parse_missing_usage_files("claude", &missing, &mut warnings, &|path: &Path| {
-                scan_claude_file(path).map(FileParse::cacheable)
+                crate::sources::claude::parse_usage_file(path).map(FileParse::cacheable)
             });
 
         assert_eq!(parsed.len(), 1);
@@ -4064,33 +2376,6 @@ mod tests {
     }
 
     #[test]
-    fn opencode_reasoning_is_included_in_output_and_total() {
-        let value = serde_json::json!({
-            "path": { "cwd": "/repo/memex" },
-            "tokens": {
-                "input": 100,
-                "output": 20,
-                "reasoning": 30,
-                "cache": { "read": 40, "write": 10 }
-            }
-        });
-        let mut events = Vec::new();
-
-        push_opencode_event(
-            &value,
-            Path::new("message.json"),
-            Some("message".into()),
-            &mut events,
-        );
-
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].tokens.reasoning, 30);
-        assert_eq!(events[0].tokens.output, 50);
-        assert_eq!(events[0].tokens.total(), 200);
-        assert_eq!(events[0].project.as_deref(), Some("opencode"));
-    }
-
-    #[test]
     fn opencode_project_filter_matches_indexed_project() {
         use crate::test_support::{EnvVarGuard, env_lock};
 
@@ -4141,57 +2426,6 @@ mod tests {
     }
 
     #[test]
-    fn cursor_nested_token_containers_are_not_recounted() {
-        let value = serde_json::json!([
-            {
-                "generationUUID": "usage-parent",
-                "composerId": "composer-main",
-                "usage": { "inputTokens": 10, "outputTokens": 5 },
-                "children": [
-                    {
-                        "generationId": "nested-request",
-                        "inputTokens": 7,
-                        "outputTokens": 3
-                    }
-                ]
-            },
-            {
-                "generationUUID": "count-parent",
-                "tokenCount": { "input_tokens": 20, "output_tokens": 8 }
-            }
-        ]);
-        let mut events = Vec::new();
-        let mut seen = HashSet::new();
-        let project_by_session =
-            HashMap::from([("composer-main".to_string(), "memex".to_string())]);
-
-        extract_cursor_objects(
-            &value,
-            "fixture",
-            "cursorDiskKV",
-            Path::new("state.vscdb"),
-            &mut events,
-            &mut seen,
-        );
-        apply_cursor_projects(&mut events, &project_by_session);
-
-        assert_eq!(events.len(), 3);
-        let ids: HashSet<_> = events
-            .iter()
-            .filter_map(|event| event.source_record_id.as_deref())
-            .collect();
-        assert_eq!(
-            ids,
-            HashSet::from(["usage-parent", "nested-request", "count-parent"])
-        );
-        assert_eq!(
-            events.iter().map(|event| event.tokens.total()).sum::<u64>(),
-            53
-        );
-        assert_eq!(events[0].project.as_deref(), Some("memex"));
-    }
-
-    #[test]
     fn cursor_project_mapping_is_recomputed_on_cache_hits() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let db_path = tmp.path().join("state.vscdb");
@@ -4212,17 +2446,17 @@ mod tests {
             scan_files_cached(
                 SourceScan {
                     source: "cursor",
-                    parser_version: CURSOR_PARSER_VERSION,
+                    parser_version: crate::sources::cursor::VERSIONS.usage,
                     volatile_reuse_ms: |_| Some(VOLATILE_DB_REUSE_MS),
                 },
                 &files,
                 Some(&mut cache),
                 &mut warnings,
                 &mut events,
-                |path| scan_cursor_db(path).map(FileParse::cacheable),
+                |path| crate::sources::cursor::parse_usage_database(path).map(FileParse::cacheable),
             );
             assert_eq!(warnings, Vec::<String>::new());
-            apply_cursor_projects(&mut events, project_by_session);
+            crate::sources::cursor::apply_projects(&mut events, project_by_session);
             events
         };
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -23,6 +23,14 @@ pub struct VectorIndex {
 }
 
 impl VectorIndex {
+    pub fn reset(dir: &Path) -> Result<()> {
+        if dir.exists() {
+            fs::remove_dir_all(dir)?;
+        }
+        fs::create_dir_all(dir)?;
+        Ok(())
+    }
+
     pub fn open_or_create(dir: &Path, dimensions: usize, model: Option<&str>) -> Result<Self> {
         fs::create_dir_all(dir)?;
         let index_path = dir.join("usearch.index");
@@ -262,6 +270,22 @@ mod tests {
         assert!(idx.contains(1));
         assert!(!idx.contains(2));
         assert_eq!(idx.dimensions(), 64);
+    }
+
+    #[test]
+    fn reset_removes_all_existing_vector_state() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = VectorIndex::open_or_create(tmp.path(), 64, Some("test")).unwrap();
+        idx.add(1, &make_vector(64, 1.0)).unwrap();
+        idx.save().unwrap();
+        assert!(tmp.path().join("usearch.index").exists());
+
+        VectorIndex::reset(tmp.path()).unwrap();
+
+        assert!(tmp.path().exists());
+        assert!(!tmp.path().join("usearch.index").exists());
+        assert!(!tmp.path().join("doc_ids.bin").exists());
+        assert!(!tmp.path().join("meta.json").exists());
     }
 
     #[test]


### PR DESCRIPTION
Persists unresolved tool-call metadata in per-file ingest state so incrementally indexed results retain their tool name, call linkage, session, and source identity. Pending state is invalidated when files are truncated, replaced, fully reindexed, deleted, or parsed with a newer version.

Moves discovery, transcript parsing, metadata extraction, hierarchy handling, usage decoding, reconciliation, and parser versions into source-owned modules for Claude, Codex, Cursor, OpenCode, Pi, and Copilot. Shared ingest and usage code now primarily orchestrates those implementations, and cold usage reconstruction uses the source decoders backed by simd-json.

Parser-version migrations now invalidate an existing vector store once, preserve its embedding model, commit the reparsed Tantivy records, and rebuild embeddings from that committed record set. This prevents stale document IDs from consuming semantic-search candidates after upgrading legacy ingest state.

Adds regression coverage for split tool calls/results, multiple outstanding and out-of-order calls, stale-state invalidation, parser-version cache invalidation and vector rebuilding, archived discovery, and source-specific usage formats.

Release-mode benchmarks against the previous version produced byte-identical normalized output across 141,491 usage events. The all-source cold scan improved by about 14%, Codex-only cold scanning improved by about 9%, and warm-cache performance was unchanged. Claude cold parsing remains within roughly 8 ms of the previous implementation.

Validation: `cargo fmt --check`, `cargo clippy -- -D warnings`, and 226 library tests.