### PR TITLE
docs: correct auto-index scope

### DIFF
--- a/skills/codex/memex-search/SKILL.md
+++ b/skills/codex/memex-search/SKILL.md
@@ -124,7 +124,8 @@ index_service_interval = 3600  # seconds (ignored when mode = "continuous")
 index_service_poll_interval = 30  # seconds
 ```
 
-`auto_index_on_search` runs an incremental index update before each search.
+When enabled, `auto_index_on_search` refreshes the index before each `memex search`;
+`memex sessions` reads the current index without triggering an update.
 `scan_cache_ttl` sets the maximum scan staleness for auto-indexing.
 `index-service` reads config defaults (mode, interval, log paths). Flags override.
 Service logs and the plist live under `~/.memex` by default.

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -125,7 +125,8 @@ index_service_interval = 3600  # seconds (ignored when mode = "continuous")
 index_service_poll_interval = 30  # seconds
 ```
 
-`auto_index_on_search` runs an incremental index update before each search.
+When enabled, `auto_index_on_search` refreshes the index before each `memex search`;
+`memex sessions` reads the current index without triggering an update.
 `scan_cache_ttl` sets the maximum scan staleness for auto-indexing.
 `index-service` reads config defaults (mode, interval, log paths). Flags override.
 Service logs and the plist live under `~/.memex` by default.

--- a/skills/opencode/memex-search/SKILL.md
+++ b/skills/opencode/memex-search/SKILL.md
@@ -35,6 +35,7 @@ If the vector index is unavailable, memex warns on stderr and falls back to lexi
 - Default mode is periodic indexing, typically every 3600 seconds; add `--interval <seconds>` to tune interval mode.
 - The service inherits indexing flags, so pass source and embedding options at install time when needed, e.g. `memex index-service enable --opencode --embeddings`.
 - On successful enable, memex writes `auto_index_on_search = false` to config when that setting is absent, so searches do not duplicate daemon work. Explicit user config is preserved.
+- When enabled, `auto_index_on_search` refreshes the index before each `memex search`; `memex sessions` reads the current index without triggering an update.
 - macOS writes `~/.memex/index-service.plist`, `~/.memex/index-service.log`, and `~/.memex/index-service.err.log`. Linux writes systemd user units under `~/.config/systemd/user/`.
 - Use `memex index-service disable` to unload and remove the service.
 


### PR DESCRIPTION
## What

- Clarify that `auto_index_on_search` refreshes the index before `memex search`.
- State that `memex sessions` reads the current index without triggering an update.
- Apply the same boundary to the core, Codex, and Opencode search skills.

## Why

The existing wording says the setting applies before each search without distinguishing the read-only sessions command, which can imply fresher session listings than the command provides.

## Impact

Documentation only. Users get an accurate expectation of when automatic indexing runs.

## Checks

- `git diff --check`
- Verified the scope statement in all three skill variants.
- Confirmed the CLI dispatch sends `memex sessions` directly to `run_sessions`, while search owns the auto-index path.
