### PR TITLE
Render Markdown in transcript previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,30 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+  transcript-markdown-performance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-transcript-markdown-perf-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Compare transcript Markdown performance
+        run: >-
+          cargo test --release --lib transcript_markdown_perf --
+          --ignored --nocapture --test-threads=1
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,9 +262,9 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitpacking"
@@ -297,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,12 +334,6 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -430,7 +439,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -444,20 +453,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "compact_str"
@@ -483,8 +478,17 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -566,31 +570,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio 1.1.1",
- "parking_lot",
- "rustix 0.38.44",
+ "rustix 1.1.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -773,11 +763,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -813,6 +802,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +835,12 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -886,6 +903,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -998,6 +1024,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastdivide"
@@ -1189,6 +1221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1251,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1249,6 +1296,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1316,6 +1369,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1658,12 +1727,12 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1675,7 +1744,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width",
  "web-time",
 ]
 
@@ -1757,18 +1826,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1797,6 +1866,17 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1923,6 +2003,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2037,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1980,6 +2075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2048,7 +2152,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-channel",
- "crossterm 0.27.0",
+ "crossterm",
  "dialoguer",
  "directories",
  "fastembed",
@@ -2072,6 +2176,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "toml",
+ "tui-markdown",
  "usearch",
  "walkdir",
 ]
@@ -2105,18 +2210,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2282,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2334,6 +2427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -2465,6 +2567,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2600,6 +2726,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +2771,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
@@ -2737,23 +2901,68 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags",
- "cassowary",
- "compact_str 0.8.1",
- "crossterm 0.28.1",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.1",
+ "palette",
+ "serde",
  "strum",
- "strum_macros",
+ "thiserror 2.0.17",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.14",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2933,6 +3142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +3211,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3268,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3162,6 +3415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,8 +3524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.1",
+ "mio",
  "signal-hook",
 ]
 
@@ -3397,23 +3655,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -3497,7 +3754,7 @@ dependencies = [
  "itertools 0.12.1",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.12.5",
  "lz4_flex",
  "measure_time",
  "memmap2",
@@ -3705,30 +3962,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3752,7 +4010,7 @@ checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str 0.9.0",
+ "compact_str",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -3787,7 +4045,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str 0.9.0",
+ "compact_str",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -3820,7 +4078,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -3867,8 +4125,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3881,6 +4139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3889,9 +4156,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3952,7 +4240,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3971,10 +4271,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-markdown"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c95afc7b66008823dea2614a800d944e18990690db47517efc66cd01ff9cee"
+dependencies = [
+ "itertools 0.15.0",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "tracing",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3999,20 +4319,14 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4675,6 +4989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,6 +5024,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,12 @@ usearch = "2"
 toml = "0.8"
 walkdir = "2.5"
 indicatif = "0.17"
-ratatui = "0.28"
-crossterm = "0.27"
+ratatui = { version = "0.30", default-features = false, features = [
+    "crossterm_0_29",
+    "unstable-rendered-line-info",
+] }
+crossterm = "0.29"
+tui-markdown = { version = "0.3.9", default-features = false }
 tempfile = "3"
 libc = "0.2"
 libloading = { version = "0.8", optional = true }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2781,8 +2781,8 @@ mod tests {
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
         let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, 0, meta.len()],
-            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, meta.len()],
+            [0, 0, 0, 0, 0, 0, 1],
             false,
         ));
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -27,6 +27,7 @@ use std::io::Stdout;
 use std::io::Write;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use tui_markdown::{AlertKind, Options as MarkdownOptions, StyleSheet, from_str_with_options};
 
 #[cfg(unix)]
 use std::ffi::CString;
