### PR TITLE
Index Hermes SQLite sessions incrementally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, OpenClaw, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, OpenClaw, Hermes, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -159,7 +159,7 @@ Token tracking is disabled by default because it scans and caches local agent lo
 token_usage = true
 ```
 
-Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot logs:
+Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, OpenClaw, Hermes, and Copilot logs:
 
 ```
 memex usage
@@ -215,7 +215,7 @@ This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents a
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|cursor|opencode|pi|openclaw|copilot`
+- `--source claude|codex|cursor|opencode|pi|openclaw|hermes|copilot`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -338,6 +338,11 @@ Service logs and the plist live under `~/.memex` by default (macOS). On Linux, s
 `include_reasoning` defaults to false. Set it to true (or pass `memex index
 --include-reasoning`) to add plaintext reasoning as BM25-only records. Encrypted
 and redacted reasoning payloads are always excluded.
+Hermes sessions are discovered at `$HERMES_HOME/state.db` or
+`~/.hermes/state.db`. New active messages are indexed incrementally by their
+SQLite message ID; Memex rebuilds the Hermes projection only after a rewind,
+schema-generation change, database replacement, parser change, or reasoning-mode
+change.
 `max_indexed_tool_*_bytes` limits oversized tool payloads while leaving user and assistant text
 unchanged. memex keeps roughly the first three quarters and final quarter, with a marker reporting
 the omitted middle. Each value must be at least 1024 bytes. Run `memex index --reindex` to apply

--- a/fixtures/trajectory_parity/hermes.sql
+++ b/fixtures/trajectory_parity/hermes.sql
@@ -1,0 +1,88 @@
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE schema_version (
+    version INTEGER NOT NULL
+);
+INSERT INTO schema_version(version) VALUES (21);
+
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    model TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    cwd TEXT,
+    billing_provider TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    rewind_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT,
+    timestamp REAL NOT NULL,
+    reasoning TEXT,
+    reasoning_content TEXT,
+    active INTEGER NOT NULL DEFAULT 1
+);
+
+INSERT INTO sessions(
+    id, source, model, started_at, ended_at, input_tokens, output_tokens,
+    cache_read_tokens, cache_write_tokens, reasoning_tokens, cwd,
+    billing_provider, estimated_cost_usd, actual_cost_usd
+) VALUES (
+    'hermes-session', 'cli', 'gpt-5.2', 1783000000.0, 1783000009.0,
+    100, 50, 20, 5, 10, '/workspace/demo', 'openai', 0.04, 0.03
+);
+
+INSERT INTO messages(id, session_id, role, content, timestamp, active)
+VALUES (101, 'hermes-session', 'user', 'Check the current directory.', 1783000001.25, 1);
+
+INSERT INTO messages(
+    id, session_id, role, content, tool_calls, timestamp, reasoning,
+    reasoning_content, active
+) VALUES (
+    102, 'hermes-session', 'assistant', NULL,
+    '[{"id":"call-hermes-1","function":{"name":"terminal","arguments":"{\"command\":\"pwd\"}"}}]',
+    1783000004.5, 'fallback reasoning', 'Check the working directory.', 1
+);
+
+INSERT INTO messages(
+    id, session_id, role, content, tool_call_id, tool_name, timestamp, active
+) VALUES (
+    103, 'hermes-session', 'tool', '/workspace/demo', 'call-hermes-1',
+    'terminal', 1783000006.0, 1
+);
+
+INSERT INTO messages(id, session_id, role, content, timestamp, active)
+VALUES (104, 'hermes-session', 'assistant', 'You are in /workspace/demo.', 1783000008.75, 1);
+
+INSERT INTO messages(id, session_id, role, content, timestamp, active)
+VALUES (105, 'hermes-session', 'user', 'rewound prompt', 1783000009.0, 0);
+
+INSERT INTO messages(id, session_id, role, content, timestamp, active)
+VALUES (
+    106, 'hermes-session', 'user',
+    char(0) || 'json:[{"type":"text","text":"Visible multimodal text"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]',
+    1783000009.5, 1
+);
+
+INSERT INTO messages(id, session_id, role, content, timestamp, reasoning_content, active)
+VALUES (
+    107, 'hermes-session', 'assistant', 'Visible encrypted-reasoning answer',
+    1783000010.0,
+    '{"type":"encrypted_reasoning","encrypted_content":"ciphertext-must-never-be-indexed"}',
+    1
+);

--- a/fixtures/trajectory_parity/hermes.sql
+++ b/fixtures/trajectory_parity/hermes.sql
@@ -43,7 +43,7 @@ INSERT INTO sessions(
     cache_read_tokens, cache_write_tokens, reasoning_tokens, cwd,
     billing_provider, estimated_cost_usd, actual_cost_usd
 ) VALUES (
-    'hermes-session', 'cli', 'gpt-5.2', 1783000000.0, 1783000009.0,
+    'hermes-session', 'cli', 'gpt-5.2', 1783000000.0, NULL,
     100, 50, 20, 5, 10, '/workspace/demo', 'openai', 0.04, 0.03
 );
 

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -788,6 +788,9 @@ fn resolve_session_cwd_from_parts(
     {
         return Some(cwd);
     }
+    if source == SourceKind::Hermes {
+        return crate::sources::hermes::session_cwd(Path::new(source_path), session_id);
+    }
     let file = std::fs::File::open(source_path).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut fallback: Option<String> = None;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,12 @@ struct IndexArgs {
     /// Skip indexing OpenClaw sessions
     #[arg(long = "no-openclaw", default_value_t = false)]
     no_openclaw: bool,
+    /// Index Hermes sessions from ~/.hermes/state.db [default: true]
+    #[arg(long, default_value_t = true)]
+    hermes: bool,
+    /// Skip indexing Hermes sessions
+    #[arg(long = "no-hermes", default_value_t = false)]
+    no_hermes: bool,
     /// Index GitHub Copilot CLI sessions from ~/.copilot [default: true]
     #[arg(long, default_value_t = true)]
     copilot: bool,
@@ -174,7 +180,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, hermes, or copilot
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -269,7 +275,7 @@ EXAMPLES:
     memex usage --source codex --since 2026-07-01
     memex usage --json")]
     Usage {
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, hermes, or copilot
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include events on or after this date/timestamp
@@ -648,6 +654,7 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
         index.cursor,
         index.pi && !index.no_pi,
         index.openclaw && !index.no_openclaw,
+        index.hermes && !index.no_hermes,
         index.copilot && !index.no_copilot,
         index.embeddings,
         index.no_embeddings,
@@ -668,6 +675,7 @@ fn run_index(
     cursor: bool,
     pi: bool,
     openclaw: bool,
+    hermes: bool,
     copilot: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
@@ -705,6 +713,7 @@ fn run_index(
         include_cursor: cursor,
         include_pi: pi,
         include_openclaw: openclaw,
+        include_hermes: hermes,
         include_copilot: copilot,
         embeddings,
         backfill_embeddings: false,
@@ -826,7 +835,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {})",
+        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {}, openclaw {}, hermes {}, copilot {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::CodexSession.idx()],
@@ -835,6 +844,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
         embedded_counts[crate::types::SourceKind::Cursor.idx()],
         embedded_counts[crate::types::SourceKind::Pi.idx()],
         embedded_counts[crate::types::SourceKind::OpenClaw.idx()],
+        embedded_counts[crate::types::SourceKind::Hermes.idx()],
         embedded_counts[crate::types::SourceKind::Copilot.idx()],
     );
 
@@ -886,6 +896,7 @@ fn run_search(
             include_cursor: true,
             include_pi: true,
             include_openclaw: true,
+            include_hermes: true,
             include_copilot: true,
             embeddings: embeddings_default,
             backfill_embeddings: false,
@@ -1995,6 +2006,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Cursor => "cursor",
         crate::types::SourceKind::Pi => "pi",
         crate::types::SourceKind::OpenClaw => "openclaw",
+        crate::types::SourceKind::Hermes => "hermes",
         crate::types::SourceKind::Copilot => "copilot",
     };
     let source_path = &record.source_path;
@@ -2623,6 +2635,9 @@ fn build_index_command_args(
     }
     if !index.openclaw || index.no_openclaw {
         args.push("--no-openclaw".to_string());
+    }
+    if !index.hermes || index.no_hermes {
+        args.push("--no-hermes".to_string());
     }
     if !index.copilot || index.no_copilot {
         args.push("--no-copilot".to_string());
@@ -3329,11 +3344,13 @@ mod tests {
             cursor: false,
             pi: false,
             openclaw: false,
+            hermes: false,
             copilot: false,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
             no_openclaw: false,
+            no_hermes: false,
             no_copilot: false,
             embeddings: false,
             no_embeddings: false,
@@ -3349,6 +3366,7 @@ mod tests {
         assert!(args.contains(&"--no-cursor".to_string()));
         assert!(args.contains(&"--no-pi".to_string()));
         assert!(args.contains(&"--no-openclaw".to_string()));
+        assert!(args.contains(&"--no-hermes".to_string()));
         assert!(args.contains(&"--no-copilot".to_string()));
     }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -35,6 +35,7 @@ pub struct IngestOptions {
     pub include_cursor: bool,
     pub include_pi: bool,
     pub include_openclaw: bool,
+    pub include_hermes: bool,
     pub include_copilot: bool,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
@@ -65,6 +66,7 @@ struct FileTask {
     pending_tool_calls: HashMap<String, PendingToolCall>,
     identity: FileIdentity,
     parser_version: u32,
+    source_generation: u64,
 }
 
 #[derive(Debug)]
@@ -200,9 +202,58 @@ fn prepare_file_task(
             pending_tool_calls,
             identity,
             parser_version,
+            source_generation: previous.map_or(0, |state| state.source_generation),
         },
         skip,
     )
+}
+
+fn prepare_hermes_task(
+    path: PathBuf,
+    include_reasoning: bool,
+    metadata: &std::fs::Metadata,
+    previous: Option<&FileState>,
+    checkpoint: crate::sources::hermes::Checkpoint,
+) -> (FileTask, bool) {
+    let (mut task, _) = prepare_file_task(
+        path,
+        SourceKind::Hermes,
+        include_reasoning,
+        metadata,
+        previous,
+    );
+    task.source_generation = checkpoint.generation;
+    let Some(previous) = previous else {
+        task.offset = 0;
+        task.turn_id = 0;
+        task.delete_first = false;
+        task.pending_tool_calls.clear();
+        return (task, false);
+    };
+    let inode_changed = previous
+        .identity
+        .device
+        .zip(previous.identity.inode)
+        .zip(task.identity.device.zip(task.identity.inode))
+        .is_some_and(|((old_device, old_inode), (new_device, new_inode))| {
+            old_device != new_device || old_inode != new_inode
+        });
+    let invalidated = task.parser_version_invalidated
+        || inode_changed
+        || checkpoint.max_message_id < previous.offset
+        || checkpoint.generation != previous.source_generation;
+    if invalidated {
+        task.offset = 0;
+        task.turn_id = 0;
+        task.delete_first = true;
+        task.pending_tool_calls.clear();
+        return (task, false);
+    }
+    task.offset = previous.offset;
+    task.turn_id = 0;
+    task.delete_first = false;
+    task.pending_tool_calls = previous.pending_tool_calls.clone();
+    (task, checkpoint.max_message_id == previous.offset)
 }
 
 fn completed_file_state(
@@ -217,6 +268,7 @@ fn completed_file_state(
         offset,
         turn_id,
         parser_version: task.parser_version,
+        source_generation: task.source_generation,
         pending_tool_calls,
         identity: task.identity.clone(),
     }
@@ -513,6 +565,29 @@ pub fn ingest_all(
         }
     }
 
+    if options.include_hermes {
+        for source_file in crate::sources::hermes::discover() {
+            let path = source_file.path;
+            let meta = path.metadata()?;
+            let checkpoint = crate::sources::hermes::checkpoint(&path)?;
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = path.to_string_lossy().to_string();
+            let (task, skip) = prepare_hermes_task(
+                path,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+                checkpoint,
+            );
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(task);
+        }
+    }
+
     if options.include_copilot {
         let copilot_files = crate::sources::copilot::discover_sessions();
         for source_file in copilot_files {
@@ -641,6 +716,14 @@ pub fn ingest_all(
                 &progress,
             )?,
             SourceKind::OpenClaw => parse_openclaw_file(
+                task,
+                options.include_reasoning,
+                &tx_record,
+                &tx_update,
+                &next_doc_id,
+                &progress,
+            )?,
+            SourceKind::Hermes => parse_hermes_file(
                 task,
                 options.include_reasoning,
                 &tx_record,
@@ -1177,6 +1260,39 @@ fn parse_openclaw_file(
         parsed,
     )
 }
+
+fn parse_hermes_file(
+    task: &FileTask,
+    include_reasoning: bool,
+    tx_record: &RecordSender,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::hermes::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: 0,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        include_reasoning,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Hermes, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Hermes,
+        source_path,
+        parsed,
+    )
+}
 fn parse_copilot_session(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -1377,6 +1493,7 @@ mod tests {
             include_cursor: false,
             include_pi: false,
             include_openclaw: false,
+            include_hermes: false,
             include_copilot: false,
             embeddings,
             backfill_embeddings: false,
@@ -1444,6 +1561,7 @@ mod tests {
                 metadata.len().min(FILE_IDENTITY_PREFIX_BYTES as u64) as usize,
             ),
             parser_version: crate::sources::index_state_version(source),
+            source_generation: 0,
         }
     }
 
@@ -2059,6 +2177,7 @@ mod tests {
             turn_id: 1,
             parser_version: crate::sources::index_state_version(SourceKind::Claude)
                 .saturating_sub(1),
+            source_generation: 0,
             pending_tool_calls: HashMap::from([(
                 "stale".to_string(),
                 PendingToolCall {
@@ -2075,6 +2194,67 @@ mod tests {
         assert!(task.parser_version_invalidated);
         assert_eq!(task.offset, 0);
         assert!(task.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn hermes_appends_resume_from_message_id_and_rewinds_rebuild() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("state.db");
+        fs::write(&path, "sqlite placeholder").expect("store");
+        let metadata = path.metadata().expect("metadata");
+        let (mut initial, _) =
+            prepare_file_task(path.clone(), SourceKind::Hermes, false, &metadata, None);
+        initial.source_generation = 7;
+        initial.pending_tool_calls.insert(
+            "call-1".to_string(),
+            PendingToolCall {
+                tool_name: Some("terminal".to_string()),
+                ..PendingToolCall::default()
+            },
+        );
+        let previous = completed_file_state(&initial, 106, 0, initial.pending_tool_calls.clone());
+
+        let (appended, skip) = prepare_hermes_task(
+            path.clone(),
+            false,
+            &metadata,
+            Some(&previous),
+            crate::sources::hermes::Checkpoint {
+                max_message_id: 107,
+                generation: 7,
+            },
+        );
+        assert!(!skip);
+        assert!(!appended.delete_first);
+        assert_eq!(appended.offset, 106);
+        assert!(appended.pending_tool_calls.contains_key("call-1"));
+
+        let (_, skip) = prepare_hermes_task(
+            path.clone(),
+            false,
+            &metadata,
+            Some(&previous),
+            crate::sources::hermes::Checkpoint {
+                max_message_id: 106,
+                generation: 7,
+            },
+        );
+        assert!(skip);
+
+        let (rewound, skip) = prepare_hermes_task(
+            path,
+            false,
+            &metadata,
+            Some(&previous),
+            crate::sources::hermes::Checkpoint {
+                max_message_id: 107,
+                generation: 8,
+            },
+        );
+        assert!(!skip);
+        assert!(rewound.delete_first);
+        assert_eq!(rewound.offset, 0);
+        assert!(rewound.pending_tool_calls.is_empty());
     }
 
     #[test]
@@ -2136,6 +2316,7 @@ mod tests {
             include_cursor: false,
             include_pi: false,
             include_openclaw: false,
+            include_hermes: false,
             include_copilot: false,
             embeddings: false,
             backfill_embeddings: false,
@@ -2512,6 +2693,7 @@ mod tests {
             include_cursor: false,
             include_pi: true,
             include_openclaw: false,
+            include_hermes: false,
             include_copilot: false,
             embeddings: false,
             backfill_embeddings: false,
@@ -2634,6 +2816,7 @@ mod tests {
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity::default(),
             parser_version: crate::sources::index_state_version(SourceKind::Pi),
+            source_generation: 0,
         };
         let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
         let next_doc_id = AtomicU64::new(1);
@@ -2713,16 +2896,17 @@ mod tests {
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity::default(),
             parser_version: crate::sources::index_state_version(SourceKind::Copilot),
+            source_generation: 0,
         };
         let (raw_tx_record, rx_record) = unbounded();
         let tx_record = RecordSender::new(raw_tx_record, IndexedToolContentLimits::default());
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
-        let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, 0, meta.len()],
-            [0, 0, 0, 0, 0, 0, 0, 1],
-            false,
-        ));
+        let mut totals = [0; SOURCE_COUNT];
+        totals[SourceKind::Copilot.idx()] = meta.len();
+        let mut file_totals = [0; SOURCE_COUNT];
+        file_totals[SourceKind::Copilot.idx()] = 1;
+        let progress = Arc::new(Progress::new(totals, file_totals, false));
 
         parse_copilot_session(&task, &tx_record, &tx_update, &next_doc_id, &progress)
             .expect("parse copilot session");

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -105,6 +105,11 @@ fn file_identity(path: &Path, metadata: &std::fs::Metadata, prefix_bytes: usize)
         inode: None,
         prefix_sha256,
         prefix_bytes: prefix_bytes as u64,
+        created_ns: metadata
+            .created()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64),
         modified_ns: metadata
             .modified()
             .ok()
@@ -113,7 +118,7 @@ fn file_identity(path: &Path, metadata: &std::fs::Metadata, prefix_bytes: usize)
     }
 }
 
-fn file_was_replaced(previous: &FileIdentity, current: &FileIdentity) -> bool {
+fn stable_file_identity_changed(previous: &FileIdentity, current: &FileIdentity) -> bool {
     previous
         .device
         .zip(previous.inode)
@@ -121,6 +126,14 @@ fn file_was_replaced(previous: &FileIdentity, current: &FileIdentity) -> bool {
         .is_some_and(|((old_device, old_inode), (new_device, new_inode))| {
             old_device != new_device || old_inode != new_inode
         })
+        || previous
+            .created_ns
+            .zip(current.created_ns)
+            .is_some_and(|(old_created_ns, new_created_ns)| old_created_ns != new_created_ns)
+}
+
+fn file_was_replaced(previous: &FileIdentity, current: &FileIdentity) -> bool {
+    stable_file_identity_changed(previous, current)
         || previous
             .prefix_sha256
             .as_ref()
@@ -230,16 +243,8 @@ fn prepare_hermes_task(
         task.pending_tool_calls.clear();
         return (task, false);
     };
-    let inode_changed = previous
-        .identity
-        .device
-        .zip(previous.identity.inode)
-        .zip(task.identity.device.zip(task.identity.inode))
-        .is_some_and(|((old_device, old_inode), (new_device, new_inode))| {
-            old_device != new_device || old_inode != new_inode
-        });
     let invalidated = task.parser_version_invalidated
-        || inode_changed
+        || stable_file_identity_changed(&previous.identity, &task.identity)
         || checkpoint.max_message_id < previous.offset
         || checkpoint.generation != previous.source_generation;
     if invalidated {
@@ -2255,6 +2260,24 @@ mod tests {
         assert!(rewound.delete_first);
         assert_eq!(rewound.offset, 0);
         assert!(rewound.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn hermes_replacement_uses_creation_time_without_device_or_inode() {
+        let previous = FileIdentity {
+            device: None,
+            inode: None,
+            created_ns: Some(100),
+            ..FileIdentity::default()
+        };
+        let replacement = FileIdentity {
+            device: None,
+            inode: None,
+            created_ns: Some(200),
+            ..FileIdentity::default()
+        };
+
+        assert!(stable_file_identity_changed(&previous, &replacement));
     }
 
     #[test]

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -246,6 +246,7 @@ fn progress_label(source: SourceKind) -> &'static str {
         SourceKind::Pi => "pi",
         SourceKind::OpenClaw => "openclaw",
         SourceKind::Copilot => "copilot",
+        SourceKind::Hermes => "hermes",
     }
 }
 

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -1,5 +1,6 @@
 use crate::types::{SourceFilter, SourceKind};
 use anyhow::Result;
+use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashSet};
@@ -66,6 +67,13 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
             .collect(),
     );
     push(
+        SourceKind::Hermes,
+        super::hermes::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
         SourceKind::Copilot,
         super::copilot::discover_sessions()
             .into_iter()
@@ -88,6 +96,9 @@ fn deduplicate(files: Vec<PathBuf>) -> Vec<PathBuf> {
 }
 
 pub fn audit_files(source: SourceKind, files: &[PathBuf]) -> Result<SourceAudit> {
+    if source == SourceKind::Hermes {
+        return audit_hermes_files(files);
+    }
     let mut audit = SourceAudit {
         source: source.storage_label().to_string(),
         files: files.len() as u64,
@@ -95,6 +106,54 @@ pub fn audit_files(source: SourceKind, files: &[PathBuf]) -> Result<SourceAudit>
     };
     for path in files {
         audit_file(source, path, &mut audit)?;
+    }
+    Ok(audit)
+}
+
+fn audit_hermes_files(files: &[PathBuf]) -> Result<SourceAudit> {
+    let mut audit = SourceAudit {
+        source: SourceKind::Hermes.storage_label().to_string(),
+        files: files.len() as u64,
+        ..SourceAudit::default()
+    };
+    for path in files {
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        if let Ok(version) =
+            connection.query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+                row.get::<_, Option<i64>>(0)
+            })
+            && let Some(version) = version
+        {
+            increment(&mut audit.producer_versions, &version.to_string());
+        }
+        let has_active = connection
+            .prepare("SELECT active FROM messages LIMIT 0")
+            .is_ok();
+        let sql = if has_active {
+            "SELECT role, COUNT(*) FROM messages WHERE COALESCE(active, 1) != 0 GROUP BY role"
+        } else {
+            "SELECT role, COUNT(*) FROM messages GROUP BY role"
+        };
+        let mut statement = connection.prepare(sql)?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (role, count) = row?;
+            let count = count.max(0) as u64;
+            audit.valid_json_lines += count;
+            *audit
+                .top_level_types
+                .entry("message".to_string())
+                .or_default() += count;
+            *audit
+                .semantic_types
+                .entry(format!("message/{role}"))
+                .or_default() += count;
+        }
     }
     Ok(audit)
 }
@@ -191,6 +250,7 @@ fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &
             }
             record_content_blocks(value.get("content"), audit);
         }
+        SourceKind::Hermes => {}
     }
 }
 

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -1,0 +1,790 @@
+use super::{
+    ConversationKind, IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions,
+    SourceFile,
+};
+use crate::state::PendingToolCall;
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    index: 1,
+    usage: 1,
+};
+
+const CONTENT_JSON_PREFIX: &str = "\0json:";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Checkpoint {
+    pub max_message_id: u64,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug)]
+struct MessageRow {
+    id: u64,
+    session_id: String,
+    role: String,
+    content: Option<String>,
+    tool_call_id: Option<String>,
+    tool_calls: Option<String>,
+    tool_name: Option<String>,
+    timestamp_ms: u64,
+    reasoning: Option<String>,
+    reasoning_content: Option<String>,
+    cwd: Option<String>,
+    parent_session_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ToolCall {
+    id: String,
+    name: Option<String>,
+    arguments: String,
+}
+
+pub fn matches_path(path: &str) -> bool {
+    Path::new(path) == database_path()
+        || ((path.contains(".hermes/") || path.contains(".hermes\\"))
+            && (path.ends_with("state.db") || path.ends_with("state.db-wal")))
+}
+
+pub fn home() -> PathBuf {
+    std::env::var_os("HERMES_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::common::home().join(".hermes"))
+}
+
+pub fn database_path() -> PathBuf {
+    home().join("state.db")
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    let path = database_path();
+    if path.is_file() {
+        vec![SourceFile {
+            source: SourceKind::Hermes,
+            path,
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn checkpoint(path: &Path) -> Result<Checkpoint> {
+    let connection = open_read_only(path)?;
+    let message_columns = table_columns(&connection, "messages")?;
+    let columns = table_columns(&connection, "sessions")?;
+    let active = if message_columns.contains("active") {
+        " WHERE COALESCE(active, 1) != 0"
+    } else {
+        ""
+    };
+    let max_message_id = connection
+        .query_row(
+            &format!("SELECT COALESCE(MAX(id), 0) FROM messages{active}"),
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        .max(0) as u64;
+    let schema_version = connection
+        .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+            row.get::<_, Option<i64>>(0)
+        })
+        .optional()
+        .ok()
+        .flatten()
+        .flatten()
+        .unwrap_or(0)
+        .max(0) as u64;
+    let rewind_generation = if columns.contains("rewind_count") {
+        connection
+            .query_row(
+                "SELECT COALESCE(SUM(rewind_count), 0) FROM sessions",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0)
+            .max(0) as u64
+    } else {
+        0
+    };
+    Ok(Checkpoint {
+        max_message_id,
+        generation: schema_version.rotate_left(32) ^ rewind_generation,
+    })
+}
+
+pub fn session_cwd(path: &Path, session_id: &str) -> Option<String> {
+    let connection = open_read_only(path).ok()?;
+    let columns = table_columns(&connection, "sessions").ok()?;
+    if !columns.contains("cwd") {
+        return None;
+    }
+    connection
+        .query_row(
+            "SELECT cwd FROM sessions WHERE id = ?1",
+            params![session_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .ok()
+        .flatten()
+        .flatten()
+        .filter(|cwd| !cwd.is_empty())
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let connection = open_read_only(path)?;
+    let rows = load_rows(&connection, state.offset)?;
+    let source_path = path.to_string_lossy().to_string();
+    let mut diagnostics = ParseDiagnostics::default();
+    let mut pending_tool_calls = state.pending_tool_calls;
+    let mut planned_calls = plan_tool_calls(&rows, &mut diagnostics);
+    let mut max_message_id = state.offset;
+
+    for row in &rows {
+        max_message_id = max_message_id.max(row.id);
+        let project = row
+            .cwd
+            .as_deref()
+            .map(super::common::project_from_path)
+            .unwrap_or_else(|| SourceKind::Hermes.label().to_string());
+        let links = row_links(row);
+        let base_turn = row.id.min((u32::MAX / 8) as u64).saturating_mul(8) as u32;
+        let mut component = 0u32;
+
+        match row.role.as_str() {
+            "user" => {
+                let text = content_text(row.content.as_deref());
+                if !text.trim().is_empty() {
+                    emit(Record {
+                        source: SourceKind::Hermes,
+                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                        ts: row.timestamp_ms,
+                        project,
+                        session_id: row.session_id.clone(),
+                        turn_id: base_turn + component,
+                        role: "user".to_string(),
+                        text,
+                        tool_name: None,
+                        tool_input: None,
+                        tool_output: None,
+                        links,
+                        source_path: source_path.clone(),
+                    })?;
+                }
+            }
+            "assistant" => {
+                if include_reasoning && let Some(reasoning) = reasoning_text(row, &mut diagnostics)
+                {
+                    let mut reasoning_links = links.clone();
+                    reasoning_links.event_id = Some(format!("{}:reasoning", row.id));
+                    emit(Record {
+                        source: SourceKind::Hermes,
+                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                        ts: row.timestamp_ms,
+                        project: project.clone(),
+                        session_id: row.session_id.clone(),
+                        turn_id: base_turn + component,
+                        role: "reasoning".to_string(),
+                        text: reasoning,
+                        tool_name: None,
+                        tool_input: None,
+                        tool_output: None,
+                        links: reasoning_links,
+                        source_path: source_path.clone(),
+                    })?;
+                    component += 1;
+                }
+
+                let text = content_text(row.content.as_deref());
+                if !text.trim().is_empty() {
+                    emit(Record {
+                        source: SourceKind::Hermes,
+                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                        ts: row.timestamp_ms,
+                        project: project.clone(),
+                        session_id: row.session_id.clone(),
+                        turn_id: base_turn + component,
+                        role: "assistant".to_string(),
+                        text,
+                        tool_name: None,
+                        tool_input: None,
+                        tool_output: None,
+                        links: links.clone(),
+                        source_path: source_path.clone(),
+                    })?;
+                    component += 1;
+                }
+
+                for call in planned_calls.remove(&row.id).unwrap_or_default() {
+                    let mut call_links = links.clone();
+                    call_links.event_id = Some(call.id.clone());
+                    call_links.parent_event_id = Some(row.id.to_string());
+                    let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                    let replaced = pending_tool_calls.insert(
+                        call.id.clone(),
+                        super::common::pending_tool_call(
+                            call.name.clone(),
+                            Some(call.id.clone()),
+                            doc_id,
+                            row.timestamp_ms,
+                            Some(&call.arguments),
+                            &call_links,
+                            &row.session_id,
+                        ),
+                    );
+                    if replaced.is_some() {
+                        diagnostics.duplicate_tool_calls += 1;
+                    }
+                    emit(Record {
+                        source: SourceKind::Hermes,
+                        doc_id,
+                        ts: row.timestamp_ms,
+                        project: project.clone(),
+                        session_id: row.session_id.clone(),
+                        turn_id: base_turn + component,
+                        role: "tool_use".to_string(),
+                        text: call.arguments.clone(),
+                        tool_name: call.name,
+                        tool_input: Some(call.arguments),
+                        tool_output: None,
+                        links: call_links,
+                        source_path: source_path.clone(),
+                    })?;
+                    component += 1;
+                }
+            }
+            "tool" => {
+                let native_call_id = row.tool_call_id.as_deref().filter(|id| !id.is_empty());
+                let matched_id = native_call_id
+                    .filter(|id| pending_tool_calls.contains_key(*id))
+                    .map(str::to_string)
+                    .or_else(|| {
+                        find_pending_call(
+                            &pending_tool_calls,
+                            &row.session_id,
+                            row.tool_name.as_deref(),
+                        )
+                    });
+                let pending = matched_id
+                    .as_ref()
+                    .and_then(|id| pending_tool_calls.remove(id));
+                if native_call_id.is_some() && pending.is_none() {
+                    diagnostics.orphan_tool_results += 1;
+                }
+                let tool_name = row
+                    .tool_name
+                    .clone()
+                    .or_else(|| pending.as_ref().and_then(|call| call.tool_name.clone()));
+                let output = content_text(row.content.as_deref());
+                let mut result_links = links;
+                if let Some(parent_id) = matched_id.or_else(|| native_call_id.map(str::to_string)) {
+                    result_links.parent_event_id = Some(parent_id.clone());
+                    result_links.parent_tool_use_id = Some(parent_id);
+                }
+                emit(Record {
+                    source: SourceKind::Hermes,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: row.timestamp_ms,
+                    project,
+                    session_id: row.session_id.clone(),
+                    turn_id: base_turn,
+                    role: "tool_result".to_string(),
+                    text: output.clone(),
+                    tool_name,
+                    tool_input: None,
+                    tool_output: Some(output),
+                    links: result_links,
+                    source_path: source_path.clone(),
+                })?;
+            }
+            "system" => {}
+            role => diagnostics.increment_unknown_semantic(role),
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: max_message_id,
+        turn_id: 0,
+        pending_tool_calls,
+        session_id: None,
+        diagnostics,
+    })
+}
+
+fn open_read_only(path: &Path) -> Result<Connection> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("open Hermes store {}", path.display()))?;
+    connection.busy_timeout(Duration::from_secs(1))?;
+    Ok(connection)
+}
+
+fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+    rows.collect::<std::result::Result<HashSet<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn optional_column(columns: &HashSet<String>, column: &str, fallback: &str) -> String {
+    if columns.contains(column) {
+        column.to_string()
+    } else {
+        fallback.to_string()
+    }
+}
+
+fn load_rows(connection: &Connection, after_id: u64) -> Result<Vec<MessageRow>> {
+    let message_columns = table_columns(connection, "messages")?;
+    let session_columns = table_columns(connection, "sessions")?;
+    let active = if message_columns.contains("active") {
+        "COALESCE(m.active, 1) != 0"
+    } else {
+        "1"
+    };
+    let sql = format!(
+        "SELECT m.id, m.session_id, m.role, m.content, m.tool_call_id, m.tool_calls,
+                m.tool_name, m.timestamp,
+                {}, {}, {}, {}
+         FROM messages m
+         LEFT JOIN sessions s ON s.id = m.session_id
+         WHERE m.id > ?1 AND {active}
+         ORDER BY m.id",
+        optional_column(&message_columns, "reasoning", "NULL"),
+        optional_column(&message_columns, "reasoning_content", "NULL"),
+        optional_column(&session_columns, "cwd", "NULL"),
+        optional_column(&session_columns, "parent_session_id", "NULL"),
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(params![after_id.min(i64::MAX as u64) as i64], |row| {
+        Ok(MessageRow {
+            id: row.get::<_, i64>(0)?.max(0) as u64,
+            session_id: row.get(1)?,
+            role: row.get(2)?,
+            content: row.get(3)?,
+            tool_call_id: row.get(4)?,
+            tool_calls: row.get(5)?,
+            tool_name: row.get(6)?,
+            timestamp_ms: timestamp_millis(row.get::<_, f64>(7)?),
+            reasoning: row.get(8)?,
+            reasoning_content: row.get(9)?,
+            cwd: row.get(10)?,
+            parent_session_id: row.get(11)?,
+        })
+    })?;
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn plan_tool_calls(
+    rows: &[MessageRow],
+    diagnostics: &mut ParseDiagnostics,
+) -> HashMap<u64, Vec<ToolCall>> {
+    let mut planned = HashMap::new();
+    for (index, row) in rows.iter().enumerate() {
+        if row.role != "assistant" {
+            continue;
+        }
+        let Some(raw) = row
+            .tool_calls
+            .as_deref()
+            .filter(|raw| !raw.trim().is_empty())
+        else {
+            continue;
+        };
+        let value: Value = match serde_json::from_str(raw) {
+            Ok(value) => value,
+            Err(_) => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
+        };
+        let Some(entries) = value.as_array() else {
+            diagnostics.increment_unknown_semantic("tool_calls_not_array");
+            continue;
+        };
+        let mut calls = entries
+            .iter()
+            .enumerate()
+            .filter_map(|(position, entry)| parse_tool_call(row.id, position, entry))
+            .collect::<Vec<_>>();
+        let idless_positions = calls
+            .iter()
+            .enumerate()
+            .filter_map(|(position, call)| call.id.starts_with("hermes:").then_some(position))
+            .collect::<Vec<_>>();
+        if !idless_positions.is_empty() {
+            let available = rows[index + 1..]
+                .iter()
+                .take_while(|next| next.role == "tool")
+                .filter_map(|next| next.tool_call_id.clone())
+                .collect::<Vec<_>>();
+            if available.len() == idless_positions.len() {
+                for (position, adopted) in idless_positions.into_iter().zip(available) {
+                    calls[position].id = adopted;
+                }
+            }
+        }
+        if !calls.is_empty() {
+            planned.insert(row.id, calls);
+        }
+    }
+    planned
+}
+
+fn parse_tool_call(row_id: u64, position: usize, value: &Value) -> Option<ToolCall> {
+    let object = value.as_object()?;
+    let function = object.get("function").and_then(Value::as_object);
+    let name = function
+        .and_then(|function| function.get("name"))
+        .or_else(|| object.get("name"))
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+    let native_id = object
+        .get("id")
+        .or_else(|| object.get("call_id"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty());
+    let arguments = function
+        .and_then(|function| function.get("arguments"))
+        .or_else(|| object.get("arguments"))
+        .map(json_text)
+        .unwrap_or_default();
+    Some(ToolCall {
+        id: native_id
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("hermes:{row_id}:{position}")),
+        name,
+        arguments,
+    })
+}
+
+fn find_pending_call(
+    pending: &HashMap<String, PendingToolCall>,
+    session_id: &str,
+    tool_name: Option<&str>,
+) -> Option<String> {
+    let matches = pending
+        .iter()
+        .filter(|(_, call)| call.session_id.as_deref() == Some(session_id))
+        .filter(|(_, call)| {
+            tool_name.is_none_or(|name| call.tool_name.as_deref().is_none_or(|value| value == name))
+        })
+        .map(|(id, _)| id.clone())
+        .collect::<Vec<_>>();
+    (matches.len() == 1).then(|| matches[0].clone())
+}
+
+fn row_links(row: &MessageRow) -> RecordLinks {
+    RecordLinks {
+        event_id: Some(row.id.to_string()),
+        parent_session_id: row.parent_session_id.clone(),
+        thread_source: row.parent_session_id.as_ref().map(|_| "fork".to_string()),
+        conversation_kind: Some(
+            if row.parent_session_id.is_some() {
+                ConversationKind::Fork
+            } else {
+                ConversationKind::Main
+            }
+            .as_str()
+            .to_string(),
+        ),
+        ..RecordLinks::default()
+    }
+}
+
+fn reasoning_text(row: &MessageRow, diagnostics: &mut ParseDiagnostics) -> Option<String> {
+    let text = row
+        .reasoning_content
+        .as_deref()
+        .filter(|text| !text.trim().is_empty())
+        .or_else(|| {
+            row.reasoning
+                .as_deref()
+                .filter(|text| !text.trim().is_empty())
+        })
+        .map(str::trim)?;
+    if is_encrypted_reasoning(text) {
+        diagnostics.encrypted_reasoning_dropped += 1;
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+fn is_encrypted_reasoning(text: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(text) else {
+        return false;
+    };
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    matches!(
+        object.get("type").and_then(Value::as_str),
+        Some("redacted_thinking" | "encrypted_reasoning")
+    ) || object.contains_key("encrypted_content")
+}
+
+fn content_text(content: Option<&str>) -> String {
+    let Some(content) = content else {
+        return String::new();
+    };
+    let value = if let Some(encoded) = content.strip_prefix(CONTENT_JSON_PREFIX) {
+        match serde_json::from_str::<Value>(encoded) {
+            Ok(value) => value,
+            Err(_) => return encoded.to_string(),
+        }
+    } else {
+        return content.to_string();
+    };
+    match value {
+        Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|block| {
+                let object = block.as_object()?;
+                let block_type = object.get("type").and_then(Value::as_str).unwrap_or("");
+                matches!(block_type, "text" | "input_text" | "output_text")
+                    .then(|| object.get("text").and_then(Value::as_str))
+                    .flatten()
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::String(text) => text,
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn json_text(value: &Value) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn timestamp_millis(value: f64) -> u64 {
+    if !value.is_finite() || value <= 0.0 {
+        return 0;
+    }
+    let millis = if value > 100_000_000_000.0 {
+        value
+    } else {
+        value * 1_000.0
+    };
+    millis.round().clamp(0.0, u64::MAX as f64) as u64
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    let connection = open_read_only(path)?;
+    let columns = table_columns(&connection, "sessions")?;
+    let expression = |column: &str, fallback: &str| {
+        if columns.contains(column) {
+            column.to_string()
+        } else {
+            fallback.to_string()
+        }
+    };
+    let sql = format!(
+        "SELECT id, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+         FROM sessions
+         ORDER BY started_at, id",
+        expression("ended_at", "started_at"),
+        expression("cwd", "NULL"),
+        expression("billing_provider", "NULL"),
+        expression("model", "NULL"),
+        expression("input_tokens", "0"),
+        expression("cache_read_tokens", "0"),
+        expression("cache_write_tokens", "0"),
+        expression("output_tokens", "0"),
+        expression("reasoning_tokens", "0"),
+        expression("actual_cost_usd", "NULL"),
+        expression("estimated_cost_usd", "NULL"),
+        expression("parent_session_id", "NULL"),
+    );
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map([], |row| {
+        let session_id: String = row.get(0)?;
+        let input = row.get::<_, i64>(5)?.max(0) as u64;
+        let cache_read = row.get::<_, i64>(6)?.max(0) as u64;
+        let cache_write = row.get::<_, i64>(7)?.max(0) as u64;
+        let output = row.get::<_, i64>(8)?.max(0) as u64;
+        let reasoning = row.get::<_, i64>(9)?.max(0) as u64;
+        let mut tokens = TokenBuckets::disjoint(input, cache_read, cache_write, output);
+        tokens.reasoning = reasoning.min(output);
+        Ok(UsageEvent {
+            source: "hermes",
+            source_path: source_path.clone(),
+            source_record_id: Some(format!("session:{session_id}")),
+            session_id: Some(session_id),
+            request_id: None,
+            message_id: None,
+            timestamp_ms: timestamp_millis(row.get::<_, f64>(1)?),
+            project: row.get(2)?,
+            provider: row.get(3)?,
+            model: row.get(4)?,
+            tokens,
+            source_cost_usd: row.get::<_, Option<f64>>(10)?.or(row.get(11)?),
+            dedupe_confidence: "exact",
+            conservative_undercount: false,
+            sidechain: row.get::<_, Option<String>>(12)?.is_some(),
+            source_order: 0,
+        })
+    })?;
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map(|events| {
+            events
+                .into_iter()
+                .filter(|event| event.tokens.additive_total() > 0)
+                .collect()
+        })
+        .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+
+    fn fixture_store() -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(include_str!("../../fixtures/trajectory_parity/hermes.sql"))
+            .unwrap();
+        drop(connection);
+        (temp, path)
+    }
+
+    #[test]
+    fn fixture_projects_active_rows_tools_usage_and_opt_in_reasoning() {
+        let (_temp, path) = fixture_store();
+        let mut records = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(parsed.offset, 107);
+        assert!(!records.iter().any(|record| record.role == "reasoning"));
+        assert!(!records.iter().any(|record| record.text.contains("rewound")));
+        assert!(
+            !records
+                .iter()
+                .any(|record| record.text.contains("ciphertext-must-never-be-indexed"))
+        );
+        assert!(records.iter().any(|record| {
+            record.role == "tool_use"
+                && record.tool_name.as_deref() == Some("terminal")
+                && record.links.event_id.as_deref() == Some("call-hermes-1")
+        }));
+        assert!(records.iter().any(|record| {
+            record.role == "tool_result"
+                && record.links.parent_tool_use_id.as_deref() == Some("call-hermes-1")
+        }));
+
+        let mut reasoning = Vec::new();
+        let reasoning_parse = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &AtomicU64::new(1),
+            |record| {
+                reasoning.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(reasoning.iter().any(|record| {
+            record.role == "reasoning" && record.text == "Check the working directory."
+        }));
+        assert_eq!(reasoning_parse.diagnostics.encrypted_reasoning_dropped, 1);
+
+        let usage = parse_usage_file(&path).unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].tokens.total(), 175);
+        assert_eq!(usage[0].source_cost_usd, Some(0.03));
+    }
+
+    #[test]
+    fn checkpoint_tracks_appends_and_rewinds_separately() {
+        let (_temp, path) = fixture_store();
+        let before = checkpoint(&path).unwrap();
+        assert_eq!(before.max_message_id, 107);
+
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO messages(id, session_id, role, content, timestamp, active)
+                 VALUES (108, 'hermes-session', 'user', 'next', 1783000011.0, 1)",
+                [],
+            )
+            .unwrap();
+        let appended = checkpoint(&path).unwrap();
+        assert_eq!(appended.max_message_id, 108);
+        assert_eq!(appended.generation, before.generation);
+
+        connection
+            .execute(
+                "UPDATE sessions SET rewind_count = rewind_count + 1
+                 WHERE id = 'hermes-session'",
+                [],
+            )
+            .unwrap();
+        let rewound = checkpoint(&path).unwrap();
+        assert_ne!(rewound.generation, appended.generation);
+    }
+
+    #[test]
+    fn incremental_parse_reads_only_new_active_messages() {
+        let (_temp, path) = fixture_store();
+        let mut records = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState {
+                offset: 104,
+                ..IndexParseState::default()
+            },
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(parsed.offset, 107);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].text, "Visible multimodal text");
+        assert_eq!(records[1].text, "Visible encrypted-reasoning answer");
+    }
+}

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    index: 1,
+    index: 2,
     usage: 1,
 };
 
@@ -609,7 +609,11 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
         "SELECT id, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
          FROM sessions
          ORDER BY started_at, id",
-        expression("ended_at", "started_at"),
+        if columns.contains("ended_at") {
+            "COALESCE(ended_at, started_at)".to_string()
+        } else {
+            "started_at".to_string()
+        },
         expression("cwd", "NULL"),
         expression("billing_provider", "NULL"),
         expression("model", "NULL"),
@@ -732,6 +736,7 @@ mod tests {
         assert_eq!(usage.len(), 1);
         assert_eq!(usage[0].tokens.total(), 175);
         assert_eq!(usage[0].source_cost_usd, Some(0.03));
+        assert_eq!(usage[0].timestamp_ms, 1_783_000_000_000);
     }
 
     #[test]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -10,6 +10,7 @@ pub mod codex;
 pub mod common;
 pub mod copilot;
 pub mod cursor;
+pub mod hermes;
 pub mod openclaw;
 pub mod opencode;
 pub mod pi;
@@ -204,6 +205,7 @@ pub fn versions(source: SourceKind) -> ParserVersions {
         SourceKind::Pi => pi::VERSIONS,
         SourceKind::OpenClaw => openclaw::VERSIONS,
         SourceKind::Copilot => copilot::VERSIONS,
+        SourceKind::Hermes => hermes::VERSIONS,
     }
 }
 
@@ -222,6 +224,7 @@ mod tests {
             SourceKind::CodexSession,
             SourceKind::Pi,
             SourceKind::OpenClaw,
+            SourceKind::Hermes,
         ] {
             assert_ne!(
                 index_state_version_for(source, false),
@@ -236,7 +239,11 @@ pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u
     let reasoning_mode = include_reasoning
         && matches!(
             source,
-            SourceKind::Claude | SourceKind::CodexSession | SourceKind::Pi | SourceKind::OpenClaw
+            SourceKind::Claude
+                | SourceKind::CodexSession
+                | SourceKind::Pi
+                | SourceKind::OpenClaw
+                | SourceKind::Hermes
         );
     (versions.identity.saturating_mul(10_000) + versions.index)
         .saturating_mul(2)
@@ -256,6 +263,8 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::Pi
     } else if openclaw::matches_path(path) {
         SourceKind::OpenClaw
+    } else if hermes::matches_path(path) {
+        SourceKind::Hermes
     } else if copilot::matches_path(path) {
         SourceKind::Copilot
     } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -56,6 +56,10 @@ pub struct FileState {
     pub turn_id: u32,
     #[serde(default)]
     pub parser_version: u32,
+    /// Source-specific invalidation generation. Append-only sources leave this at zero;
+    /// SQLite-backed sources can advance it when prior rows may have changed.
+    #[serde(default)]
+    pub source_generation: u64,
     #[serde(default)]
     pub pending_tool_calls: HashMap<String, PendingToolCall>,
     #[serde(default)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,10 @@ pub struct FileIdentity {
     /// prevents a short file's fingerprint from changing merely because its prefix grew.
     #[serde(default)]
     pub prefix_bytes: u64,
+    /// File creation time when the platform exposes it. This provides a stable replacement
+    /// signal on platforms where device and inode metadata are unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_ns: Option<i64>,
     /// Nanosecond-resolution modification marker for detecting same-size rewrites.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modified_ns: Option<i64>,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1534,6 +1534,10 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
         SourceKind::Opencode => cwd_from_opencode_session(Path::new(&first.source_path)),
         SourceKind::Pi => cwd_from_pi_session(Path::new(&first.source_path)),
         SourceKind::OpenClaw => cwd_from_pi_session(Path::new(&first.source_path)),
+        SourceKind::Hermes => {
+            crate::sources::hermes::session_cwd(Path::new(&first.source_path), &first.session_id)
+                .map(PathBuf::from)
+        }
         SourceKind::CodexHistory => None,
     }
     .filter(|path| path.is_dir())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -393,6 +393,7 @@ enum SourceChoice {
     Cursor,
     Pi,
     OpenClaw,
+    Hermes,
     Copilot,
 }
 
@@ -405,7 +406,8 @@ impl SourceChoice {
             SourceChoice::Opencode => SourceChoice::Cursor,
             SourceChoice::Cursor => SourceChoice::Pi,
             SourceChoice::Pi => SourceChoice::OpenClaw,
-            SourceChoice::OpenClaw => SourceChoice::Copilot,
+            SourceChoice::OpenClaw => SourceChoice::Hermes,
+            SourceChoice::Hermes => SourceChoice::Copilot,
             SourceChoice::Copilot => SourceChoice::All,
         }
     }
@@ -419,6 +421,7 @@ impl SourceChoice {
             SourceChoice::Cursor => Some(SourceFilter::Cursor),
             SourceChoice::Pi => Some(SourceFilter::Pi),
             SourceChoice::OpenClaw => Some(SourceFilter::OpenClaw),
+            SourceChoice::Hermes => Some(SourceFilter::Hermes),
             SourceChoice::Copilot => Some(SourceFilter::Copilot),
         }
     }
@@ -432,6 +435,7 @@ impl SourceChoice {
             SourceChoice::Cursor => "cursor",
             SourceChoice::Pi => "pi",
             SourceChoice::OpenClaw => "openclaw",
+            SourceChoice::Hermes => "hermes",
             SourceChoice::Copilot => "copilot",
         }
     }
@@ -926,6 +930,7 @@ impl App {
                     include_cursor: true,
                     include_pi: true,
                     include_openclaw: true,
+                    include_hermes: true,
                     include_copilot: true,
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
@@ -1260,6 +1265,8 @@ impl App {
                     SourceChoice::Opencode,
                     SourceChoice::Cursor,
                     SourceChoice::Pi,
+                    SourceChoice::OpenClaw,
+                    SourceChoice::Hermes,
                     SourceChoice::Copilot,
                 ]
                 .into_iter()
@@ -2073,6 +2080,7 @@ impl App {
                 .clone()
                 .or_else(|| default_resume_template("pi")),
             SourceKind::OpenClaw => None,
+            SourceKind::Hermes => None,
             SourceKind::Copilot => self
                 .config
                 .copilot_resume_cmd
@@ -2113,6 +2121,10 @@ impl App {
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "pi",
+            SourceKind::Hermes => {
+                self.set_status("sharing Hermes SQLite sessions is not supported yet");
+                return Ok(());
+            }
             SourceKind::Copilot => "copilot",
         };
         let source_path = session.source_path.clone();
@@ -3485,6 +3497,7 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
         SourceChoice::Cursor => label == "cursor",
         SourceChoice::Pi => label == "pi",
         SourceChoice::OpenClaw => label == "openclaw",
+        SourceChoice::Hermes => label == "hermes",
         SourceChoice::Copilot => label == "copilot",
         SourceChoice::All => false,
     }
@@ -3498,6 +3511,7 @@ fn source_color(source: SourceKind) -> Color {
         SourceKind::Cursor => Color::Rgb(170, 150, 200),
         SourceKind::Pi => Color::Rgb(120, 190, 190),
         SourceKind::OpenClaw => Color::Rgb(235, 160, 110),
+        SourceKind::Hermes => Color::Rgb(205, 150, 225),
         SourceKind::Copilot => Color::Rgb(140, 160, 220),
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,10 +12,11 @@ pub enum SourceKind {
     Pi,
     OpenClaw,
     Copilot,
+    Hermes,
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 8] = [
+    pub const ALL: [SourceKind; 9] = [
         SourceKind::Claude,
         SourceKind::CodexSession,
         SourceKind::CodexHistory,
@@ -24,6 +25,7 @@ impl SourceKind {
         SourceKind::Pi,
         SourceKind::OpenClaw,
         SourceKind::Copilot,
+        SourceKind::Hermes,
     ];
     pub const COUNT: usize = Self::ALL.len();
 
@@ -37,6 +39,7 @@ impl SourceKind {
             SourceKind::Pi => 5,
             SourceKind::OpenClaw => 6,
             SourceKind::Copilot => 7,
+            SourceKind::Hermes => 8,
         }
     }
 
@@ -50,6 +53,7 @@ impl SourceKind {
             5 => Some(SourceKind::Pi),
             6 => Some(SourceKind::OpenClaw),
             7 => Some(SourceKind::Copilot),
+            8 => Some(SourceKind::Hermes),
             _ => None,
         }
     }
@@ -63,6 +67,7 @@ impl SourceKind {
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
+            SourceKind::Hermes => "hermes",
         }
     }
 
@@ -76,6 +81,7 @@ impl SourceKind {
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
+            SourceKind::Hermes => "hermes",
         }
     }
 
@@ -93,6 +99,7 @@ impl SourceKind {
             "pi" => Some(SourceKind::Pi),
             "openclaw" => Some(SourceKind::OpenClaw),
             "copilot" => Some(SourceKind::Copilot),
+            "hermes" => Some(SourceKind::Hermes),
             _ => None,
         }
     }
@@ -109,6 +116,7 @@ pub enum SourceFilter {
     #[value(name = "openclaw", alias = "open-claw")]
     OpenClaw,
     Copilot,
+    Hermes,
 }
 
 impl SourceFilter {
@@ -123,6 +131,7 @@ impl SourceFilter {
             SourceFilter::Pi => source == SourceKind::Pi,
             SourceFilter::OpenClaw => source == SourceKind::OpenClaw,
             SourceFilter::Copilot => source == SourceKind::Copilot,
+            SourceFilter::Hermes => source == SourceKind::Hermes,
         }
     }
 
@@ -135,6 +144,7 @@ impl SourceFilter {
             SourceFilter::Pi => &["pi"],
             SourceFilter::OpenClaw => &["openclaw"],
             SourceFilter::Copilot => &["copilot"],
+            SourceFilter::Hermes => &["hermes"],
         }
     }
 
@@ -147,6 +157,7 @@ impl SourceFilter {
             SourceFilter::Pi => "pi",
             SourceFilter::OpenClaw => "openclaw",
             SourceFilter::Copilot => "copilot",
+            SourceFilter::Hermes => "hermes",
         }
     }
 }
@@ -257,6 +268,15 @@ mod tests {
 
         assert_eq!(SourceKind::from_path(unix_path), SourceKind::Pi);
         assert_eq!(SourceKind::from_path(windows_path), SourceKind::Pi);
+    }
+
+    #[test]
+    fn from_path_recognizes_hermes_store() {
+        let unix_path = "/Users/nico/.hermes/state.db";
+        let windows_path = "C:\\Users\\nico\\.hermes\\state.db";
+
+        assert_eq!(SourceKind::from_path(unix_path), SourceKind::Hermes);
+        assert_eq!(SourceKind::from_path(windows_path), SourceKind::Hermes);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -503,12 +503,13 @@ fn assemble_usage_events(
     };
     type SourceScanner =
         fn(&mut Vec<UsageEvent>, &mut Vec<String>, Option<&mut UsageCache>) -> Result<()>;
-    const SCANNERS: [(SourceFilter, SourceScanner); 7] = [
+    const SCANNERS: [(SourceFilter, SourceScanner); 8] = [
         (SourceFilter::Claude, scan_claude),
         (SourceFilter::Codex, scan_codex),
         (SourceFilter::Opencode, scan_opencode),
         (SourceFilter::Pi, scan_pi),
         (SourceFilter::OpenClaw, scan_openclaw),
+        (SourceFilter::Hermes, scan_hermes),
         (SourceFilter::Cursor, scan_cursor),
         (SourceFilter::Copilot, scan_copilot),
     ];
@@ -1210,6 +1211,19 @@ fn scan_openclaw(
         out,
         |path| crate::sources::openclaw::parse_usage_file(path).map(FileParse::cacheable),
     );
+    Ok(())
+}
+
+fn scan_hermes(
+    out: &mut Vec<UsageEvent>,
+    _warnings: &mut Vec<String>,
+    _cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    // Hermes uses WAL mode. A fresh read is cheap (one aggregate row per session) and
+    // avoids reusing a cache entry keyed only to state.db while new frames live in -wal.
+    for source_file in crate::sources::hermes::discover() {
+        out.extend(crate::sources::hermes::parse_usage_file(&source_file.path)?);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Adds Hermes `state.db` as a first-class source across indexing, search filters, the TUI, source audits, and token usage.

The indexer opens the SQLite store read-only and resumes from the last active AUTOINCREMENT message ID, preserving pending tool-call attribution across scans. Ordinary appends only project new rows; a full Hermes projection reset is limited to rewinds, schema-generation changes, database replacement, parser changes, or reasoning-mode changes.

Plaintext reasoning remains opt-in and BM25-only. Structured encrypted and redacted reasoning payloads are always dropped. Discovery supports `HERMES_HOME` and the default `~/.hermes/state.db`.