### PR TITLE
docs: correct embedding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ memex tui
 ```
 
 Notes:
-- Embeddings are enabled by default.
+- Embeddings are disabled by default. Pass `--embeddings` to generate them during indexing.
 - Searches run an incremental reindex by default (configurable).
 - Concurrent searches coalesce stale auto-index work: one process refreshes while other lexical
   searches query the last committed index. Semantic and hybrid searches wait for vector writes to
@@ -326,9 +326,9 @@ runtime to the daemon.
 
 ## Embeddings
 
-Disable:
+Enable during indexing:
 ```
-memex index --no-embeddings
+memex index --embeddings
 ```
 
 Recommended when embeddings are on (especially non-`potion` models): run the background

--- a/skills/codex/memex-search/SKILL.md
+++ b/skills/codex/memex-search/SKILL.md
@@ -15,9 +15,9 @@ Use this skill to index local history and retrieve results in a structured way.
   - `memex index-service enable --continuous`
 - Full rebuild (clears index):
   - `memex reindex`
-- Embeddings are on by default.
-- Disable embeddings:
-  - `memex index --no-embeddings`
+- Embeddings are off by default.
+- Enable embeddings during indexing:
+  - `memex index --embeddings`
 - Backfill embeddings only:
   - `memex embed`
 - Common flags:

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -16,9 +16,9 @@ Use this skill to index local history and retrieve results in a structured, LLM-
   - `memex index-service enable --continuous`
 - Full rebuild (clears index):
   - `memex reindex`
-- Embeddings are on by default.
-- Disable embeddings:
-  - `memex index --no-embeddings`
+- Embeddings are off by default.
+- Enable embeddings during indexing:
+  - `memex index --embeddings`
 - Backfill embeddings only:
   - `memex embed`
 - Common flags:


### PR DESCRIPTION
## What changed

- state that embeddings are disabled by default
- show `memex index --embeddings` as the opt-in indexing command
- align the README and bundled Claude/Codex search skills

## Why

`UserConfig::embeddings_default()` falls back to `false`, while the documentation said embeddings were enabled by default and instructed users how to disable them. That made the documented default disagree with the CLI behavior.

## Impact

Users and agents now receive the correct default and the direct opt-in command. No runtime behavior changes.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`
- repository-wide scan for stale embedding-default claims
