### PR TITLE
Add multi-machine SSH federation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
-      - name: Run tests
+      - name: Run unit and integration tests
         run: cargo test --verbose -- --test-threads=1
 
   clippy:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,53 @@ Human output:
 memex search "your query" -v
 ```
 
+## Multiple machines over SSH
+
+Each machine keeps and updates its own index. The coordinating memex queries configured
+machines concurrently over SSH, merges their rankings, and keeps the originating machine
+attached to every result. The TUI uses the same backend for search, history previews,
+sharing, token charts, and interactive resume.
+
+Install a protocol-compatible memex binary on each machine and configure SSH normally in
+`~/.ssh/config`. Then add machines to `~/.memex/config.toml`:
+
+```toml
+[multi_machine]
+default = ["local", "mini"]
+timeout_seconds = 10
+
+[[machines]]
+id = "mini"
+label = "Mac mini"
+
+[machines.control]
+type = "ssh"
+host = "mini" # SSH config alias
+
+[machines.index]
+type = "remote"
+```
+
+The `ssh = "mini"` field is a shorthand for the `machines.control` table. Set
+`command = "/path/to/memex"` when `memex` is not on the non-interactive SSH `PATH`.
+SSH keys, users, ports, jump hosts, and host-key policy remain in `~/.ssh/config`.
+
+```sh
+memex search "tantivy corruption"             # configured defaults
+memex search "tantivy corruption" --machine mini
+memex usage --machine local --machine mini
+```
+
+Unavailable machines produce partial results with a warning. Remote token usage requires
+`token_usage = true` in that machine's memex config. The index backend is intentionally
+separate from the control transport so an immutable S3 split backend can replace
+`type = "remote"` later while SSH continues to handle indexing and resume.
+
+In the TUI, use the `machines` dropdown (or press `m` while the session list is focused)
+to select the configured default set, `local`, or one remote machine. The machine, source,
+project, and query filters are shared by the session results and token chart; the range
+dropdown bounds the chart.
+
 ## Token usage
 
 Token tracking is disabled by default because it scans and caches local agent logs. Enable it in `~/.memex/config.toml`:

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,6 +1,7 @@
 use crate::types::{Record, SourceFilter, SourceKind};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params, params_from_iter};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -8,7 +9,8 @@ use std::time::Duration;
 
 const SCHEMA_VERSION: i64 = 2;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ProjectGrouping {
     #[default]
     Flat,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,9 @@ use crate::embed::{EmbedRuntimeConfig, EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_all, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt, LeaseHolder};
+use crate::machine::{
+    LocatedRecord, SearchMode, SearchSpec, UsageSpec, federated_search, federated_usage,
+};
 use crate::transfer::{
     TransferMode as CoreTransferMode, TransferOptions, TransferTarget as CoreTransferTarget,
     transfer_session,
@@ -157,7 +160,7 @@ TIMESTAMP FORMAT:
     Unix milliseconds: 1705315800000
 
 OUTPUT FIELDS (--fields):
-    score, ts, doc_id, project, role, session_id, source, source_path, text, snippet, matches
+    machine, score, ts, doc_id, project, role, session_id, source, source_path, text, snippet, matches
     event_id, parent_event_id, logical_parent_event_id, parent_session_id, thread_source, conversation_kind
     parent_tool_use_id, source_tool_use_id, source_tool_assistant_uuid")]
     Search {
@@ -223,6 +226,9 @@ OUTPUT FIELDS (--fields):
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
+        /// Machine to search (repeatable). Defaults to multi_machine.default or all configured machines.
+        #[arg(long, value_name = "ID")]
+        machine: Vec<String>,
     },
     /// Interactive terminal UI for browsing sessions
     Tui {
@@ -288,6 +294,9 @@ EXAMPLES:
         /// Cost source: stored source cost, automatic fallback, or API-rate repricing
         #[arg(long, value_enum, default_value = "auto")]
         cost: CostMode,
+        /// Machine to include (repeatable). Defaults to multi_machine.default or all configured machines.
+        #[arg(long, value_name = "ID")]
+        machine: Vec<String>,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -363,6 +372,13 @@ EXAMPLES:
         /// Generate the intermediate transcript without importing into the target
         #[arg(long)]
         dry_run: bool,
+        /// Path to memex data directory [default: ~/.memex]
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
+    /// Internal versioned RPC endpoint used by remote memex clients
+    #[command(hide = true)]
+    Rpc {
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -461,7 +477,10 @@ pub fn run() -> Result<()> {
     let cli = Cli::parse();
     // Bare `memex` opens the TUI home screen.
     let command = cli.command.unwrap_or(Commands::Tui { root: None });
-    let should_check = !matches!(command, Commands::Tui { .. } | Commands::Update { .. });
+    let should_check = !matches!(
+        command,
+        Commands::Tui { .. } | Commands::Update { .. } | Commands::Rpc { .. }
+    );
     if should_check {
         check_for_update_async(None);
     }
@@ -505,6 +524,7 @@ pub fn run() -> Result<()> {
             sort,
             verbose,
             root,
+            machine,
         } => {
             run_search(
                 query,
@@ -528,6 +548,7 @@ pub fn run() -> Result<()> {
                 sort,
                 verbose,
                 root,
+                machine,
             )?;
         }
         Commands::Tui { root } => {
@@ -593,8 +614,18 @@ pub fn run() -> Result<()> {
             events,
             cost,
             root,
+            machine,
         } => {
-            run_usage(source, since, until, json, events, cost, root)?;
+            run_usage(UsageCommandOptions {
+                source,
+                since,
+                until,
+                json,
+                include_events: events,
+                cost_mode: cost,
+                root,
+                machines: machine,
+            })?;
         }
         Commands::AnalyticsBackfill { root } => {
             run_analytics_backfill(root)?;
@@ -626,6 +657,9 @@ pub fn run() -> Result<()> {
             root,
         } => {
             run_transfer(session_id, source, to, mode, turns, dry_run, root)?;
+        }
+        Commands::Rpc { root } => {
+            crate::machine::run_rpc_stdio(root)?;
         }
     }
     Ok(())
@@ -868,61 +902,10 @@ fn run_search(
     sort: SortBy,
     verbose: bool,
     root: Option<PathBuf>,
+    machines: Vec<String>,
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let model_choice = config.resolve_model(None)?;
-    let embed_runtime = config.resolve_embed_runtime()?;
-    let auto_index_on_search = config.auto_index_on_search_default();
-    let embeddings_default = config.embeddings_default();
-    let scan_cache_ttl = config.scan_cache_ttl();
-    let auto_index_options = auto_index_on_search.then(|| {
-        let tool_content_limits = config.indexed_tool_content_limits()?;
-        Ok::<_, anyhow::Error>(IngestOptions {
-            claude_source: default_claude_source(),
-            include_agents: false,
-            include_reasoning: config.include_reasoning_default(),
-            include_codex: true,
-            include_opencode: true,
-            include_cursor: true,
-            include_pi: true,
-            include_openclaw: true,
-            include_copilot: true,
-            embeddings: embeddings_default,
-            backfill_embeddings: false,
-            model: model_choice,
-            embed_runtime: embed_runtime.clone(),
-            tool_content_limits,
-        })
-    });
-    let auto_index_options = auto_index_options.transpose()?;
-    let mut refresh_contended = false;
-    let mut refresh_holder = None;
-    if let Some(options) = auto_index_options.as_ref() {
-        paths.ensure_dirs()?;
-        match IngestLease::try_acquire(&paths, "search auto-index")? {
-            LeaseAttempt::Acquired(lease) => {
-                let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
-                let _ = ingest_if_stale(&paths, &index, options, scan_cache_ttl, &lease)?;
-            }
-            LeaseAttempt::Busy(holder) => {
-                refresh_contended = true;
-                refresh_holder = holder;
-            }
-        }
-    }
-    let index = if refresh_contended {
-        open_index_during_contended_refresh(
-            &paths,
-            auto_index_options.as_ref().expect("auto-index options"),
-            scan_cache_ttl,
-            refresh_holder.as_ref(),
-            semantic || hybrid,
-        )?
-    } else {
-        SearchIndex::open_or_create(&paths.index)?
-    };
-
     let options = QueryOptions {
         query,
         project,
@@ -956,6 +939,89 @@ fn run_search(
         (limit * 5).max(limit + 10)
     } else {
         limit
+    };
+
+    if !machines.is_empty() || !config.machines.is_empty() {
+        let spec = SearchSpec {
+            query: options.query.clone(),
+            project: options.project.clone(),
+            role: options.role.clone(),
+            tool: options.tool.clone(),
+            session_id: options.session_id.clone(),
+            source: options.source,
+            since: options.since,
+            until: options.until,
+            limit: candidate_limit,
+            mode: if hybrid {
+                SearchMode::Hybrid
+            } else if semantic {
+                SearchMode::Semantic
+            } else {
+                SearchMode::Lexical
+            },
+            recency_weight,
+            recency_half_life_days,
+            min_score,
+            project_grouping: None,
+        };
+        let mut federated = federated_search(&paths, &config, &machines, &spec, true)?;
+        for (machine, error) in &federated.failures {
+            eprintln!("Warning: machine '{machine}' unavailable: {error}");
+        }
+        let mut merged_render = render.clone();
+        merged_render.min_score = None;
+        federated.items = apply_post_processing_located(federated.items, &merged_render);
+        return render_located_results(federated.items, &render);
+    }
+
+    let model_choice = config.resolve_model(None)?;
+    let embed_runtime = config.resolve_embed_runtime()?;
+    let scan_cache_ttl = config.scan_cache_ttl();
+    let auto_index_options = config.auto_index_on_search_default().then(|| {
+        let tool_content_limits = config.indexed_tool_content_limits()?;
+        Ok::<_, anyhow::Error>(IngestOptions {
+            claude_source: default_claude_source(),
+            include_agents: false,
+            include_reasoning: config.include_reasoning_default(),
+            include_codex: true,
+            include_opencode: true,
+            include_cursor: true,
+            include_pi: true,
+            include_openclaw: true,
+            include_copilot: true,
+            embeddings: config.embeddings_default(),
+            backfill_embeddings: false,
+            model: model_choice,
+            embed_runtime: embed_runtime.clone(),
+            tool_content_limits,
+        })
+    });
+    let auto_index_options = auto_index_options.transpose()?;
+    let mut refresh_contended = false;
+    let mut refresh_holder = None;
+    if let Some(options) = auto_index_options.as_ref() {
+        paths.ensure_dirs()?;
+        match IngestLease::try_acquire(&paths, "search auto-index")? {
+            LeaseAttempt::Acquired(lease) => {
+                let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
+                let _ = ingest_if_stale(&paths, &index, options, scan_cache_ttl, &lease)?;
+            }
+            LeaseAttempt::Busy(holder) => {
+                refresh_contended = true;
+                refresh_holder = holder;
+            }
+        }
+    }
+    let index = if refresh_contended {
+        open_index_during_contended_refresh(
+            &paths,
+            auto_index_options.as_ref().expect("auto-index options"),
+            scan_cache_ttl,
+            refresh_holder.as_ref(),
+            semantic || hybrid,
+        )?
+    } else {
+        SearchIndex::open_or_create(&paths.index)?
     };
 
     if hybrid {
@@ -1271,6 +1337,7 @@ struct MatchSpan {
 
 #[derive(Serialize)]
 struct SearchHit {
+    machine: String,
     score: f32,
     ts: String,
     doc_id: u64,
@@ -1287,20 +1354,44 @@ struct SearchHit {
 }
 
 fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOptions) -> Result<()> {
+    render_located_results(
+        results
+            .into_iter()
+            .map(|(score, record)| LocatedRecord {
+                machine: crate::machine::LOCAL_MACHINE_ID.to_string(),
+                score,
+                record,
+            })
+            .collect(),
+        render,
+    )
+}
+
+fn render_located_results(results: Vec<LocatedRecord>, render: &RenderOptions) -> Result<()> {
     if render.verbose {
-        for (score, record) in results {
+        for LocatedRecord {
+            machine,
+            score,
+            record,
+        } in results
+        {
             let ts = format_ts(record.ts);
             let text = summarize(&record.text, 200);
             println!(
-                "[{score:.3}] {} {} {} {} {} {}",
-                ts, record.doc_id, record.project, record.role, record.session_id, text
+                "[{score:.3}] {} {} {} {} {} {} {}",
+                machine, ts, record.doc_id, record.project, record.role, record.session_id, text
             );
         }
         return Ok(());
     }
 
     let mut output = Vec::new();
-    for (score, record) in results {
+    for LocatedRecord {
+        machine,
+        score,
+        record,
+    } in results
+    {
         let ts = format_ts(record.ts);
         let text_ref = record.text.as_str();
         let wants_snippet = wants_field(&render.fields, "snippet");
@@ -1326,6 +1417,9 @@ fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOpti
             let mut map = serde_json::Map::new();
             if fields.contains("score") {
                 map.insert("score".to_string(), Value::from(score));
+            }
+            if fields.contains("machine") {
+                map.insert("machine".to_string(), Value::from(machine.clone()));
             }
             if fields.contains("ts") {
                 map.insert("ts".to_string(), Value::from(ts));
@@ -1409,6 +1503,7 @@ fn render_results(results: Vec<(f32, crate::types::Record)>, render: &RenderOpti
             Value::Object(map)
         } else {
             serde_json::to_value(SearchHit {
+                machine,
                 score,
                 ts,
                 doc_id: record.doc_id,
@@ -1502,7 +1597,7 @@ fn run_stats(root: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn run_usage(
+struct UsageCommandOptions {
     source: Option<SourceFilter>,
     since: Option<String>,
     until: Option<String>,
@@ -1510,9 +1605,68 @@ fn run_usage(
     include_events: bool,
     cost_mode: CostMode,
     root: Option<PathBuf>,
-) -> Result<()> {
+    machines: Vec<String>,
+}
+
+fn run_usage(options: UsageCommandOptions) -> Result<()> {
+    let UsageCommandOptions {
+        source,
+        since,
+        until,
+        json,
+        include_events,
+        cost_mode,
+        root,
+        machines,
+    } = options;
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+    let since_ms = parse_ts_millis(since)?;
+    let until_ms = parse_ts_millis(until)?;
+    if !machines.is_empty() || !config.machines.is_empty() {
+        let report = federated_usage(
+            &paths,
+            &config,
+            &machines,
+            &UsageSpec {
+                source,
+                project: None,
+                project_grouping: crate::analytics::ProjectGrouping::Flat,
+                session_keys: None,
+                machine_session_keys: None,
+                since_ms,
+                until_ms,
+                cost_mode,
+                include_events,
+                memo_ttl_ms: 0,
+            },
+        )?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            println!("{}", report.authority);
+            print_usage_rows(
+                report.events,
+                report.total_tokens,
+                report.known_cost_usd,
+                report.priced_events,
+                report.unpriced_events,
+                &report.cache_waste,
+                &report.by_source,
+            );
+            println!(
+                "cost: API-equivalent at {} pricing, catalog {} ({} priced, {} unpriced events)",
+                format!("{:?}", report.cost_mode).to_lowercase(),
+                report.price_catalog,
+                format_count(report.priced_events),
+                format_count(report.unpriced_events),
+            );
+            for warning in &report.warnings {
+                eprintln!("warning: {warning}");
+            }
+        }
+        return Ok(());
+    }
     if !config.token_usage_enabled() {
         return Err(anyhow!(
             "token usage tracking is disabled; set `token_usage = true` in {}",
@@ -1524,8 +1678,8 @@ fn run_usage(
         project: None,
         project_grouping: crate::analytics::ProjectGrouping::Flat,
         session_keys: None,
-        since_ms: parse_ts_millis(since)?,
-        until_ms: parse_ts_millis(until)?,
+        since_ms,
+        until_ms,
         cost_mode,
         include_events,
         cache_path: Some(paths.state.join("usage-cache.sqlite3")),
@@ -1621,6 +1775,27 @@ fn run_usage(
 }
 
 fn print_usage_table(report: &crate::usage::UsageReport) {
+    print_usage_rows(
+        report.events,
+        report.total_tokens,
+        report.known_cost_usd,
+        report.priced_events,
+        report.unpriced_events,
+        &report.cache_waste,
+        &report.by_source,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_usage_rows(
+    events: u64,
+    total_tokens: u64,
+    known_cost_usd: f64,
+    priced_events: u64,
+    unpriced_events: u64,
+    cache_waste: &crate::usage::CacheWaste,
+    by_source: &[crate::usage::UsageSummary],
+) {
     const HEADERS: [&str; 10] = [
         "source",
         "events",
@@ -1635,15 +1810,15 @@ fn print_usage_table(report: &crate::usage::UsageReport) {
     ];
     let mut totals = crate::usage::UsageSummary {
         source: "total".to_string(),
-        events: report.events,
-        total_tokens: report.total_tokens,
-        known_cost_usd: report.known_cost_usd,
-        priced_events: report.priced_events,
-        unpriced_events: report.unpriced_events,
-        cache_waste: report.cache_waste.clone(),
+        events,
+        total_tokens,
+        known_cost_usd,
+        priced_events,
+        unpriced_events,
+        cache_waste: cache_waste.clone(),
         ..Default::default()
     };
-    for row in &report.by_source {
+    for row in by_source {
         totals.uncached_input += row.uncached_input;
         totals.cache_read += row.cache_read;
         totals.cache_write += row.cache_write;
@@ -1683,7 +1858,7 @@ fn print_usage_table(report: &crate::usage::UsageReport) {
         ]
     };
     let mut table: Vec<[String; 10]> = vec![HEADERS.map(str::to_string)];
-    table.extend(report.by_source.iter().map(cells));
+    table.extend(by_source.iter().map(cells));
     table.push(cells(&totals));
     let mut widths = [0usize; 10];
     for row in &table {
@@ -3057,6 +3232,50 @@ fn apply_post_processing(
     results
 }
 
+fn apply_post_processing_located(
+    mut results: Vec<LocatedRecord>,
+    render: &RenderOptions,
+) -> Vec<LocatedRecord> {
+    if let Some(min_score) = render.min_score {
+        results.retain(|result| result.score >= min_score);
+    }
+
+    match render.sort {
+        SortBy::Score => {
+            results.sort_by(|left, right| {
+                right
+                    .score
+                    .partial_cmp(&left.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+        }
+        SortBy::Ts => {
+            results.sort_by_key(|result| std::cmp::Reverse(result.record.ts));
+        }
+    }
+
+    if let Some(k) = render.top_n_per_session {
+        let mut per_session: HashMap<(String, String, String), usize> = HashMap::new();
+        results.retain(|result| {
+            let count = per_session
+                .entry((
+                    result.machine.clone(),
+                    result.record.source.storage_label().to_string(),
+                    result.record.session_id.clone(),
+                ))
+                .or_default();
+            if *count >= k {
+                return false;
+            }
+            *count += 1;
+            true
+        });
+    }
+
+    results.truncate(render.limit);
+    results
+}
+
 fn format_ts(ts: u64) -> String {
     if ts == 0 {
         return "-".to_string();
@@ -3491,6 +3710,31 @@ mod tests {
             panic!("expected usage command");
         };
         assert_eq!(root, Some(PathBuf::from("/tmp/custom-memex")));
+    }
+
+    #[test]
+    fn search_and_usage_accept_repeated_machine_filters() {
+        let search = Cli::try_parse_from([
+            "memex",
+            "search",
+            "needle",
+            "--machine",
+            "local",
+            "--machine",
+            "mini",
+        ])
+        .expect("parse search machines");
+        let Some(Commands::Search { machine, .. }) = search.command else {
+            panic!("expected search command");
+        };
+        assert_eq!(machine, ["local", "mini"]);
+
+        let usage =
+            Cli::try_parse_from(["memex", "usage", "--machine", "mini"]).expect("parse usage");
+        let Some(Commands::Usage { machine, .. }) = usage.command else {
+            panic!("expected usage command");
+        };
+        assert_eq!(machine, ["mini"]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::embed::{EmbedRuntimeConfig, ExecutionProviderChoice, ModelChoice};
 use anyhow::{Result, anyhow};
 use directories::BaseDirs;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -64,7 +64,7 @@ impl Default for IndexedToolContentLimits {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct UserConfig {
     pub embeddings: Option<bool>,
     pub auto_index_on_search: Option<bool>,
@@ -123,6 +123,81 @@ pub struct UserConfig {
     pub pi_resume_cmd: Option<String>,
     /// Resume command template for GitHub Copilot CLI sessions.
     pub copilot_resume_cmd: Option<String>,
+    /// Multi-machine search and control defaults.
+    #[serde(default)]
+    pub multi_machine: MultiMachineConfig,
+    /// Other machines whose indexes can be queried through a backend.
+    #[serde(default)]
+    pub machines: Vec<MachineConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct MultiMachineConfig {
+    /// Machines searched when --machine is not supplied. "local" is the current machine.
+    #[serde(default)]
+    pub default: Vec<String>,
+    /// Per-machine SSH request timeout.
+    pub timeout_seconds: Option<u64>,
+}
+
+impl MultiMachineConfig {
+    pub fn timeout_seconds(&self) -> u64 {
+        self.timeout_seconds.unwrap_or(10).max(1)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MachineConfig {
+    pub id: String,
+    pub label: Option<String>,
+    /// Backwards-compatible shorthand for an SSH control transport.
+    pub ssh: Option<String>,
+    /// Executable used by the SSH RPC command. Defaults to "memex".
+    pub command: Option<String>,
+    pub enabled: Option<bool>,
+    pub control: Option<ControlConfig>,
+    pub index: Option<IndexBackendConfig>,
+}
+
+impl MachineConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+
+    pub fn ssh_target(&self) -> Option<&str> {
+        self.control
+            .as_ref()
+            .filter(|control| control.kind == "ssh")
+            .map(|control| control.host.as_str())
+            .or(self.ssh.as_deref())
+    }
+
+    pub fn command(&self) -> &str {
+        self.command.as_deref().unwrap_or("memex")
+    }
+
+    pub fn uses_remote_index(&self) -> bool {
+        self.index
+            .as_ref()
+            .map(|index| index.kind == "remote")
+            .unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ControlConfig {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub host: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IndexBackendConfig {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+    pub cache: Option<PathBuf>,
 }
 
 impl UserConfig {
@@ -292,6 +367,34 @@ mod tests {
     #[test]
     fn token_usage_is_disabled_by_default() {
         assert!(!UserConfig::default().token_usage_enabled());
+    }
+
+    #[test]
+    fn parses_ssh_machine_backend_configuration() {
+        let config: UserConfig = toml::from_str(
+            r#"
+                [multi_machine]
+                default = ["local", "mini"]
+                timeout_seconds = 7
+
+                [[machines]]
+                id = "mini"
+                label = "Mac mini"
+
+                [machines.control]
+                type = "ssh"
+                host = "mini.local"
+
+                [machines.index]
+                type = "remote"
+            "#,
+        )
+        .expect("parse config");
+
+        assert_eq!(config.multi_machine.default, ["local", "mini"]);
+        assert_eq!(config.multi_machine.timeout_seconds(), 7);
+        assert_eq!(config.machines[0].ssh_target(), Some("mini.local"));
+        assert!(config.machines[0].uses_remote_index());
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2781,8 +2781,8 @@ mod tests {
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
         let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, 0, meta.len()],
-            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, meta.len()],
+            [0, 0, 0, 0, 0, 0, 1],
             false,
         ));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod embed;
 pub mod index;
 pub mod ingest;
 pub mod lease;
+pub mod machine;
 pub mod progress;
 pub mod sources;
 pub mod state;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,0 +1,1426 @@
+use crate::analytics::{AnalyticsStore, ProjectGrouping, analytics_path};
+use crate::config::{MachineConfig, Paths, UserConfig, default_claude_source};
+use crate::embed::EmbedderHandle;
+use crate::index::{QueryOptions, SearchIndex};
+use crate::ingest::{IngestOptions, IngestReport, ingest_all, ingest_if_stale};
+use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease};
+use crate::types::{Record, SourceFilter};
+use crate::usage::{
+    CacheWaste, CostMode, UsageQuery, UsageSummary, scan_usage, scan_usage_activity,
+};
+use crate::vector::VectorIndex;
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+pub const LOCAL_MACHINE_ID: &str = "local";
+const RPC_PROTOCOL: u32 = 1;
+const RRF_K: f32 = 60.0;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchMode {
+    Lexical,
+    Semantic,
+    Hybrid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchSpec {
+    pub query: String,
+    pub project: Option<String>,
+    pub role: Option<String>,
+    pub tool: Option<String>,
+    pub session_id: Option<String>,
+    pub source: Option<SourceFilter>,
+    pub since: Option<u64>,
+    pub until: Option<u64>,
+    pub limit: usize,
+    pub mode: SearchMode,
+    pub recency_weight: f32,
+    pub recency_half_life_days: f32,
+    pub min_score: Option<f32>,
+    pub project_grouping: Option<ProjectGrouping>,
+}
+
+impl SearchSpec {
+    fn query_options(&self) -> QueryOptions {
+        QueryOptions {
+            query: self.query.clone(),
+            project: self.project.clone(),
+            role: self.role.clone(),
+            tool: self.tool.clone(),
+            session_id: self.session_id.clone(),
+            source: self.source,
+            since: self.since,
+            until: self.until,
+            limit: self.limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocatedRecord {
+    pub machine: String,
+    pub score: f32,
+    pub record: Record,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionContext {
+    pub records: Vec<Record>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageSpec {
+    pub source: Option<SourceFilter>,
+    pub project: Option<String>,
+    pub project_grouping: crate::analytics::ProjectGrouping,
+    pub session_keys: Option<Vec<(String, String)>>,
+    #[serde(default)]
+    pub machine_session_keys: Option<Vec<(String, String, String)>>,
+    pub since_ms: Option<u64>,
+    pub until_ms: Option<u64>,
+    pub cost_mode: CostMode,
+    pub include_events: bool,
+    pub memo_ttl_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageReportWire {
+    pub authority: String,
+    pub events: u64,
+    pub total_tokens: u64,
+    pub unknown_model_events: u64,
+    pub conservative_events: u64,
+    pub cost_mode: CostMode,
+    pub price_catalog: String,
+    pub known_cost_usd: f64,
+    pub priced_events: u64,
+    pub unpriced_events: u64,
+    pub cache_waste: CacheWaste,
+    pub by_source: Vec<UsageSummary>,
+    pub details: Vec<serde_json::Value>,
+    pub warnings: Vec<String>,
+    pub failures: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageActivityPointWire {
+    pub machine: String,
+    pub source: String,
+    pub timestamp_ms: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug)]
+pub struct Federated<T> {
+    pub items: Vec<T>,
+    pub failures: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum RpcOperation {
+    Ping,
+    Search {
+        spec: SearchSpec,
+    },
+    Recent {
+        limit: usize,
+        project_grouping: Option<ProjectGrouping>,
+    },
+    Session {
+        session_id: String,
+        source_path: String,
+    },
+    Index,
+    Usage {
+        spec: UsageSpec,
+    },
+    UsageActivity {
+        spec: UsageSpec,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RpcRequest {
+    protocol: u32,
+    request: RpcOperation,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum RpcPayload {
+    Pong {
+        version: String,
+    },
+    Records {
+        records: Vec<(f32, Record)>,
+    },
+    Session {
+        context: SessionContext,
+    },
+    Index {
+        records_added: usize,
+        records_embedded: usize,
+        files_scanned: usize,
+        files_skipped: usize,
+    },
+    Usage {
+        report: Box<UsageReportWire>,
+    },
+    UsageActivity {
+        points: Vec<UsageActivityPointWire>,
+        partial: bool,
+    },
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RpcResponse {
+    protocol: u32,
+    response: RpcPayload,
+}
+
+pub fn selected_machine_ids(config: &UserConfig, requested: &[String]) -> Result<Vec<String>> {
+    let mut ids = if !requested.is_empty() {
+        requested.to_vec()
+    } else if !config.multi_machine.default.is_empty() {
+        config.multi_machine.default.clone()
+    } else {
+        let mut defaults = vec![LOCAL_MACHINE_ID.to_string()];
+        defaults.extend(
+            config
+                .machines
+                .iter()
+                .filter(|machine| machine.enabled())
+                .map(|machine| machine.id.clone()),
+        );
+        defaults
+    };
+    let mut seen = std::collections::HashSet::new();
+    ids.retain(|id| seen.insert(id.clone()));
+    if ids.is_empty() {
+        ids.push(LOCAL_MACHINE_ID.to_string());
+    }
+    for id in &ids {
+        if id == LOCAL_MACHINE_ID {
+            continue;
+        }
+        let machine = config
+            .machines
+            .iter()
+            .find(|machine| machine.id == *id)
+            .ok_or_else(|| anyhow!("unknown machine '{id}'"))?;
+        validate_machine(machine)?;
+    }
+    Ok(ids)
+}
+
+pub fn federated_search(
+    paths: &Paths,
+    config: &UserConfig,
+    requested: &[String],
+    spec: &SearchSpec,
+    auto_index_local: bool,
+) -> Result<Federated<LocatedRecord>> {
+    let ids = selected_machine_ids(config, requested)?;
+    let timeout = Duration::from_secs(config.multi_machine.timeout_seconds());
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let tx = tx.clone();
+            let spec = spec.clone();
+            if id == LOCAL_MACHINE_ID {
+                let paths = paths.clone();
+                let config = config.clone();
+                scope.spawn(move || {
+                    let result = search_local(&paths, &config, &spec, auto_index_local);
+                    let _ = tx.send((LOCAL_MACHINE_ID.to_string(), result));
+                });
+            } else {
+                let machine = config
+                    .machines
+                    .iter()
+                    .find(|machine| machine.id == *id)
+                    .expect("selected machines were validated")
+                    .clone();
+                scope.spawn(move || {
+                    let result =
+                        rpc_records(&machine, RpcOperation::Search { spec }, timeout, "search");
+                    let _ = tx.send((machine.id.clone(), result));
+                });
+            }
+        }
+        drop(tx);
+    });
+
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
+    for (machine, result) in rx {
+        match result {
+            Ok(records) => successes.push((machine, records)),
+            Err(err) => failures.push((machine, err.to_string())),
+        }
+    }
+    if successes.is_empty() {
+        let message = failures
+            .iter()
+            .map(|(machine, error)| format!("{machine}: {error}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        bail!("all machine searches failed: {message}");
+    }
+
+    let use_rrf = successes.len() > 1;
+    let mut items = Vec::new();
+    for (machine, mut records) in successes {
+        records.sort_by(|left, right| {
+            right
+                .0
+                .partial_cmp(&left.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        items.extend(
+            records
+                .into_iter()
+                .enumerate()
+                .map(|(rank, (score, record))| LocatedRecord {
+                    machine: machine.clone(),
+                    score: if use_rrf {
+                        1.0 / (RRF_K + rank as f32 + 1.0)
+                    } else {
+                        score
+                    },
+                    record,
+                }),
+        );
+    }
+    items.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| right.record.ts.cmp(&left.record.ts))
+    });
+    if items.len() > spec.limit {
+        items.truncate(spec.limit);
+    }
+    Ok(Federated { items, failures })
+}
+
+pub fn federated_recent(
+    paths: &Paths,
+    config: &UserConfig,
+    requested: &[String],
+    limit: usize,
+    project_grouping: Option<ProjectGrouping>,
+    auto_index_local: bool,
+) -> Result<Federated<LocatedRecord>> {
+    let ids = selected_machine_ids(config, requested)?;
+    let timeout = Duration::from_secs(config.multi_machine.timeout_seconds());
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let tx = tx.clone();
+            if id == LOCAL_MACHINE_ID {
+                let paths = paths.clone();
+                let config = config.clone();
+                scope.spawn(move || {
+                    let _ = tx.send((
+                        LOCAL_MACHINE_ID.to_string(),
+                        recent_local(&paths, &config, limit, project_grouping, auto_index_local),
+                    ));
+                });
+            } else {
+                let machine = config
+                    .machines
+                    .iter()
+                    .find(|machine| machine.id == *id)
+                    .expect("selected machines were validated")
+                    .clone();
+                scope.spawn(move || {
+                    let result = rpc_records(
+                        &machine,
+                        RpcOperation::Recent {
+                            limit,
+                            project_grouping,
+                        },
+                        timeout,
+                        "recent sessions",
+                    );
+                    let _ = tx.send((machine.id.clone(), result));
+                });
+            }
+        }
+        drop(tx);
+    });
+    let mut items = Vec::new();
+    let mut failures = Vec::new();
+    let mut successes = 0usize;
+    for (id, records) in rx {
+        match records {
+            Ok(records) => {
+                successes += 1;
+                items.extend(records.into_iter().map(|(score, record)| LocatedRecord {
+                    machine: id.clone(),
+                    score,
+                    record,
+                }));
+            }
+            Err(err) => failures.push((id, err.to_string())),
+        }
+    }
+    if successes == 0 {
+        bail!(
+            "all machines failed: {}",
+            failures
+                .iter()
+                .map(|(machine, error)| format!("{machine}: {error}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+    }
+    items.sort_by_key(|item| std::cmp::Reverse(item.record.ts));
+    Ok(Federated { items, failures })
+}
+
+pub fn session_records(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    session_id: &str,
+    source_path: &str,
+) -> Result<Vec<Record>> {
+    Ok(session_context(paths, config, machine_id, session_id, source_path)?.records)
+}
+
+pub fn session_context(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    session_id: &str,
+    source_path: &str,
+) -> Result<SessionContext> {
+    if machine_id == LOCAL_MACHINE_ID {
+        let index = SearchIndex::open_or_create(&paths.index)?;
+        return Ok(SessionContext {
+            records: records_for_session(&index, session_id, source_path)?,
+            cwd: discover_cwd(std::path::Path::new(source_path), session_id),
+        });
+    }
+    let machine = config
+        .machines
+        .iter()
+        .find(|machine| machine.id == machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    match rpc(
+        machine,
+        RpcOperation::Session {
+            session_id: session_id.to_string(),
+            source_path: source_path.to_string(),
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )? {
+        RpcPayload::Session { context } => Ok(context),
+        RpcPayload::Error { message } => Err(anyhow!("session failed: {message}")),
+        other => Err(anyhow!("session returned unexpected response: {other:?}")),
+    }
+}
+
+pub fn machine_by_id<'a>(config: &'a UserConfig, id: &str) -> Option<&'a MachineConfig> {
+    config.machines.iter().find(|machine| machine.id == id)
+}
+
+fn usage_spec_for_machine(spec: &UsageSpec, machine: &str) -> UsageSpec {
+    let mut machine_spec = spec.clone();
+    if let Some(keys) = &spec.machine_session_keys {
+        machine_spec.session_keys = Some(
+            keys.iter()
+                .filter(|(key_machine, _, _)| key_machine == machine)
+                .map(|(_, source, session_id)| (source.clone(), session_id.clone()))
+                .collect(),
+        );
+        machine_spec.machine_session_keys = None;
+    }
+    machine_spec
+}
+
+pub fn federated_usage(
+    paths: &Paths,
+    config: &UserConfig,
+    requested: &[String],
+    spec: &UsageSpec,
+) -> Result<UsageReportWire> {
+    let ids = selected_machine_ids(config, requested)?;
+    let timeout = Duration::from_secs(config.multi_machine.timeout_seconds());
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let tx = tx.clone();
+            let spec = usage_spec_for_machine(spec, id);
+            if id == LOCAL_MACHINE_ID {
+                let paths = paths.clone();
+                let config = config.clone();
+                scope.spawn(move || {
+                    let result = usage_local(&paths, &config, &spec);
+                    let _ = tx.send((LOCAL_MACHINE_ID.to_string(), result));
+                });
+            } else {
+                let machine = config
+                    .machines
+                    .iter()
+                    .find(|machine| machine.id == *id)
+                    .expect("selected machines were validated")
+                    .clone();
+                scope.spawn(move || {
+                    let result = match rpc(&machine, RpcOperation::Usage { spec }, timeout) {
+                        Ok(RpcPayload::Usage { report }) => Ok(*report),
+                        Ok(RpcPayload::Error { message }) => Err(anyhow!(message)),
+                        Ok(other) => Err(anyhow!("unexpected usage response: {other:?}")),
+                        Err(err) => Err(err),
+                    };
+                    let _ = tx.send((machine.id.clone(), result));
+                });
+            }
+        }
+        drop(tx);
+    });
+
+    let mut reports = Vec::new();
+    let mut failures = Vec::new();
+    for (machine, result) in rx {
+        match result {
+            Ok(report) => reports.push((machine, report)),
+            Err(err) => failures.push((machine, err.to_string())),
+        }
+    }
+    if reports.is_empty() {
+        bail!(
+            "all machine usage scans failed: {}",
+            failures
+                .iter()
+                .map(|(machine, error)| format!("{machine}: {error}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+    }
+    Ok(merge_usage_reports(reports, failures, spec.cost_mode))
+}
+
+pub fn federated_usage_activity(
+    paths: &Paths,
+    config: &UserConfig,
+    requested: &[String],
+    spec: &UsageSpec,
+) -> Result<(Vec<UsageActivityPointWire>, bool)> {
+    let ids = selected_machine_ids(config, requested)?;
+    let timeout = Duration::from_secs(config.multi_machine.timeout_seconds());
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let tx = tx.clone();
+            let spec = usage_spec_for_machine(spec, id);
+            if id == LOCAL_MACHINE_ID {
+                let paths = paths.clone();
+                let config = config.clone();
+                scope.spawn(move || {
+                    let result = usage_activity_local(&paths, &config, &spec);
+                    let _ = tx.send((LOCAL_MACHINE_ID.to_string(), result));
+                });
+            } else {
+                let machine = config
+                    .machines
+                    .iter()
+                    .find(|machine| machine.id == *id)
+                    .expect("selected machines were validated")
+                    .clone();
+                scope.spawn(move || {
+                    let result = match rpc(&machine, RpcOperation::UsageActivity { spec }, timeout)
+                    {
+                        Ok(RpcPayload::UsageActivity { points, partial }) => Ok((points, partial)),
+                        Ok(RpcPayload::Error { message }) => Err(anyhow!(message)),
+                        Ok(other) => Err(anyhow!("unexpected usage activity response: {other:?}")),
+                        Err(err) => Err(err),
+                    };
+                    let _ = tx.send((machine.id.clone(), result));
+                });
+            }
+        }
+        drop(tx);
+    });
+    let mut points = Vec::new();
+    let mut partial = false;
+    let mut successes = 0usize;
+    let mut errors = Vec::new();
+    for (machine, result) in rx {
+        match result {
+            Ok((mut machine_points, machine_partial)) => {
+                successes += 1;
+                partial |= machine_partial;
+                for point in &mut machine_points {
+                    point.machine.clone_from(&machine);
+                }
+                points.extend(machine_points);
+            }
+            Err(err) => {
+                partial = true;
+                errors.push(format!("{machine}: {err}"));
+            }
+        }
+    }
+    if successes == 0 {
+        bail!(
+            "all machine usage activity scans failed: {}",
+            errors.join("; ")
+        );
+    }
+    points.sort_by_key(|point| point.timestamp_ms);
+    Ok((points, partial))
+}
+
+pub fn remote_shell_command(machine: &MachineConfig, command: &str) -> Result<String> {
+    validate_machine(machine)?;
+    let target = machine
+        .ssh_target()
+        .ok_or_else(|| anyhow!("machine '{}' has no SSH control transport", machine.id))?;
+    Ok(format!(
+        "ssh -t -- {} {}",
+        shell_quote(target),
+        shell_quote(command)
+    ))
+}
+
+pub fn run_rpc_stdio(root: Option<std::path::PathBuf>) -> Result<()> {
+    let paths = Paths::new(root)?;
+    let config = UserConfig::load(&paths)?;
+    let mut input = Vec::new();
+    std::io::stdin().read_to_end(&mut input)?;
+    let request: RpcRequest =
+        serde_json::from_slice(&input).context("invalid memex RPC request")?;
+    let response = if request.protocol != RPC_PROTOCOL {
+        RpcPayload::Error {
+            message: format!(
+                "unsupported RPC protocol {}; expected {RPC_PROTOCOL}",
+                request.protocol
+            ),
+        }
+    } else {
+        match handle_rpc(&paths, &config, request.request) {
+            Ok(response) => response,
+            Err(err) => RpcPayload::Error {
+                message: err.to_string(),
+            },
+        }
+    };
+    serde_json::to_writer(
+        std::io::stdout(),
+        &RpcResponse {
+            protocol: RPC_PROTOCOL,
+            response,
+        },
+    )?;
+    Ok(())
+}
+
+fn handle_rpc(paths: &Paths, config: &UserConfig, request: RpcOperation) -> Result<RpcPayload> {
+    match request {
+        RpcOperation::Ping => Ok(RpcPayload::Pong {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        }),
+        RpcOperation::Search { spec } => Ok(RpcPayload::Records {
+            records: search_local(paths, config, &spec, true)?,
+        }),
+        RpcOperation::Recent {
+            limit,
+            project_grouping,
+        } => Ok(RpcPayload::Records {
+            records: recent_local(paths, config, limit, project_grouping, true)?,
+        }),
+        RpcOperation::Session {
+            session_id,
+            source_path,
+        } => {
+            let index = SearchIndex::open_or_create(&paths.index)?;
+            let records = records_for_session(&index, &session_id, &source_path)?;
+            Ok(RpcPayload::Session {
+                context: SessionContext {
+                    records,
+                    cwd: discover_cwd(std::path::Path::new(&source_path), &session_id),
+                },
+            })
+        }
+        RpcOperation::Index => {
+            let report = index_local(paths, config, false)?;
+            Ok(RpcPayload::Index {
+                records_added: report.records_added,
+                records_embedded: report.records_embedded,
+                files_scanned: report.files_scanned,
+                files_skipped: report.files_skipped,
+            })
+        }
+        RpcOperation::Usage { spec } => Ok(RpcPayload::Usage {
+            report: Box::new(usage_local(paths, config, &spec)?),
+        }),
+        RpcOperation::UsageActivity { spec } => {
+            let (points, partial) = usage_activity_local(paths, config, &spec)?;
+            Ok(RpcPayload::UsageActivity { points, partial })
+        }
+    }
+}
+
+fn usage_local(paths: &Paths, config: &UserConfig, spec: &UsageSpec) -> Result<UsageReportWire> {
+    if !config.token_usage_enabled() {
+        bail!("token usage tracking is disabled on this machine");
+    }
+    let report = scan_usage(&usage_query(paths, spec))?;
+    let details = report
+        .details
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(UsageReportWire {
+        authority: report.authority.to_string(),
+        events: report.events,
+        total_tokens: report.total_tokens,
+        unknown_model_events: report.unknown_model_events,
+        conservative_events: report.conservative_events,
+        cost_mode: report.cost_mode,
+        price_catalog: report.price_catalog.to_string(),
+        known_cost_usd: report.known_cost_usd,
+        priced_events: report.priced_events,
+        unpriced_events: report.unpriced_events,
+        cache_waste: report.cache_waste.clone(),
+        by_source: report.by_source.clone(),
+        details,
+        warnings: report.warnings.clone(),
+        failures: Vec::new(),
+    })
+}
+
+fn usage_activity_local(
+    paths: &Paths,
+    config: &UserConfig,
+    spec: &UsageSpec,
+) -> Result<(Vec<UsageActivityPointWire>, bool)> {
+    if !config.token_usage_enabled() {
+        bail!("token usage tracking is disabled on this machine");
+    }
+    let (points, partial) = scan_usage_activity(&usage_query(paths, spec))?;
+    Ok((
+        points
+            .into_iter()
+            .map(|point| UsageActivityPointWire {
+                machine: LOCAL_MACHINE_ID.to_string(),
+                source: point.source.to_string(),
+                timestamp_ms: point.timestamp_ms,
+                total_tokens: point.total_tokens,
+            })
+            .collect(),
+        partial,
+    ))
+}
+
+fn usage_query(paths: &Paths, spec: &UsageSpec) -> UsageQuery {
+    UsageQuery {
+        source: spec.source,
+        project: spec.project.clone(),
+        project_grouping: spec.project_grouping,
+        session_keys: spec
+            .session_keys
+            .as_ref()
+            .map(|keys| keys.iter().cloned().collect()),
+        since_ms: spec.since_ms,
+        until_ms: spec.until_ms,
+        cost_mode: spec.cost_mode,
+        include_events: spec.include_events,
+        cache_path: Some(paths.state.join("usage-cache.sqlite3")),
+        memo_ttl_ms: spec.memo_ttl_ms,
+    }
+}
+
+fn merge_usage_reports(
+    reports: Vec<(String, UsageReportWire)>,
+    failures: Vec<(String, String)>,
+    cost_mode: CostMode,
+) -> UsageReportWire {
+    let multi = reports.len() + failures.len() > 1;
+    let mut merged = UsageReportWire {
+        authority: "multi-machine reconstructed usage (not subscription quota)".to_string(),
+        events: 0,
+        total_tokens: 0,
+        unknown_model_events: 0,
+        conservative_events: 0,
+        cost_mode,
+        price_catalog: reports
+            .first()
+            .map(|(_, report)| report.price_catalog.clone())
+            .unwrap_or_default(),
+        known_cost_usd: 0.0,
+        priced_events: 0,
+        unpriced_events: 0,
+        cache_waste: CacheWaste::default(),
+        by_source: Vec::new(),
+        details: Vec::new(),
+        warnings: Vec::new(),
+        failures,
+    };
+    for (machine, mut report) in reports {
+        merged.events = merged.events.saturating_add(report.events);
+        merged.total_tokens = merged.total_tokens.saturating_add(report.total_tokens);
+        merged.unknown_model_events = merged
+            .unknown_model_events
+            .saturating_add(report.unknown_model_events);
+        merged.conservative_events = merged
+            .conservative_events
+            .saturating_add(report.conservative_events);
+        merged.known_cost_usd += report.known_cost_usd;
+        merged.priced_events = merged.priced_events.saturating_add(report.priced_events);
+        merged.unpriced_events = merged
+            .unpriced_events
+            .saturating_add(report.unpriced_events);
+        absorb_cache_waste(&mut merged.cache_waste, &report.cache_waste);
+        for row in &mut report.by_source {
+            if multi || machine != LOCAL_MACHINE_ID {
+                row.source = format!("{machine}/{}", row.source);
+            }
+        }
+        merged.by_source.extend(report.by_source);
+        for mut detail in report.details {
+            if let Some(object) = detail.as_object_mut() {
+                object.insert(
+                    "machine".to_string(),
+                    serde_json::Value::String(machine.clone()),
+                );
+            }
+            merged.details.push(detail);
+        }
+        merged.warnings.extend(
+            report
+                .warnings
+                .into_iter()
+                .map(|warning| format!("{machine}: {warning}")),
+        );
+    }
+    for (machine, error) in &merged.failures {
+        merged
+            .warnings
+            .push(format!("{machine}: usage unavailable: {error}"));
+    }
+    merged
+}
+
+fn absorb_cache_waste(total: &mut CacheWaste, row: &CacheWaste) {
+    total.missed_tokens = total.missed_tokens.saturating_add(row.missed_tokens);
+    total.missed_cost_usd += row.missed_cost_usd;
+    total.miss_count = total.miss_count.saturating_add(row.miss_count);
+    total.idle_misses = total.idle_misses.saturating_add(row.idle_misses);
+    total.model_switch_misses = total
+        .model_switch_misses
+        .saturating_add(row.model_switch_misses);
+}
+
+fn search_local(
+    paths: &Paths,
+    config: &UserConfig,
+    spec: &SearchSpec,
+    auto_index: bool,
+) -> Result<Vec<(f32, Record)>> {
+    if auto_index {
+        ensure_local_index(paths, config)?;
+    }
+    let index = SearchIndex::open_or_create(&paths.index)?;
+    let options = spec.query_options();
+    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let mut results = match spec.mode {
+        SearchMode::Lexical => index.search(&options)?,
+        SearchMode::Semantic => {
+            let vector = match VectorIndex::open(&paths.vectors) {
+                Ok(vector) => vector,
+                Err(err) if err.to_string() == "vector index not found" => {
+                    return lexical_results(&index, &options, spec, now_ms);
+                }
+                Err(err) => return Err(err),
+            };
+            let model = config.resolve_model(None)?;
+            let runtime = config.resolve_embed_runtime()?;
+            let mut embedder = EmbedderHandle::with_model_and_runtime(model, &runtime)?;
+            let embedding = embedder
+                .embed_texts(&[spec.query.as_str()])?
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow!("embedding missing"))?;
+            let mut records = Vec::new();
+            for (doc_id, distance) in vector.search(&embedding, spec.limit)? {
+                if let Some(record) = index.get_by_doc_id(doc_id)?
+                    && matches_filters(&record, &options)
+                {
+                    records.push((1.0 / (1.0 + distance), record));
+                }
+            }
+            records
+        }
+        SearchMode::Hybrid => {
+            let vector = match VectorIndex::open(&paths.vectors) {
+                Ok(vector) => vector,
+                Err(err) if err.to_string() == "vector index not found" => {
+                    return lexical_results(&index, &options, spec, now_ms);
+                }
+                Err(err) => return Err(err),
+            };
+            let candidate_limit = (spec.limit * 5).clamp(50, 500);
+            let lexical = index.search(&QueryOptions {
+                limit: candidate_limit,
+                ..options.clone()
+            })?;
+            let model = config.resolve_model(None)?;
+            let runtime = config.resolve_embed_runtime()?;
+            let mut embedder = EmbedderHandle::with_model_and_runtime(model, &runtime)?;
+            let embedding = embedder
+                .embed_texts(&[spec.query.as_str()])?
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow!("embedding missing"))?;
+            let semantic = vector.search(&embedding, candidate_limit)?;
+            let mut records = HashMap::new();
+            let mut scores = HashMap::<u64, f32>::new();
+            for (rank, (_, record)) in lexical.into_iter().enumerate() {
+                if matches_filters(&record, &options) {
+                    *scores.entry(record.doc_id).or_default() += 1.0 / (RRF_K + rank as f32 + 1.0);
+                    records.insert(record.doc_id, record);
+                }
+            }
+            for (rank, (doc_id, _)) in semantic.into_iter().enumerate() {
+                if let Some(record) = index.get_by_doc_id(doc_id)?
+                    && matches_filters(&record, &options)
+                {
+                    *scores.entry(doc_id).or_default() += 1.0 / (RRF_K + rank as f32 + 1.0);
+                    records.entry(doc_id).or_insert(record);
+                }
+            }
+            scores
+                .into_iter()
+                .filter_map(|(doc_id, score)| records.remove(&doc_id).map(|record| (score, record)))
+                .collect()
+        }
+    };
+    for (score, record) in &mut results {
+        *score = apply_recency(
+            *score,
+            record.ts,
+            now_ms,
+            spec.recency_weight,
+            spec.recency_half_life_days,
+        );
+    }
+    results.retain(|(_, record)| matches_filters(record, &options));
+    if let Some(min_score) = spec.min_score {
+        results.retain(|(score, _)| *score >= min_score);
+    }
+    results.sort_by(|left, right| {
+        right
+            .0
+            .partial_cmp(&left.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| right.1.ts.cmp(&left.1.ts))
+    });
+    results.truncate(spec.limit);
+    apply_project_grouping(paths, &mut results, spec.project_grouping);
+    Ok(results)
+}
+
+fn lexical_results(
+    index: &SearchIndex,
+    options: &QueryOptions,
+    spec: &SearchSpec,
+    now_ms: u64,
+) -> Result<Vec<(f32, Record)>> {
+    let mut results = index.search(options)?;
+    for (score, record) in &mut results {
+        *score = apply_recency(
+            *score,
+            record.ts,
+            now_ms,
+            spec.recency_weight,
+            spec.recency_half_life_days,
+        );
+    }
+    results.retain(|(_, record)| matches_filters(record, options));
+    if let Some(min_score) = spec.min_score {
+        results.retain(|(score, _)| *score >= min_score);
+    }
+    Ok(results)
+}
+
+fn recent_local(
+    paths: &Paths,
+    config: &UserConfig,
+    limit: usize,
+    project_grouping: Option<ProjectGrouping>,
+    auto_index: bool,
+) -> Result<Vec<(f32, Record)>> {
+    if auto_index {
+        ensure_local_index(paths, config)?;
+    }
+    let index = SearchIndex::open_or_create(&paths.index)?;
+    let mut records: Vec<_> = index
+        .recent_records(limit)?
+        .into_iter()
+        .map(|record| (0.0, record))
+        .collect();
+    apply_project_grouping(paths, &mut records, project_grouping);
+    Ok(records)
+}
+
+fn apply_project_grouping(
+    paths: &Paths,
+    records: &mut [(f32, Record)],
+    grouping: Option<ProjectGrouping>,
+) {
+    let Some(grouping) = grouping.filter(|grouping| *grouping != ProjectGrouping::Flat) else {
+        return;
+    };
+    let Ok(store) = AnalyticsStore::open_read_only(analytics_path(&paths.state)) else {
+        return;
+    };
+    let keys: Vec<_> = records
+        .iter()
+        .map(|(_, record)| {
+            (
+                record.source,
+                record.session_id.clone(),
+                record.source_path.clone(),
+            )
+        })
+        .collect();
+    let Ok(projects) = store.query_session_projects(&keys, grouping) else {
+        return;
+    };
+    for (_, record) in records {
+        let key = (
+            record.source,
+            record.session_id.clone(),
+            record.source_path.clone(),
+        );
+        if let Some(project) = projects.get(&key) {
+            record.project.clone_from(project);
+        }
+    }
+}
+
+fn ensure_local_index(paths: &Paths, config: &UserConfig) -> Result<()> {
+    if config.auto_index_on_search_default() {
+        let _ = index_local(paths, config, true)?;
+    }
+    Ok(())
+}
+
+fn index_local(paths: &Paths, config: &UserConfig, stale_only: bool) -> Result<IngestReport> {
+    paths.ensure_dirs()?;
+    let lease = IngestLease::acquire(paths, "RPC index", INGEST_LEASE_TIMEOUT)?;
+    let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;
+    let options = IngestOptions {
+        claude_source: default_claude_source(),
+        include_agents: false,
+        include_reasoning: config.include_reasoning_default(),
+        include_codex: true,
+        include_opencode: true,
+        include_cursor: true,
+        include_pi: true,
+        include_openclaw: true,
+        include_copilot: true,
+        embeddings: config.embeddings_default(),
+        backfill_embeddings: false,
+        model: config.resolve_model(None)?,
+        embed_runtime: config.resolve_embed_runtime()?,
+        tool_content_limits: config.indexed_tool_content_limits()?,
+    };
+    if stale_only {
+        Ok(
+            ingest_if_stale(paths, &index, &options, config.scan_cache_ttl(), &lease)?.unwrap_or(
+                IngestReport {
+                    records_added: 0,
+                    records_embedded: 0,
+                    files_scanned: 0,
+                    files_skipped: 0,
+                    diagnostics: Default::default(),
+                },
+            ),
+        )
+    } else {
+        ingest_all(paths, &index, &options, &lease)
+    }
+}
+
+fn records_for_session(
+    index: &SearchIndex,
+    session_id: &str,
+    source_path: &str,
+) -> Result<Vec<Record>> {
+    let mut records = index.records_by_session_id(session_id)?;
+    if !source_path.is_empty() {
+        records.retain(|record| record.source_path == source_path);
+    }
+    records.sort_by(|left, right| {
+        left.turn_id
+            .cmp(&right.turn_id)
+            .then_with(|| left.ts.cmp(&right.ts))
+            .then_with(|| left.doc_id.cmp(&right.doc_id))
+    });
+    Ok(records)
+}
+
+fn discover_cwd(path: &std::path::Path, session_id: &str) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let mut fallback = None;
+    for line in std::io::BufRead::lines(reader).map_while(Result::ok) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let cwd = value
+            .get("cwd")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                value
+                    .get("payload")
+                    .and_then(|payload| payload.get("cwd"))
+                    .and_then(|value| value.as_str())
+            })
+            .map(str::to_string);
+        if fallback.is_none() {
+            fallback.clone_from(&cwd);
+        }
+        let matches_session = value
+            .get("sessionId")
+            .and_then(|value| value.as_str())
+            .or_else(|| value.get("session_id").and_then(|value| value.as_str()))
+            .is_some_and(|id| id == session_id);
+        if matches_session && cwd.is_some() {
+            return cwd;
+        }
+        if value.get("type").and_then(|value| value.as_str()) == Some("session_meta")
+            && cwd.is_some()
+        {
+            return cwd;
+        }
+    }
+    fallback
+}
+
+fn rpc_records(
+    machine: &MachineConfig,
+    operation: RpcOperation,
+    timeout: Duration,
+    context: &str,
+) -> Result<Vec<(f32, Record)>> {
+    match rpc(machine, operation, timeout)? {
+        RpcPayload::Records { records } => Ok(records),
+        RpcPayload::Error { message } => Err(anyhow!("{context} failed: {message}")),
+        other => Err(anyhow!("{context} returned unexpected response: {other:?}")),
+    }
+}
+
+fn rpc(machine: &MachineConfig, operation: RpcOperation, timeout: Duration) -> Result<RpcPayload> {
+    validate_machine(machine)?;
+    if !machine.uses_remote_index() {
+        bail!(
+            "machine '{}' uses unsupported index backend '{}'",
+            machine.id,
+            machine
+                .index
+                .as_ref()
+                .map(|index| index.kind.as_str())
+                .unwrap_or("unknown")
+        );
+    }
+    let target = machine
+        .ssh_target()
+        .ok_or_else(|| anyhow!("machine '{}' has no SSH control transport", machine.id))?;
+    let command = format!("{} rpc", machine.command());
+    let mut child = Command::new("ssh")
+        .args(["-T", "-o", "BatchMode=yes", "--", target, &command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start SSH for '{}'", machine.id))?;
+    let request = serde_json::to_vec(&RpcRequest {
+        protocol: RPC_PROTOCOL,
+        request: operation,
+    })?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("missing SSH stdin"))?
+        .write_all(&request)?;
+
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("missing SSH stdout"))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("missing SSH stderr"))?;
+    let stdout_thread = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).map(|_| bytes)
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).map(|_| bytes)
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!(
+                "SSH request to '{}' timed out after {}s",
+                machine.id,
+                timeout.as_secs()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| anyhow!("SSH stdout reader panicked"))??;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| anyhow!("SSH stderr reader panicked"))??;
+    if !status.success() {
+        let message = String::from_utf8_lossy(&stderr).trim().to_string();
+        bail!(
+            "SSH request to '{}' exited with {status}: {}",
+            machine.id,
+            if message.is_empty() {
+                "no error output"
+            } else {
+                &message
+            }
+        );
+    }
+    let response: RpcResponse = serde_json::from_slice(&stdout)
+        .with_context(|| format!("invalid RPC response from '{}'", machine.id))?;
+    if response.protocol != RPC_PROTOCOL {
+        bail!(
+            "machine '{}' uses RPC protocol {}; expected {RPC_PROTOCOL}",
+            machine.id,
+            response.protocol
+        );
+    }
+    Ok(response.response)
+}
+
+fn validate_machine(machine: &MachineConfig) -> Result<()> {
+    if machine.id.is_empty()
+        || machine.id == LOCAL_MACHINE_ID
+        || !machine
+            .id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        bail!("invalid machine id '{}'", machine.id);
+    }
+    let target = machine
+        .ssh_target()
+        .ok_or_else(|| anyhow!("machine '{}' has no SSH control transport", machine.id))?;
+    if target.starts_with('-') || target.is_empty() || target.chars().any(char::is_whitespace) {
+        bail!("machine '{}' has an unsafe SSH target", machine.id);
+    }
+    let command = machine.command();
+    if command.starts_with('-')
+        || command.is_empty()
+        || !command.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-' | b'~')
+        })
+    {
+        bail!("machine '{}' has an unsafe command", machine.id);
+    }
+    Ok(())
+}
+
+fn matches_filters(record: &Record, options: &QueryOptions) -> bool {
+    options
+        .project
+        .as_ref()
+        .is_none_or(|project| record.project == *project)
+        && options
+            .role
+            .as_ref()
+            .is_none_or(|role| record.role == *role)
+        && options
+            .tool
+            .as_ref()
+            .is_none_or(|tool| record.tool_name.as_deref() == Some(tool.as_str()))
+        && options
+            .session_id
+            .as_ref()
+            .is_none_or(|session| record.session_id == *session)
+        && options
+            .source
+            .is_none_or(|source| source.matches(record.source))
+        && options.since.is_none_or(|since| record.ts >= since)
+        && options.until.is_none_or(|until| record.ts <= until)
+}
+
+fn apply_recency(score: f32, ts: u64, now_ms: u64, weight: f32, half_life_days: f32) -> f32 {
+    if score <= 0.0 || weight <= 0.0 || half_life_days <= 0.0 || ts == 0 {
+        return score;
+    }
+    let age_ms = now_ms.saturating_sub(ts);
+    let age_days = age_ms as f32 / (1000.0 * 60.0 * 60.0 * 24.0);
+    let decay = (-std::f32::consts::LN_2 * age_days / half_life_days).exp();
+    score * (1.0 + weight * decay)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ControlConfig, IndexBackendConfig, MultiMachineConfig};
+
+    fn machine(id: &str) -> MachineConfig {
+        MachineConfig {
+            id: id.to_string(),
+            label: None,
+            ssh: None,
+            command: None,
+            enabled: None,
+            control: Some(ControlConfig {
+                kind: "ssh".to_string(),
+                host: "mini".to_string(),
+            }),
+            index: Some(IndexBackendConfig {
+                kind: "remote".to_string(),
+                bucket: None,
+                prefix: None,
+                cache: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn selection_defaults_to_local_and_enabled_machines() {
+        let config = UserConfig {
+            machines: vec![machine("mini")],
+            ..UserConfig::default()
+        };
+        assert_eq!(
+            selected_machine_ids(&config, &[]).unwrap(),
+            vec!["local", "mini"]
+        );
+    }
+
+    #[test]
+    fn usage_session_keys_are_partitioned_by_machine() {
+        let spec = UsageSpec {
+            source: None,
+            project: None,
+            project_grouping: ProjectGrouping::Flat,
+            session_keys: None,
+            machine_session_keys: Some(vec![
+                ("local".into(), "codex".into(), "shared".into()),
+                ("mini".into(), "claude".into(), "shared".into()),
+            ]),
+            since_ms: None,
+            until_ms: None,
+            cost_mode: CostMode::Source,
+            include_events: false,
+            memo_ttl_ms: 0,
+        };
+
+        let local = usage_spec_for_machine(&spec, "local");
+        let mini = usage_spec_for_machine(&spec, "mini");
+        let other = usage_spec_for_machine(&spec, "other");
+
+        assert_eq!(
+            local.session_keys,
+            Some(vec![("codex".into(), "shared".into())])
+        );
+        assert_eq!(
+            mini.session_keys,
+            Some(vec![("claude".into(), "shared".into())])
+        );
+        assert_eq!(other.session_keys, Some(Vec::new()));
+        assert!(local.machine_session_keys.is_none());
+        assert!(mini.machine_session_keys.is_none());
+    }
+
+    #[test]
+    fn explicit_defaults_are_respected() {
+        let config = UserConfig {
+            multi_machine: MultiMachineConfig {
+                default: vec!["mini".to_string()],
+                timeout_seconds: None,
+            },
+            machines: vec![machine("mini")],
+            ..UserConfig::default()
+        };
+        assert_eq!(selected_machine_ids(&config, &[]).unwrap(), vec!["mini"]);
+    }
+
+    #[test]
+    fn unsafe_ssh_targets_are_rejected() {
+        let mut machine = machine("mini");
+        machine.control.as_mut().unwrap().host = "-oProxyCommand=oops".to_string();
+        assert!(validate_machine(&machine).is_err());
+    }
+
+    #[test]
+    fn usage_reports_merge_and_keep_machine_provenance() {
+        let report = |tokens, source: &str| UsageReportWire {
+            authority: "local".to_string(),
+            events: 1,
+            total_tokens: tokens,
+            unknown_model_events: 0,
+            conservative_events: 0,
+            cost_mode: CostMode::Auto,
+            price_catalog: "test".to_string(),
+            known_cost_usd: 0.5,
+            priced_events: 1,
+            unpriced_events: 0,
+            cache_waste: CacheWaste::default(),
+            by_source: vec![UsageSummary {
+                source: source.to_string(),
+                events: 1,
+                total_tokens: tokens,
+                ..UsageSummary::default()
+            }],
+            details: Vec::new(),
+            warnings: Vec::new(),
+            failures: Vec::new(),
+        };
+
+        let merged = merge_usage_reports(
+            vec![
+                ("local".to_string(), report(10, "codex")),
+                ("mini".to_string(), report(20, "claude")),
+            ],
+            Vec::new(),
+            CostMode::Auto,
+        );
+
+        assert_eq!(merged.events, 2);
+        assert_eq!(merged.total_tokens, 30);
+        assert_eq!(merged.by_source[0].source, "local/codex");
+        assert_eq!(merged.by_source[1].source, "mini/claude");
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,6 +3,11 @@ use crate::config::{Paths, UserConfig, default_claude_source};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt};
+use crate::machine::{
+    LOCAL_MACHINE_ID, SearchMode, SearchSpec, UsageSpec, federated_recent, federated_search,
+    federated_usage_activity, machine_by_id, remote_shell_command, session_context,
+    session_records,
+};
 use crate::types::{Record, SourceFilter, SourceKind};
 use crate::usage::{CostMode, UsageQuery, scan_usage_activity};
 use anyhow::Result;
@@ -52,6 +57,7 @@ enum SearchUpdate {
     Results {
         request_id: u64,
         sessions: Vec<SessionSummary>,
+        failures: MachineFailures,
     },
     Projects {
         request_id: u64,
@@ -110,6 +116,9 @@ enum SearchUpdate {
     },
 }
 
+type MachineFailures = Vec<(String, String)>;
+type SearchRequestResult = Result<(Vec<SessionSummary>, MachineFailures)>;
+
 #[derive(Clone, Debug)]
 struct DetailRequest {
     request_id: u64,
@@ -124,6 +133,7 @@ struct SearchRequest {
     request_id: u64,
     query: String,
     project: String,
+    machines: Vec<String>,
     source: SourceChoice,
     since: Option<u64>,
     grouping: ProjectGrouping,
@@ -381,6 +391,7 @@ impl ProjectDisplayMode {
 enum HomeDropdown {
     None,
     Range,
+    Machine,
     Source,
     Project,
 }
@@ -436,10 +447,23 @@ impl SourceChoice {
             SourceChoice::Copilot => "copilot",
         }
     }
+
+    fn from_source(source: SourceKind) -> Self {
+        match source {
+            SourceKind::Claude => SourceChoice::Claude,
+            SourceKind::Codex => SourceChoice::Codex,
+            SourceKind::Opencode => SourceChoice::Opencode,
+            SourceKind::Cursor => SourceChoice::Cursor,
+            SourceKind::Pi => SourceChoice::Pi,
+            SourceKind::OpenClaw => SourceChoice::OpenClaw,
+            SourceKind::Copilot => SourceChoice::Copilot,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
 struct SessionSummary {
+    machine: String,
     session_id: String,
     project: String,
     source: SourceKind,
@@ -476,6 +500,8 @@ struct App {
     focus: Focus,
     query: String,
     project: String,
+    machine: String,
+    home_machines: Vec<String>,
     source: SourceChoice,
     all_projects: Vec<String>,
     project_options: Vec<String>,
@@ -517,6 +543,7 @@ struct App {
     home_dropdown_state: ListState,
     home_dropdown_area: Rect,
     home_range_area: Rect,
+    home_machine_area: Rect,
     home_source_area: Rect,
     home_project_area: Rect,
     home_sources: Vec<SourceChoice>,
@@ -746,11 +773,12 @@ pub fn run(
     let (detail_tx, detail_rx) = std::sync::mpsc::channel();
     spawn_search_worker(
         paths.clone(),
+        config.clone(),
         index.clone(),
         search_request_rx,
         search_tx.clone(),
     );
-    spawn_detail_worker(index.clone(), detail_rx, search_tx.clone());
+    spawn_detail_worker(paths.clone(), config.clone(), detail_rx, search_tx.clone());
 
     let mut app = App::new(
         paths,
@@ -782,6 +810,14 @@ pub fn run(
 
 impl App {
     fn new(paths: Paths, config: UserConfig, index: SearchIndex, channels: AppChannels) -> Self {
+        let mut home_machines = vec![LOCAL_MACHINE_ID.to_string()];
+        home_machines.extend(
+            config
+                .machines
+                .iter()
+                .filter(|machine| machine.enabled())
+                .map(|machine| machine.id.clone()),
+        );
         Self {
             paths,
             config,
@@ -789,6 +825,8 @@ impl App {
             focus: Focus::Query,
             query: String::new(),
             project: String::new(),
+            machine: String::new(),
+            home_machines,
             home_activity: Vec::new(),
             home_result_activity: Vec::new(),
             home_activity_range: TimelineRange::Month,
@@ -805,6 +843,7 @@ impl App {
             home_dropdown_state: ListState::default(),
             home_dropdown_area: Rect::default(),
             home_range_area: Rect::default(),
+            home_machine_area: Rect::default(),
             home_source_area: Rect::default(),
             home_project_area: Rect::default(),
             home_sources: Vec::new(),
@@ -879,7 +918,9 @@ impl App {
     }
 
     fn home_chart_is_filtered(&self) -> bool {
-        !self.query.trim().is_empty()
+        !self.config.machines.is_empty()
+            || !self.query.trim().is_empty()
+            || !self.machine.is_empty()
             || self.source != SourceChoice::All
             || !self.project.trim().is_empty()
     }
@@ -997,7 +1038,7 @@ impl App {
         let session_changed = self
             .last_detail_session
             .as_ref()
-            .map(|s| s != &session.session_id)
+            .map(|s| s != &format!("{}:{}", session.machine, session.session_id))
             .unwrap_or(true);
         let query_changed = self
             .last_detail_query
@@ -1024,7 +1065,7 @@ impl App {
         self.detail_state = LoadState::Loading;
         self.detail_lines.clear();
         self.detail_scroll = 0;
-        self.last_detail_session = Some(session.session_id.clone());
+        self.last_detail_session = Some(format!("{}:{}", session.machine, session.session_id));
         self.last_detail_query = Some(query_now);
         self.last_detail_mode = self.preview_mode;
         self.last_detail_find = Some(find_now);
@@ -1069,6 +1110,7 @@ impl App {
             request_id,
             query,
             project: self.project.trim().to_string(),
+            machines: self.selected_machines(),
             source: self.source,
             since: self.sessions_since,
             grouping: self.project_display.grouping(),
@@ -1220,7 +1262,7 @@ impl App {
     }
 
     fn kickoff_home_token_activity(&mut self) {
-        if !self.config.token_usage_enabled() {
+        if !self.config.token_usage_enabled() && self.config.machines.is_empty() {
             self.invalidate_home_token_activity();
             return;
         }
@@ -1230,16 +1272,76 @@ impl App {
         self.home_token_activity_state = LoadState::Loading;
         self.home_token_activity_partial = false;
         let tx = self.search_tx.clone();
+        let paths = self.paths.clone();
+        let config = self.config.clone();
+        let machines = self.selected_machines();
+        let source = self.source.as_filter();
+        let project = (!self.project.trim().is_empty()).then(|| self.project.trim().to_string());
+        let project_grouping = self.project_display.grouping();
+        let session_keys = home_token_session_keys(&self.query, &self.results);
+        let local_session_keys = session_keys.as_ref().map(|keys| {
+            keys.iter()
+                .filter(|(machine, _, _)| machine == LOCAL_MACHINE_ID)
+                .map(|(_, source, session_id)| (source.clone(), session_id.clone()))
+                .collect()
+        });
         let query = home_token_usage_query(
             self.source,
             &self.project,
             self.project_display.grouping(),
-            home_token_session_keys(&self.query, &self.results),
+            local_session_keys,
             self.home_activity_range,
             now_ms(),
             self.paths.state.join("usage-cache.sqlite3"),
         );
         std::thread::spawn(move || {
+            if !config.machines.is_empty() {
+                let result = federated_usage_activity(
+                    &paths,
+                    &config,
+                    &machines,
+                    &UsageSpec {
+                        source,
+                        project,
+                        project_grouping,
+                        session_keys: None,
+                        machine_session_keys: session_keys.map(|keys| keys.into_iter().collect()),
+                        since_ms: query.since_ms,
+                        until_ms: query.until_ms,
+                        cost_mode: query.cost_mode,
+                        include_events: false,
+                        memo_ttl_ms: query.memo_ttl_ms,
+                    },
+                )
+                .map(|(events, partial)| {
+                    let points = events
+                        .into_iter()
+                        .filter_map(|event| {
+                            let source = SourceKind::from_label(&event.source)?;
+                            (event.timestamp_ms > 0 && event.total_tokens > 0).then_some(
+                                HomeChartPoint {
+                                    source,
+                                    timestamp_ms: event.timestamp_ms,
+                                    value: event.total_tokens,
+                                },
+                            )
+                        })
+                        .collect();
+                    (points, partial)
+                });
+                let _ = match result {
+                    Ok((points, partial)) => tx.send(SearchUpdate::HomeTokenActivity {
+                        request_id,
+                        points,
+                        partial,
+                    }),
+                    Err(error) => tx.send(SearchUpdate::HomeTokenActivityError {
+                        request_id,
+                        message: error.to_string(),
+                    }),
+                };
+                return;
+            }
             let result = scan_usage_activity(&query).map(|(events, partial)| {
                 let points = events
                     .into_iter()
@@ -1325,6 +1427,11 @@ impl App {
                 .iter()
                 .map(|range| range.short_label().to_string())
                 .collect(),
+            HomeDropdown::Machine => {
+                let mut options = vec!["default machines".to_string()];
+                options.extend(self.home_machines.iter().cloned());
+                options
+            }
             HomeDropdown::Source => {
                 let mut options = vec!["all".to_string()];
                 options.extend(self.home_sources.iter().map(|s| s.label().to_string()));
@@ -1347,6 +1454,12 @@ impl App {
             HomeDropdown::Range => TimelineRange::ALL
                 .iter()
                 .position(|range| *range == self.home_activity_range)
+                .unwrap_or(0),
+            HomeDropdown::Machine => self
+                .home_machines
+                .iter()
+                .position(|machine| *machine == self.machine)
+                .map(|idx| idx + 1)
                 .unwrap_or(0),
             HomeDropdown::Source => self
                 .home_sources
@@ -1387,6 +1500,8 @@ impl App {
             return;
         };
         let refresh_activity = self.home_dropdown == HomeDropdown::Range;
+        let machine_selection = self.home_dropdown == HomeDropdown::Machine;
+        let previous_machine = self.machine.clone();
         let source_selection = self.home_dropdown == HomeDropdown::Source;
         let previous_source = self.source;
         let project_selection = self.home_dropdown == HomeDropdown::Project;
@@ -1398,6 +1513,14 @@ impl App {
                     .copied()
                     .unwrap_or(TimelineRange::Month);
                 false
+            }
+            HomeDropdown::Machine => {
+                self.machine = if idx == 0 {
+                    String::new()
+                } else {
+                    self.home_machines.get(idx - 1).cloned().unwrap_or_default()
+                };
+                true
             }
             HomeDropdown::Source => {
                 self.source = if idx == 0 {
@@ -1423,7 +1546,8 @@ impl App {
         self.close_home_dropdown();
         let source_changed = source_selection && self.source != previous_source;
         let project_changed = project_selection && self.project != previous_project;
-        let token_filter_changed = source_changed || project_changed;
+        let machine_changed = machine_selection && self.machine != previous_machine;
+        let token_filter_changed = machine_changed || source_changed || project_changed;
         if token_filter_changed {
             self.invalidate_home_token_activity();
         }
@@ -1431,6 +1555,14 @@ impl App {
             self.kickoff_search();
         } else if refresh_activity {
             self.kickoff_home_activity();
+        }
+    }
+
+    fn selected_machines(&self) -> Vec<String> {
+        if self.machine.is_empty() {
+            Vec::new()
+        } else {
+            vec![self.machine.clone()]
         }
     }
 
@@ -1469,7 +1601,7 @@ impl App {
     }
 
     fn toggle_home_chart_mode(&mut self) {
-        if !self.config.token_usage_enabled() {
+        if !self.config.token_usage_enabled() && self.config.machines.is_empty() {
             return;
         }
         self.home_chart_mode = self.home_chart_mode.toggle();
@@ -1563,7 +1695,19 @@ impl App {
             SearchUpdate::Results {
                 request_id,
                 sessions,
+                failures,
             } if request_id == self.active_search_request => {
+                for session in &sessions {
+                    let source = SourceChoice::from_source(session.source);
+                    if !self.home_sources.contains(&source) {
+                        self.home_sources.push(source);
+                    }
+                    if !session.project.is_empty() && !self.home_projects.contains(&session.project)
+                    {
+                        self.home_projects.push(session.project.clone());
+                    }
+                }
+                self.home_projects.sort();
                 self.home_result_activity = session_activity(&sessions);
                 self.results = sessions;
                 self.sessions_state = if self.results.is_empty() {
@@ -1582,7 +1726,19 @@ impl App {
                 self.last_detail_session = None;
                 self.detail_scroll = 0;
                 if !self.results.is_empty() || self.index_state != IndexState::Loading {
-                    self.set_status(format!("{} sessions", self.results.len()));
+                    if failures.is_empty() {
+                        self.set_status(format!("{} sessions", self.results.len()));
+                    } else {
+                        let machines = failures
+                            .iter()
+                            .map(|(machine, _)| machine.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        self.set_status(format!(
+                            "{} sessions; unavailable: {machines}",
+                            self.results.len()
+                        ));
+                    }
                 }
                 self.update_detail();
                 if self.layout_mode == LayoutMode::Home
@@ -2068,49 +2224,70 @@ impl App {
             self.set_status("no session selected");
             return Ok(());
         };
-        let Some(session) = self.results.get(idx) else {
+        let Some(session) = self.results.get(idx).cloned() else {
             self.set_status("no session selected");
             return Ok(());
         };
+        let remote = session.machine != LOCAL_MACHINE_ID;
         let template = match session.source {
             SourceKind::Claude => self
                 .config
                 .claude_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("claude")),
+                .or_else(|| default_resume_template("claude", remote)),
             SourceKind::Codex => self
                 .config
                 .codex_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("codex")),
+                .or_else(|| default_resume_template("codex", remote)),
             SourceKind::Opencode => self
                 .config
                 .opencode_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("opencode")),
+                .or_else(|| default_resume_template("opencode", remote)),
             SourceKind::Cursor => self
                 .config
                 .cursor_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("cursor")),
+                .or_else(|| default_resume_template("cursor", remote)),
             SourceKind::Pi => self
                 .config
                 .pi_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("pi")),
+                .or_else(|| default_resume_template("pi", remote)),
             SourceKind::OpenClaw => None,
             SourceKind::Copilot => self
                 .config
                 .copilot_resume_cmd
                 .clone()
-                .or_else(|| default_resume_template("copilot")),
+                .or_else(|| default_resume_template("copilot", remote)),
         };
         let Some(template) = template else {
             self.set_status("resume command not configured in config.toml");
             return Ok(());
         };
-        let cwd = resolve_session_cwd(session).unwrap_or_else(|| session.source_dir.clone());
-        let command = expand_resume_template(&template, session, &cwd);
+        let cwd = if remote {
+            session_context(
+                &self.paths,
+                &self.config,
+                &session.machine,
+                &session.session_id,
+                &session.source_path,
+            )
+            .ok()
+            .and_then(|context| context.cwd)
+        } else {
+            resolve_session_cwd(&session)
+        }
+        .unwrap_or_else(|| session.source_dir.clone());
+        let local_command = expand_resume_template(&template, &session, &cwd);
+        let command = if remote {
+            let machine = machine_by_id(&self.config, &session.machine)
+                .ok_or_else(|| anyhow::anyhow!("unknown machine '{}'", session.machine))?;
+            remote_shell_command(machine, &local_command)?
+        } else {
+            local_command
+        };
         run_external_command(self, terminal, &command)?;
         self.set_status(format!("ran: {command}"));
         Ok(())
@@ -2121,13 +2298,13 @@ impl App {
             self.set_status("no session selected");
             return Ok(());
         };
-        let Some(session) = self.results.get(idx) else {
+        let Some(session) = self.results.get(idx).cloned() else {
             self.set_status("no session selected");
             return Ok(());
         };
 
         // Check if agentexport is installed
-        if find_in_path("agentexport").is_none() {
+        if session.machine == LOCAL_MACHINE_ID && find_in_path("agentexport").is_none() {
             self.set_status("agentexport not found (brew install nicosuave/tap/agentexport)");
             return Ok(());
         }
@@ -2146,9 +2323,31 @@ impl App {
         self.set_status("sharing...");
 
         // Run agentexport in background
-        let output = std::process::Command::new("agentexport")
-            .args(["publish", "--tool", tool, "--transcript", &source_path])
-            .output();
+        let output = if session.machine == LOCAL_MACHINE_ID {
+            std::process::Command::new("agentexport")
+                .args(["publish", "--tool", tool, "--transcript", &source_path])
+                .output()
+        } else {
+            let Some(machine) = machine_by_id(&self.config, &session.machine) else {
+                self.set_status(format!("unknown machine '{}'", session.machine));
+                return Ok(());
+            };
+            let Some(target) = machine.ssh_target() else {
+                self.set_status(format!(
+                    "machine '{}' has no SSH transport",
+                    session.machine
+                ));
+                return Ok(());
+            };
+            let command = format!(
+                "agentexport publish --tool {} --transcript {}",
+                shell_quote(tool),
+                shell_quote(&source_path)
+            );
+            std::process::Command::new("ssh")
+                .args(["-T", "--", target, &command])
+                .output()
+        };
 
         match output {
             Ok(output) if output.status.success() => {
@@ -2578,6 +2777,9 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
             KeyCode::Char('t') if app.home_dropdown == HomeDropdown::Range => {
                 app.close_home_dropdown();
             }
+            KeyCode::Char('m') if app.home_dropdown == HomeDropdown::Machine => {
+                app.close_home_dropdown();
+            }
             KeyCode::Char('s') if app.home_dropdown == HomeDropdown::Source => {
                 app.close_home_dropdown();
             }
@@ -2657,6 +2859,9 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
         }
         KeyCode::Char('t') if app.home_range_area.width > 0 => {
             app.open_home_dropdown(HomeDropdown::Range);
+        }
+        KeyCode::Char('m') if app.home_machine_area.width > 0 => {
+            app.open_home_dropdown(HomeDropdown::Machine);
         }
         KeyCode::Char('s') => {
             app.open_home_dropdown(HomeDropdown::Source);
@@ -2751,6 +2956,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     app.home_input_area = Rect::default();
     app.home_list_area = Rect::default();
     app.home_range_area = Rect::default();
+    app.home_machine_area = Rect::default();
     app.home_source_area = Rect::default();
     app.home_project_area = Rect::default();
     app.home_dropdown_area = Rect::default();
@@ -2920,7 +3126,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     );
     y += 4;
 
-    // Header row: label on the left, source/project dropdown anchors on the right.
+    // Header row: label on the left, machine/source/project dropdown anchors on the right.
     let searching = !app.query.trim().is_empty();
     let header_area = col(y, 1);
     let mut header_spans = vec![Span::styled(
@@ -2933,6 +3139,18 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     if app.sessions_state == LoadState::Loading && !app.results.is_empty() {
         header_spans.push(Span::styled(format!("  {}", app.spinner()), theme.muted));
     }
+    let machine_word = if app.home_machines.len() > 1 {
+        format!(
+            "{} ▾",
+            if app.machine.is_empty() {
+                "machines".to_string()
+            } else {
+                truncate_end(&app.machine, 12)
+            }
+        )
+    } else {
+        String::new()
+    };
     let source_word = format!("{} ▾", app.source.label());
     let project_word = format!(
         "{} ▾",
@@ -2942,20 +3160,29 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
             truncate_end(&app.project, 16)
         }
     );
+    let machine_width = machine_word.chars().count() as u16;
     let source_width = source_word.chars().count() as u16;
     let project_width_hdr = project_word.chars().count() as u16;
     let header_cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Min(4),
+            Constraint::Length(machine_width),
+            Constraint::Length(if machine_width > 0 { 3 } else { 0 }),
             Constraint::Length(source_width),
             Constraint::Length(3),
             Constraint::Length(project_width_hdr),
         ])
         .split(header_area);
-    app.home_source_area = header_cols[1];
-    app.home_project_area = header_cols[3];
+    app.home_machine_area = header_cols[1];
+    app.home_source_area = header_cols[3];
+    app.home_project_area = header_cols[5];
     frame.render_widget(Paragraph::new(Line::from(header_spans)), header_cols[0]);
+    let machine_style = if app.machine.is_empty() {
+        theme.muted
+    } else {
+        theme.accent
+    };
     let source_style = if app.source == SourceChoice::All {
         theme.muted
     } else {
@@ -2966,13 +3193,19 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     } else {
         theme.accent
     };
+    if machine_width > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(machine_word, machine_style))),
+            header_cols[1],
+        );
+    }
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(source_word, source_style))),
-        header_cols[1],
+        header_cols[3],
     );
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(project_word, project_style))),
-        header_cols[3],
+        header_cols[5],
     );
     y += 1;
 
@@ -3044,6 +3277,7 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
     }
     let anchor = match app.home_dropdown {
         HomeDropdown::Range => app.home_range_area,
+        HomeDropdown::Machine => app.home_machine_area,
         HomeDropdown::Source => app.home_source_area,
         HomeDropdown::Project => app.home_project_area,
         HomeDropdown::None => Rect::default(),
@@ -3147,12 +3381,13 @@ fn home_token_usage_query(
 fn home_token_session_keys(
     query: &str,
     sessions: &[SessionSummary],
-) -> Option<HashSet<(String, String)>> {
+) -> Option<HashSet<(String, String, String)>> {
     (!query.trim().is_empty()).then(|| {
         sessions
             .iter()
             .map(|session| {
                 (
+                    session.machine.clone(),
                     session.source.label().to_string(),
                     session.session_id.clone(),
                 )
@@ -3534,7 +3769,7 @@ fn results_project_width(results: &[SessionSummary]) -> usize {
     results
         .iter()
         .take(60)
-        .map(|session| session.project.chars().count())
+        .map(|session| displayed_project(session).chars().count())
         .max()
         .unwrap_or(8)
         .clamp(6, 24)
@@ -3569,6 +3804,7 @@ fn session_result_line(
     theme: &Theme,
 ) -> Line<'static> {
     let ts = format_relative_ts(session.last_ts);
+    let project = displayed_project(session);
     let mut spans = vec![
         Span::styled(format!("{ts:>4}"), theme.accent),
         Span::raw("  "),
@@ -3579,7 +3815,7 @@ fn session_result_line(
         Span::styled(
             format!(
                 "{:<width$}",
-                truncate_middle(&session.project, project_width),
+                truncate_middle(&project, project_width),
                 width = project_width
             ),
             theme.text,
@@ -3596,6 +3832,14 @@ fn session_result_line(
         spans.extend(match_context_spans(&snippet, terms, detail_width, theme));
     }
     Line::from(spans)
+}
+
+fn displayed_project(session: &SessionSummary) -> String {
+    if session.machine == LOCAL_MACHINE_ID {
+        session.project.clone()
+    } else {
+        format!("{}:{}", session.machine, session.project)
+    }
 }
 
 fn truncate_end(value: &str, width: usize) -> String {
@@ -4307,7 +4551,7 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
     if app.layout_mode == LayoutMode::Home {
         right_spans.push(Span::raw("   "));
         right_spans.push(Span::styled("chart", theme.muted));
-        if app.config.token_usage_enabled() {
+        if app.config.token_usage_enabled() || !app.config.machines.is_empty() {
             right_spans.push(Span::styled("(^t) ", theme.accent));
         } else {
             right_spans.push(Span::raw(" "));
@@ -4619,6 +4863,7 @@ fn sessions_from_analytics(
 
 fn session_summary_from_row(row: SessionRow) -> SessionSummary {
     SessionSummary {
+        machine: LOCAL_MACHINE_ID.to_string(),
         session_id: row.session_id,
         project: row.display_project,
         source: row.source,
@@ -4742,6 +4987,7 @@ fn add_record_to_session(
     let entry = sessions
         .entry(record.session_id.clone())
         .or_insert(SessionSummary {
+            machine: LOCAL_MACHINE_ID.to_string(),
             session_id: record.session_id.clone(),
             project: record.project.clone(),
             source: record.source,
@@ -4767,8 +5013,48 @@ fn add_record_to_session(
     }
 }
 
+fn add_located_record_to_session(
+    sessions: &mut HashMap<String, SessionSummary>,
+    located: crate::machine::LocatedRecord,
+) {
+    let machine = located.machine;
+    let score = located.score;
+    let record = located.record;
+    let key = format!(
+        "{}\0{}\0{}\0{}",
+        machine,
+        record.source.storage_label(),
+        record.session_id,
+        record.source_path
+    );
+    let entry = sessions.entry(key).or_insert(SessionSummary {
+        machine,
+        session_id: record.session_id.clone(),
+        project: record.project.clone(),
+        source: record.source,
+        last_ts: record.ts,
+        hit_count: 0,
+        top_score: score,
+        snippet: summarize(&record.text, 160),
+        source_path: record.source_path.clone(),
+        source_dir: parent_dir(&record.source_path),
+    });
+    entry.hit_count += 1;
+    entry.last_ts = entry.last_ts.max(record.ts);
+    if score >= entry.top_score {
+        entry.top_score = score;
+        let snippet = summarize(&record.text, 160);
+        if !snippet.is_empty() {
+            entry.snippet = snippet;
+        }
+        entry.source_path = record.source_path;
+        entry.source_dir = parent_dir(&entry.source_path);
+    }
+}
+
 fn spawn_search_worker(
     paths: Paths,
+    config: UserConfig,
     index: SearchIndex,
     rx: std::sync::mpsc::Receiver<SearchRequest>,
     tx: std::sync::mpsc::Sender<SearchUpdate>,
@@ -4781,10 +5067,11 @@ fn spawn_search_worker(
                 request = newer;
             }
             let request_id = request.request_id;
-            let update = match run_search_request(&paths, &index, request) {
-                Ok(sessions) => SearchUpdate::Results {
+            let update = match run_search_request(&paths, &config, &index, request) {
+                Ok((sessions, failures)) => SearchUpdate::Results {
                     request_id,
                     sessions,
+                    failures,
                 },
                 Err(err) => SearchUpdate::SearchError {
                     request_id,
@@ -4800,10 +5087,83 @@ fn spawn_search_worker(
 
 fn run_search_request(
     paths: &Paths,
+    config: &UserConfig,
     index: &SearchIndex,
     request: SearchRequest,
-) -> Result<Vec<SessionSummary>> {
+) -> SearchRequestResult {
     let project = (!request.project.is_empty()).then_some(request.project.as_str());
+    if !config.machines.is_empty() {
+        let federated = if request.query.is_empty() {
+            federated_recent(
+                paths,
+                config,
+                &request.machines,
+                (RECENT_SESSIONS_LIMIT * RECENT_RECORDS_MULTIPLIER).max(200),
+                Some(request.grouping),
+                false,
+            )?
+        } else {
+            let tantivy_project = if request.grouping == ProjectGrouping::Flat {
+                project.map(str::to_string)
+            } else {
+                None
+            };
+            federated_search(
+                paths,
+                config,
+                &request.machines,
+                &SearchSpec {
+                    query: request.query.clone(),
+                    project: tantivy_project,
+                    role: None,
+                    tool: None,
+                    session_id: None,
+                    source: request.source.as_filter(),
+                    since: request.since,
+                    until: None,
+                    limit: RESULT_LIMIT * 5,
+                    mode: SearchMode::Lexical,
+                    recency_weight: 1.0,
+                    recency_half_life_days: 30.0,
+                    min_score: None,
+                    project_grouping: Some(request.grouping),
+                },
+                false,
+            )?
+        };
+        let failures = federated.failures;
+        let mut by_session = HashMap::new();
+        for located in federated.items {
+            if request.since.is_some_and(|since| located.record.ts < since) {
+                continue;
+            }
+            if request
+                .source
+                .as_filter()
+                .is_some_and(|source| !source.matches(located.record.source))
+            {
+                continue;
+            }
+            add_located_record_to_session(&mut by_session, located);
+        }
+        let mut sessions: Vec<_> = by_session.into_values().collect();
+        if request.query.is_empty() {
+            sessions.sort_by_key(|session| std::cmp::Reverse(session.last_ts));
+        } else {
+            sessions.sort_by(|left, right| {
+                right
+                    .top_score
+                    .partial_cmp(&left.top_score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| right.last_ts.cmp(&left.last_ts))
+            });
+        }
+        if let Some(project) = project {
+            sessions.retain(|session| session.project == project);
+        }
+        sessions.truncate(RESULT_LIMIT);
+        return Ok((sessions, failures));
+    }
     if request.query.is_empty() {
         return sessions_from_analytics(
             paths,
@@ -4814,7 +5174,8 @@ fn run_search_request(
         )
         .or_else(|_| {
             sessions_from_recent(index, request.source.as_filter(), request.since, project)
-        });
+        })
+        .map(|sessions| (sessions, Vec::new()));
     }
 
     let tantivy_project = if request.grouping == ProjectGrouping::Flat {
@@ -4834,11 +5195,12 @@ fn run_search_request(
     if let Some(project) = project {
         sessions.retain(|session| session.project == project);
     }
-    Ok(sessions)
+    Ok((sessions, Vec::new()))
 }
 
 fn spawn_detail_worker(
-    index: SearchIndex,
+    paths: Paths,
+    config: UserConfig,
     rx: std::sync::mpsc::Receiver<DetailRequest>,
     tx: std::sync::mpsc::Sender<SearchUpdate>,
 ) {
@@ -4847,13 +5209,22 @@ fn spawn_detail_worker(
             while let Ok(newer) = rx.try_recv() {
                 request = newer;
             }
-            let update = match build_detail_lines(
-                &index,
-                &request.session,
-                request.mode,
-                &request.query,
-                request.show_tools,
-            ) {
+            let records = session_records(
+                &paths,
+                &config,
+                &request.session.machine,
+                &request.session.session_id,
+                &request.session.source_path,
+            );
+            let update = match records.and_then(|records| {
+                build_detail_lines_from_records(
+                    records,
+                    &request.session,
+                    request.mode,
+                    &request.query,
+                    request.show_tools,
+                )
+            }) {
                 Ok(lines) => SearchUpdate::DetailResults {
                     request_id: request.request_id,
                     lines,
@@ -4877,7 +5248,18 @@ fn build_detail_lines(
     query: &str,
     show_tools: bool,
 ) -> Result<Vec<PreviewLine>> {
-    let mut records = index.records_by_session_id(&session.session_id)?;
+    let records = index.records_by_session_id(&session.session_id)?;
+    build_detail_lines_from_records(records, session, mode, query, show_tools)
+}
+
+fn build_detail_lines_from_records(
+    mut records: Vec<Record>,
+    session: &SessionSummary,
+    mode: PreviewMode,
+    query: &str,
+    show_tools: bool,
+) -> Result<Vec<PreviewLine>> {
+    records.retain(|record| record.source_path == session.source_path);
     records.sort_by(|a, b| {
         a.turn_id
             .cmp(&b.turn_id)
@@ -4886,7 +5268,11 @@ fn build_detail_lines(
     });
     let mut lines = vec![PreviewLine::SessionHeader {
         project: session.project.clone(),
-        source: session.source.label().to_string(),
+        source: if session.machine == LOCAL_MACHINE_ID {
+            session.source.label().to_string()
+        } else {
+            format!("{}:{}", session.machine, session.source.label())
+        },
         session_id: session.session_id.clone(),
     }];
     if records.is_empty() {
@@ -4993,17 +5379,25 @@ fn expand_resume_template(template: &str, session: &SessionSummary, cwd: &str) -
         .replace("{cwd}", cwd)
 }
 
-fn default_resume_template(cmd: &str) -> Option<String> {
+fn default_resume_template(cmd: &str, remote: bool) -> Option<String> {
     match cmd {
-        "claude" => {
-            find_in_path("claude").map(|_| "cd {cwd} && claude --resume {session_id}".to_string())
+        "claude" if remote || find_in_path("claude").is_some() => {
+            Some("cd {cwd_shell} && claude --resume {session_id}".to_string())
         }
-        "codex" => find_in_path("codex").map(|_| "codex resume {session_id}".to_string()),
-        "opencode" => find_in_path("opencode").map(|_| "opencode resume {session_id}".to_string()),
-        "cursor" => {
-            find_in_path("cursor-agent").map(|_| "cursor-agent --resume {session_id}".to_string())
+        "codex" if remote || find_in_path("codex").is_some() => {
+            Some("codex resume {session_id}".to_string())
         }
-        "pi" => find_in_path("pi").map(|_| "pi --session {source_path_shell}".to_string()),
+        "opencode" if remote || find_in_path("opencode").is_some() => {
+            Some("opencode resume {session_id}".to_string())
+        }
+        "cursor" => (remote || find_in_path("cursor-agent").is_some())
+            .then(|| "cursor-agent --resume {session_id}".to_string()),
+        "pi" if remote || find_in_path("pi").is_some() => {
+            Some("pi --session {source_path_shell}".to_string())
+        }
+        "copilot" if remote || find_in_path("copilot").is_some() => {
+            Some("copilot --resume {session_id}".to_string())
+        }
         _ => None,
     }
 }
@@ -5811,6 +6205,8 @@ fn handle_home_mouse(mouse: MouseEvent, terminal: &mut TuiTerminal, app: &mut Ap
             let pos = ratatui::layout::Position::new(mouse.column, mouse.row);
             if app.home_range_area.contains(pos) {
                 app.open_home_dropdown(HomeDropdown::Range);
+            } else if app.home_machine_area.contains(pos) {
+                app.open_home_dropdown(HomeDropdown::Machine);
             } else if app.home_source_area.contains(pos) {
                 app.open_home_dropdown(HomeDropdown::Source);
             } else if app.home_project_area.contains(pos) {
@@ -6091,6 +6487,7 @@ mod tests {
         let (detail_tx, _detail_rx) = std::sync::mpsc::channel();
         spawn_search_worker(
             paths.clone(),
+            UserConfig::default(),
             index.clone(),
             search_request_rx,
             search_tx.clone(),
@@ -6152,6 +6549,7 @@ mod tests {
     fn enter_browse_switches_to_split_and_selects_first() {
         let (_tmp, mut app) = test_app();
         app.results.push(SessionSummary {
+            machine: LOCAL_MACHINE_ID.to_string(),
             session_id: "session".to_string(),
             project: "project".to_string(),
             source: SourceKind::Claude,
@@ -6287,6 +6685,7 @@ mod tests {
         app.handle_search_update(SearchUpdate::Results {
             request_id: 3,
             sessions: vec![SessionSummary {
+                machine: LOCAL_MACHINE_ID.to_string(),
                 session_id: "session".to_string(),
                 project: "project".to_string(),
                 source: SourceKind::Pi,
@@ -6297,6 +6696,7 @@ mod tests {
                 source_path: "source.jsonl".to_string(),
                 source_dir: String::new(),
             }],
+            failures: Vec::new(),
         });
 
         assert_eq!(
@@ -6469,6 +6869,7 @@ mod tests {
     fn token_session_filter_uses_accepted_source_qualified_results() {
         let sessions = vec![
             SessionSummary {
+                machine: LOCAL_MACHINE_ID.to_string(),
                 session_id: "shared".into(),
                 project: "memex".into(),
                 source: SourceKind::Codex,
@@ -6480,6 +6881,7 @@ mod tests {
                 source_dir: String::new(),
             },
             SessionSummary {
+                machine: LOCAL_MACHINE_ID.to_string(),
                 session_id: "shared".into(),
                 project: "memex".into(),
                 source: SourceKind::Claude,
@@ -6490,13 +6892,26 @@ mod tests {
                 source_path: "claude.jsonl".into(),
                 source_dir: String::new(),
             },
+            SessionSummary {
+                machine: "mini".into(),
+                session_id: "shared".into(),
+                project: "memex".into(),
+                source: SourceKind::Codex,
+                last_ts: 1,
+                hit_count: 1,
+                top_score: 1.0,
+                snippet: String::new(),
+                source_path: "remote-codex.jsonl".into(),
+                source_dir: String::new(),
+            },
         ];
 
         let keys = home_token_session_keys("needle", &sessions).expect("session keys");
 
-        assert!(keys.contains(&("codex".into(), "shared".into())));
-        assert!(keys.contains(&("claude".into(), "shared".into())));
-        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&("local".into(), "codex".into(), "shared".into())));
+        assert!(keys.contains(&("local".into(), "claude".into(), "shared".into())));
+        assert!(keys.contains(&("mini".into(), "codex".into(), "shared".into())));
+        assert_eq!(keys.len(), 3);
         assert!(home_token_session_keys("  ", &sessions).is_none());
     }
 
@@ -6590,6 +7005,20 @@ mod tests {
     }
 
     #[test]
+    fn machine_dropdown_applies_to_search_and_chart_filter() {
+        let (_tmp, mut app) = test_app();
+        app.home_machines = vec!["local".to_string(), "mini".to_string()];
+        app.open_home_dropdown(HomeDropdown::Machine);
+        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        app.move_home_dropdown_selection(2);
+        app.apply_home_dropdown();
+        assert_eq!(app.machine, "mini");
+        assert_eq!(app.selected_machines(), vec!["mini"]);
+        assert!(app.home_chart_is_filtered());
+        assert_eq!(app.home_dropdown, HomeDropdown::None);
+    }
+
+    #[test]
     fn project_dropdown_first_entry_clears_filter() {
         let (_tmp, mut app) = test_app();
         app.home_projects = vec!["memex".to_string()];
@@ -6650,6 +7079,7 @@ mod tests {
         app.handle_search_update(SearchUpdate::Results {
             request_id: 1,
             sessions: Vec::new(),
+            failures: Vec::new(),
         });
 
         assert_eq!(app.sessions_state, LoadState::Loading);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SourceKind {
     #[default]
     Claude,
@@ -92,8 +93,9 @@ impl SourceKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum SourceFilter {
     Claude,
     Codex,
@@ -167,7 +169,7 @@ pub struct RecordLinks {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
-    #[serde(skip)]
+    #[serde(default)]
     pub source: SourceKind,
     pub doc_id: u64,
     pub ts: u64,

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -33,7 +33,7 @@ pub struct UsageQuery {
     pub memo_ttl_ms: u64,
 }
 
-#[derive(Clone, Copy, Debug, Default, Serialize, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 #[value(rename_all = "kebab-case")]
 pub enum CostMode {
@@ -120,7 +120,7 @@ pub struct UsageEvent {
     pub(crate) source_order: u64,
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct UsageSummary {
     pub source: String,
     pub events: u64,
@@ -139,7 +139,7 @@ pub struct UsageSummary {
 /// Estimated prompt-cache waste: prompt tokens that were in the previous request's prompt
 /// (so a warm cache would have served them as cache reads) but were re-billed at
 /// input/cache-write rates instead.
-#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct CacheWaste {
     pub missed_tokens: u64,
     /// Extra USD paid vs. a full cache hit, at catalog rates; misses on unpriced models

--- a/tests/multi_machine.rs
+++ b/tests/multi_machine.rs
@@ -1,0 +1,150 @@
+#![cfg(unix)]
+
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn memex_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_memex"))
+}
+
+fn write_config(root: &Path, contents: &str) {
+    fs::create_dir_all(root).expect("create memex root");
+    fs::write(root.join("config.toml"), contents).expect("write memex config");
+}
+
+#[test]
+fn rpc_ping_round_trips_through_the_real_binary() {
+    let root = tempfile::tempdir().expect("temporary root");
+    write_config(root.path(), "auto_index_on_search = false\n");
+
+    let mut child = Command::new(memex_binary())
+        .args(["rpc", "--root"])
+        .arg(root.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start memex rpc");
+    child
+        .stdin
+        .take()
+        .expect("RPC stdin")
+        .write_all(br#"{"protocol":1,"request":{"op":"ping"}}"#)
+        .expect("write RPC request");
+    let output = child.wait_with_output().expect("wait for memex rpc");
+
+    assert!(
+        output.status.success(),
+        "RPC failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).expect("valid RPC response");
+    assert_eq!(response["protocol"], 1);
+    assert_eq!(response["response"]["kind"], "pong");
+    assert_eq!(response["response"]["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn federated_search_uses_the_configured_ssh_rpc_backend() {
+    let temp = tempfile::tempdir().expect("temporary workspace");
+    let coordinator_root = temp.path().join("coordinator");
+    let remote_root = temp.path().join("remote");
+    let empty_source = temp.path().join("empty-source");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("create fake bin directory");
+    fs::create_dir_all(&empty_source).expect("create empty source directory");
+    write_config(&remote_root, "auto_index_on_search = false\n");
+
+    let binary = memex_binary();
+    let index_output = Command::new(&binary)
+        .args(["index", "--source"])
+        .arg(&empty_source)
+        .args([
+            "--no-codex",
+            "--no-opencode",
+            "--no-cursor",
+            "--no-pi",
+            "--no-openclaw",
+            "--no-copilot",
+            "--no-embeddings",
+            "--root",
+        ])
+        .arg(&remote_root)
+        .output()
+        .expect("initialize remote index");
+    assert!(
+        index_output.status.success(),
+        "remote index initialization failed: {}",
+        String::from_utf8_lossy(&index_output.stderr)
+    );
+
+    let command = binary
+        .to_str()
+        .expect("memex binary path must be UTF-8")
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    write_config(
+        &coordinator_root,
+        &format!(
+            r#"auto_index_on_search = false
+
+[multi_machine]
+default = ["remote"]
+timeout_seconds = 5
+
+[[machines]]
+id = "remote"
+command = "{command}"
+
+[machines.control]
+type = "ssh"
+host = "integration-host"
+
+[machines.index]
+type = "remote"
+"#
+        ),
+    );
+
+    let fake_ssh = fake_bin.join("ssh");
+    fs::write(
+        &fake_ssh,
+        r#"#!/bin/sh
+for argument in "$@"; do
+  remote_command="$argument"
+done
+exec sh -c "$remote_command --root \"$MEMEX_TEST_REMOTE_ROOT\""
+"#,
+    )
+    .expect("write fake ssh");
+    let mut permissions = fs::metadata(&fake_ssh)
+        .expect("fake ssh metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
+
+    let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&inherited_path));
+    let test_path = std::env::join_paths(paths).expect("construct test PATH");
+    let output = Command::new(binary)
+        .args(["search", "needle", "--root"])
+        .arg(&coordinator_root)
+        .args(["--machine", "remote", "--json-array"])
+        .env("PATH", test_path)
+        .env("MEMEX_TEST_REMOTE_ROOT", &remote_root)
+        .output()
+        .expect("run federated search");
+
+    assert!(
+        output.status.success(),
+        "federated search failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let results: Value = serde_json::from_slice(&output.stdout).expect("JSON search output");
+    assert_eq!(results, Value::Array(Vec::new()));
+}


### PR DESCRIPTION
Adds SSH-backed multi-machine search across the CLI and TUI, including remote browsing, resume, sharing, token usage, and machine-aware filters.

Adds versioned RPC transport, partial-failure handling, and CI integration coverage using the real binary over a hermetic fake SSH transport.