@@ -525,10 +526,16 @@ struct App {
     quick_popup: bool,
     quick_scroll: usize,
     quick_lines: Vec<PreviewLine>,
+    quick_rendered_height: usize,
+    quick_layout_width: u16,
+    quick_line_offsets: Vec<usize>,
     preview_mode: PreviewMode,
     show_tools: bool,
     find_query: String,
     detail_lines: Vec<PreviewLine>,
+    detail_rendered_height: usize,
+    detail_layout_width: u16,
+    detail_line_offsets: Vec<usize>,
     detail_state: LoadState,
     active_detail_request: u64,
     detail_scroll: usize,
@@ -573,7 +580,80 @@ enum PreviewLine {
         highlight: bool,
     },
     Text(String),
+    Styled {
+        spans: Vec<PreviewSpan>,
+        alignment: Option<Alignment>,
+    },
     Empty,
+}
+
+#[derive(Clone, Debug)]
+struct PreviewSpan {
+    content: String,
+    style: Style,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TranscriptMarkdownStyle;
+
+impl StyleSheet for TranscriptMarkdownStyle {
+    fn heading(&self, level: u8) -> Style {
+        let mut style = Style::default()
+            .fg(if level <= 2 { COLOR_ACCENT } else { COLOR_TEXT })
+            .add_modifier(Modifier::BOLD);
+        if level == 1 {
+            style = style.add_modifier(Modifier::UNDERLINED);
+        }
+        style
+    }
+
+    fn code(&self) -> Style {
+        Style::default().fg(Color::Rgb(185, 185, 185))
+    }
+
+    fn link(&self) -> Style {
+        Style::default()
+            .fg(COLOR_ACCENT)
+            .add_modifier(Modifier::UNDERLINED)
+    }
+
+    fn blockquote(&self) -> Style {
+        Style::default()
+            .fg(COLOR_MUTED)
+            .add_modifier(Modifier::ITALIC)
+    }
+
+    fn heading_meta(&self) -> Style {
+        Style::default().fg(COLOR_MUTED).add_modifier(Modifier::DIM)
+    }
+
+    fn metadata_block(&self) -> Style {
+        Style::default().fg(COLOR_MUTED)
+    }
+
+    fn html(&self) -> Style {
+        Style::default().fg(COLOR_MUTED).add_modifier(Modifier::DIM)
+    }
+
+    fn alert(&self, _kind: AlertKind) -> Style {
+        Style::default().fg(COLOR_ACCENT)
+    }
+
+    fn table_header(&self) -> Style {
+        Style::default()
+            .fg(COLOR_ACCENT)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    fn table_border(&self) -> Style {
+        Style::default().fg(COLOR_DIVIDER)
+    }
+
+    fn image_alt(&self) -> Style {
+        Style::default()
+            .fg(COLOR_MUTED)
+            .add_modifier(Modifier::ITALIC)
+    }
 }
 
 struct Theme {
@@ -838,10 +918,16 @@ impl App {
             quick_popup: false,
             quick_scroll: 0,
             quick_lines: Vec::new(),
+            quick_rendered_height: 0,
+            quick_layout_width: 0,
+            quick_line_offsets: Vec::new(),
             preview_mode: PreviewMode::Matches,
             show_tools: false,
             find_query: String::new(),
             detail_lines: Vec::new(),
+            detail_rendered_height: 0,
+            detail_layout_width: 0,
+            detail_line_offsets: Vec::new(),
             detail_state: LoadState::Idle,
             active_detail_request: 0,
             detail_scroll: 0,
@@ -1023,6 +1109,9 @@ impl App {
         self.active_detail_request = request_id;
         self.detail_state = LoadState::Loading;
         self.detail_lines.clear();
+        self.detail_rendered_height = 0;
+        self.detail_layout_width = 0;
+        self.detail_line_offsets.clear();
         self.detail_scroll = 0;
         self.last_detail_session = Some(session.session_id.clone());
         self.last_detail_query = Some(query_now);
@@ -1043,6 +1132,9 @@ impl App {
     fn clear_detail(&mut self, message: &str) {
         self.active_detail_request = self.next_request_id();
         self.detail_lines = vec![PreviewLine::Text(message.to_string())];
+        self.detail_rendered_height = 0;
+        self.detail_layout_width = 0;
+        self.detail_line_offsets.clear();
         self.detail_state = LoadState::Empty;
         self.detail_scroll = 0;
         self.last_detail_session = None;
@@ -1671,6 +1763,9 @@ impl App {
                 if request_id == self.active_detail_request =>
             {
                 self.detail_lines = lines;
+                self.detail_rendered_height = 0;
+                self.detail_layout_width = 0;
+                self.detail_line_offsets.clear();
                 self.detail_state = if self.detail_lines.is_empty() {
                     LoadState::Empty
                 } else {
@@ -1684,6 +1779,9 @@ impl App {
             } if request_id == self.active_detail_request => {
                 self.detail_state = LoadState::Error(message.clone());
                 self.detail_lines = vec![PreviewLine::Text(format!("preview error: {message}"))];
+                self.detail_rendered_height = 0;
+                self.detail_layout_width = 0;
+                self.detail_line_offsets.clear();
                 self.detail_scroll = 0;
             }
             SearchUpdate::HomeActivity { request_id, points }
@@ -1833,10 +1931,11 @@ impl App {
             return;
         }
         let view_height = self.preview_area.height as usize;
+        let line_count = self.detail_rendered_height.max(self.detail_lines.len());
         let max_scroll = if view_height == 0 {
-            self.detail_lines.len().saturating_sub(1)
+            line_count.saturating_sub(1)
         } else {
-            self.detail_lines.len().saturating_sub(view_height)
+            line_count.saturating_sub(view_height)
         };
         let next = (self.detail_scroll as isize + delta).clamp(0, max_scroll as isize) as usize;
         self.detail_scroll = next;
@@ -1847,10 +1946,11 @@ impl App {
             return;
         }
         let view_height = quick_popup_content_height(self.body_area) as usize;
+        let line_count = self.quick_rendered_height.max(self.quick_lines.len());
         let max_scroll = if view_height == 0 {
-            self.quick_lines.len().saturating_sub(1)
+            line_count.saturating_sub(1)
         } else {
-            self.quick_lines.len().saturating_sub(view_height)
+            line_count.saturating_sub(view_height)
         };
         let next = (self.quick_scroll as isize + delta).clamp(0, max_scroll as isize) as usize;
         self.quick_scroll = next;
@@ -1987,6 +2087,9 @@ impl App {
     }
 
     fn update_quick_lines(&mut self) {
+        self.quick_rendered_height = 0;
+        self.quick_layout_width = 0;
+        self.quick_line_offsets.clear();
         let Some(idx) = self.selected.selected() else {
             self.quick_lines = vec![PreviewLine::Text("no session selected".to_string())];
             return;
@@ -4138,20 +4241,28 @@ fn draw_preview_panel(
         );
         return content;
     }
-    let view_height = content.height as usize;
-    let start = app.detail_scroll.min(app.detail_lines.len());
-    let end = if view_height == 0 {
-        start
-    } else {
-        (start + view_height).min(app.detail_lines.len())
-    };
-    let visible_lines: Vec<Line> = app.detail_lines[start..end]
+    if app.detail_layout_width != content.width {
+        app.detail_line_offsets = preview_line_offsets(&app.detail_lines, theme, content.width);
+        app.detail_rendered_height = app.detail_line_offsets.last().copied().unwrap_or(0);
+        app.detail_layout_width = content.width;
+    }
+    let max_scroll = app
+        .detail_rendered_height
+        .saturating_sub(content.height as usize);
+    app.detail_scroll = app.detail_scroll.min(max_scroll);
+    let (visible_range, local_scroll) = preview_line_window(
+        &app.detail_line_offsets,
+        app.detail_scroll,
+        content.height as usize,
+    );
+    let rendered_lines: Vec<Line> = app.detail_lines[visible_range]
         .iter()
         .map(|line| render_preview_line(line, theme))
         .collect();
-    let detail = Paragraph::new(visible_lines)
+    let detail = Paragraph::new(rendered_lines)
         .style(theme.text)
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap { trim: true })
+        .scroll((local_scroll.min(u16::MAX as usize) as u16, 0));
     frame.render_widget(detail, content);
     content
 }
@@ -4181,20 +4292,28 @@ fn draw_quick_popup(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, ar
     ]);
     frame.render_widget(Paragraph::new(title), header);
 
-    let view_height = content.height as usize;
-    let start = app.quick_scroll.min(app.quick_lines.len());
-    let end = if view_height == 0 {
-        start
-    } else {
-        (start + view_height).min(app.quick_lines.len())
-    };
-    let visible_lines: Vec<Line> = app.quick_lines[start..end]
+    if app.quick_layout_width != content.width {
+        app.quick_line_offsets = preview_line_offsets(&app.quick_lines, theme, content.width);
+        app.quick_rendered_height = app.quick_line_offsets.last().copied().unwrap_or(0);
+        app.quick_layout_width = content.width;
+    }
+    let max_scroll = app
+        .quick_rendered_height
+        .saturating_sub(content.height as usize);
+    app.quick_scroll = app.quick_scroll.min(max_scroll);
+    let (visible_range, local_scroll) = preview_line_window(
+        &app.quick_line_offsets,
+        app.quick_scroll,
+        content.height as usize,
+    );
+    let rendered_lines: Vec<Line> = app.quick_lines[visible_range]
         .iter()
         .map(|line| render_preview_line(line, theme))
         .collect();
-    let detail = Paragraph::new(visible_lines)
+    let detail = Paragraph::new(rendered_lines)
         .style(theme.text)
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap { trim: true })
+        .scroll((local_scroll.min(u16::MAX as usize) as u16, 0));
     frame.render_widget(detail, content);
     content
 }
@@ -5340,6 +5459,15 @@ where
 }
 
 fn append_record(lines: &mut Vec<PreviewLine>, record: &Record, highlight: bool) {
+    append_record_with_markdown(lines, record, highlight, true);
+}
+
+fn append_record_with_markdown(
+    lines: &mut Vec<PreviewLine>,
+    record: &Record,
+    highlight: bool,
+    render_markdown: bool,
+) {
     let role = if record.role.is_empty() {
         "unknown"
     } else {
@@ -5361,12 +5489,43 @@ fn append_record(lines: &mut Vec<PreviewLine>, record: &Record, highlight: bool)
     let sanitized = sanitize_preview_lines(&text);
     if sanitized.is_empty() {
         lines.push(PreviewLine::Text("<empty>".to_string()));
+    } else if render_markdown && supports_markdown_preview(role) {
+        append_markdown(lines, &sanitized.join("\n"));
     } else {
         for line in sanitized {
             lines.push(PreviewLine::Text(line));
         }
     }
     lines.push(PreviewLine::Empty);
+}
+
+fn supports_markdown_preview(role: &str) -> bool {
+    matches!(role, "user" | "assistant")
+}
+
+fn append_markdown(lines: &mut Vec<PreviewLine>, markdown: &str) {
+    let options = MarkdownOptions::new(TranscriptMarkdownStyle);
+    let rendered = from_str_with_options(markdown, &options);
+    if rendered.lines.is_empty() {
+        lines.push(PreviewLine::Text("<empty>".to_string()));
+        return;
+    }
+
+    for line in rendered.lines {
+        let line_style = line.style;
+        let spans = line
+            .spans
+            .into_iter()
+            .map(|span| PreviewSpan {
+                content: span.content.into_owned(),
+                style: line_style.patch(span.style),
+            })
+            .collect();
+        lines.push(PreviewLine::Styled {
+            spans,
+            alignment: line.alignment,
+        });
+    }
 }
 
 fn sanitize_preview_lines(text: &str) -> Vec<String> {
@@ -5492,6 +5651,49 @@ fn role_color(role: &str) -> Color {
     }
 }
 
+fn preview_line_offsets(lines: &[PreviewLine], theme: &Theme, width: u16) -> Vec<usize> {
+    let mut offsets = Vec::with_capacity(lines.len().saturating_add(1));
+    offsets.push(0);
+    for line in lines {
+        let rendered = render_preview_line(line, theme);
+        let height = Paragraph::new(rendered)
+            .style(theme.text)
+            .wrap(Wrap { trim: true })
+            .line_count(width)
+            .max(1);
+        offsets.push(
+            offsets
+                .last()
+                .copied()
+                .unwrap_or(0usize)
+                .saturating_add(height),
+        );
+    }
+    offsets
+}
+
+fn preview_line_window(
+    offsets: &[usize],
+    scroll: usize,
+    viewport_height: usize,
+) -> (std::ops::Range<usize>, usize) {
+    let line_count = offsets.len().saturating_sub(1);
+    if line_count == 0 {
+        return (0..0, 0);
+    }
+
+    let first = offsets[1..]
+        .partition_point(|end| *end <= scroll)
+        .min(line_count.saturating_sub(1));
+    let local_scroll = scroll.saturating_sub(offsets[first]);
+    let viewport_end = scroll.saturating_add(viewport_height.max(1));
+    let end = offsets[..line_count]
+        .partition_point(|start| *start < viewport_end)
+        .max(first.saturating_add(1))
+        .min(line_count);
+    (first..end, local_scroll)
+}
+
 fn render_preview_line<'a>(line: &'a PreviewLine, theme: &Theme) -> Line<'a> {
     match line {
         PreviewLine::SessionHeader {
@@ -5529,6 +5731,18 @@ fn render_preview_line<'a>(line: &'a PreviewLine, theme: &Theme) -> Line<'a> {
             ])
         }
         PreviewLine::Text(text) => Line::from(Span::raw(text.as_str())),
+        PreviewLine::Styled { spans, alignment } => {
+            let mut line = Line::from(
+                spans
+                    .iter()
+                    .map(|span| Span::styled(span.content.as_str(), span.style))
+                    .collect::<Vec<_>>(),
+            );
+            if let Some(alignment) = alignment {
+                line = line.alignment(*alignment);
+            }
+            line
+        }
         PreviewLine::Empty => Line::from(""),
     }
 }
@@ -6069,6 +6283,8 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 mod tests {
     use super::*;
     use crate::types::{RecordLinks, SourceKind};
+    use ratatui::{backend::TestBackend, buffer::Buffer, widgets::Widget};
+    use std::hint::black_box;
 
     fn create_stale_schema_index(dir: &std::path::Path) {
         std::fs::create_dir_all(dir).expect("create index dir");
@@ -6139,6 +6355,171 @@ mod tests {
             links: RecordLinks::default(),
             source_path: "source.jsonl".to_string(),
         }
+    }
+
+    fn markdown_perf_records() -> Vec<Record> {
+        (0..96)
+            .map(|idx| {
+                record(
+                    if idx % 4 == 0 { "user" } else { "assistant" },
+                    &format!(
+                        "## Transcript item {idx}\n\n\
+                         This message contains **strong text**, _emphasis_, an \
+                         [external link](https://example.com/{idx}), and `inline_code({idx})`.\n\n\
+                         - first list item with enough prose to wrap in a narrow preview\n\
+                         - second list item with ~~removed~~ and ==highlighted== content\n\n\
+                         ```rust\n\
+                         fn transcript_item_{idx}() -> usize {{\n    {idx}\n}}\n\
+                         ```\n\n\
+                         | field | value |\n\
+                         | --- | ---: |\n\
+                         | item | {idx} |"
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn build_perf_preview(records: &[Record], render_markdown: bool) -> Vec<PreviewLine> {
+        let mut lines = Vec::new();
+        for record in records {
+            append_record_with_markdown(&mut lines, record, false, render_markdown);
+        }
+        lines
+    }
+
+    fn median_duration(mut operation: impl FnMut()) -> Duration {
+        const SAMPLE_COUNT: usize = 5;
+        const SAMPLE_TIME: Duration = Duration::from_millis(60);
+
+        operation();
+        let mut samples = Vec::with_capacity(SAMPLE_COUNT);
+        for _ in 0..SAMPLE_COUNT {
+            let started = Instant::now();
+            let mut iterations = 0u32;
+            while started.elapsed() < SAMPLE_TIME {
+                operation();
+                iterations = iterations.saturating_add(1);
+            }
+            samples.push(started.elapsed() / iterations.max(1));
+        }
+        samples.sort_unstable();
+        samples[SAMPLE_COUNT / 2]
+    }
+
+    fn assert_perf_bound(
+        label: &str,
+        markdown: Duration,
+        plain: Duration,
+        max_ratio: u32,
+        slack: Duration,
+    ) {
+        let budget = plain.saturating_mul(max_ratio).saturating_add(slack);
+        let ratio = markdown.as_secs_f64() / plain.as_secs_f64().max(f64::EPSILON);
+        eprintln!(
+            "{label}: markdown={markdown:?}/iter plain={plain:?}/iter ratio={ratio:.2}x \
+             budget={budget:?}"
+        );
+        assert!(
+            markdown <= budget,
+            "{label} Markdown path took {markdown:?}; expected <= {budget:?} \
+             ({max_ratio}x plain {plain:?} plus {slack:?})"
+        );
+    }
+
+    fn render_perf_viewports(
+        lines: &[PreviewLine],
+        offsets: &[usize],
+        theme: &Theme,
+        width: u16,
+        height: u16,
+    ) {
+        let total_height = offsets.last().copied().unwrap_or(0);
+        let max_scroll = total_height.saturating_sub(height as usize);
+        for scroll in [
+            0,
+            max_scroll / 4,
+            max_scroll / 2,
+            max_scroll.saturating_mul(3) / 4,
+            max_scroll,
+        ] {
+            let (range, local_scroll) = preview_line_window(offsets, scroll, height as usize);
+            let rendered = lines[range]
+                .iter()
+                .map(|line| render_preview_line(line, theme))
+                .collect::<Vec<_>>();
+            let paragraph = Paragraph::new(rendered)
+                .style(theme.text)
+                .wrap(Wrap { trim: true })
+                .scroll((local_scroll.min(u16::MAX as usize) as u16, 0));
+            let area = Rect::new(0, 0, width, height);
+            let mut buffer = Buffer::empty(area);
+            Widget::render(paragraph, area, &mut buffer);
+            black_box(buffer);
+        }
+    }
+
+    #[test]
+    #[ignore = "CI-only Markdown performance comparison"]
+    fn transcript_markdown_perf_build() {
+        let records = markdown_perf_records();
+        let plain = median_duration(|| {
+            black_box(build_perf_preview(black_box(&records), false));
+        });
+        let markdown = median_duration(|| {
+            black_box(build_perf_preview(black_box(&records), true));
+        });
+
+        // Parsing Markdown is expected to be slower than copying plain lines. This broad ceiling
+        // catches accidental repeated parsing or superlinear behavior without making shared CI
+        // runners fail over ordinary scheduling noise.
+        assert_perf_bound(
+            "transcript build",
+            markdown,
+            plain,
+            40,
+            Duration::from_millis(2),
+        );
+    }
+
+    #[test]
+    #[ignore = "CI-only Markdown performance comparison"]
+    fn transcript_markdown_perf_viewport() {
+        let records = markdown_perf_records();
+        let plain_lines = build_perf_preview(&records, false);
+        let markdown_lines = build_perf_preview(&records, true);
+        let theme = Theme::new();
+        let width = 80;
+        let height = 24;
+        let plain_offsets = preview_line_offsets(&plain_lines, &theme, width);
+        let markdown_offsets = preview_line_offsets(&markdown_lines, &theme, width);
+
+        let plain = median_duration(|| {
+            render_perf_viewports(
+                black_box(&plain_lines),
+                black_box(&plain_offsets),
+                &theme,
+                width,
+                height,
+            );
+        });
+        let markdown = median_duration(|| {
+            render_perf_viewports(
+                black_box(&markdown_lines),
+                black_box(&markdown_offsets),
+                &theme,
+                width,
+                height,
+            );
+        });
+
+        assert_perf_bound(
+            "cached viewport render",
+            markdown,
+            plain,
+            12,
+            Duration::from_micros(500),
+        );
     }
 
     #[test]
@@ -6721,6 +7102,118 @@ mod tests {
             record_preview_text(&record),
             "{\n  \"cmd\": \"pwd && rg --files\",\n  \"workdir\": \"/tmp/app\",\n  \"yield_time_ms\": 1000\n}"
         );
+    }
+
+    #[test]
+    fn assistant_preview_renders_markdown_to_styled_lines() {
+        let record = record(
+            "assistant",
+            "# Result\n\nUse **bold text** and `inline_code()`.",
+        );
+        let mut lines = Vec::new();
+
+        append_record(&mut lines, &record, false);
+
+        let rendered_text = lines
+            .iter()
+            .filter_map(|line| match line {
+                PreviewLine::Styled { spans, .. } => Some(
+                    spans
+                        .iter()
+                        .map(|span| span.content.as_str())
+                        .collect::<String>(),
+                ),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered_text.contains("Result"));
+        assert!(rendered_text.contains("bold text"));
+        assert!(!rendered_text.contains("**"));
+        assert!(lines.iter().any(|line| match line {
+            PreviewLine::Styled { spans, .. } => spans.iter().any(|span| {
+                span.content.contains("bold text")
+                    && span.style.add_modifier.contains(Modifier::BOLD)
+            }),
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn tool_preview_keeps_markdown_markers_as_plain_text() {
+        let record = record("tool_result", "status: **literal marker**");
+        let mut lines = Vec::new();
+
+        append_record(&mut lines, &record, false);
+
+        assert!(lines.iter().any(
+            |line| matches!(line, PreviewLine::Text(text) if text == "status: **literal marker**")
+        ));
+        assert!(
+            !lines
+                .iter()
+                .any(|line| matches!(line, PreviewLine::Styled { .. }))
+        );
+    }
+
+    #[test]
+    fn markdown_parsing_is_isolated_per_transcript_message() {
+        let mut lines = Vec::new();
+        append_record(
+            &mut lines,
+            &record("assistant", "```rust\nlet unfinished = true;"),
+            false,
+        );
+        append_record(
+            &mut lines,
+            &record("assistant", "# Independent heading"),
+            false,
+        );
+
+        assert!(lines.iter().any(|line| match line {
+            PreviewLine::Styled { spans, .. } => spans.iter().any(|span| {
+                span.content.contains("Independent heading")
+                    && span.style.add_modifier.contains(Modifier::BOLD)
+            }),
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn preview_scroll_uses_wrapped_markdown_height() {
+        let (_tmp, mut app) = test_app();
+        app.detail_state = LoadState::Loaded;
+        append_markdown(
+            &mut app.detail_lines,
+            &format!("**wrapped** {}", "transcript prose ".repeat(100)),
+        );
+        let logical_height = app.detail_lines.len();
+        let backend = TestBackend::new(32, 10);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let theme = Theme::new();
+        let mut content_area = Rect::default();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                content_area = draw_preview_panel(frame, &mut app, &theme, area);
+            })
+            .expect("draw preview");
+        app.preview_area = content_area;
+
+        assert!(app.detail_rendered_height > logical_height);
+        assert!(app.detail_rendered_height > content_area.height as usize);
+        app.scroll_detail(1);
+        assert_eq!(app.detail_scroll, 1);
+    }
+
+    #[test]
+    fn preview_window_skips_offscreen_logical_lines() {
+        let offsets = vec![0, 10, 11, 21];
+
+        assert_eq!(preview_line_window(&offsets, 5, 3), (0..1, 5));
+        assert_eq!(preview_line_window(&offsets, 10, 5), (1..3, 0));
+        assert_eq!(preview_line_window(&offsets, 20, 5), (2..3, 9));
     }
 
     #[test]


### PR DESCRIPTION
Render user and assistant transcript messages with tui-markdown while keeping tool output plain.

Parse Markdown once in the detail worker, cache wrapped line offsets by width, and render only the visible viewport. Upgrade Ratatui and Crossterm for compatibility.

Add CI-only Markdown-on/off performance comparisons for transcript construction and cached viewport rendering.