### PR TITLE
fix: query with active vector metadata

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use crate::ingest::{IngestOptions, ingest_all, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt, LeaseHolder};
 use crate::machine::{
     LocatedRecord, SearchMode, SearchSpec, UsageSpec, federated_search, federated_usage,
+    resolve_vector_query_model,
 };
 use crate::transfer::{
     TransferMode as CoreTransferMode, TransferOptions, TransferTarget as CoreTransferTarget,
@@ -1251,7 +1252,7 @@ fn run_semantic_search(
     let vector = match VectorIndex::open(&ctx.paths.vectors) {
         Ok(vector) => vector,
         Err(err) if is_missing_vector_index_error(&err) => {
-            warn_vector_index_missing("semantic");
+            warn_vector_index_unavailable("semantic");
             return run_lexical_search(
                 index,
                 options,
@@ -1262,7 +1263,17 @@ fn run_semantic_search(
         }
         Err(err) => return Err(err),
     };
-    let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
+    let Some(query_model) = resolve_vector_query_model(&vector, || Ok(ctx.model_choice))? else {
+        warn_vector_index_unavailable("semantic");
+        return run_lexical_search(
+            index,
+            options,
+            ctx.render,
+            ctx.recency_weight,
+            ctx.recency_half_life_days,
+        );
+    };
+    let mut embedder = EmbedderHandle::with_model_and_runtime(query_model, ctx.embed_runtime)?;
     let embeddings = embedder.embed_texts(&[options.query.as_str()])?;
     let embedding = embeddings
         .first()
@@ -1298,7 +1309,7 @@ fn run_hybrid_search(
     let vector = match VectorIndex::open(&ctx.paths.vectors) {
         Ok(vector) => vector,
         Err(err) if is_missing_vector_index_error(&err) => {
-            warn_vector_index_missing("hybrid");
+            warn_vector_index_unavailable("hybrid");
             return run_lexical_search(
                 index,
                 options,
@@ -1309,7 +1320,17 @@ fn run_hybrid_search(
         }
         Err(err) => return Err(err),
     };
-    let mut embedder = EmbedderHandle::with_model_and_runtime(ctx.model_choice, ctx.embed_runtime)?;
+    let Some(query_model) = resolve_vector_query_model(&vector, || Ok(ctx.model_choice))? else {
+        warn_vector_index_unavailable("hybrid");
+        return run_lexical_search(
+            index,
+            options,
+            ctx.render,
+            ctx.recency_weight,
+            ctx.recency_half_life_days,
+        );
+    };
+    let mut embedder = EmbedderHandle::with_model_and_runtime(query_model, ctx.embed_runtime)?;
 
     let bm25_k = (limit * 5).clamp(50, 500);
     let vector_k = (limit * 5).clamp(50, 500);
@@ -1399,7 +1420,7 @@ fn is_missing_vector_index_error(err: &anyhow::Error) -> bool {
     err.to_string() == "vector index not found"
 }
 
-fn warn_vector_index_missing(mode: &str) {
+fn warn_vector_index_unavailable(mode: &str) {
     eprintln!(
         "Warning: {mode} search requested, but the local vector index is not available; falling back to lexical search. Run 'memex embed' to build embeddings."
     );

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,6 +1,6 @@
 use crate::analytics::{AnalyticsStore, ProjectGrouping, analytics_path};
 use crate::config::{MachineConfig, Paths, UserConfig, default_claude_source};
-use crate::embed::EmbedderHandle;
+use crate::embed::{EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, IngestReport, ingest_all, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease};
@@ -828,6 +828,19 @@ fn absorb_cache_waste(total: &mut CacheWaste, row: &CacheWaste) {
         .saturating_add(row.model_switch_misses);
 }
 
+pub(crate) fn resolve_vector_query_model(
+    vector: &VectorIndex,
+    configured_model: impl FnOnce() -> Result<ModelChoice>,
+) -> Result<Option<ModelChoice>> {
+    if vector.is_empty() {
+        return Ok(None);
+    }
+    match vector.model() {
+        Some(model) => Ok(Some(ModelChoice::parse(model)?)),
+        None => Ok(Some(configured_model()?)),
+    }
+}
+
 fn search_local(
     paths: &Paths,
     config: &UserConfig,
@@ -850,7 +863,10 @@ fn search_local(
                 }
                 Err(err) => return Err(err),
             };
-            let model = config.resolve_model(None)?;
+            let Some(model) = resolve_vector_query_model(&vector, || config.resolve_model(None))?
+            else {
+                return lexical_results(&index, &options, spec, now_ms);
+            };
             let runtime = config.resolve_embed_runtime()?;
             let mut embedder = EmbedderHandle::with_model_and_runtime(model, &runtime)?;
             let embedding = embedder
@@ -876,12 +892,15 @@ fn search_local(
                 }
                 Err(err) => return Err(err),
             };
+            let Some(model) = resolve_vector_query_model(&vector, || config.resolve_model(None))?
+            else {
+                return lexical_results(&index, &options, spec, now_ms);
+            };
             let candidate_limit = (spec.limit * 5).clamp(50, 500);
             let lexical = index.search(&QueryOptions {
                 limit: candidate_limit,
                 ..options.clone()
             })?;
-            let model = config.resolve_model(None)?;
             let runtime = config.resolve_embed_runtime()?;
             let mut embedder = EmbedderHandle::with_model_and_runtime(model, &runtime)?;
             let embedding = embedder
@@ -1296,6 +1315,8 @@ fn shell_quote(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::config::{ControlConfig, IndexBackendConfig, MultiMachineConfig};
+    use crate::types::{RecordLinks, SourceKind};
+    use tempfile::TempDir;
 
     fn machine(id: &str) -> MachineConfig {
         MachineConfig {
@@ -1314,6 +1335,103 @@ mod tests {
                 prefix: None,
                 cache: None,
             }),
+        }
+    }
+
+    fn search_spec(mode: SearchMode) -> SearchSpec {
+        SearchSpec {
+            query: "query readiness".to_string(),
+            project: None,
+            role: None,
+            tool: None,
+            session_id: None,
+            source: None,
+            since: None,
+            until: None,
+            limit: 10,
+            mode,
+            recency_weight: 0.0,
+            recency_half_life_days: 30.0,
+            min_score: None,
+            project_grouping: None,
+        }
+    }
+
+    #[test]
+    fn vector_query_model_prefers_metadata_and_uses_configured_fallback() {
+        let tmp = TempDir::new().unwrap();
+
+        let mut with_metadata =
+            VectorIndex::open_or_create(&tmp.path().join("with-metadata"), 64, Some("bge"))
+                .unwrap();
+        with_metadata.add(1, &[0.0; 64]).unwrap();
+        let selected = resolve_vector_query_model(&with_metadata, || {
+            Err(anyhow!("configured fallback should not be resolved"))
+        })
+        .unwrap();
+        assert_eq!(selected, Some(ModelChoice::BGESmall));
+
+        let mut without_metadata =
+            VectorIndex::open_or_create(&tmp.path().join("without-metadata"), 64, None).unwrap();
+        without_metadata.add(1, &[0.0; 64]).unwrap();
+        let selected =
+            resolve_vector_query_model(&without_metadata, || Ok(ModelChoice::MiniLM)).unwrap();
+        assert_eq!(selected, Some(ModelChoice::MiniLM));
+    }
+
+    #[test]
+    fn empty_vector_index_falls_back_for_federated_semantic_and_hybrid_search() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+
+        let index = SearchIndex::open_or_create_for_ingest(&paths.index).unwrap();
+        let mut writer = index.writer().unwrap();
+        index
+            .add_record(
+                &mut writer,
+                &Record {
+                    source: SourceKind::Codex,
+                    doc_id: 1,
+                    ts: 1,
+                    project: "memex".to_string(),
+                    session_id: "session".to_string(),
+                    turn_id: 1,
+                    role: "assistant".to_string(),
+                    text: "query readiness".to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: "session.jsonl".to_string(),
+                },
+            )
+            .unwrap();
+        writer.commit().unwrap();
+
+        let vector = VectorIndex::open_or_create(&paths.vectors, 64, Some("bge")).unwrap();
+        assert_eq!(
+            resolve_vector_query_model(&vector, || {
+                Err(anyhow!("configured fallback should not be resolved"))
+            })
+            .unwrap(),
+            None
+        );
+        vector.save().unwrap();
+
+        for mode in [SearchMode::Semantic, SearchMode::Hybrid] {
+            let result = federated_search(
+                &paths,
+                &UserConfig::default(),
+                &[LOCAL_MACHINE_ID.to_string()],
+                &search_spec(mode),
+                false,
+            )
+            .unwrap();
+
+            assert!(result.failures.is_empty());
+            assert_eq!(result.items.len(), 1);
+            assert_eq!(result.items[0].record.doc_id, 1);
         }
     }
 


### PR DESCRIPTION
## What changed

- use the model recorded in the active vector index for semantic and hybrid queries
- resolve the configured model only for legacy vector metadata without a stored model
- fall back to lexical search when the vector index exists but contains no vectors
- cover both local CLI and federated/RPC search paths

## Why

Query embedding must use the same model that produced the active vector generation. Resolving the current configuration unconditionally can create incompatible query vectors after a model setting changes. An empty vector index also should not initialize an embedder only to return no results.

## Impact

Semantic and hybrid searches remain compatible with the active generation across configuration changes. Empty vector indexes return useful lexical results without loading an embedding model.

## Validation

- focused machine/search suite: 7 passed
- remaining unit suite: 282 passed, 2 ignored
- integration tests: 3 passed
- doctests: passed
- isolated upstream TUI test: 1 passed
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`

The TUI test was run separately because it starts an unjoined local-history scan that holds the usage-test lock when combined with the rest of the suite; the partitioned runs cover every test.
