### PR TITLE
Unify Codex history sources

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -815,7 +815,7 @@ fn resolve_session_cwd_from_parts(
             return cwd;
         }
 
-        if source == SourceKind::CodexSession
+        if source == SourceKind::Codex
             && value.get("type").and_then(|v| v.as_str()) == Some("session_meta")
         {
             let payload_cwd = value
@@ -927,7 +927,7 @@ mod tests {
 
     fn record(project: &str, session_id: &str, source_path: &Path, ts: u64) -> Record {
         Record {
-            source: SourceKind::CodexSession,
+            source: SourceKind::Codex,
             doc_id: ts,
             ts,
             project: project.to_string(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -830,11 +830,10 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, history {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {})",
+        "embedded {} vectors (claude {}, codex {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
-        embedded_counts[crate::types::SourceKind::CodexSession.idx()],
-        embedded_counts[crate::types::SourceKind::CodexHistory.idx()],
+        embedded_counts[crate::types::SourceKind::Codex.idx()],
         embedded_counts[crate::types::SourceKind::Opencode.idx()],
         embedded_counts[crate::types::SourceKind::Cursor.idx()],
         embedded_counts[crate::types::SourceKind::Pi.idx()],
@@ -2043,7 +2042,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
     let record = &records[0];
     let tool = match record.source {
         crate::types::SourceKind::Claude => "claude",
-        crate::types::SourceKind::CodexSession | crate::types::SourceKind::CodexHistory => "codex",
+        crate::types::SourceKind::Codex => "codex",
         crate::types::SourceKind::Opencode => "opencode",
         crate::types::SourceKind::Cursor => "cursor",
         crate::types::SourceKind::Pi => "pi",

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -391,7 +391,7 @@ pub fn ingest_all(
             let key = path.to_string_lossy().to_string();
             let (task, skip) = prepare_file_task(
                 path,
-                SourceKind::CodexSession,
+                SourceKind::Codex,
                 options.include_reasoning,
                 &meta,
                 state.files.get(&key),
@@ -412,7 +412,7 @@ pub fn ingest_all(
             let key = history_path.to_string_lossy().to_string();
             let (task, skip) = prepare_file_task(
                 history_path,
-                SourceKind::CodexHistory,
+                SourceKind::Codex,
                 options.include_reasoning,
                 &meta,
                 state.files.get(&key),
@@ -612,22 +612,27 @@ pub fn ingest_all(
                 &next_doc_id,
                 &progress,
             )?,
-            SourceKind::CodexSession => parse_codex_session(
-                task,
-                options.include_reasoning,
-                &tx_record,
-                &tx_update,
-                &next_doc_id,
-                &progress,
-            )?,
-            SourceKind::CodexHistory => parse_codex_history(
-                task,
-                &tx_record,
-                &tx_update,
-                &next_doc_id,
-                &session_ids,
-                &progress,
-            )?,
+            SourceKind::Codex => {
+                if crate::sources::codex::is_history_path(&task.path) {
+                    parse_codex_history(
+                        task,
+                        &tx_record,
+                        &tx_update,
+                        &next_doc_id,
+                        &session_ids,
+                        &progress,
+                    )?
+                } else {
+                    parse_codex_session(
+                        task,
+                        options.include_reasoning,
+                        &tx_record,
+                        &tx_update,
+                        &next_doc_id,
+                        &progress,
+                    )?
+                }
+            }
             SourceKind::Opencode => parse_opencode_file(
                 task,
                 &tx_record,
@@ -987,7 +992,7 @@ fn parse_codex_session(
         include_reasoning,
         next_doc_id,
         |record| {
-            progress.add_produced(SourceKind::CodexSession, 1);
+            progress.add_produced(SourceKind::Codex, 1);
             tx_record.send(record)
         },
     )?;
@@ -995,7 +1000,7 @@ fn parse_codex_session(
         task,
         tx_update,
         progress,
-        SourceKind::CodexSession,
+        SourceKind::Codex,
         source_path,
         parsed,
     )
@@ -1020,7 +1025,7 @@ fn parse_codex_history(
         session_ids,
         next_doc_id,
         |record| {
-            progress.add_produced(SourceKind::CodexHistory, 1);
+            progress.add_produced(SourceKind::Codex, 1);
             tx_record.send(record)
         },
     )?;
@@ -1028,7 +1033,7 @@ fn parse_codex_history(
         task,
         tx_update,
         progress,
-        SourceKind::CodexHistory,
+        SourceKind::Codex,
         source_path,
         parsed,
     )
@@ -1906,7 +1911,7 @@ mod tests {
         let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
         let next_doc_id = AtomicU64::new(10);
         let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
-        let first = incremental_task(&path, SourceKind::CodexSession, 0, 0, HashMap::new());
+        let first = incremental_task(&path, SourceKind::Codex, 0, 0, HashMap::new());
         parse_codex_session(
             &first,
             false,
@@ -1936,7 +1941,7 @@ mod tests {
             .expect("append result");
         let second = incremental_task(
             &path,
-            SourceKind::CodexSession,
+            SourceKind::Codex,
             first_state.offset,
             first_state.turn_id,
             first_state.pending_tool_calls,
@@ -1967,7 +1972,7 @@ mod tests {
             "11111111-1111-4111-8111-111111111111"
         );
         assert_eq!(result_record.project, "memex");
-        assert_eq!(result_record.source, SourceKind::CodexSession);
+        assert_eq!(result_record.source, SourceKind::Codex);
         assert_eq!(result_record.source_path, path.to_string_lossy());
         assert!(second_state.pending_tool_calls.is_empty());
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -239,8 +239,7 @@ impl Progress {
 fn progress_label(source: SourceKind) -> &'static str {
     match source {
         SourceKind::Claude => "claude",
-        SourceKind::CodexSession => "codex",
-        SourceKind::CodexHistory => "codex-history",
+        SourceKind::Codex => "codex",
         SourceKind::Opencode => "opencode",
         SourceKind::Cursor => "cursor",
         SourceKind::Pi => "pi",

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -30,7 +30,7 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
 
     push(SourceKind::Claude, super::claude::usage_files());
     push(
-        SourceKind::CodexSession,
+        SourceKind::Codex,
         super::codex::discover_rollouts()
             .into_iter()
             .map(|file| file.path)
@@ -134,7 +134,7 @@ fn audit_file(source: SourceKind, path: &Path, audit: &mut SourceAudit) -> Resul
 
 fn producer_version(source: SourceKind, value: &Value) -> Option<String> {
     let version = match source {
-        SourceKind::CodexSession | SourceKind::CodexHistory => value
+        SourceKind::Codex => value
             .get("payload")
             .and_then(|payload| payload.get("cli_version")),
         _ => value.get("version"),
@@ -148,7 +148,7 @@ fn producer_version(source: SourceKind, value: &Value) -> Option<String> {
 
 fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &mut SourceAudit) {
     match source {
-        SourceKind::CodexSession | SourceKind::CodexHistory => {
+        SourceKind::Codex => {
             if let Some(payload) = value.get("payload").and_then(Value::as_object)
                 && let Some(payload_type) = payload.get("type").and_then(Value::as_str)
             {
@@ -239,7 +239,7 @@ mod tests {
         )
         .unwrap();
 
-        let audit = audit_files(SourceKind::CodexSession, &[path]).unwrap();
+        let audit = audit_files(SourceKind::Codex, &[path]).unwrap();
         assert_eq!(audit.files, 1);
         assert_eq!(audit.valid_json_lines, 2);
         assert_eq!(audit.malformed_json_lines, 1);

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 3,
+    index: 4,
     usage: 4,
 };
 
@@ -29,12 +29,16 @@ pub fn classify_path(path: &str) -> Option<SourceKind> {
         || path.contains(".codex/archived_sessions")
         || path.contains(".codex\\archived_sessions")
     {
-        Some(SourceKind::CodexSession)
+        Some(SourceKind::Codex)
     } else if path.contains(".codex/history.jsonl") || path.contains(".codex\\history.jsonl") {
-        Some(SourceKind::CodexHistory)
+        Some(SourceKind::Codex)
     } else {
         None
     }
+}
+
+pub fn is_history_path(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("history.jsonl")
 }
 
 pub fn homes() -> Vec<PathBuf> {
@@ -68,7 +72,7 @@ pub fn discover_rollouts() -> Vec<SourceFile> {
     super::common::jsonl_files(rollout_roots())
         .into_iter()
         .map(|path| SourceFile {
-            source: SourceKind::CodexSession,
+            source: SourceKind::Codex,
             path,
         })
         .collect()
@@ -122,7 +126,7 @@ struct SessionMeta {
 fn fallback_meta(path: &Path) -> SessionMeta {
     SessionMeta {
         session_id: session_id_from_path(path).unwrap_or_else(|| "unknown".to_string()),
-        project: SourceKind::CodexSession.label().to_string(),
+        project: SourceKind::Codex.label().to_string(),
         cwd: None,
         links: SessionLinks {
             conversation_kind: Some(ConversationKind::Main.as_str().to_string()),
@@ -214,7 +218,7 @@ pub fn probe(path: &Path) -> Result<SourceMetadata> {
     };
     Ok(SourceMetadata {
         session: SessionIdentity {
-            source: SourceKind::CodexSession,
+            source: SourceKind::Codex,
             session_id: metadata.session_id,
             parent_session_id: metadata.links.parent_session_id,
             conversation_kind: kind,
@@ -297,7 +301,7 @@ pub(crate) fn parse_index_records(
                 let mut links = metadata.links.record_links();
                 links.event_id = super::common::borrowed_string(payload, "id");
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -357,7 +361,7 @@ pub(crate) fn parse_index_records(
                     continue;
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -408,7 +412,7 @@ pub(crate) fn parse_index_records(
                     }
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id,
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -446,7 +450,7 @@ pub(crate) fn parse_index_records(
                     links.parent_tool_use_id = Some(call_id.to_string());
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -494,7 +498,7 @@ pub(crate) fn parse_index_records(
                     }
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id,
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -550,7 +554,7 @@ pub(crate) fn parse_index_records(
                     }
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id,
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -594,7 +598,7 @@ pub(crate) fn parse_index_records(
                     links.parent_tool_use_id = Some(call_id.to_string());
                 }
                 emit(Record {
-                    source: SourceKind::CodexSession,
+                    source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
                     ts: timestamp,
                     project: metadata.project.clone(),
@@ -700,10 +704,10 @@ pub(crate) fn parse_history_records(
             .max(0) as u64
             * 1000;
         emit(Record {
-            source: SourceKind::CodexHistory,
+            source: SourceKind::Codex,
             doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
             ts: timestamp,
-            project: SourceKind::CodexSession.label().to_string(),
+            project: SourceKind::Codex.label().to_string(),
             session_id: session_id.to_string(),
             turn_id,
             role: "user".to_string(),
@@ -1369,6 +1373,34 @@ mod tests {
         fs::write(archived.join("archived.jsonl"), "{}\n").unwrap();
         let files = super::super::common::jsonl_files([active, archived]);
         assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn history_records_use_the_canonical_codex_source() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("history.jsonl");
+        fs::write(
+            &path,
+            "{\"session_id\":\"missing-session\",\"ts\":42,\"text\":\"fallback prompt\"}\n",
+        )
+        .unwrap();
+        let mut records = Vec::new();
+
+        parse_history_records(
+            &path,
+            IndexParseState::default(),
+            &HashSet::new(),
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].source, SourceKind::Codex);
+        assert_eq!(records[0].project, "codex");
     }
 
     #[test]

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -28,9 +28,9 @@ pub fn classify_path(path: &str) -> Option<SourceKind> {
         || path.contains(".codex\\sessions")
         || path.contains(".codex/archived_sessions")
         || path.contains(".codex\\archived_sessions")
+        || path.contains(".codex/history.jsonl")
+        || path.contains(".codex\\history.jsonl")
     {
-        Some(SourceKind::Codex)
-    } else if path.contains(".codex/history.jsonl") || path.contains(".codex\\history.jsonl") {
         Some(SourceKind::Codex)
     } else {
         None

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -198,7 +198,7 @@ impl UsageParseOutput {
 pub fn versions(source: SourceKind) -> ParserVersions {
     match source {
         SourceKind::Claude => claude::VERSIONS,
-        SourceKind::CodexSession | SourceKind::CodexHistory => codex::VERSIONS,
+        SourceKind::Codex => codex::VERSIONS,
         SourceKind::Cursor => cursor::VERSIONS,
         SourceKind::Opencode => opencode::VERSIONS,
         SourceKind::Pi => pi::VERSIONS,
@@ -219,7 +219,7 @@ mod tests {
     fn reasoning_mode_is_part_of_index_state_version() {
         for source in [
             SourceKind::Claude,
-            SourceKind::CodexSession,
+            SourceKind::Codex,
             SourceKind::Pi,
             SourceKind::OpenClaw,
         ] {
@@ -236,7 +236,7 @@ pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u
     let reasoning_mode = include_reasoning
         && matches!(
             source,
-            SourceKind::Claude | SourceKind::CodexSession | SourceKind::Pi | SourceKind::OpenClaw
+            SourceKind::Claude | SourceKind::Codex | SourceKind::Pi | SourceKind::OpenClaw
         );
     (versions.identity.saturating_mul(10_000) + versions.index)
         .saturating_mul(2)

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1528,13 +1528,12 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
     let first = records.first()?;
     match first.source {
         SourceKind::Claude => cwd_from_jsonl(Path::new(&first.source_path)),
-        SourceKind::CodexSession => cwd_from_codex_session(Path::new(&first.source_path)),
+        SourceKind::Codex => cwd_from_codex_session(Path::new(&first.source_path)),
         SourceKind::Copilot => cwd_from_copilot_session(Path::new(&first.source_path)),
         SourceKind::Cursor => cwd_from_cursor_session(Path::new(&first.source_path)),
         SourceKind::Opencode => cwd_from_opencode_session(Path::new(&first.source_path)),
         SourceKind::Pi => cwd_from_pi_session(Path::new(&first.source_path)),
         SourceKind::OpenClaw => cwd_from_pi_session(Path::new(&first.source_path)),
-        SourceKind::CodexHistory => None,
     }
     .filter(|path| path.is_dir())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2078,7 +2078,7 @@ impl App {
                 .claude_resume_cmd
                 .clone()
                 .or_else(|| default_resume_template("claude")),
-            SourceKind::CodexSession | SourceKind::CodexHistory => self
+            SourceKind::Codex => self
                 .config
                 .codex_resume_cmd
                 .clone()
@@ -2134,7 +2134,7 @@ impl App {
 
         let tool = match session.source {
             SourceKind::Claude => "claude",
-            SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
+            SourceKind::Codex => "codex",
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
@@ -3519,7 +3519,7 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
 fn source_color(source: SourceKind) -> Color {
     match source {
         SourceKind::Claude => Color::Rgb(214, 138, 88),
-        SourceKind::CodexSession | SourceKind::CodexHistory => Color::Rgb(160, 180, 200),
+        SourceKind::Codex => Color::Rgb(160, 180, 200),
         SourceKind::Opencode => Color::Rgb(150, 180, 150),
         SourceKind::Cursor => Color::Rgb(170, 150, 200),
         SourceKind::Pi => Color::Rgb(120, 190, 190),
@@ -5615,7 +5615,7 @@ fn resolve_session_cwd(session: &SessionSummary) -> Option<String> {
             return cwd;
         }
 
-        if session.source == SourceKind::CodexSession
+        if session.source == SourceKind::Codex
             && value.get("type").and_then(|v| v.as_str()) == Some("session_meta")
         {
             let payload_cwd = value
@@ -6125,7 +6125,7 @@ mod tests {
 
     fn record(role: &str, text: &str) -> Record {
         Record {
-            source: SourceKind::CodexSession,
+            source: SourceKind::Codex,
             doc_id: 1,
             ts: 0,
             project: "project".to_string(),
@@ -6232,12 +6232,12 @@ mod tests {
                 value: 3,
             },
             HomeChartPoint {
-                source: SourceKind::CodexSession,
+                source: SourceKind::Codex,
                 timestamp_ms: 4,
                 value: 1,
             },
             HomeChartPoint {
-                source: SourceKind::CodexHistory,
+                source: SourceKind::Codex,
                 timestamp_ms: 5,
                 value: 1,
             },
@@ -6259,7 +6259,7 @@ mod tests {
             value: 1,
         }];
         app.home_result_activity = vec![HomeChartPoint {
-            source: SourceKind::CodexSession,
+            source: SourceKind::Codex,
             timestamp_ms: 20,
             value: 1,
         }];
@@ -6334,7 +6334,7 @@ mod tests {
                 value: 2,
             },
             HomeChartPoint {
-                source: SourceKind::CodexSession,
+                source: SourceKind::Codex,
                 timestamp_ms: 500,
                 value: 2,
             },
@@ -6343,7 +6343,7 @@ mod tests {
         // codex the top cell.
         let grid = home_chart_grid(&points, (0, 1000), 1, 2);
         assert_eq!(grid[1][0].1, source_color(SourceKind::Claude));
-        assert_eq!(grid[0][0].1, source_color(SourceKind::CodexSession));
+        assert_eq!(grid[0][0].1, source_color(SourceKind::Codex));
     }
 
     #[test]
@@ -6355,7 +6355,7 @@ mod tests {
                 value: 2,
             },
             HomeChartPoint {
-                source: SourceKind::CodexSession,
+                source: SourceKind::Codex,
                 timestamp_ms: 50,
                 value: 3,
             },
@@ -6384,7 +6384,7 @@ mod tests {
                 value: 1,
             },
             HomeChartPoint {
-                source: SourceKind::CodexSession,
+                source: SourceKind::Codex,
                 timestamp_ms: 90,
                 value: 1,
             },
@@ -6471,7 +6471,7 @@ mod tests {
             SessionSummary {
                 session_id: "shared".into(),
                 project: "memex".into(),
-                source: SourceKind::CodexHistory,
+                source: SourceKind::Codex,
                 last_ts: 1,
                 hit_count: 1,
                 top_score: 1.0,
@@ -6779,11 +6779,11 @@ mod tests {
 
     #[test]
     fn timeline_chart_grid_uses_source_colors() {
-        let events = vec![(SourceKind::Claude, 10), (SourceKind::CodexSession, 90)];
+        let events = vec![(SourceKind::Claude, 10), (SourceKind::Codex, 90)];
         let grid = timeline_chart_grid(&events, (0, 100), 2, 1, 1);
 
         assert_eq!(grid[0][0].1, source_color(SourceKind::Claude));
-        assert_eq!(grid[0][1].1, source_color(SourceKind::CodexSession));
+        assert_eq!(grid[0][1].1, source_color(SourceKind::Codex));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum SourceKind {
     #[default]
     Claude,
-    CodexSession,
-    CodexHistory,
+    Codex,
     Opencode,
     Cursor,
     Pi,
@@ -15,10 +14,9 @@ pub enum SourceKind {
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 8] = [
+    pub const ALL: [SourceKind; 7] = [
         SourceKind::Claude,
-        SourceKind::CodexSession,
-        SourceKind::CodexHistory,
+        SourceKind::Codex,
         SourceKind::Opencode,
         SourceKind::Cursor,
         SourceKind::Pi,
@@ -30,26 +28,24 @@ impl SourceKind {
     pub fn idx(self) -> usize {
         match self {
             SourceKind::Claude => 0,
-            SourceKind::CodexSession => 1,
-            SourceKind::CodexHistory => 2,
-            SourceKind::Opencode => 3,
-            SourceKind::Cursor => 4,
-            SourceKind::Pi => 5,
-            SourceKind::OpenClaw => 6,
-            SourceKind::Copilot => 7,
+            SourceKind::Codex => 1,
+            SourceKind::Opencode => 2,
+            SourceKind::Cursor => 3,
+            SourceKind::Pi => 4,
+            SourceKind::OpenClaw => 5,
+            SourceKind::Copilot => 6,
         }
     }
 
     pub fn from_idx(idx: usize) -> Option<Self> {
         match idx {
             0 => Some(SourceKind::Claude),
-            1 => Some(SourceKind::CodexSession),
-            2 => Some(SourceKind::CodexHistory),
-            3 => Some(SourceKind::Opencode),
-            4 => Some(SourceKind::Cursor),
-            5 => Some(SourceKind::Pi),
-            6 => Some(SourceKind::OpenClaw),
-            7 => Some(SourceKind::Copilot),
+            1 => Some(SourceKind::Codex),
+            2 => Some(SourceKind::Opencode),
+            3 => Some(SourceKind::Cursor),
+            4 => Some(SourceKind::Pi),
+            5 => Some(SourceKind::OpenClaw),
+            6 => Some(SourceKind::Copilot),
             _ => None,
         }
     }
@@ -57,7 +53,7 @@ impl SourceKind {
     pub fn label(self) -> &'static str {
         match self {
             SourceKind::Claude => "claude",
-            SourceKind::CodexSession | SourceKind::CodexHistory => "codex",
+            SourceKind::Codex => "codex",
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
@@ -69,8 +65,7 @@ impl SourceKind {
     pub fn storage_label(self) -> &'static str {
         match self {
             SourceKind::Claude => "claude",
-            SourceKind::CodexSession => "codex-session",
-            SourceKind::CodexHistory => "codex-history",
+            SourceKind::Codex => "codex",
             SourceKind::Opencode => "opencode",
             SourceKind::Cursor => "cursor",
             SourceKind::Pi => "pi",
@@ -86,8 +81,7 @@ impl SourceKind {
     pub fn from_label(label: &str) -> Option<Self> {
         match label {
             "claude" => Some(SourceKind::Claude),
-            "codex" | "codex-session" => Some(SourceKind::CodexSession),
-            "codex-history" => Some(SourceKind::CodexHistory),
+            "codex" | "codex-session" | "codex-history" => Some(SourceKind::Codex),
             "opencode" => Some(SourceKind::Opencode),
             "cursor" => Some(SourceKind::Cursor),
             "pi" => Some(SourceKind::Pi),
@@ -115,9 +109,7 @@ impl SourceFilter {
     pub fn matches(self, source: SourceKind) -> bool {
         match self {
             SourceFilter::Claude => source == SourceKind::Claude,
-            SourceFilter::Codex => {
-                source == SourceKind::CodexSession || source == SourceKind::CodexHistory
-            }
+            SourceFilter::Codex => source == SourceKind::Codex,
             SourceFilter::Opencode => source == SourceKind::Opencode,
             SourceFilter::Cursor => source == SourceKind::Cursor,
             SourceFilter::Pi => source == SourceKind::Pi,
@@ -214,6 +206,14 @@ mod tests {
     }
 
     #[test]
+    fn legacy_codex_labels_converge_to_codex() {
+        for label in ["codex", "codex-session", "codex-history"] {
+            assert_eq!(SourceKind::from_label(label), Some(SourceKind::Codex));
+        }
+        assert_eq!(SourceKind::Codex.storage_label(), "codex");
+    }
+
+    #[test]
     fn openclaw_source_filter_uses_unhyphenated_cli_name() {
         assert_eq!(
             SourceFilter::from_str("openclaw", true),
@@ -231,10 +231,19 @@ mod tests {
         let windows_path =
             "C:\\tmp\\.codex\\archived_sessions\\rollout-2026-02-10T11-16-28-abc.jsonl";
 
-        assert_eq!(SourceKind::from_path(unix_path), SourceKind::CodexSession);
+        assert_eq!(SourceKind::from_path(unix_path), SourceKind::Codex);
+        assert_eq!(SourceKind::from_path(windows_path), SourceKind::Codex);
+    }
+
+    #[test]
+    fn from_path_recognizes_codex_history_as_codex() {
         assert_eq!(
-            SourceKind::from_path(windows_path),
-            SourceKind::CodexSession
+            SourceKind::from_path("/tmp/.codex/history.jsonl"),
+            SourceKind::Codex
+        );
+        assert_eq!(
+            SourceKind::from_path("C:\\tmp\\.codex\\history.jsonl"),
+            SourceKind::Codex
         );
     }
 


### PR DESCRIPTION
Collapses Codex session transcripts and `history.jsonl` fallback records into one canonical `codex` source across indexing, storage, filtering, progress, analytics, transfer, and the TUI. Legacy `codex-session` and `codex-history` labels remain readable, and the parser version bump rewrites existing indexed records.

Validation: `cargo fmt --check` and `cargo clippy -- -D warnings` passed.