### PR TITLE
Coalesce concurrent search indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ memex tui
 Notes:
 - Embeddings are enabled by default.
 - Searches run an incremental reindex by default (configurable).
+- Concurrent searches coalesce stale auto-index work: one process refreshes while other lexical
+  searches query the last committed index. Semantic and hybrid searches wait for vector writes to
+  finish. Explicit `index`, `reindex`, `embed`, and analytics backfill commands wait up to 30
+  seconds for another index mutation to finish and report its holder on timeout.
 
 Full transcript:
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_all, ingest_if_stale};
+use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt, LeaseHolder};
 use crate::transfer::{
     TransferMode as CoreTransferMode, TransferOptions, TransferTarget as CoreTransferTarget,
     transfer_session,
@@ -690,6 +691,8 @@ fn run_index(
         no_embeddings,
         "embeddings",
     )?;
+    let operation = if reindex { "reindex" } else { "index" };
+    let lease = IngestLease::acquire(&paths, operation, INGEST_LEASE_TIMEOUT)?;
     if reindex && paths.root.exists() {
         std::fs::remove_dir_all(&paths.root)?;
     }
@@ -713,7 +716,7 @@ fn run_index(
         tool_content_limits,
     };
 
-    let report = ingest_all(&paths, &index, &opts)?;
+    let report = ingest_all(&paths, &index, &opts, &lease)?;
     if report.records_embedded > 0 {
         println!(
             "indexed {} records, embedded {} across {} files (skipped {})",
@@ -742,6 +745,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
 
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+    let _lease = IngestLease::acquire(&paths, "embed", INGEST_LEASE_TIMEOUT)?;
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
@@ -873,11 +877,9 @@ fn run_search(
     let auto_index_on_search = config.auto_index_on_search_default();
     let embeddings_default = config.embeddings_default();
     let scan_cache_ttl = config.scan_cache_ttl();
-    if auto_index_on_search {
+    let auto_index_options = auto_index_on_search.then(|| {
         let tool_content_limits = config.indexed_tool_content_limits()?;
-        paths.ensure_dirs()?;
-        let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
-        let opts = IngestOptions {
+        Ok::<_, anyhow::Error>(IngestOptions {
             claude_source: default_claude_source(),
             include_agents: false,
             include_reasoning: config.include_reasoning_default(),
@@ -892,11 +894,35 @@ fn run_search(
             model: model_choice,
             embed_runtime: embed_runtime.clone(),
             tool_content_limits,
-        };
-        // Skip indexing if we recently scanned (within TTL)
-        let _ = ingest_if_stale(&paths, &index, &opts, scan_cache_ttl)?;
+        })
+    });
+    let auto_index_options = auto_index_options.transpose()?;
+    let mut refresh_contended = false;
+    let mut refresh_holder = None;
+    if let Some(options) = auto_index_options.as_ref() {
+        paths.ensure_dirs()?;
+        match IngestLease::try_acquire(&paths, "search auto-index")? {
+            LeaseAttempt::Acquired(lease) => {
+                let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
+                let _ = ingest_if_stale(&paths, &index, options, scan_cache_ttl, &lease)?;
+            }
+            LeaseAttempt::Busy(holder) => {
+                refresh_contended = true;
+                refresh_holder = holder;
+            }
+        }
     }
-    let index = SearchIndex::open_or_create(&paths.index)?;
+    let index = if refresh_contended {
+        open_index_during_contended_refresh(
+            &paths,
+            auto_index_options.as_ref().expect("auto-index options"),
+            scan_cache_ttl,
+            refresh_holder.as_ref(),
+            semantic || hybrid,
+        )?
+    } else {
+        SearchIndex::open_or_create(&paths.index)?
+    };
 
     let options = QueryOptions {
         query,
@@ -970,6 +996,32 @@ fn run_search(
         recency_weight,
         recency_half_life_days,
     )
+}
+
+fn open_index_during_contended_refresh(
+    paths: &Paths,
+    options: &IngestOptions,
+    scan_cache_ttl: u64,
+    holder: Option<&LeaseHolder>,
+    require_stable_vectors: bool,
+) -> Result<SearchIndex> {
+    let can_read_committed_index =
+        !require_stable_vectors && holder.is_some_and(|holder| holder.operation != "reindex");
+    if can_read_committed_index
+        && paths.index.join("meta.json").exists()
+        && let Ok(index) = SearchIndex::open_or_create(&paths.index)
+    {
+        return Ok(index);
+    }
+
+    let lease = IngestLease::acquire(
+        paths,
+        "search waiting for index initialization",
+        INGEST_LEASE_TIMEOUT,
+    )?;
+    let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
+    let _ = ingest_if_stale(paths, &index, options, scan_cache_ttl, &lease)?;
+    Ok(index)
 }
 
 struct SearchContext<'a> {
@@ -1698,6 +1750,7 @@ fn format_usd(value: f64) -> String {
 
 fn run_analytics_backfill(root: Option<PathBuf>) -> Result<()> {
     let paths = Paths::new(root)?;
+    let _lease = IngestLease::acquire(&paths, "analytics backfill", INGEST_LEASE_TIMEOUT)?;
     paths.ensure_dirs()?;
     let index = SearchIndex::open_or_create(&paths.index)?;
     let db = analytics_path(&paths.state);

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2338,6 +2338,21 @@ mod tests {
     }
 
     #[test]
+    fn updating_scan_cache_replaces_malformed_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");
+        paths.ensure_dirs().expect("dirs");
+        let cache_path = paths.state.join("scan_cache.json");
+        fs::write(&cache_path, "{\"last_scan_ts\":").expect("seed malformed cache");
+
+        update_scan_cache(&paths, 7, 42).expect("update scan cache");
+
+        let cache = ScanCache::load(&cache_path).expect("load replaced cache");
+        assert_eq!(cache.file_count, 7);
+        assert_eq!(cache.total_bytes, 42);
+    }
+
+    #[test]
     fn can_skip_noop_index_with_compatible_vectors() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().to_path_buf())).expect("paths");

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2,12 +2,13 @@ use crate::analytics::{AnalyticsStore, AnalyticsWriter, analytics_path, backfill
 use crate::config::{IndexedToolContentLimits, Paths};
 use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::SearchIndex;
+use crate::lease::IngestLease;
 use crate::progress::{Progress, SOURCE_COUNT};
 use crate::state::{FileIdentity, FileState, IngestState, PendingToolCall, ScanCache};
 #[cfg(test)]
 use crate::types::RecordLinks;
 use crate::types::{Record, SourceKind};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
@@ -315,6 +316,7 @@ pub fn ingest_if_stale(
     index: &SearchIndex,
     options: &IngestOptions,
     ttl_seconds: u64,
+    lease: &IngestLease,
 ) -> Result<Option<IngestReport>> {
     let cache_path = paths.state.join("scan_cache.json");
     let cache = ScanCache::load(&cache_path)?;
@@ -323,7 +325,7 @@ pub fn ingest_if_stale(
         return Ok(None);
     }
 
-    let report = ingest_all(paths, index, options)?;
+    let report = ingest_all(paths, index, options, lease)?;
     Ok(Some(report))
 }
 
@@ -331,6 +333,7 @@ pub fn ingest_all(
     paths: &Paths,
     index: &SearchIndex,
     options: &IngestOptions,
+    _lease: &IngestLease,
 ) -> Result<IngestReport> {
     // Apply additive analytics migrations even when the scan finds no changed files.
     drop(AnalyticsStore::open(analytics_path(&paths.state))?);
@@ -551,7 +554,7 @@ pub fn ingest_all(
         if analytics_needs_backfill {
             backfill_from_index(&analytics_db, index)?;
         }
-        update_scan_cache(paths, files_scanned, total_bytes);
+        update_scan_cache(paths, files_scanned, total_bytes)?;
         return Ok(IngestReport {
             records_added: 0,
             records_embedded: 0,
@@ -579,6 +582,9 @@ pub fn ingest_all(
         .filter(|t| t.delete_first)
         .map(|t| t.path.to_string_lossy().to_string())
         .collect();
+    let writer = index
+        .writer()
+        .context("failed to initialize the Tantivy index writer")?;
     let writer_index = index.clone();
     let writer_ctx = WriterContext {
         embeddings,
@@ -591,11 +597,12 @@ pub fn ingest_all(
         embed_runtime: options.embed_runtime.clone(),
         tool_content_limits: options.tool_content_limits,
     };
-    let writer_handle =
-        std::thread::spawn(move || writer_loop(writer_index, rx_record, delete_paths, writer_ctx));
+    let writer_handle = std::thread::spawn(move || {
+        writer_loop(writer_index, writer, rx_record, delete_paths, writer_ctx)
+    });
 
     let tasks_arc = Arc::new(tasks);
-    tasks_arc.par_iter().try_for_each(|task| -> Result<()> {
+    let parser_result = tasks_arc.par_iter().try_for_each(|task| -> Result<()> {
         match task.source {
             SourceKind::Claude => parse_claude_file(
                 task,
@@ -653,7 +660,7 @@ pub fn ingest_all(
             }
         }
         Ok(())
-    })?;
+    });
 
     drop(tx_record);
     drop(tx_update);
@@ -662,7 +669,9 @@ pub fn ingest_all(
         .join()
         .map_err(|_| anyhow!("writer thread panicked"))?;
     progress.finish();
-    let (records_added, records_embedded) = writer_result?;
+    let (records_added, records_embedded) =
+        writer_result.context("index writer stopped before ingestion completed")?;
+    parser_result?;
     if analytics_needs_backfill {
         backfill_from_index(&analytics_db, index)?;
     } else {
@@ -683,7 +692,7 @@ pub fn ingest_all(
     state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
     state.save(&state_path)?;
 
-    update_scan_cache(paths, files_scanned, total_bytes);
+    update_scan_cache(paths, files_scanned, total_bytes)?;
 
     Ok(IngestReport {
         records_added,
@@ -694,11 +703,11 @@ pub fn ingest_all(
     })
 }
 
-fn update_scan_cache(paths: &Paths, files_scanned: usize, total_bytes: u64) {
+fn update_scan_cache(paths: &Paths, files_scanned: usize, total_bytes: u64) -> Result<()> {
     let cache_path = paths.state.join("scan_cache.json");
-    let mut cache = ScanCache::load(&cache_path).unwrap_or_default();
+    let mut cache = ScanCache::load(&cache_path)?;
     cache.update(files_scanned, total_bytes);
-    let _ = cache.save(&cache_path);
+    cache.save(&cache_path)
 }
 
 fn can_skip_fresh_scan(
@@ -764,6 +773,7 @@ fn record_needs_embedding(record: &Record) -> bool {
 
 fn writer_loop(
     index: SearchIndex,
+    mut writer: tantivy::IndexWriter,
     rx: Receiver<Record>,
     delete_paths: Vec<String>,
     ctx: WriterContext,
@@ -779,7 +789,6 @@ fn writer_loop(
         embed_runtime,
         tool_content_limits,
     } = ctx;
-    let mut writer = index.writer()?;
     let mut analytics = AnalyticsWriter::open(&analytics_path)?;
     for path in delete_paths {
         index.delete_by_source_path(&mut writer, &path);
@@ -1365,7 +1374,7 @@ mod tests {
     use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn ingest_options(embeddings: bool, model: ModelChoice) -> IngestOptions {
         IngestOptions {
@@ -1396,6 +1405,11 @@ mod tests {
     fn open_search_index(paths: &Paths) -> SearchIndex {
         fs::create_dir_all(&paths.index).expect("create index dir");
         SearchIndex::open_or_create(&paths.index).expect("open search index")
+    }
+
+    fn ingest_lease(paths: &Paths) -> IngestLease {
+        IngestLease::acquire(paths, "test ingest", Duration::from_secs(1))
+            .expect("acquire ingest lease")
     }
 
     fn save_search_records(paths: &Paths, records: &[Record]) -> SearchIndex {
@@ -1496,6 +1510,32 @@ mod tests {
             result,
             Err(crossbeam_channel::TrySendError::Full(_))
         ));
+    }
+
+    #[test]
+    fn writer_initialization_error_is_not_masked_by_disconnected_channel() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(temp.path().join("memex"))).expect("paths");
+        paths.ensure_dirs().expect("ensure dirs");
+        let claude_root = temp.path().join("claude");
+        let project = claude_root.join("-tmp-project");
+        fs::create_dir_all(&project).expect("create project");
+        fs::write(
+            project.join("session.jsonl"),
+            r#"{"type":"user","uuid":"u1","sessionId":"session","timestamp":"2026-07-26T17:00:00Z","message":{"content":"hello"}}"#,
+        )
+        .expect("write transcript");
+        let index = SearchIndex::open_or_create(&paths.index).expect("index");
+        let _existing_writer = index.writer().expect("existing writer");
+        let lease = ingest_lease(&paths);
+        let mut options = ingest_options(false, ModelChoice::default());
+        options.claude_source = claude_root;
+
+        let error = ingest_all(&paths, &index, &options, &lease).expect_err("writer collision");
+        let message = format!("{error:#}");
+
+        assert!(message.contains("failed to initialize the Tantivy index writer"));
+        assert!(!message.contains("disconnected channel"));
     }
 
     #[test]
@@ -2144,7 +2184,8 @@ mod tests {
             tool_content_limits: IndexedToolContentLimits::default(),
         };
 
-        let report = ingest_all(&paths, &index, &options).expect("ingest");
+        let lease = ingest_lease(&paths);
+        let report = ingest_all(&paths, &index, &options, &lease).expect("ingest");
         assert_eq!(report.records_added, 4);
 
         let mut records = index
@@ -2520,7 +2561,8 @@ mod tests {
             tool_content_limits: IndexedToolContentLimits::default(),
         };
 
-        let report = ingest_all(&paths, &index, &options).expect("ingest");
+        let lease = ingest_lease(&paths);
+        let report = ingest_all(&paths, &index, &options, &lease).expect("ingest");
         assert_eq!(report.records_added, 10);
 
         let mut records = index
@@ -2810,8 +2852,9 @@ mod tests {
             tool_content_limits: IndexedToolContentLimits::default(),
         };
 
+        let writer = index.writer().expect("open writer");
         let (records_added, records_embedded) =
-            writer_loop(index, rx_record, Vec::new(), ctx).expect("write copilot record");
+            writer_loop(index, writer, rx_record, Vec::new(), ctx).expect("write copilot record");
 
         assert_eq!(records_added, 1);
         assert_eq!(records_embedded, 0);

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -1,0 +1,183 @@
+use crate::config::Paths;
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+pub const INGEST_LEASE_TIMEOUT: Duration = Duration::from_secs(30);
+const INGEST_LEASE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug)]
+pub enum LeaseAttempt {
+    Acquired(IngestLease),
+    Busy(Option<LeaseHolder>),
+}
+
+#[derive(Debug)]
+pub struct IngestLease {
+    file: File,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LeaseHolder {
+    pub pid: u32,
+    pub operation: String,
+    pub started_at: u64,
+}
+
+impl IngestLease {
+    pub fn try_acquire(paths: &Paths, operation: impl Into<String>) -> Result<LeaseAttempt> {
+        let path = lease_path(paths);
+        let mut file = open_lease_file(&path)?;
+        match file.try_lock() {
+            Ok(()) => {
+                write_holder(&mut file, operation.into())?;
+                Ok(LeaseAttempt::Acquired(Self { file }))
+            }
+            Err(TryLockError::WouldBlock) => Ok(LeaseAttempt::Busy(read_holder(&path))),
+            Err(TryLockError::Error(error)) => Err(error)
+                .with_context(|| format!("failed to acquire index lease {}", path.display())),
+        }
+    }
+
+    pub fn acquire(paths: &Paths, operation: impl Into<String>, timeout: Duration) -> Result<Self> {
+        let path = lease_path(paths);
+        let operation = operation.into();
+        let started = Instant::now();
+        loop {
+            match Self::try_acquire(paths, operation.clone())? {
+                LeaseAttempt::Acquired(lease) => return Ok(lease),
+                LeaseAttempt::Busy(_) if started.elapsed() < timeout => {
+                    thread::sleep(INGEST_LEASE_POLL_INTERVAL);
+                }
+                LeaseAttempt::Busy(holder) => {
+                    return Err(lease_timeout_error(&path, timeout, holder));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for IngestLease {
+    fn drop(&mut self) {
+        let _ = self.file.set_len(0);
+        let _ = self.file.unlock();
+    }
+}
+
+fn lease_path(paths: &Paths) -> PathBuf {
+    let parent = paths.root.parent().unwrap_or_else(|| Path::new("."));
+    let root_name = paths
+        .root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("memex");
+    parent.join(format!(".{root_name}.ingest.lock"))
+}
+
+fn open_lease_file(path: &Path) -> Result<File> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("index lease path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)?;
+    OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("failed to open index lease {}", path.display()))
+}
+
+fn write_holder(file: &mut File, operation: String) -> Result<()> {
+    let holder = LeaseHolder {
+        pid: std::process::id(),
+        operation,
+        started_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0),
+    };
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    serde_json::to_writer(&mut *file, &holder)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    Ok(())
+}
+
+fn read_holder(path: &Path) -> Option<LeaseHolder> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(contents.trim()).ok()
+}
+
+fn lease_timeout_error(
+    path: &Path,
+    timeout: Duration,
+    holder: Option<LeaseHolder>,
+) -> anyhow::Error {
+    match holder {
+        Some(holder) => anyhow!(
+            "timed out after {:.1}s waiting for index lease held by pid {} for '{}' since unix timestamp {} ({})",
+            timeout.as_secs_f32(),
+            holder.pid,
+            holder.operation,
+            holder.started_at,
+            path.display()
+        ),
+        None => anyhow!(
+            "timed out after {:.1}s waiting for index lease {}",
+            timeout.as_secs_f32(),
+            path.display()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contended_lease_reports_holder() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(temp.path().join("memex"))).expect("paths");
+        let first = match IngestLease::try_acquire(&paths, "first").expect("first lease") {
+            LeaseAttempt::Acquired(lease) => lease,
+            LeaseAttempt::Busy(_) => panic!("first lease should be available"),
+        };
+
+        let holder = match IngestLease::try_acquire(&paths, "second").expect("second lease") {
+            LeaseAttempt::Acquired(_) => panic!("second lease should be contended"),
+            LeaseAttempt::Busy(holder) => holder.expect("holder metadata"),
+        };
+
+        assert_eq!(holder.pid, std::process::id());
+        assert_eq!(holder.operation, "first");
+        drop(first);
+        assert!(matches!(
+            IngestLease::try_acquire(&paths, "third").expect("third lease"),
+            LeaseAttempt::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn timed_out_lease_names_the_holder() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(temp.path().join("memex"))).expect("paths");
+        let _first = match IngestLease::try_acquire(&paths, "long reindex").expect("first lease") {
+            LeaseAttempt::Acquired(lease) => lease,
+            LeaseAttempt::Busy(_) => panic!("first lease should be available"),
+        };
+
+        let error = IngestLease::acquire(&paths, "second index", Duration::from_millis(1))
+            .expect_err("lease should time out");
+        let message = error.to_string();
+
+        assert!(message.contains(&format!("pid {}", std::process::id())));
+        assert!(message.contains("long reindex"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod embed;
 pub mod index;
 pub mod ingest;
+pub mod lease;
 pub mod progress;
 pub mod sources;
 pub mod state;

--- a/src/state.rs
+++ b/src/state.rs
@@ -81,7 +81,7 @@ impl ScanCache {
             return Ok(Self::default());
         }
         let data = fs::read_to_string(path)?;
-        let cache = serde_json::from_str(&data)?;
+        let cache = serde_json::from_str(&data).unwrap_or_default();
         Ok(cache)
     }
 
@@ -194,5 +194,18 @@ mod tests {
         cache.save(&path).expect("save cache");
 
         assert_eq!(ScanCache::load(&path).expect("load cache").file_count, 3);
+    }
+
+    #[test]
+    fn malformed_scan_cache_loads_as_default() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("scan_cache.json");
+        fs::write(&path, "{\"last_scan_ts\":").expect("seed malformed cache");
+
+        let cache = ScanCache::load(&path).expect("load malformed cache");
+
+        assert_eq!(cache.last_scan_ts, 0);
+        assert_eq!(cache.file_count, 0);
+        assert_eq!(cache.total_bytes, 0);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -85,12 +86,8 @@ impl ScanCache {
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
         let data = serde_json::to_string(self)?;
-        fs::write(path, data)?;
-        Ok(())
+        atomic_write(path, data.as_bytes())
     }
 
     /// Check if the cache is still valid (within TTL seconds)
@@ -139,11 +136,63 @@ impl IngestState {
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
         let data = serde_json::to_string_pretty(self)?;
-        fs::write(path, data)?;
-        Ok(())
+        atomic_write(path, data.as_bytes())
+    }
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("state path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(data)?;
+    temporary.as_file().sync_all()?;
+    temporary.persist(path).map_err(|error| error.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_saves_replace_existing_files_atomically() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("ingest.json");
+        fs::write(&path, "old state").expect("seed state");
+
+        let state = IngestState {
+            next_doc_id: 42,
+            files: HashMap::new(),
+        };
+        state.save(&path).expect("save state");
+
+        assert_eq!(
+            IngestState::load(&path).expect("load state").next_doc_id,
+            42
+        );
+        assert!(
+            fs::read_dir(temp.path())
+                .expect("read tempdir")
+                .all(|entry| entry.expect("directory entry").path() == path)
+        );
+    }
+
+    #[test]
+    fn scan_cache_saves_replace_existing_files_atomically() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("scan_cache.json");
+        fs::write(&path, "old cache").expect("seed cache");
+
+        let cache = ScanCache {
+            last_scan_ts: 12,
+            file_count: 3,
+            total_bytes: 99,
+        };
+        cache.save(&path).expect("save cache");
+
+        assert_eq!(ScanCache::load(&path).expect("load cache").file_count, 3);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,6 +2,7 @@ use crate::analytics::{AnalyticsStore, ProjectGrouping, SessionRow, analytics_pa
 use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_if_stale};
+use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt};
 use crate::types::{Record, SourceFilter, SourceKind};
 use crate::usage::{CostMode, UsageQuery, scan_usage_activity};
 use anyhow::Result;
@@ -712,11 +713,19 @@ pub fn run(
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let index = if config.auto_index_on_search_default() {
+    if config.auto_index_on_search_default() {
         paths.ensure_dirs()?;
-        SearchIndex::open_or_create_for_ingest(&paths.index)?
-    } else {
+    }
+    let index = if paths.index.join("meta.json").exists() {
         SearchIndex::open_or_create(&paths.index)?
+    } else {
+        let _lease =
+            IngestLease::acquire(&paths, "TUI index initialization", INGEST_LEASE_TIMEOUT)?;
+        if config.auto_index_on_search_default() {
+            SearchIndex::open_or_create_for_ingest(&paths.index)?
+        } else {
+            SearchIndex::open_or_create(&paths.index)?
+        }
     };
     let (index_tx, index_rx) = std::sync::mpsc::channel();
     let (search_tx, search_rx) = std::sync::mpsc::channel();
@@ -913,6 +922,10 @@ impl App {
         std::thread::spawn(move || {
             let _ = tx.send(IndexUpdate::Started);
             let result = (|| -> Result<Option<crate::ingest::IngestReport>> {
+                let lease = match IngestLease::try_acquire(&paths, "TUI auto-index")? {
+                    LeaseAttempt::Acquired(lease) => lease,
+                    LeaseAttempt::Busy(_) => return Ok(None),
+                };
                 let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
                 let embeddings_default = config.embeddings_default();
                 let model_choice = config.resolve_model(None)?;
@@ -933,7 +946,7 @@ impl App {
                     embed_runtime: config.resolve_embed_runtime()?,
                     tool_content_limits,
                 };
-                ingest_if_stale(&paths, &index, &opts, config.scan_cache_ttl())
+                ingest_if_stale(&paths, &index, &opts, config.scan_cache_ttl(), &lease)
             })();
             match result {
                 Ok(Some(report)) => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -707,26 +707,39 @@ impl StdIoRedirect {
     }
 }
 
+fn open_tui_index(paths: &Paths, auto_index: bool) -> Result<SearchIndex> {
+    let index = if paths.index.join("meta.json").exists() {
+        match SearchIndex::open_or_create(&paths.index) {
+            Ok(index) => return Ok(index),
+            Err(error) if !auto_index => return Err(error),
+            Err(_) => {
+                let _lease =
+                    IngestLease::acquire(paths, "TUI index initialization", INGEST_LEASE_TIMEOUT)?;
+                SearchIndex::open_or_create_for_ingest(&paths.index)?
+            }
+        }
+    } else {
+        let _lease = IngestLease::acquire(paths, "TUI index initialization", INGEST_LEASE_TIMEOUT)?;
+        if auto_index {
+            SearchIndex::open_or_create_for_ingest(&paths.index)?
+        } else {
+            SearchIndex::open_or_create(&paths.index)?
+        }
+    };
+    Ok(index)
+}
+
 pub fn run(
     root: Option<PathBuf>,
     update_rx: Option<std::sync::mpsc::Receiver<String>>,
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    if config.auto_index_on_search_default() {
+    let auto_index = config.auto_index_on_search_default();
+    if auto_index {
         paths.ensure_dirs()?;
     }
-    let index = if paths.index.join("meta.json").exists() {
-        SearchIndex::open_or_create(&paths.index)?
-    } else {
-        let _lease =
-            IngestLease::acquire(&paths, "TUI index initialization", INGEST_LEASE_TIMEOUT)?;
-        if config.auto_index_on_search_default() {
-            SearchIndex::open_or_create_for_ingest(&paths.index)?
-        } else {
-            SearchIndex::open_or_create(&paths.index)?
-        }
-    };
+    let index = open_tui_index(&paths, auto_index)?;
     let (index_tx, index_rx) = std::sync::mpsc::channel();
     let (search_tx, search_rx) = std::sync::mpsc::channel();
     let (search_request_tx, search_request_rx) = std::sync::mpsc::channel();
@@ -6057,6 +6070,16 @@ mod tests {
     use super::*;
     use crate::types::{RecordLinks, SourceKind};
 
+    fn create_stale_schema_index(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).expect("create index dir");
+        let mut builder = tantivy::schema::SchemaBuilder::default();
+        builder.add_u64_field("doc_id", tantivy::schema::INDEXED | tantivy::schema::STORED);
+        let index =
+            tantivy::Index::create_in_dir(dir, builder.build()).expect("create stale schema index");
+        drop(index);
+        std::fs::write(dir.join("sentinel"), "stale").expect("write sentinel");
+    }
+
     fn test_app() -> (tempfile::TempDir, App) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
@@ -6086,6 +6109,18 @@ mod tests {
             },
         );
         (tmp, app)
+    }
+
+    #[test]
+    fn auto_index_tui_startup_rebuilds_stale_schema() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        create_stale_schema_index(&paths.index);
+
+        let index = open_tui_index(&paths, true).expect("rebuild stale index");
+
+        assert_eq!(index.doc_count().expect("doc count"), 0);
+        assert!(!paths.index.join("sentinel").exists());
     }
 
     fn record(role: &str, text: &str) -> Record {

--- a/tests/concurrent_search.rs
+++ b/tests/concurrent_search.rs
@@ -1,0 +1,156 @@
+use serde_json::{Value, json};
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::sync::{Arc, Barrier};
+
+const CONCURRENT_SEARCHES: usize = 8;
+const APPENDED_RECORDS: usize = 1_500;
+
+#[test]
+fn concurrent_searches_coalesce_stale_auto_indexing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let root = temp.path().join("memex");
+    let claude_root = home.join(".claude").join("projects");
+    let project = claude_root.join("-tmp-concurrent-search");
+    let transcript = project.join("session.jsonl");
+    fs::create_dir_all(&project).expect("create Claude project");
+    fs::create_dir_all(&root).expect("create memex root");
+    fs::write(
+        root.join("config.toml"),
+        "auto_index_on_search = true\nembeddings = false\nscan_cache_ttl = 3600\n",
+    )
+    .expect("write config");
+
+    let mut transcript_file = File::create(&transcript).expect("create transcript");
+    write_claude_record(&mut transcript_file, 0, "seed");
+    transcript_file.flush().expect("flush seed transcript");
+
+    let initial = isolated_memex(&home)
+        .args([
+            "index",
+            "--source",
+            claude_root.to_str().expect("Claude root"),
+            "--no-codex",
+            "--no-opencode",
+            "--no-cursor",
+            "--no-pi",
+            "--no-copilot",
+            "--no-embeddings",
+        ])
+        .arg("--root")
+        .arg(&root)
+        .output()
+        .expect("run initial index");
+    assert_success(&initial, "initial index");
+
+    let mut transcript_file = OpenOptions::new()
+        .append(true)
+        .open(&transcript)
+        .expect("open transcript for append");
+    for record_id in 1..=APPENDED_RECORDS {
+        write_claude_record(
+            &mut transcript_file,
+            record_id,
+            &format!("concurrent-marker record {record_id}"),
+        );
+    }
+    transcript_file.flush().expect("flush appended transcript");
+    fs::remove_file(root.join("state").join("scan_cache.json")).expect("expire scan cache");
+
+    let barrier = Arc::new(Barrier::new(CONCURRENT_SEARCHES));
+    let handles = (0..CONCURRENT_SEARCHES)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            let home = home.clone();
+            let root = root.clone();
+            std::thread::spawn(move || {
+                let mut command = isolated_memex(&home);
+                command.args(["search", "seed", "--json-array", "--fields", "doc_id"]);
+                command.arg("--root").arg(&root);
+                barrier.wait();
+                command.output().expect("run concurrent search")
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        let output = handle.join().expect("join concurrent search");
+        assert_success(&output, "concurrent search");
+        let value: Value = serde_json::from_slice(&output.stdout).expect("valid search JSON");
+        assert!(value.is_array());
+    }
+
+    let final_search = isolated_memex(&home)
+        .args([
+            "search",
+            "concurrent-marker",
+            "--limit",
+            "2000",
+            "--json-array",
+            "--fields",
+            "doc_id",
+        ])
+        .arg("--root")
+        .arg(&root)
+        .output()
+        .expect("run final search");
+    assert_success(&final_search, "final search");
+    let rows: Vec<Value> =
+        serde_json::from_slice(&final_search.stdout).expect("valid final search JSON");
+    assert_eq!(rows.len(), APPENDED_RECORDS);
+    let doc_ids = rows
+        .iter()
+        .map(|row| row["doc_id"].as_u64().expect("numeric doc id"))
+        .collect::<HashSet<_>>();
+    assert_eq!(doc_ids.len(), APPENDED_RECORDS);
+
+    let stats = isolated_memex(&home)
+        .arg("stats")
+        .arg("--root")
+        .arg(&root)
+        .output()
+        .expect("run stats");
+    assert_success(&stats, "stats");
+    let stats = String::from_utf8(stats.stdout).expect("UTF-8 stats");
+    assert!(
+        stats.contains(&format!("documents: {}", APPENDED_RECORDS + 1)),
+        "unexpected stats output: {stats}"
+    );
+}
+
+fn isolated_memex(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_memex"));
+    command
+        .env("HOME", home)
+        .env("CODEX_HOME", home.join(".codex"))
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local").join("share"))
+        .env("PI_CODING_AGENT_DIR", home.join(".pi").join("agent"));
+    command
+}
+
+fn write_claude_record(file: &mut File, record_id: usize, text: &str) {
+    let record = json!({
+        "type": "user",
+        "uuid": format!("user-{record_id}"),
+        "parentUuid": Value::Null,
+        "sessionId": "concurrent-search-session",
+        "isSidechain": false,
+        "timestamp": "2026-07-26T17:00:00Z",
+        "message": { "content": text }
+    });
+    writeln!(file, "{record}").expect("write Claude record");
+}
+
+fn assert_success(output: &Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Concurrent `memex search` calls could all start stale auto-index work. When one process lost Tantivy's writer lock, its parser threads surfaced the secondary `sending on a disconnected channel` error instead of the real lock contention.

This change adds a cross-process ingestion lease shared by search auto-indexing, explicit indexing, reindexing, embedding, analytics backfill, and TUI refreshes. Concurrent lexical searches can use the last committed index, while semantic and hybrid searches wait for vector writes. Writer initialization now happens before parser fan-out, state files are replaced atomically, and timeout errors identify the lease holder.

A subprocess regression launches eight simultaneous searches against one stale index and verifies that every search succeeds without duplicate records. The focused regressions, `cargo fmt --check`, and `cargo clippy -- -D warnings` pass.