### PR TITLE
Expand transcript parsing and add OpenClaw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, OpenClaw, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -83,6 +83,7 @@ Configure memex declaratively (generates `~/.memex/config.toml`):
           enable = true;
           settings = {
             embeddings = true;
+            include_reasoning = false;
             model = "minilm";
             execution_provider = "auto"; # coreml on macOS, cpu elsewhere
             cuda_device_id = 0; # optional when execution_provider = "cuda"
@@ -116,6 +117,10 @@ Index (incremental):
 ```
 memex index
 ```
+
+Plaintext reasoning is excluded by default because it is usually low-value search noise. Opt
+in with `memex index --include-reasoning`; reasoning records remain BM25-only. Encrypted and
+redacted payloads, along with reasoning signature fields, are always excluded.
 
 Search (JSONL default):
 ```
@@ -154,7 +159,7 @@ Token tracking is disabled by default because it scans and caches local agent lo
 token_usage = true
 ```
 
-Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, and Copilot logs:
+Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot logs:
 
 ```
 memex usage
@@ -210,7 +215,7 @@ This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents a
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|cursor|opencode|pi|copilot`
+- `--source claude|codex|cursor|opencode|pi|openclaw|copilot`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -303,6 +308,7 @@ Create `~/.memex/config.toml` (or `<root>/config.toml` if you use `--root`):
 ```toml
 embeddings = true
 auto_index_on_search = true
+include_reasoning = false  # opt in to plaintext reasoning; encrypted/redacted payloads stay excluded
 token_usage = false  # opt in to local token and cost tracking
 model = "minilm"  # minilm, bge, nomic, gemma, potion
 execution_provider = "auto"  # auto, cpu, coreml, cuda
@@ -329,6 +335,9 @@ pi_resume_cmd = "pi --session {source_path_shell}"
 Service logs and the plist live under `~/.memex` by default (macOS). On Linux, systemd units are created in `~/.config/systemd/user/`.
 
 `scan_cache_ttl` controls how long auto-indexing considers scans fresh.
+`include_reasoning` defaults to false. Set it to true (or pass `memex index
+--include-reasoning`) to add plaintext reasoning as BM25-only records. Encrypted
+and redacted reasoning payloads are always excluded.
 `max_indexed_tool_*_bytes` limits oversized tool payloads while leaving user and assistant text
 unchanged. memex keeps roughly the first three quarters and final quarter, with a marker reporting
 the omitted middle. Each value must be at least 1024 bytes. Run `memex index --reindex` to apply

--- a/fixtures/trajectory_parity/claude.jsonl
+++ b/fixtures/trajectory_parity/claude.jsonl
@@ -1,0 +1,3 @@
+{"type":"assistant","uuid":"assistant-1","sessionId":"claude-session","cwd":"/workspace/project","timestamp":"2026-07-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Plain Claude reasoning","signature":"signature-must-never-be-indexed"},{"type":"redacted_thinking","data":"ciphertext-must-never-be-indexed"},{"type":"text","text":"Visible answer"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"README.md"}}]}}
+{"type":"user","uuid":"user-1","parentUuid":"assistant-1","sessionId":"claude-session","cwd":"/workspace/project","timestamp":"2026-07-01T00:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"README contents"}]}}
+not-json

--- a/fixtures/trajectory_parity/codex.jsonl
+++ b/fixtures/trajectory_parity/codex.jsonl
@@ -1,0 +1,10 @@
+{"timestamp":"2026-07-01T00:00:00Z","type":"session_meta","payload":{"id":"codex-session","cwd":"/workspace/project","cli_version":"0.140.0"}}
+{"timestamp":"2026-07-01T00:00:01Z","type":"event_msg","payload":{"type":"agent_reasoning","text":"Plaintext summary only"}}
+{"timestamp":"2026-07-01T00:00:01Z","type":"response_item","payload":{"type":"reasoning","encrypted_content":"ciphertext-must-never-be-indexed","summary":[]}}
+{"timestamp":"2026-07-01T00:00:02Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"custom-1","input":"*** Begin Patch"}}
+{"timestamp":"2026-07-01T00:00:03Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"custom-1","output":"Done"}}
+{"timestamp":"2026-07-01T00:00:04Z","type":"response_item","payload":{"type":"web_search_call","call_id":"web-1","action":{"type":"search","query":"rust parser"}}}
+{"timestamp":"2026-07-01T00:00:05Z","type":"response_item","payload":{"type":"tool_search_call","call_id":"search-1","arguments":{"query":"filesystem"}}}
+{"timestamp":"2026-07-01T00:00:06Z","type":"response_item","payload":{"type":"tool_search_output","call_id":"search-1","tools":[{"name":"read_file"}]}}
+{"timestamp":"2026-07-01T00:00:07Z","type":"response_item","payload":{"type":"future_semantic_event","value":"ignored"}}
+not-json

--- a/fixtures/trajectory_parity/openclaw.jsonl
+++ b/fixtures/trajectory_parity/openclaw.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","id":"openclaw-session","timestamp":"2026-07-01T00:00:00Z","cwd":"/workspace/openclaw"}
+{"type":"message","id":"assistant-1","timestamp":1782864001000,"message":{"role":"assistant","model":"delivery-mirror","content":[{"type":"text","text":"Mirrored assistant prose"}],"usage":{"input":2,"output":3}}}

--- a/fixtures/trajectory_parity/pi.jsonl
+++ b/fixtures/trajectory_parity/pi.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","id":"pi-session","timestamp":"2026-07-01T00:00:00Z","cwd":"/workspace/project"}
+{"type":"message","id":"assistant-1","timestamp":1782864001000,"message":{"role":"assistant","timestamp":1782864001000,"content":[{"type":"thinking","thinking":"Plain Pi reasoning"},{"type":"redacted_thinking","data":"ciphertext-must-never-be-indexed"},{"type":"text","text":"I will read the file."},{"type":"toolCall","id":"tool-1","name":"Read","arguments":{"path":"README.md"}}]}}
+{"type":"message","id":"result-1","timestamp":1782864002000,"message":{"role":"tool","toolCallId":"tool-1","toolName":"Read","content":[{"type":"text","text":"permission denied"}],"isError":true}}
+{"type":"message","id":"unknown-1","timestamp":1782864003000,"message":{"role":"futureRole","content":"ignored"}}
+not-json

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -25,6 +25,7 @@ in {
         Supported keys:
         - embeddings (bool)
         - auto_index_on_search (bool)
+        - include_reasoning (bool): opt in to plaintext reasoning records
         - token_usage (bool): opt in to local token and cost tracking
         - model (string): "minilm", "bge", "nomic", "gemma", "potion"
         - execution_provider (string): "auto", "cpu", "coreml", "cuda"
@@ -50,6 +51,7 @@ in {
         execution_provider = "auto";
         cuda_device_id = 0;
         auto_index_on_search = true;
+        include_reasoning = false;
         token_usage = false;
       };
     };

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -828,7 +828,8 @@ fn resolve_session_cwd_from_parts(
             }
         }
 
-        if source == SourceKind::Pi && value.get("type").and_then(|v| v.as_str()) == Some("session")
+        if matches!(source, SourceKind::Pi | SourceKind::OpenClaw)
+            && value.get("type").and_then(|v| v.as_str()) == Some("session")
         {
             let cwd = value
                 .get("cwd")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, and Copilot",
+    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot",
     after_help = "\
 QUICK START:
     memex                           # Browse sessions interactively
@@ -52,6 +52,9 @@ struct IndexArgs {
     /// Include agent subprocess conversations (Claude Code subagents)
     #[arg(long)]
     include_agents: bool,
+    /// Index plaintext reasoning as BM25-only records (encrypted/redacted reasoning is always dropped)
+    #[arg(long)]
+    include_reasoning: bool,
     /// Index Codex sessions from ~/.codex [default: true]
     #[arg(long, default_value_t = true)]
     codex: bool,
@@ -73,6 +76,12 @@ struct IndexArgs {
     /// Skip indexing Pi sessions
     #[arg(long = "no-pi", default_value_t = false)]
     no_pi: bool,
+    /// Index OpenClaw sessions from ~/.openclaw or ~/.clawdbot [default: true]
+    #[arg(long, default_value_t = true)]
+    openclaw: bool,
+    /// Skip indexing OpenClaw sessions
+    #[arg(long = "no-openclaw", default_value_t = false)]
+    no_openclaw: bool,
     /// Index GitHub Copilot CLI sessions from ~/.copilot [default: true]
     #[arg(long, default_value_t = true)]
     copilot: bool,
@@ -91,12 +100,15 @@ struct IndexArgs {
     /// Path to memex data directory [default: ~/.memex]
     #[arg(long)]
     root: Option<PathBuf>,
+    /// Print aggregate parser diagnostics without transcript content
+    #[arg(long)]
+    diagnostics: bool,
 }
 
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Index Claude, Codex, Cursor, OpenCode, Pi, and Copilot conversation history
+    /// Index Claude, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot conversation history
     #[command(after_help = "\
 EXAMPLES:
     memex index                         # Index all supported local history
@@ -162,7 +174,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -257,7 +269,7 @@ EXAMPLES:
     memex usage --source codex --since 2026-07-01
     memex usage --json")]
     Usage {
-        /// Filter by source: claude, codex, cursor, opencode, pi, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include events on or after this date/timestamp
@@ -285,6 +297,13 @@ EXAMPLES:
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
+    },
+    /// Report privacy-safe transcript structure and producer-version counts
+    #[command(hide = true)]
+    SourceAudit {
+        /// Limit the audit to one source
+        #[arg(long)]
+        source: Option<SourceFilter>,
     },
     /// Install the memex-search skill for Claude, Codex, Opencode, and/or Pi
     Setup {
@@ -579,6 +598,10 @@ pub fn run() -> Result<()> {
         Commands::AnalyticsBackfill { root } => {
             run_analytics_backfill(root)?;
         }
+        Commands::SourceAudit { source } => {
+            let audits = crate::sources::audit::audit_installed_sources(source)?;
+            println!("{}", serde_json::to_string_pretty(&audits)?);
+        }
         Commands::Setup { force } => {
             run_setup(force)?;
         }
@@ -619,16 +642,19 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
     run_index(
         index.source.clone(),
         index.include_agents,
+        index.include_reasoning,
         index.codex && !index.no_codex,
         index.opencode && !index.no_opencode,
         index.cursor,
         index.pi && !index.no_pi,
+        index.openclaw && !index.no_openclaw,
         index.copilot && !index.no_copilot,
         index.embeddings,
         index.no_embeddings,
         index.model.clone(),
         index.root.clone(),
         reindex,
+        index.diagnostics,
     )
 }
 
@@ -636,16 +662,19 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
 fn run_index(
     source: Option<PathBuf>,
     include_agents: bool,
+    include_reasoning: bool,
     codex: bool,
     opencode: bool,
     cursor: bool,
     pi: bool,
+    openclaw: bool,
     copilot: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
     model: Option<String>,
     root: Option<PathBuf>,
     reindex: bool,
+    print_diagnostics: bool,
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
@@ -654,6 +683,7 @@ fn run_index(
     let model_choice = config.resolve_model(model)?;
     let embed_runtime = config.resolve_embed_runtime()?;
     let tool_content_limits = config.indexed_tool_content_limits()?;
+    let include_reasoning = include_reasoning || config.include_reasoning_default();
     let embeddings = resolve_flag(
         config.embeddings_default(),
         embeddings_flag,
@@ -669,10 +699,12 @@ fn run_index(
     let opts = IngestOptions {
         claude_source: source.unwrap_or_else(default_claude_source),
         include_agents,
+        include_reasoning,
         include_codex: codex,
         include_opencode: opencode,
         include_cursor: cursor,
         include_pi: pi,
+        include_openclaw: openclaw,
         include_copilot: copilot,
         embeddings,
         backfill_embeddings: false,
@@ -694,6 +726,12 @@ fn run_index(
         println!(
             "indexed {} records across {} files (skipped {})",
             report.records_added, report.files_scanned, report.files_skipped
+        );
+    }
+    if print_diagnostics && !report.diagnostics.is_empty() {
+        println!(
+            "parser diagnostics:\n{}",
+            serde_json::to_string_pretty(&report.diagnostics)?
         );
     }
     Ok(())
@@ -788,7 +826,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {}, copilot {})",
+        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::CodexSession.idx()],
@@ -796,6 +834,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
         embedded_counts[crate::types::SourceKind::Opencode.idx()],
         embedded_counts[crate::types::SourceKind::Cursor.idx()],
         embedded_counts[crate::types::SourceKind::Pi.idx()],
+        embedded_counts[crate::types::SourceKind::OpenClaw.idx()],
         embedded_counts[crate::types::SourceKind::Copilot.idx()],
     );
 
@@ -841,10 +880,12 @@ fn run_search(
         let opts = IngestOptions {
             claude_source: default_claude_source(),
             include_agents: false,
+            include_reasoning: config.include_reasoning_default(),
             include_codex: true,
             include_opencode: true,
             include_cursor: true,
             include_pi: true,
+            include_openclaw: true,
             include_copilot: true,
             embeddings: embeddings_default,
             backfill_embeddings: false,
@@ -1953,6 +1994,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Opencode => "opencode",
         crate::types::SourceKind::Cursor => "cursor",
         crate::types::SourceKind::Pi => "pi",
+        crate::types::SourceKind::OpenClaw => "openclaw",
         crate::types::SourceKind::Copilot => "copilot",
     };
     let source_path = &record.source_path;
@@ -2564,6 +2606,9 @@ fn build_index_command_args(
     if index.include_agents {
         args.push("--include-agents".to_string());
     }
+    if index.include_reasoning {
+        args.push("--include-reasoning".to_string());
+    }
     if !index.codex || index.no_codex {
         args.push("--no-codex".to_string());
     }
@@ -2576,6 +2621,9 @@ fn build_index_command_args(
     if !index.pi || index.no_pi {
         args.push("--no-pi".to_string());
     }
+    if !index.openclaw || index.no_openclaw {
+        args.push("--no-openclaw".to_string());
+    }
     if !index.copilot || index.no_copilot {
         args.push("--no-copilot".to_string());
     }
@@ -2584,6 +2632,9 @@ fn build_index_command_args(
     }
     if index.no_embeddings {
         args.push("--no-embeddings".to_string());
+    }
+    if index.diagnostics {
+        args.push("--diagnostics".to_string());
     }
     if continuous {
         args.push("--watch".to_string());
@@ -3272,19 +3323,23 @@ mod tests {
         let index = IndexArgs {
             source: None,
             include_agents: false,
+            include_reasoning: false,
             codex: false,
             opencode: false,
             cursor: false,
             pi: false,
+            openclaw: false,
             copilot: false,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
+            no_openclaw: false,
             no_copilot: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
             root: None,
+            diagnostics: false,
         };
 
         let args = build_index_command_args(&index, false, 30);
@@ -3293,6 +3348,7 @@ mod tests {
         assert!(args.contains(&"--no-opencode".to_string()));
         assert!(args.contains(&"--no-cursor".to_string()));
         assert!(args.contains(&"--no-pi".to_string()));
+        assert!(args.contains(&"--no-openclaw".to_string()));
         assert!(args.contains(&"--no-copilot".to_string()));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ impl Default for IndexedToolContentLimits {
 pub struct UserConfig {
     pub embeddings: Option<bool>,
     pub auto_index_on_search: Option<bool>,
+    /// Index plaintext model reasoning. Encrypted/redacted reasoning is always excluded.
+    pub include_reasoning: Option<bool>,
     /// Reconstruct token usage from local agent logs (disabled by default).
     pub token_usage: Option<bool>,
     /// Embedding model: minilm, bge, nomic, gemma (default), potion
@@ -140,6 +142,10 @@ impl UserConfig {
 
     pub fn auto_index_on_search_default(&self) -> bool {
         self.auto_index_on_search.unwrap_or(true)
+    }
+
+    pub fn include_reasoning_default(&self) -> bool {
+        self.include_reasoning.unwrap_or(false)
     }
 
     pub fn token_usage_enabled(&self) -> bool {
@@ -286,6 +292,18 @@ mod tests {
     #[test]
     fn token_usage_is_disabled_by_default() {
         assert!(!UserConfig::default().token_usage_enabled());
+    }
+
+    #[test]
+    fn reasoning_is_opt_in() {
+        assert!(!UserConfig::default().include_reasoning_default());
+        assert!(
+            UserConfig {
+                include_reasoning: Some(true),
+                ..UserConfig::default()
+            }
+            .include_reasoning_default()
+        );
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -15,8 +15,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 const EMBED_BATCH_SIZE: usize = 64;
 const EMBED_MAX_CHARS: usize = 8192;
@@ -29,10 +29,12 @@ const RECORD_CHANNEL_CAPACITY: usize = 8;
 pub struct IngestOptions {
     pub claude_source: PathBuf,
     pub include_agents: bool,
+    pub include_reasoning: bool,
     pub include_codex: bool,
     pub include_opencode: bool,
     pub include_cursor: bool,
     pub include_pi: bool,
+    pub include_openclaw: bool,
     pub include_copilot: bool,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
@@ -47,6 +49,7 @@ pub struct IngestReport {
     pub records_embedded: usize,
     pub files_scanned: usize,
     pub files_skipped: usize,
+    pub diagnostics: crate::sources::ParseDiagnostics,
 }
 
 #[derive(Debug)]
@@ -69,6 +72,7 @@ struct FileUpdate {
     path: String,
     state: FileState,
     session_id: Option<String>,
+    diagnostics: crate::sources::ParseDiagnostics,
 }
 
 const FILE_IDENTITY_PREFIX_BYTES: usize = 4096;
@@ -125,6 +129,7 @@ fn file_was_replaced(previous: &FileIdentity, current: &FileIdentity) -> bool {
 fn prepare_file_task(
     path: PathBuf,
     source: SourceKind,
+    include_reasoning: bool,
     metadata: &std::fs::Metadata,
     previous: Option<&FileState>,
 ) -> (FileTask, bool) {
@@ -146,7 +151,7 @@ fn prepare_file_task(
         .unwrap_or_else(|| size.min(FILE_IDENTITY_PREFIX_BYTES as u64))
         .min(size) as usize;
     let identity = file_identity(&path, metadata, prefix_bytes);
-    let parser_version = crate::sources::index_state_version(source);
+    let parser_version = crate::sources::index_state_version_for(source, include_reasoning);
     let parser_version_invalidated =
         previous.is_some_and(|previous| previous.parser_version != parser_version);
     let (offset, turn_id, delete_first, pending_tool_calls, skip) = match previous {
@@ -221,15 +226,39 @@ fn completed_file_state(
 struct RecordSender {
     sender: Sender<Record>,
     limits: IndexedToolContentLimits,
+    diagnostics: Arc<Mutex<crate::sources::ParseDiagnostics>>,
 }
 
 impl RecordSender {
+    #[cfg(test)]
     fn new(sender: Sender<Record>, limits: IndexedToolContentLimits) -> Self {
-        Self { sender, limits }
+        Self::with_diagnostics(
+            sender,
+            limits,
+            Arc::new(Mutex::new(crate::sources::ParseDiagnostics::default())),
+        )
+    }
+
+    fn with_diagnostics(
+        sender: Sender<Record>,
+        limits: IndexedToolContentLimits,
+        diagnostics: Arc<Mutex<crate::sources::ParseDiagnostics>>,
+    ) -> Self {
+        Self {
+            sender,
+            limits,
+            diagnostics,
+        }
     }
 
     fn send(&self, mut record: Record) -> Result<()> {
-        limit_record_tool_content(&mut record, self.limits);
+        let (input_truncated, output_truncated) =
+            limit_record_tool_content(&mut record, self.limits);
+        if input_truncated || output_truncated {
+            let mut diagnostics = self.diagnostics.lock().unwrap();
+            diagnostics.truncated_tool_inputs += u64::from(input_truncated);
+            diagnostics.truncated_tool_outputs += u64::from(output_truncated);
+        }
         self.sender.send(record)?;
         Ok(())
     }
@@ -330,8 +359,13 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::Claude, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Claude,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -352,8 +386,13 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::CodexSession, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::CodexSession,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -371,6 +410,7 @@ pub fn ingest_all(
             let (task, skip) = prepare_file_task(
                 history_path,
                 SourceKind::CodexHistory,
+                options.include_reasoning,
                 &meta,
                 state.files.get(&key),
             );
@@ -390,8 +430,13 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::Opencode, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Opencode,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -408,8 +453,13 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::Cursor, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Cursor,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -426,8 +476,35 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::Pi, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Pi,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(task);
+        }
+    }
+
+    if options.include_openclaw {
+        for source_file in crate::sources::openclaw::discover() {
+            let path = source_file.path;
+            let meta = path.metadata()?;
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = path.to_string_lossy().to_string();
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::OpenClaw,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -444,8 +521,13 @@ pub fn ingest_all(
             files_scanned += 1;
             total_bytes += meta.len();
             let key = path.to_string_lossy().to_string();
-            let (task, skip) =
-                prepare_file_task(path, SourceKind::Copilot, &meta, state.files.get(&key));
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Copilot,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
             if skip {
                 files_skipped += 1;
                 continue;
@@ -475,6 +557,7 @@ pub fn ingest_all(
             records_embedded: 0,
             files_scanned,
             files_skipped,
+            diagnostics: Default::default(),
         });
     }
 
@@ -483,7 +566,12 @@ pub fn ingest_all(
     let progress = Arc::new(Progress::new(totals, file_totals, embeddings));
 
     let (raw_tx_record, rx_record) = record_channel();
-    let tx_record = RecordSender::new(raw_tx_record, options.tool_content_limits);
+    let shared_diagnostics = Arc::new(Mutex::new(crate::sources::ParseDiagnostics::default()));
+    let tx_record = RecordSender::with_diagnostics(
+        raw_tx_record,
+        options.tool_content_limits,
+        shared_diagnostics.clone(),
+    );
     let (tx_update, rx_update) = unbounded::<FileUpdate>();
 
     let delete_paths: Vec<String> = tasks
@@ -509,12 +597,22 @@ pub fn ingest_all(
     let tasks_arc = Arc::new(tasks);
     tasks_arc.par_iter().try_for_each(|task| -> Result<()> {
         match task.source {
-            SourceKind::Claude => {
-                parse_claude_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
-            }
-            SourceKind::CodexSession => {
-                parse_codex_session(task, &tx_record, &tx_update, &next_doc_id, &progress)?
-            }
+            SourceKind::Claude => parse_claude_file(
+                task,
+                options.include_reasoning,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+            )?,
+            SourceKind::CodexSession => parse_codex_session(
+                task,
+                options.include_reasoning,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+            )?,
             SourceKind::CodexHistory => parse_codex_history(
                 task,
                 &tx_record,
@@ -534,7 +632,22 @@ pub fn ingest_all(
             SourceKind::Cursor => {
                 parse_cursor_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?
             }
-            SourceKind::Pi => parse_pi_file(task, &tx_record, &tx_update, &next_doc_id, &progress)?,
+            SourceKind::Pi => parse_pi_file(
+                task,
+                options.include_reasoning,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+            )?,
+            SourceKind::OpenClaw => parse_openclaw_file(
+                task,
+                options.include_reasoning,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+            )?,
             SourceKind::Copilot => {
                 parse_copilot_session(task, &tx_record, &tx_update, &next_doc_id, &progress)?
             }
@@ -556,9 +669,11 @@ pub fn ingest_all(
         AnalyticsStore::open(&analytics_db)?.mark_complete()?;
     }
 
+    let mut diagnostics = shared_diagnostics.lock().unwrap().clone();
     let mut updated_files = HashMap::new();
     while let Ok(update) = rx_update.recv() {
         updated_files.insert(update.path.clone(), update.state.clone());
+        diagnostics.merge(update.diagnostics);
         let _ = update.session_id;
     }
 
@@ -575,6 +690,7 @@ pub fn ingest_all(
         records_embedded,
         files_scanned,
         files_skipped,
+        diagnostics,
     })
 }
 
@@ -693,7 +809,7 @@ fn writer_loop(
 
     for mut record in rx.iter() {
         // Parsers apply the limit before queueing; enforce it here as a defensive boundary too.
-        limit_record_tool_content(&mut record, tool_content_limits);
+        let _ = limit_record_tool_content(&mut record, tool_content_limits);
         analytics.record(&record)?;
         index.add_record(&mut writer, &record)?;
         let source_idx = record.source.idx();
@@ -812,6 +928,7 @@ fn backfill_embeddings(
 
 fn parse_claude_file(
     task: &FileTask,
+    include_reasoning: bool,
     tx_record: &RecordSender,
     tx_update: &Sender<FileUpdate>,
     next_doc_id: &AtomicU64,
@@ -825,6 +942,7 @@ fn parse_claude_file(
             turn_id: task.turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
+        include_reasoning,
         next_doc_id,
         |record| {
             progress.add_produced(SourceKind::Claude, 1);
@@ -843,6 +961,7 @@ fn parse_claude_file(
 
 fn parse_codex_session(
     task: &FileTask,
+    include_reasoning: bool,
     tx_record: &RecordSender,
     tx_update: &Sender<FileUpdate>,
     next_doc_id: &AtomicU64,
@@ -856,6 +975,7 @@ fn parse_codex_session(
             turn_id: task.turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
+        include_reasoning,
         next_doc_id,
         |record| {
             progress.add_produced(SourceKind::CodexSession, 1);
@@ -925,6 +1045,7 @@ fn finish_source_parse(
         path: source_path,
         state,
         session_id: parsed.session_id,
+        diagnostics: parsed.diagnostics,
     })?;
     Ok(())
 }
@@ -994,6 +1115,7 @@ fn parse_cursor_file(
 }
 fn parse_pi_file(
     task: &FileTask,
+    include_reasoning: bool,
     tx_record: &RecordSender,
     tx_update: &Sender<FileUpdate>,
     next_doc_id: &AtomicU64,
@@ -1007,6 +1129,7 @@ fn parse_pi_file(
             turn_id: task.turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
+        include_reasoning,
         next_doc_id,
         |record| {
             progress.add_produced(SourceKind::Pi, 1);
@@ -1018,6 +1141,38 @@ fn parse_pi_file(
         tx_update,
         progress,
         SourceKind::Pi,
+        source_path,
+        parsed,
+    )
+}
+fn parse_openclaw_file(
+    task: &FileTask,
+    include_reasoning: bool,
+    tx_record: &RecordSender,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::openclaw::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        include_reasoning,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::OpenClaw, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::OpenClaw,
         source_path,
         parsed,
     )
@@ -1117,7 +1272,12 @@ fn truncate_for_embedding(mut text: String) -> String {
     text
 }
 
-fn limit_record_tool_content(record: &mut Record, limits: IndexedToolContentLimits) {
+fn limit_record_tool_content(
+    record: &mut Record,
+    limits: IndexedToolContentLimits,
+) -> (bool, bool) {
+    let original_input_len = record.tool_input.as_ref().map(String::len);
+    let original_output_len = record.tool_output.as_ref().map(String::len);
     let text_limit = match record.role.as_str() {
         "tool_use" => Some(limits.input_bytes),
         "tool_result" => Some(limits.output_bytes),
@@ -1134,6 +1294,14 @@ fn limit_record_tool_content(record: &mut Record, limits: IndexedToolContentLimi
     if let Some(tool_output) = record.tool_output.as_mut() {
         truncate_for_index(tool_output, limits.output_bytes);
     }
+    (
+        original_input_len
+            .zip(record.tool_input.as_ref().map(String::len))
+            .is_some_and(|(before, after)| after < before),
+        original_output_len
+            .zip(record.tool_output.as_ref().map(String::len))
+            .is_some_and(|(before, after)| after < before),
+    )
 }
 
 fn truncate_for_index(text: &mut String, max_bytes: usize) {
@@ -1203,10 +1371,12 @@ mod tests {
         IngestOptions {
             claude_source: PathBuf::from("/does/not/exist"),
             include_agents: false,
+            include_reasoning: false,
             include_codex: false,
             include_opencode: false,
             include_cursor: false,
             include_pi: false,
+            include_openclaw: false,
             include_copilot: false,
             embeddings,
             backfill_embeddings: false,
@@ -1610,8 +1780,15 @@ mod tests {
         let next_doc_id = AtomicU64::new(1);
         let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
         let first = incremental_task(&path, SourceKind::Claude, 0, 0, HashMap::new());
-        parse_claude_file(&first, &tx_record, &tx_update, &next_doc_id, &progress)
-            .expect("parse calls");
+        parse_claude_file(
+            &first,
+            false,
+            &tx_record,
+            &tx_update,
+            &next_doc_id,
+            &progress,
+        )
+        .expect("parse calls");
         let first_records: Vec<_> = rx_record.try_iter().collect();
         let first_state = rx_update.try_recv().expect("first state").state;
         assert_eq!(first_records.len(), 2);
@@ -1640,8 +1817,15 @@ mod tests {
             first_state.turn_id,
             first_state.pending_tool_calls,
         );
-        parse_claude_file(&second, &tx_record, &tx_update, &next_doc_id, &progress)
-            .expect("parse results");
+        parse_claude_file(
+            &second,
+            false,
+            &tx_record,
+            &tx_update,
+            &next_doc_id,
+            &progress,
+        )
+        .expect("parse results");
         let second_records: Vec<_> = rx_record.try_iter().collect();
         let second_state = rx_update.try_recv().expect("second state").state;
 
@@ -1683,8 +1867,15 @@ mod tests {
         let next_doc_id = AtomicU64::new(10);
         let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
         let first = incremental_task(&path, SourceKind::CodexSession, 0, 0, HashMap::new());
-        parse_codex_session(&first, &tx_record, &tx_update, &next_doc_id, &progress)
-            .expect("parse call");
+        parse_codex_session(
+            &first,
+            false,
+            &tx_record,
+            &tx_update,
+            &next_doc_id,
+            &progress,
+        )
+        .expect("parse call");
         let call_record = rx_record.try_recv().expect("call record");
         let first_state = rx_update.try_recv().expect("first state").state;
         assert_eq!(call_record.tool_name.as_deref(), Some("shell"));
@@ -1710,8 +1901,15 @@ mod tests {
             first_state.turn_id,
             first_state.pending_tool_calls,
         );
-        parse_codex_session(&second, &tx_record, &tx_update, &next_doc_id, &progress)
-            .expect("parse result");
+        parse_codex_session(
+            &second,
+            false,
+            &tx_record,
+            &tx_update,
+            &next_doc_id,
+            &progress,
+        )
+        .expect("parse result");
         let result_record = rx_record.try_recv().expect("result record");
         let second_state = rx_update.try_recv().expect("second state").state;
 
@@ -1741,7 +1939,7 @@ mod tests {
         fs::write(&path, "original transcript with a pending call\n").expect("write original");
         let metadata = path.metadata().expect("original metadata");
         let (mut original, _) =
-            prepare_file_task(path.clone(), SourceKind::Claude, &metadata, None);
+            prepare_file_task(path.clone(), SourceKind::Claude, false, &metadata, None);
         original.pending_tool_calls.insert(
             "stale".to_string(),
             PendingToolCall {
@@ -1761,6 +1959,7 @@ mod tests {
         let (truncated, skip) = prepare_file_task(
             path.clone(),
             SourceKind::Claude,
+            false,
             &truncated_meta,
             Some(&prior),
         );
@@ -1777,8 +1976,13 @@ mod tests {
         .expect("write replacement");
         fs::rename(&replacement, &path).expect("replace path");
         let replacement_meta = path.metadata().expect("replacement metadata");
-        let (replaced, skip) =
-            prepare_file_task(path, SourceKind::Claude, &replacement_meta, Some(&prior));
+        let (replaced, skip) = prepare_file_task(
+            path,
+            SourceKind::Claude,
+            false,
+            &replacement_meta,
+            Some(&prior),
+        );
         assert!(!skip);
         assert!(replaced.delete_first);
         assert_eq!(replaced.offset, 0);
@@ -1793,7 +1997,8 @@ mod tests {
         let path = temp.path().join("session.jsonl");
         fs::write(&path, "tool call\n").expect("write call");
         let metadata = path.metadata().expect("call metadata");
-        let (mut first, _) = prepare_file_task(path.clone(), SourceKind::Claude, &metadata, None);
+        let (mut first, _) =
+            prepare_file_task(path.clone(), SourceKind::Claude, false, &metadata, None);
         first.pending_tool_calls.insert(
             "call-1".to_string(),
             PendingToolCall {
@@ -1814,6 +2019,7 @@ mod tests {
         let (appended, skip) = prepare_file_task(
             path,
             SourceKind::Claude,
+            false,
             &appended_metadata,
             Some(&previous),
         );
@@ -1862,7 +2068,8 @@ mod tests {
             )]),
             identity,
         };
-        let (task, skip) = prepare_file_task(path, SourceKind::Claude, &metadata, Some(&previous));
+        let (task, skip) =
+            prepare_file_task(path, SourceKind::Claude, false, &metadata, Some(&previous));
         assert!(!skip);
         assert!(task.delete_first);
         assert!(task.parser_version_invalidated);
@@ -1923,10 +2130,12 @@ mod tests {
         let options = IngestOptions {
             claude_source: claude_root,
             include_agents: false,
+            include_reasoning: false,
             include_codex: false,
             include_opencode: false,
             include_cursor: false,
             include_pi: false,
+            include_openclaw: false,
             include_copilot: false,
             embeddings: false,
             backfill_embeddings: false,
@@ -2297,10 +2506,12 @@ mod tests {
         let options = IngestOptions {
             claude_source: tmp.path().join("missing-claude"),
             include_agents: false,
+            include_reasoning: false,
             include_codex: false,
             include_opencode: false,
             include_cursor: false,
             include_pi: true,
+            include_openclaw: false,
             include_copilot: false,
             embeddings: false,
             backfill_embeddings: false,
@@ -2337,7 +2548,7 @@ mod tests {
         assert_eq!(records[1].links.parent_event_id.as_deref(), Some("a1"));
         assert_eq!(records[2].role, "assistant");
         assert!(records[2].text.contains("I will run a command"));
-        assert!(records[2].text.contains("Thinking:"));
+        assert!(!records[2].text.contains("considering options"));
         assert_eq!(records[2].links.event_id.as_deref(), Some("a1"));
         assert_eq!(records[2].links.parent_event_id.as_deref(), Some("u1"));
         assert_eq!(records[3].role, "tool_result");
@@ -2427,7 +2638,15 @@ mod tests {
         let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
         let next_doc_id = AtomicU64::new(1);
 
-        parse_pi_file(&task, &tx_record, &tx_update, &next_doc_id, &progress).expect("parse pi");
+        parse_pi_file(
+            &task,
+            false,
+            &tx_record,
+            &tx_update,
+            &next_doc_id,
+            &progress,
+        )
+        .expect("parse pi");
         drop(tx_record);
         let records: Vec<_> = rx_record.try_iter().collect();
 
@@ -2500,8 +2719,8 @@ mod tests {
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
         let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, meta.len()],
-            [0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, meta.len()],
+            [0, 0, 0, 0, 0, 0, 0, 1],
             false,
         ));
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -244,6 +244,7 @@ fn progress_label(source: SourceKind) -> &'static str {
         SourceKind::Opencode => "opencode",
         SourceKind::Cursor => "cursor",
         SourceKind::Pi => "pi",
+        SourceKind::OpenClaw => "openclaw",
         SourceKind::Copilot => "copilot",
     }
 }

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -1,0 +1,261 @@
+use crate::types::{SourceFilter, SourceKind};
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashSet};
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct SourceAudit {
+    pub source: String,
+    pub files: u64,
+    pub valid_json_lines: u64,
+    pub malformed_json_lines: u64,
+    pub non_object_json_lines: u64,
+    pub encrypted_reasoning_rows: u64,
+    pub top_level_types: BTreeMap<String, u64>,
+    pub semantic_types: BTreeMap<String, u64>,
+    pub content_block_types: BTreeMap<String, u64>,
+    pub producer_versions: BTreeMap<String, u64>,
+}
+
+pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<SourceAudit>> {
+    let mut groups = Vec::new();
+    let mut push = |kind: SourceKind, files: Vec<PathBuf>| {
+        if source.is_none_or(|filter| filter.matches(kind)) {
+            groups.push((kind, files));
+        }
+    };
+
+    push(SourceKind::Claude, super::claude::usage_files());
+    push(
+        SourceKind::CodexSession,
+        super::codex::discover_rollouts()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
+        SourceKind::Opencode,
+        super::opencode::discover_sessions()?
+            .into_iter()
+            .map(|file| file.path)
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
+            .collect(),
+    );
+    push(
+        SourceKind::Cursor,
+        super::cursor::discover_transcripts()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
+        SourceKind::Pi,
+        super::pi::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
+        SourceKind::OpenClaw,
+        super::openclaw::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
+        SourceKind::Copilot,
+        super::copilot::discover_sessions()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+
+    groups
+        .into_iter()
+        .map(|(kind, files)| audit_files(kind, &deduplicate(files)))
+        .collect()
+}
+
+fn deduplicate(files: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    files
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+pub fn audit_files(source: SourceKind, files: &[PathBuf]) -> Result<SourceAudit> {
+    let mut audit = SourceAudit {
+        source: source.storage_label().to_string(),
+        files: files.len() as u64,
+        ..SourceAudit::default()
+    };
+    for path in files {
+        audit_file(source, path, &mut audit)?;
+    }
+    Ok(audit)
+}
+
+fn audit_file(source: SourceKind, path: &Path, audit: &mut SourceAudit) -> Result<()> {
+    let reader = std::io::BufReader::new(std::fs::File::open(path)?);
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => {
+                audit.malformed_json_lines += 1;
+                continue;
+            }
+        };
+        let Some(object) = value.as_object() else {
+            audit.non_object_json_lines += 1;
+            continue;
+        };
+        audit.valid_json_lines += 1;
+        let top_level = object
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("<missing>");
+        increment(&mut audit.top_level_types, top_level);
+
+        if let Some(version) = producer_version(source, &value) {
+            increment(&mut audit.producer_versions, &version);
+        }
+        record_semantics(source, &value, top_level, audit);
+    }
+    Ok(())
+}
+
+fn producer_version(source: SourceKind, value: &Value) -> Option<String> {
+    let version = match source {
+        SourceKind::CodexSession | SourceKind::CodexHistory => value
+            .get("payload")
+            .and_then(|payload| payload.get("cli_version")),
+        _ => value.get("version"),
+    }?;
+    match version {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &mut SourceAudit) {
+    match source {
+        SourceKind::CodexSession | SourceKind::CodexHistory => {
+            if let Some(payload) = value.get("payload").and_then(Value::as_object)
+                && let Some(payload_type) = payload.get("type").and_then(Value::as_str)
+            {
+                increment(
+                    &mut audit.semantic_types,
+                    &format!("{top_level}/{payload_type}"),
+                );
+                if payload.contains_key("encrypted_content") {
+                    audit.encrypted_reasoning_rows += 1;
+                }
+                record_content_blocks(payload.get("content"), audit);
+            }
+        }
+        SourceKind::Claude => {
+            if matches!(top_level, "user" | "assistant") {
+                increment(&mut audit.semantic_types, top_level);
+                if let Some(content) = value
+                    .get("message")
+                    .and_then(|message| message.get("content"))
+                {
+                    record_content_blocks(Some(content), audit);
+                }
+            }
+        }
+        SourceKind::Pi | SourceKind::OpenClaw => {
+            if top_level == "message"
+                && let Some(message) = value.get("message").and_then(Value::as_object)
+            {
+                let role = message
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<missing>");
+                increment(&mut audit.semantic_types, &format!("message/{role}"));
+                record_content_blocks(message.get("content"), audit);
+            }
+        }
+        SourceKind::Opencode | SourceKind::Cursor | SourceKind::Copilot => {
+            if let Some(role) = value.get("role").and_then(Value::as_str) {
+                increment(&mut audit.semantic_types, role);
+            }
+            record_content_blocks(value.get("content"), audit);
+        }
+    }
+}
+
+fn record_content_blocks(content: Option<&Value>, audit: &mut SourceAudit) {
+    let Some(array) = content.and_then(Value::as_array) else {
+        return;
+    };
+    for block in array {
+        let Some(object) = block.as_object() else {
+            continue;
+        };
+        let block_type = object
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("<missing>");
+        increment(&mut audit.content_block_types, block_type);
+        if matches!(block_type, "redacted_thinking" | "encrypted_reasoning")
+            || object.contains_key("encrypted_content")
+        {
+            audit.encrypted_reasoning_rows += 1;
+        }
+    }
+}
+
+fn increment(map: &mut BTreeMap<String, u64>, key: &str) {
+    *map.entry(key.to_string()).or_default() += 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn audit_reports_structure_without_field_values() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("codex.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"cli_version\":\"1.2.3\"}}\n",
+                "{\"type\":\"response_item\",\"payload\":{\"type\":\"reasoning\",",
+                "\"encrypted_content\":\"ciphertext\",\"summary\":[]}}\n",
+                "not-json\n"
+            ),
+        )
+        .unwrap();
+
+        let audit = audit_files(SourceKind::CodexSession, &[path]).unwrap();
+        assert_eq!(audit.files, 1);
+        assert_eq!(audit.valid_json_lines, 2);
+        assert_eq!(audit.malformed_json_lines, 1);
+        assert_eq!(audit.encrypted_reasoning_rows, 1);
+        assert_eq!(audit.producer_versions.get("1.2.3"), Some(&1));
+        let json = serde_json::to_string(&audit).unwrap();
+        assert!(!json.contains("ciphertext"));
+    }
+
+    #[test]
+    fn audit_reports_numeric_producer_versions() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pi.jsonl");
+        fs::write(&path, "{\"type\":\"session\",\"version\":3}\n").unwrap();
+
+        let audit = audit_files(SourceKind::Pi, &[path]).unwrap();
+        assert_eq!(audit.producer_versions.get("3"), Some(&1));
+    }
+}

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConversationKind, IndexParseOutput, IndexParseState, ParserVersions, SessionIdentity,
-    SourceFile, SourceMetadata,
+    ConversationKind, IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions,
+    SessionIdentity, SourceFile, SourceMetadata,
 };
 use crate::types::{Record, RecordLinks, SourceKind};
 use crate::usage::{TokenBuckets, UsageEvent};
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
-    identity: 1,
-    index: 2,
+    identity: 2,
+    index: 3,
     usage: 4,
 };
 
@@ -30,12 +30,23 @@ pub fn discover(root: &Path, include_agents: bool) -> Result<Vec<SourceFile>> {
         {
             continue;
         }
-        if !include_agents
-            && entry
-                .file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with("agent-"))
-        {
+        let name = entry.file_name().to_string_lossy();
+        let is_agent = name.starts_with("agent-");
+        let under_subagents = entry.path().ancestors().any(|ancestor| {
+            ancestor.file_name().and_then(|name| name.to_str()) == Some("subagents")
+        });
+        if is_agent && !include_agents {
+            continue;
+        }
+        if under_subagents && (!include_agents || !is_agent) {
+            continue;
+        }
+        let relative_depth = entry
+            .path()
+            .strip_prefix(root)
+            .map(|path| path.components().count())
+            .unwrap_or(0);
+        if relative_depth > 2 && !under_subagents {
             continue;
         }
         files.push(SourceFile {
@@ -221,6 +232,7 @@ pub fn probe(path: &Path) -> Result<SourceMetadata> {
 pub(crate) fn parse_index_records(
     path: &Path,
     state: IndexParseState,
+    include_reasoning: bool,
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
@@ -238,6 +250,7 @@ pub(crate) fn parse_index_records(
     let is_agent_file = is_subagent_path(path);
     let source_path = path.to_string_lossy().to_string();
     let mut buffer = Vec::new();
+    let mut diagnostics = ParseDiagnostics::default();
 
     while start < mmap.len() {
         let slice = &mmap[start..];
@@ -249,10 +262,15 @@ pub(crate) fn parse_index_records(
         }
         buffer.clear();
         buffer.extend_from_slice(line);
-        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
-            continue;
+        let value = match simd_json::to_borrowed_value(&mut buffer) {
+            Ok(value) => value,
+            Err(_) => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
         };
         let Some(object) = value.as_object() else {
+            diagnostics.non_object_json_lines += 1;
             continue;
         };
         let entry_type = object
@@ -260,6 +278,24 @@ pub(crate) fn parse_index_records(
             .and_then(|value| value.as_str())
             .unwrap_or("");
         if entry_type != "user" && entry_type != "assistant" {
+            if !matches!(
+                entry_type,
+                "progress"
+                    | "summary"
+                    | "system"
+                    | "file-history-snapshot"
+                    | "queue-operation"
+                    | "pr-link"
+                    | "last-prompt"
+                    | "custom-title"
+                    | "ai-title"
+                    | "agent-name"
+                    | "permission-mode"
+                    | "attachment"
+                    | "mode"
+            ) {
+                diagnostics.increment_unknown_top_level(entry_type);
+            }
             continue;
         }
         let entry_uuid = super::common::borrowed_string(object, "uuid");
@@ -300,6 +336,7 @@ pub(crate) fn parse_index_records(
         };
         let content = message.get("content");
         let mut text_parts = Vec::new();
+        let mut content_index = 0usize;
         if let Some(content) = content {
             if let Some(text) = content.as_str() {
                 text_parts.push(text);
@@ -339,7 +376,7 @@ pub(crate) fn parse_index_records(
                             }
                             let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
                             if let Some(tool_id) = tool_id {
-                                pending_tool_calls.insert(
+                                let replaced = pending_tool_calls.insert(
                                     tool_id.clone(),
                                     super::common::pending_tool_call(
                                         tool_name.clone(),
@@ -351,6 +388,9 @@ pub(crate) fn parse_index_records(
                                         &session_id,
                                     ),
                                 );
+                                if replaced.is_some() {
+                                    diagnostics.duplicate_tool_calls += 1;
+                                }
                             }
                             emit(Record {
                                 source: SourceKind::Claude,
@@ -369,8 +409,48 @@ pub(crate) fn parse_index_records(
                             })?;
                             turn_id += 1;
                         }
-                        _ => {}
+                        "thinking" => {
+                            let thinking = block_object
+                                .get("thinking")
+                                .and_then(|value| value.as_str())
+                                .map(str::trim)
+                                .filter(|text| !text.is_empty());
+                            if let Some(thinking) = thinking {
+                                if include_reasoning {
+                                    let mut links = entry_links.clone();
+                                    links.event_id = entry_uuid
+                                        .as_ref()
+                                        .map(|uuid| format!("{uuid}:reasoning:{content_index}"));
+                                    emit(Record {
+                                        source: SourceKind::Claude,
+                                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                        ts: timestamp,
+                                        project: project.clone(),
+                                        session_id: session_id.clone(),
+                                        turn_id,
+                                        role: "reasoning".to_string(),
+                                        text: thinking.to_string(),
+                                        tool_name: None,
+                                        tool_input: None,
+                                        tool_output: None,
+                                        links,
+                                        source_path: source_path.clone(),
+                                    })?;
+                                    turn_id += 1;
+                                }
+                            } else if block_object.contains_key("signature")
+                                || block_object.contains_key("data")
+                            {
+                                diagnostics.encrypted_reasoning_dropped += 1;
+                            }
+                        }
+                        "redacted_thinking" => {
+                            diagnostics.encrypted_reasoning_dropped += 1;
+                        }
+                        "tool_result" | "image" => {}
+                        unknown => diagnostics.increment_unknown_semantic(unknown),
                     }
+                    content_index += 1;
                 }
             }
         }
@@ -397,10 +477,13 @@ pub(crate) fn parse_index_records(
                     .get("tool_use_id")
                     .and_then(|value| value.as_str())
                     .map(str::to_string);
-                let tool_name = tool_use_id
+                let pending = tool_use_id
                     .as_ref()
-                    .and_then(|id| pending_tool_calls.remove(id))
-                    .and_then(|call| call.tool_name);
+                    .and_then(|id| pending_tool_calls.remove(id));
+                if tool_use_id.is_some() && pending.is_none() {
+                    diagnostics.orphan_tool_results += 1;
+                }
+                let tool_name = pending.and_then(|call| call.tool_name);
                 let mut links = entry_links.clone();
                 if let Some(tool_use_id) = &tool_use_id {
                     links.event_id = entry_uuid
@@ -454,6 +537,7 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls,
         session_id: Some(session_id),
+        diagnostics,
     })
 }
 
@@ -664,6 +748,22 @@ mod tests {
     }
 
     #[test]
+    fn discovery_excludes_nested_workflow_journals() {
+        let temp = tempfile::tempdir().unwrap();
+        let subagents = temp.path().join("project/session/subagents/workflows/run");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(subagents.join("agent-child.jsonl"), "{}\n").unwrap();
+        fs::write(subagents.join("journal.jsonl"), "{}\n").unwrap();
+
+        let files = discover(temp.path(), true).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path.file_name().and_then(|name| name.to_str()),
+            Some("agent-child.jsonl")
+        );
+    }
+
+    #[test]
     fn probe_shares_sidechain_session_and_project_identity() {
         let temp = tempfile::tempdir().unwrap();
         let project = temp.path().join("-Users-nico-Code-memex");
@@ -733,5 +833,56 @@ mod tests {
         let events = parse_usage_file(&path).unwrap();
         assert_eq!(events[0].timestamp_ms, 1_776_386_452_000);
         assert_eq!(events[1].timestamp_ms, 1_776_386_452_437);
+    }
+
+    #[test]
+    fn parity_fixture_makes_plain_reasoning_opt_in_and_drops_redacted_payloads() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("claude.jsonl");
+        fs::write(
+            &path,
+            include_str!("../../fixtures/trajectory_parity/claude.jsonl"),
+        )
+        .unwrap();
+
+        let mut without_reasoning = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                without_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(
+            !without_reasoning
+                .iter()
+                .any(|record| record.role == "reasoning")
+        );
+        assert_eq!(parsed.diagnostics.encrypted_reasoning_dropped, 1);
+        assert_eq!(parsed.diagnostics.malformed_json_lines, 1);
+
+        let mut with_reasoning = Vec::new();
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &AtomicU64::new(1),
+            |record| {
+                with_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(with_reasoning.iter().any(|record| {
+            record.role == "reasoning" && record.text == "Plain Claude reasoning"
+        }));
+        assert!(!with_reasoning.iter().any(|record| {
+            record.text.contains("ciphertext-must-never-be-indexed")
+                || record.text.contains("signature-must-never-be-indexed")
+        }));
     }
 }

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConversationKind, IndexParseOutput, IndexParseState, ParserVersions, SessionIdentity,
-    SourceFile, SourceMetadata, UsageDependency, UsageParseOutput,
+    ConversationKind, IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions,
+    SessionIdentity, SourceFile, SourceMetadata, UsageDependency, UsageParseOutput,
 };
 use crate::types::{Record, RecordLinks, SourceKind};
 use crate::usage::{TokenBuckets, UsageEvent};
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 2,
+    index: 3,
     usage: 4,
 };
 
@@ -229,6 +229,7 @@ pub fn probe(path: &Path) -> Result<SourceMetadata> {
 pub(crate) fn parse_index_records(
     path: &Path,
     state: IndexParseState,
+    include_reasoning: bool,
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
@@ -240,6 +241,7 @@ pub(crate) fn parse_index_records(
     let source_path = path.to_string_lossy().to_string();
     let mut metadata = read_meta_until(path, state.offset)?;
     let mut buffer = Vec::new();
+    let mut diagnostics = ParseDiagnostics::default();
 
     while start < mmap.len() {
         let slice = &mmap[start..];
@@ -251,10 +253,15 @@ pub(crate) fn parse_index_records(
         }
         buffer.clear();
         buffer.extend_from_slice(line);
-        let Ok(value) = simd_json::to_borrowed_value(&mut buffer) else {
-            continue;
+        let value = match simd_json::to_borrowed_value(&mut buffer) {
+            Ok(value) => value,
+            Err(_) => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
         };
         let Some(object) = value.as_object() else {
+            diagnostics.non_object_json_lines += 1;
             continue;
         };
         let entry_type = object
@@ -272,7 +279,46 @@ pub(crate) fn parse_index_records(
             }
             continue;
         }
+        if entry_type == "turn_context" {
+            continue;
+        }
+        if entry_type == "event_msg" {
+            let Some(payload) = object.get("payload").and_then(|value| value.as_object()) else {
+                continue;
+            };
+            if payload.get("type").and_then(|value| value.as_str()) == Some("agent_reasoning")
+                && include_reasoning
+                && let Some(text) = payload
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+            {
+                let mut links = metadata.links.record_links();
+                links.event_id = super::common::borrowed_string(payload, "id");
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "reasoning".to_string(),
+                    text: text.to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            continue;
+        }
         if entry_type != "response_item" {
+            if !matches!(entry_type, "compacted" | "world_state" | "ghost_snapshot") {
+                diagnostics.increment_unknown_top_level(entry_type);
+            }
             continue;
         }
         let Some(payload) = object.get("payload").and_then(|value| value.as_object()) else {
@@ -345,7 +391,7 @@ pub(crate) fn parse_index_records(
                 }
                 let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
                 if let Some(call_id) = call_id {
-                    pending_tool_calls.insert(
+                    let replaced = pending_tool_calls.insert(
                         call_id.clone(),
                         super::common::pending_tool_call(
                             tool_name.clone(),
@@ -357,6 +403,9 @@ pub(crate) fn parse_index_records(
                             &metadata.session_id,
                         ),
                     );
+                    if replaced.is_some() {
+                        diagnostics.duplicate_tool_calls += 1;
+                    }
                 }
                 emit(Record {
                     source: SourceKind::CodexSession,
@@ -380,14 +429,14 @@ pub(crate) fn parse_index_records(
                     .get("call_id")
                     .and_then(|value| value.as_str())
                     .unwrap_or("");
-                let tool_name = (!call_id.is_empty())
+                let pending = (!call_id.is_empty())
                     .then(|| pending_tool_calls.remove(call_id))
-                    .flatten()
-                    .and_then(|call| call.tool_name);
-                let tool_output = payload
-                    .get("output")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_string);
+                    .flatten();
+                if !call_id.is_empty() && pending.is_none() {
+                    diagnostics.orphan_tool_results += 1;
+                }
+                let tool_name = pending.and_then(|call| call.tool_name);
+                let tool_output = payload.get("output").and_then(value_text);
                 let text = tool_output.clone().unwrap_or_default();
                 if text.is_empty() {
                     continue;
@@ -413,7 +462,160 @@ pub(crate) fn parse_index_records(
                 })?;
                 turn_id += 1;
             }
-            _ => {}
+            "custom_tool_call" => {
+                let tool_name = payload
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                let tool_input = payload.get("input").and_then(value_text);
+                let call_id = payload
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                if let Some(call_id) = &call_id {
+                    links.event_id = Some(call_id.clone());
+                }
+                let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                if let Some(call_id) = call_id {
+                    let replaced = pending_tool_calls.insert(
+                        call_id.clone(),
+                        super::common::pending_tool_call(
+                            tool_name.clone(),
+                            Some(call_id),
+                            doc_id,
+                            timestamp,
+                            tool_input.as_deref(),
+                            &links,
+                            &metadata.session_id,
+                        ),
+                    );
+                    if replaced.is_some() {
+                        diagnostics.duplicate_tool_calls += 1;
+                    }
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id,
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "tool_use".to_string(),
+                    text: tool_input.clone().unwrap_or_default(),
+                    tool_name,
+                    tool_input,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            "web_search_call" | "tool_search_call" => {
+                let tool_name = if payload_type == "web_search_call" {
+                    "web_search"
+                } else {
+                    "tool_search"
+                };
+                let tool_input = if payload_type == "web_search_call" {
+                    payload
+                        .get("action")
+                        .or_else(|| payload.get("query"))
+                        .and_then(value_text)
+                } else {
+                    payload.get("arguments").and_then(value_text)
+                };
+                let call_id = payload
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                if let Some(call_id) = &call_id {
+                    links.event_id = Some(call_id.clone());
+                }
+                let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                if let Some(call_id) = call_id {
+                    let replaced = pending_tool_calls.insert(
+                        call_id.clone(),
+                        super::common::pending_tool_call(
+                            Some(tool_name.to_string()),
+                            Some(call_id),
+                            doc_id,
+                            timestamp,
+                            tool_input.as_deref(),
+                            &links,
+                            &metadata.session_id,
+                        ),
+                    );
+                    if replaced.is_some() {
+                        diagnostics.duplicate_tool_calls += 1;
+                    }
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id,
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "tool_use".to_string(),
+                    text: tool_input.clone().unwrap_or_default(),
+                    tool_name: Some(tool_name.to_string()),
+                    tool_input,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            "custom_tool_call_output" | "tool_search_output" => {
+                let call_id = payload
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let pending = (!call_id.is_empty())
+                    .then(|| pending_tool_calls.remove(call_id))
+                    .flatten();
+                if !call_id.is_empty() && pending.is_none() {
+                    diagnostics.orphan_tool_results += 1;
+                }
+                let tool_name = pending.and_then(|call| call.tool_name).or_else(|| {
+                    (payload_type == "tool_search_output").then(|| "tool_search".to_string())
+                });
+                let tool_output = if payload_type == "tool_search_output" {
+                    payload.get("tools").and_then(value_text)
+                } else {
+                    payload.get("output").and_then(value_text)
+                };
+                let text = tool_output.clone().unwrap_or_default();
+                if text.is_empty() {
+                    continue;
+                }
+                if !call_id.is_empty() {
+                    links.parent_event_id = Some(call_id.to_string());
+                    links.parent_tool_use_id = Some(call_id.to_string());
+                }
+                emit(Record {
+                    source: SourceKind::CodexSession,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "tool_result".to_string(),
+                    text,
+                    tool_name,
+                    tool_input: None,
+                    tool_output,
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+            }
+            "reasoning" => {
+                if payload.contains_key("encrypted_content") {
+                    diagnostics.encrypted_reasoning_dropped += 1;
+                }
+            }
+            _ => diagnostics.increment_unknown_semantic(payload_type),
         }
     }
 
@@ -422,7 +624,29 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls,
         session_id: Some(metadata.session_id),
+        diagnostics,
     })
+}
+
+fn value_text(value: &BorrowedValue<'_>) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    if let Some(array) = value.as_array() {
+        let text = array
+            .iter()
+            .filter_map(|item| {
+                item.as_object()
+                    .and_then(|object| object.get("text").or_else(|| object.get("content")))
+                    .and_then(|value| value.as_str())
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !text.is_empty() {
+            return Some(text);
+        }
+    }
+    Some(value.to_string())
 }
 
 pub(crate) fn parse_history_records(
@@ -500,6 +724,7 @@ pub(crate) fn parse_history_records(
         turn_id,
         pending_tool_calls: state.pending_tool_calls,
         session_id: None,
+        diagnostics: Default::default(),
     })
 }
 
@@ -1167,5 +1392,80 @@ mod tests {
             ConversationKind::Subagent
         );
         assert_eq!(metadata.project.as_deref(), Some("memex"));
+    }
+
+    #[test]
+    fn parity_fixture_indexes_semantic_tools_and_filters_encrypted_reasoning() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("codex.jsonl");
+        fs::write(
+            &path,
+            include_str!("../../fixtures/trajectory_parity/codex.jsonl"),
+        )
+        .unwrap();
+
+        let mut without_reasoning = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                without_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(
+            !without_reasoning
+                .iter()
+                .any(|record| record.role == "reasoning")
+        );
+        assert_eq!(parsed.diagnostics.encrypted_reasoning_dropped, 1);
+        assert_eq!(parsed.diagnostics.malformed_json_lines, 1);
+        assert_eq!(
+            parsed
+                .diagnostics
+                .unknown_semantic_types
+                .get("future_semantic_event"),
+            Some(&1)
+        );
+
+        let mut with_reasoning = Vec::new();
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &AtomicU64::new(1),
+            |record| {
+                with_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(with_reasoning
+            .iter()
+            .any(|record| record.role == "reasoning"
+                && record.text == "Plaintext summary only"));
+        assert!(
+            with_reasoning
+                .iter()
+                .any(|record| record.tool_name.as_deref() == Some("apply_patch"))
+        );
+        assert!(
+            with_reasoning
+                .iter()
+                .any(|record| record.tool_name.as_deref() == Some("web_search"))
+        );
+        assert!(
+            with_reasoning
+                .iter()
+                .any(|record| record.tool_name.as_deref() == Some("tool_search"))
+        );
+        assert!(
+            !with_reasoning
+                .iter()
+                .any(|record| { record.text.contains("ciphertext-must-never-be-indexed") })
+        );
     }
 }

--- a/src/sources/copilot.rs
+++ b/src/sources/copilot.rs
@@ -341,6 +341,7 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls,
         session_id: Some(session_id),
+        diagnostics: Default::default(),
     })
 }
 

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -282,6 +282,7 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls,
         session_id: Some(session_id),
+        diagnostics: Default::default(),
     })
 }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -4,11 +4,13 @@
 //! adapters in this module make them share source identity, discovery, hierarchy, and
 //! parser-version rules without introducing a persisted normalized transcript store.
 
+pub mod audit;
 pub mod claude;
 pub mod codex;
 pub mod common;
 pub mod copilot;
 pub mod cursor;
+pub mod openclaw;
 pub mod opencode;
 pub mod pi;
 
@@ -16,6 +18,7 @@ use crate::state::PendingToolCall;
 use crate::types::SourceKind;
 use crate::usage::UsageEvent;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -88,6 +91,60 @@ pub(crate) struct IndexParseOutput {
     pub turn_id: u32,
     pub pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
     pub session_id: Option<String>,
+    pub diagnostics: ParseDiagnostics,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct ParseDiagnostics {
+    pub malformed_json_lines: u64,
+    pub non_object_json_lines: u64,
+    pub unknown_top_level_types: HashMap<String, u64>,
+    pub unknown_semantic_types: HashMap<String, u64>,
+    pub orphan_tool_results: u64,
+    pub duplicate_tool_calls: u64,
+    pub encrypted_reasoning_dropped: u64,
+    pub truncated_tool_inputs: u64,
+    pub truncated_tool_outputs: u64,
+}
+
+impl ParseDiagnostics {
+    pub fn increment_unknown_top_level(&mut self, value: &str) {
+        if !value.is_empty() {
+            *self
+                .unknown_top_level_types
+                .entry(value.to_string())
+                .or_default() += 1;
+        }
+    }
+
+    pub fn increment_unknown_semantic(&mut self, value: &str) {
+        if !value.is_empty() {
+            *self
+                .unknown_semantic_types
+                .entry(value.to_string())
+                .or_default() += 1;
+        }
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.malformed_json_lines += other.malformed_json_lines;
+        self.non_object_json_lines += other.non_object_json_lines;
+        self.orphan_tool_results += other.orphan_tool_results;
+        self.duplicate_tool_calls += other.duplicate_tool_calls;
+        self.encrypted_reasoning_dropped += other.encrypted_reasoning_dropped;
+        self.truncated_tool_inputs += other.truncated_tool_inputs;
+        self.truncated_tool_outputs += other.truncated_tool_outputs;
+        for (key, count) in other.unknown_top_level_types {
+            *self.unknown_top_level_types.entry(key).or_default() += count;
+        }
+        for (key, count) in other.unknown_semantic_types {
+            *self.unknown_semantic_types.entry(key).or_default() += count;
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 /// A file whose content a cached usage projection depends on. Sources that reconstruct
@@ -145,13 +202,45 @@ pub fn versions(source: SourceKind) -> ParserVersions {
         SourceKind::Cursor => cursor::VERSIONS,
         SourceKind::Opencode => opencode::VERSIONS,
         SourceKind::Pi => pi::VERSIONS,
+        SourceKind::OpenClaw => openclaw::VERSIONS,
         SourceKind::Copilot => copilot::VERSIONS,
     }
 }
 
 pub fn index_state_version(source: SourceKind) -> u32 {
+    index_state_version_for(source, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_mode_is_part_of_index_state_version() {
+        for source in [
+            SourceKind::Claude,
+            SourceKind::CodexSession,
+            SourceKind::Pi,
+            SourceKind::OpenClaw,
+        ] {
+            assert_ne!(
+                index_state_version_for(source, false),
+                index_state_version_for(source, true)
+            );
+        }
+    }
+}
+
+pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u32 {
     let versions = versions(source);
-    versions.identity.saturating_mul(10_000) + versions.index
+    let reasoning_mode = include_reasoning
+        && matches!(
+            source,
+            SourceKind::Claude | SourceKind::CodexSession | SourceKind::Pi | SourceKind::OpenClaw
+        );
+    (versions.identity.saturating_mul(10_000) + versions.index)
+        .saturating_mul(2)
+        .saturating_add(u32::from(reasoning_mode))
 }
 
 /// Compatibility classification for persisted records that only carry a source path.
@@ -165,6 +254,8 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::Cursor
     } else if pi::matches_path(path) {
         SourceKind::Pi
+    } else if openclaw::matches_path(path) {
+        SourceKind::OpenClaw
     } else if copilot::matches_path(path) {
         SourceKind::Copilot
     } else {

--- a/src/sources/openclaw.rs
+++ b/src/sources/openclaw.rs
@@ -2,6 +2,7 @@ use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
 use crate::types::{Record, SourceKind};
 use crate::usage::UsageEvent;
 use anyhow::Result;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 
@@ -19,22 +20,29 @@ pub fn matches_path(path: &str) -> bool {
         || (path.contains(".clawdbot/agents") || path.contains(".clawdbot\\agents"))
 }
 
-pub fn state_dir() -> PathBuf {
+pub fn state_dirs() -> Vec<PathBuf> {
     if let Some(path) =
         std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("CLAWDBOT_STATE_DIR"))
     {
-        return PathBuf::from(path);
+        return vec![PathBuf::from(path)];
     }
-    let current = super::common::home().join(".openclaw");
-    if current.exists() {
-        current
-    } else {
-        super::common::home().join(".clawdbot")
-    }
+    let home = super::common::home();
+    vec![home.join(".openclaw"), home.join(".clawdbot")]
 }
 
 pub fn discover() -> Vec<SourceFile> {
-    discover_from_state_dir(&state_dir())
+    discover_from_state_dirs(&state_dirs())
+}
+
+fn discover_from_state_dirs(roots: &[PathBuf]) -> Vec<SourceFile> {
+    let mut seen = HashSet::new();
+    let mut files = roots
+        .iter()
+        .flat_map(|root| discover_from_state_dir(root))
+        .filter(|file| seen.insert(file.path.clone()))
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files
 }
 
 fn discover_from_state_dir(root: &Path) -> Vec<SourceFile> {
@@ -105,6 +113,27 @@ mod tests {
             files[0].path.file_name().and_then(|name| name.to_str()),
             Some("one.jsonl")
         );
+    }
+
+    #[test]
+    fn discovery_scans_current_and_legacy_stores_together() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join(".openclaw");
+        let legacy = temp.path().join(".clawdbot");
+        for (root, name) in [(&current, "current.jsonl"), (&legacy, "legacy.jsonl")] {
+            let sessions = root.join("agents/main/sessions");
+            fs::create_dir_all(&sessions).unwrap();
+            fs::write(sessions.join(name), "{}\n").unwrap();
+        }
+
+        let files = discover_from_state_dirs(&[current, legacy]);
+        assert_eq!(files.len(), 2);
+        assert!(
+            files
+                .iter()
+                .any(|file| file.path.ends_with("current.jsonl"))
+        );
+        assert!(files.iter().any(|file| file.path.ends_with("legacy.jsonl")));
     }
 
     #[test]

--- a/src/sources/openclaw.rs
+++ b/src/sources/openclaw.rs
@@ -1,0 +1,151 @@
+use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use crate::types::{Record, SourceKind};
+use crate::usage::UsageEvent;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    // OpenClaw delegates the SessionManager projection to the Pi parser.
+    index: 3,
+    usage: 4,
+};
+
+const DELIVERY_MIRROR_MODEL: &str = "delivery-mirror";
+
+pub fn matches_path(path: &str) -> bool {
+    (path.contains(".openclaw/agents") || path.contains(".openclaw\\agents"))
+        || (path.contains(".clawdbot/agents") || path.contains(".clawdbot\\agents"))
+}
+
+pub fn state_dir() -> PathBuf {
+    if let Some(path) =
+        std::env::var_os("OPENCLAW_STATE_DIR").or_else(|| std::env::var_os("CLAWDBOT_STATE_DIR"))
+    {
+        return PathBuf::from(path);
+    }
+    let current = super::common::home().join(".openclaw");
+    if current.exists() {
+        current
+    } else {
+        super::common::home().join(".clawdbot")
+    }
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    discover_from_state_dir(&state_dir())
+}
+
+fn discover_from_state_dir(root: &Path) -> Vec<SourceFile> {
+    let agents = root.join("agents");
+    let Ok(agent_entries) = std::fs::read_dir(agents) else {
+        return Vec::new();
+    };
+    let mut files = Vec::new();
+    for agent in agent_entries.flatten() {
+        let sessions = agent.path().join("sessions");
+        let Ok(session_entries) = std::fs::read_dir(sessions) else {
+            continue;
+        };
+        for entry in session_entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+                files.push(SourceFile {
+                    source: SourceKind::OpenClaw,
+                    path,
+                });
+            }
+        }
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    super::pi::parse_index_records_for(
+        path,
+        state,
+        SourceKind::OpenClaw,
+        include_reasoning,
+        next_doc_id,
+        emit,
+    )
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    super::pi::parse_usage_file_for(path, "openclaw", &[DELIVERY_MIRROR_MODEL])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::AtomicU64;
+
+    #[test]
+    fn discovery_scans_agent_session_files_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let sessions = temp.path().join("agents/main/sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(sessions.join("one.jsonl"), "{}\n").unwrap();
+        fs::write(sessions.join("one.json"), "{}\n").unwrap();
+        fs::write(temp.path().join("journal.jsonl"), "{}\n").unwrap();
+
+        let files = discover_from_state_dir(temp.path());
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].source, SourceKind::OpenClaw);
+        assert_eq!(
+            files[0].path.file_name().and_then(|name| name.to_str()),
+            Some("one.jsonl")
+        );
+    }
+
+    #[test]
+    fn path_classification_accepts_current_and_legacy_stores() {
+        assert!(matches_path(
+            "/Users/test/.openclaw/agents/main/sessions/one.jsonl"
+        ));
+        assert!(matches_path(
+            r"C:\Users\test\.clawdbot\agents\main\sessions\one.jsonl"
+        ));
+    }
+
+    #[test]
+    fn parity_fixture_uses_pi_projection_and_filters_placeholder_model() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("openclaw.jsonl");
+        fs::write(
+            &path,
+            include_str!("../../fixtures/trajectory_parity/openclaw.jsonl"),
+        )
+        .unwrap();
+
+        let mut records = Vec::new();
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].source, SourceKind::OpenClaw);
+        assert_eq!(records[0].text, "Mirrored assistant prose");
+
+        let usage = parse_usage_file(&path).unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].source, "openclaw");
+        assert_eq!(usage[0].model, None);
+    }
+}

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -257,6 +257,7 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls: state.pending_tool_calls,
         session_id: Some(session_id),
+        diagnostics: Default::default(),
     })
 }
 

--- a/src/sources/pi.rs
+++ b/src/sources/pi.rs
@@ -1,4 +1,4 @@
-use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
 use crate::types::{Record, RecordLinks, SourceKind};
 use crate::usage::{TokenBuckets, UsageEvent};
 use anyhow::Result;
@@ -13,8 +13,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 2,
-    usage: 3,
+    index: 3,
+    usage: 4,
 };
 
 pub fn matches_path(path: &str) -> bool {
@@ -156,6 +156,9 @@ fn content_text(content: Option<&BorrowedValue<'_>>) -> String {
             let Some(object) = item.as_object() else {
                 continue;
             };
+            if object.contains_key("encrypted_content") {
+                continue;
+            }
             match object
                 .get("type")
                 .and_then(|value| value.as_str())
@@ -166,10 +169,9 @@ fn content_text(content: Option<&BorrowedValue<'_>>) -> String {
                         parts.push(text.to_string());
                     }
                 }
-                "thinking" => {
-                    if let Some(text) = object.get("thinking").and_then(|value| value.as_str()) {
-                        parts.push(format!("Thinking:\n{text}"));
-                    }
+                "thinking" | "redacted_thinking" | "encrypted_reasoning" => {
+                    // Plaintext reasoning is projected separately as role=reasoning so it
+                    // remains BM25-only and is never embedded as assistant prose.
                 }
                 "toolCall" => {}
                 _ => {
@@ -218,6 +220,25 @@ fn bash_text(command: &str, output: &str, exit_code: Option<i64>) -> String {
 pub(crate) fn parse_index_records(
     path: &Path,
     state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    parse_index_records_for(
+        path,
+        state,
+        SourceKind::Pi,
+        include_reasoning,
+        next_doc_id,
+        emit,
+    )
+}
+
+pub(crate) fn parse_index_records_for(
+    path: &Path,
+    state: IndexParseState,
+    source: SourceKind,
+    include_reasoning: bool,
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
@@ -227,9 +248,10 @@ pub(crate) fn parse_index_records(
     let mut turn_id = state.turn_id;
 
     let source_path = path.to_string_lossy().to_string();
-    let mut session_id = crate::sources::pi::session_id_from_path(path);
-    let mut project = crate::sources::pi::project_from_path(path);
+    let mut session_id = session_id_from_path(path);
+    let mut project = project_from_path(path);
     let mut pending_tool_calls = state.pending_tool_calls;
+    let mut diagnostics = ParseDiagnostics::default();
 
     let mut buf = Vec::new();
     if start > 0 && !mmap.is_empty() {
@@ -258,18 +280,20 @@ pub(crate) fn parse_index_records(
         buf.extend_from_slice(line);
         let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
         };
         let obj = match value.as_object() {
             Some(o) => o,
-            None => continue,
+            None => {
+                diagnostics.non_object_json_lines += 1;
+                continue;
+            }
         };
         let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let timestamp = obj
-            .get("timestamp")
-            .and_then(|v| v.as_str())
-            .and_then(super::common::parse_iso_millis)
-            .unwrap_or(0);
+        let timestamp = obj.get("timestamp").map(timestamp_millis).unwrap_or(0);
         let conversation_kind = match entry_type {
             "branch_summary" => "branch",
             "compaction" => "compaction",
@@ -292,7 +316,7 @@ pub(crate) fn parse_index_records(
                 continue;
             }
             let record = Record {
-                source: SourceKind::Pi,
+                source,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                 ts: timestamp,
                 project: project.clone(),
@@ -323,7 +347,7 @@ pub(crate) fn parse_index_records(
                 format!("custom_message({custom_type})")
             };
             let record = Record {
-                source: SourceKind::Pi,
+                source,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                 ts: timestamp,
                 project: project.clone(),
@@ -343,6 +367,12 @@ pub(crate) fn parse_index_records(
         }
 
         if entry_type != "message" {
+            if !matches!(
+                entry_type,
+                "model_change" | "thinking_level_change" | "session_info" | "label" | "custom"
+            ) {
+                diagnostics.increment_unknown_top_level(entry_type);
+            }
             continue;
         }
         let message = match obj.get("message").and_then(|v| v.as_object()) {
@@ -350,11 +380,7 @@ pub(crate) fn parse_index_records(
             None => continue,
         };
         let timestamp = if timestamp == 0 {
-            message
-                .get("timestamp")
-                .and_then(|v| v.as_str())
-                .and_then(super::common::parse_iso_millis)
-                .unwrap_or(0)
+            message.get("timestamp").map(timestamp_millis).unwrap_or(0)
         } else {
             timestamp
         };
@@ -383,7 +409,56 @@ pub(crate) fn parse_index_records(
                         let Some(block_obj) = block.as_object() else {
                             continue;
                         };
-                        if block_obj.get("type").and_then(|v| v.as_str()) != Some("toolCall") {
+                        let block_type = block_obj
+                            .get("type")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("");
+                        if block_type == "thinking" {
+                            let thinking = block_obj
+                                .get("thinking")
+                                .and_then(|value| value.as_str())
+                                .map(str::trim)
+                                .filter(|text| !text.is_empty());
+                            if let Some(thinking) = thinking {
+                                if include_reasoning {
+                                    let mut links = base_links.clone();
+                                    links.event_id = base_links
+                                        .event_id
+                                        .as_ref()
+                                        .map(|id| format!("{id}:reasoning"));
+                                    emit(Record {
+                                        source,
+                                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                        ts: timestamp,
+                                        project: project.clone(),
+                                        session_id: session_id.clone(),
+                                        turn_id,
+                                        role: "reasoning".to_string(),
+                                        text: thinking.to_string(),
+                                        tool_name: None,
+                                        tool_input: None,
+                                        tool_output: None,
+                                        links,
+                                        source_path: source_path.clone(),
+                                    })?;
+                                    turn_id += 1;
+                                }
+                            } else if block_obj.contains_key("encrypted_content")
+                                || block_obj.contains_key("data")
+                                || block_obj.contains_key("signature")
+                            {
+                                diagnostics.encrypted_reasoning_dropped += 1;
+                            }
+                            continue;
+                        }
+                        if matches!(block_type, "redacted_thinking" | "encrypted_reasoning") {
+                            diagnostics.encrypted_reasoning_dropped += 1;
+                            continue;
+                        }
+                        if block_type != "toolCall" {
+                            if !matches!(block_type, "text" | "image") {
+                                diagnostics.increment_unknown_semantic(block_type);
+                            }
                             continue;
                         }
                         let tool_name = block_obj
@@ -402,7 +477,7 @@ pub(crate) fn parse_index_records(
                         }
                         let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
                         if let Some(tool_call_id) = tool_call_id {
-                            pending_tool_calls.insert(
+                            let replaced = pending_tool_calls.insert(
                                 tool_call_id.clone(),
                                 super::common::pending_tool_call(
                                     tool_name.clone(),
@@ -414,9 +489,12 @@ pub(crate) fn parse_index_records(
                                     &session_id,
                                 ),
                             );
+                            if replaced.is_some() {
+                                diagnostics.duplicate_tool_calls += 1;
+                            }
                         }
                         let record = Record {
-                            source: SourceKind::Pi,
+                            source,
                             doc_id,
                             ts: timestamp,
                             project: project.clone(),
@@ -440,7 +518,7 @@ pub(crate) fn parse_index_records(
                     continue;
                 }
                 let record = Record {
-                    source: SourceKind::Pi,
+                    source,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: project.clone(),
@@ -457,7 +535,7 @@ pub(crate) fn parse_index_records(
                 emit(record)?;
                 turn_id += 1;
             }
-            "toolResult" => {
+            "toolResult" | "tool" => {
                 let tool_call_id = message
                     .get("toolCallId")
                     .and_then(|v| v.as_str())
@@ -472,10 +550,19 @@ pub(crate) fn parse_index_records(
                             .flatten()
                             .and_then(|call| call.tool_name.clone())
                     });
-                if !tool_call_id.is_empty() {
-                    pending_tool_calls.remove(tool_call_id);
+                if !tool_call_id.is_empty() && pending_tool_calls.remove(tool_call_id).is_none() {
+                    diagnostics.orphan_tool_results += 1;
                 }
-                let tool_output = Some(content_text(message.get("content")));
+                let mut output = content_text(message.get("content"));
+                if message
+                    .get("isError")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false)
+                    && !output.to_ascii_lowercase().starts_with("error")
+                {
+                    output = format!("Error: {output}");
+                }
+                let tool_output = Some(output);
                 let text = tool_output.clone().unwrap_or_default();
                 if text.trim().is_empty() {
                     continue;
@@ -485,7 +572,7 @@ pub(crate) fn parse_index_records(
                     links.parent_tool_use_id = Some(tool_call_id.to_string());
                 }
                 let record = Record {
-                    source: SourceKind::Pi,
+                    source,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: project.clone(),
@@ -526,7 +613,7 @@ pub(crate) fn parse_index_records(
                     continue;
                 }
                 let record = Record {
-                    source: SourceKind::Pi,
+                    source,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: project.clone(),
@@ -557,7 +644,7 @@ pub(crate) fn parse_index_records(
                     continue;
                 }
                 let record = Record {
-                    source: SourceKind::Pi,
+                    source,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: project.clone(),
@@ -574,7 +661,7 @@ pub(crate) fn parse_index_records(
                 emit(record)?;
                 turn_id += 1;
             }
-            _ => {}
+            _ => diagnostics.increment_unknown_semantic(role),
         }
     }
 
@@ -583,10 +670,19 @@ pub(crate) fn parse_index_records(
         turn_id,
         pending_tool_calls,
         session_id: Some(session_id),
+        diagnostics,
     })
 }
 
 pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    parse_usage_file_for(path, "pi", &[])
+}
+
+pub(crate) fn parse_usage_file_for(
+    path: &Path,
+    source: &'static str,
+    excluded_models: &[&str],
+) -> Result<Vec<UsageEvent>> {
     let file = File::open(path)?;
     let mmap = unsafe { Mmap::map(&file)? };
     let source_path: Arc<str> = Arc::from(path.to_string_lossy());
@@ -683,7 +779,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
         );
         if tokens.additive_total() > 0 {
             events.push(UsageEvent {
-                source: "pi",
+                source,
                 source_path: source_path.clone(),
                 source_record_id: Some(format!("line:{index}")),
                 session_id: Some(session.clone()),
@@ -696,7 +792,8 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
                     .or_else(|| current_provider.clone()),
                 model: borrowed_string(message, &["model", "modelId"])
                     .or_else(|| borrowed_string(&value, &["model", "modelId"]))
-                    .or_else(|| current_model.clone()),
+                    .or_else(|| current_model.clone())
+                    .filter(|model| !excluded_models.contains(&model.as_str())),
                 tokens,
                 source_cost_usd: usage
                     .get("cost")
@@ -739,4 +836,74 @@ fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
         })
         .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn parity_fixture_supports_aliases_errors_numeric_timestamps_and_opt_in_reasoning() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pi.jsonl");
+        fs::write(
+            &path,
+            include_str!("../../fixtures/trajectory_parity/pi.jsonl"),
+        )
+        .unwrap();
+
+        let mut without_reasoning = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                without_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(
+            !without_reasoning
+                .iter()
+                .any(|record| record.role == "reasoning")
+        );
+        let result = without_reasoning
+            .iter()
+            .find(|record| record.role == "tool_result")
+            .unwrap();
+        assert_eq!(result.ts, 1_782_864_002_000);
+        assert_eq!(result.text, "Error: permission denied");
+        assert_eq!(parsed.diagnostics.malformed_json_lines, 1);
+        assert_eq!(parsed.diagnostics.encrypted_reasoning_dropped, 1);
+        assert_eq!(
+            parsed.diagnostics.unknown_semantic_types.get("futureRole"),
+            Some(&1)
+        );
+
+        let mut with_reasoning = Vec::new();
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &AtomicU64::new(1),
+            |record| {
+                with_reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(
+            with_reasoning.iter().any(|record| {
+                record.role == "reasoning" && record.text == "Plain Pi reasoning"
+            })
+        );
+        assert!(
+            !with_reasoning
+                .iter()
+                .any(|record| record.text.contains("ciphertext-must-never-be-indexed"))
+        );
+    }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1533,6 +1533,7 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
         SourceKind::Cursor => cwd_from_cursor_session(Path::new(&first.source_path)),
         SourceKind::Opencode => cwd_from_opencode_session(Path::new(&first.source_path)),
         SourceKind::Pi => cwd_from_pi_session(Path::new(&first.source_path)),
+        SourceKind::OpenClaw => cwd_from_pi_session(Path::new(&first.source_path)),
         SourceKind::CodexHistory => None,
     }
     .filter(|path| path.is_dir())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -392,6 +392,7 @@ enum SourceChoice {
     Opencode,
     Cursor,
     Pi,
+    OpenClaw,
     Copilot,
 }
 
@@ -403,7 +404,8 @@ impl SourceChoice {
             SourceChoice::Codex => SourceChoice::Opencode,
             SourceChoice::Opencode => SourceChoice::Cursor,
             SourceChoice::Cursor => SourceChoice::Pi,
-            SourceChoice::Pi => SourceChoice::Copilot,
+            SourceChoice::Pi => SourceChoice::OpenClaw,
+            SourceChoice::OpenClaw => SourceChoice::Copilot,
             SourceChoice::Copilot => SourceChoice::All,
         }
     }
@@ -416,6 +418,7 @@ impl SourceChoice {
             SourceChoice::Opencode => Some(SourceFilter::Opencode),
             SourceChoice::Cursor => Some(SourceFilter::Cursor),
             SourceChoice::Pi => Some(SourceFilter::Pi),
+            SourceChoice::OpenClaw => Some(SourceFilter::OpenClaw),
             SourceChoice::Copilot => Some(SourceFilter::Copilot),
         }
     }
@@ -428,6 +431,7 @@ impl SourceChoice {
             SourceChoice::Opencode => "opencode",
             SourceChoice::Cursor => "cursor",
             SourceChoice::Pi => "pi",
+            SourceChoice::OpenClaw => "openclaw",
             SourceChoice::Copilot => "copilot",
         }
     }
@@ -916,10 +920,12 @@ impl App {
                 let opts = IngestOptions {
                     claude_source: default_claude_source(),
                     include_agents: false,
+                    include_reasoning: config.include_reasoning_default(),
                     include_codex: true,
                     include_opencode: true,
                     include_cursor: true,
                     include_pi: true,
+                    include_openclaw: true,
                     include_copilot: true,
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
@@ -2066,6 +2072,7 @@ impl App {
                 .pi_resume_cmd
                 .clone()
                 .or_else(|| default_resume_template("pi")),
+            SourceKind::OpenClaw => None,
             SourceKind::Copilot => self
                 .config
                 .copilot_resume_cmd
@@ -2105,6 +2112,7 @@ impl App {
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
+            SourceKind::OpenClaw => "pi",
             SourceKind::Copilot => "copilot",
         };
         let source_path = session.source_path.clone();
@@ -3476,6 +3484,7 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
         SourceChoice::Opencode => label == "opencode",
         SourceChoice::Cursor => label == "cursor",
         SourceChoice::Pi => label == "pi",
+        SourceChoice::OpenClaw => label == "openclaw",
         SourceChoice::Copilot => label == "copilot",
         SourceChoice::All => false,
     }
@@ -3488,6 +3497,7 @@ fn source_color(source: SourceKind) -> Color {
         SourceKind::Opencode => Color::Rgb(150, 180, 150),
         SourceKind::Cursor => Color::Rgb(170, 150, 200),
         SourceKind::Pi => Color::Rgb(120, 190, 190),
+        SourceKind::OpenClaw => Color::Rgb(235, 160, 110),
         SourceKind::Copilot => Color::Rgb(140, 160, 220),
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,17 +10,19 @@ pub enum SourceKind {
     Opencode,
     Cursor,
     Pi,
+    OpenClaw,
     Copilot,
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 7] = [
+    pub const ALL: [SourceKind; 8] = [
         SourceKind::Claude,
         SourceKind::CodexSession,
         SourceKind::CodexHistory,
         SourceKind::Opencode,
         SourceKind::Cursor,
         SourceKind::Pi,
+        SourceKind::OpenClaw,
         SourceKind::Copilot,
     ];
     pub const COUNT: usize = Self::ALL.len();
@@ -33,7 +35,8 @@ impl SourceKind {
             SourceKind::Opencode => 3,
             SourceKind::Cursor => 4,
             SourceKind::Pi => 5,
-            SourceKind::Copilot => 6,
+            SourceKind::OpenClaw => 6,
+            SourceKind::Copilot => 7,
         }
     }
 
@@ -45,7 +48,8 @@ impl SourceKind {
             3 => Some(SourceKind::Opencode),
             4 => Some(SourceKind::Cursor),
             5 => Some(SourceKind::Pi),
-            6 => Some(SourceKind::Copilot),
+            6 => Some(SourceKind::OpenClaw),
+            7 => Some(SourceKind::Copilot),
             _ => None,
         }
     }
@@ -57,6 +61,7 @@ impl SourceKind {
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
+            SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
         }
     }
@@ -69,6 +74,7 @@ impl SourceKind {
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
+            SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
         }
     }
@@ -85,6 +91,7 @@ impl SourceKind {
             "opencode" => Some(SourceKind::Opencode),
             "cursor" => Some(SourceKind::Cursor),
             "pi" => Some(SourceKind::Pi),
+            "openclaw" => Some(SourceKind::OpenClaw),
             "copilot" => Some(SourceKind::Copilot),
             _ => None,
         }
@@ -99,6 +106,8 @@ pub enum SourceFilter {
     Opencode,
     Cursor,
     Pi,
+    #[value(name = "openclaw", alias = "open-claw")]
+    OpenClaw,
     Copilot,
 }
 
@@ -112,6 +121,7 @@ impl SourceFilter {
             SourceFilter::Opencode => source == SourceKind::Opencode,
             SourceFilter::Cursor => source == SourceKind::Cursor,
             SourceFilter::Pi => source == SourceKind::Pi,
+            SourceFilter::OpenClaw => source == SourceKind::OpenClaw,
             SourceFilter::Copilot => source == SourceKind::Copilot,
         }
     }
@@ -123,6 +133,7 @@ impl SourceFilter {
             SourceFilter::Opencode => &["opencode"],
             SourceFilter::Cursor => &["cursor"],
             SourceFilter::Pi => &["pi"],
+            SourceFilter::OpenClaw => &["openclaw"],
             SourceFilter::Copilot => &["copilot"],
         }
     }
@@ -134,6 +145,7 @@ impl SourceFilter {
             SourceFilter::Opencode => "opencode",
             SourceFilter::Cursor => "cursor",
             SourceFilter::Pi => "pi",
+            SourceFilter::OpenClaw => "openclaw",
             SourceFilter::Copilot => "copilot",
         }
     }
@@ -185,7 +197,8 @@ pub struct Record {
 
 #[cfg(test)]
 mod tests {
-    use super::SourceKind;
+    use super::{SourceFilter, SourceKind};
+    use clap::ValueEnum;
     use std::collections::HashSet;
 
     #[test]
@@ -198,6 +211,18 @@ mod tests {
             assert!(labels.insert(source.storage_label()));
             assert_eq!(SourceKind::from_label(source.storage_label()), Some(source));
         }
+    }
+
+    #[test]
+    fn openclaw_source_filter_uses_unhyphenated_cli_name() {
+        assert_eq!(
+            SourceFilter::from_str("openclaw", true),
+            Ok(SourceFilter::OpenClaw)
+        );
+        assert_eq!(
+            SourceFilter::from_str("open-claw", true),
+            Ok(SourceFilter::OpenClaw)
+        );
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -503,11 +503,12 @@ fn assemble_usage_events(
     };
     type SourceScanner =
         fn(&mut Vec<UsageEvent>, &mut Vec<String>, Option<&mut UsageCache>) -> Result<()>;
-    const SCANNERS: [(SourceFilter, SourceScanner); 6] = [
+    const SCANNERS: [(SourceFilter, SourceScanner); 7] = [
         (SourceFilter::Claude, scan_claude),
         (SourceFilter::Codex, scan_codex),
         (SourceFilter::Opencode, scan_opencode),
         (SourceFilter::Pi, scan_pi),
+        (SourceFilter::OpenClaw, scan_openclaw),
         (SourceFilter::Cursor, scan_cursor),
         (SourceFilter::Copilot, scan_copilot),
     ];
@@ -1184,6 +1185,30 @@ fn scan_pi(
         warnings,
         out,
         |path| crate::sources::pi::parse_usage_file(path).map(FileParse::cacheable),
+    );
+    Ok(())
+}
+
+fn scan_openclaw(
+    out: &mut Vec<UsageEvent>,
+    warnings: &mut Vec<String>,
+    cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    let files = crate::sources::openclaw::discover()
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<_>>();
+    scan_files_cached(
+        SourceScan {
+            source: "openclaw",
+            parser_version: crate::sources::openclaw::VERSIONS.usage,
+            volatile_reuse_ms: |_| None,
+        },
+        &files,
+        cache,
+        warnings,
+        out,
+        |path| crate::sources::openclaw::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
 }


### PR DESCRIPTION
Expands the local transcript indexer to retain activity that was previously skipped and to avoid treating unrelated sidecar files as conversations.

Codex indexing now includes agent reasoning summaries, custom tool calls and results, web searches, and tool-search events. Claude discovery includes real `agent-*.jsonl` subagent sessions only when requested while excluding nested workflow journals and sidecars. Pi accepts both tool-result role spellings, preserves failed results, and handles numeric timestamps correctly.

Plaintext reasoning is excluded by default because it is usually low-value search material. It can be enabled with `memex index --include-reasoning` or `include_reasoning = true` in `config.toml`, and remains BM25-only. Encrypted, signed-only, and redacted reasoning is always detected and discarded.

The change also adds OpenClaw as a Pi-derived source, including discovery, indexing, usage reporting, source filters, and TUI support. Aggregate parser diagnostics, a privacy-safe structural audit, and sanitized fixtures make unknown or changing transcript shapes visible without retaining transcript contents.

Validated with `cargo test`, `cargo fmt --check`, and `cargo clippy -- -D warnings`.