### PR TITLE
Add onnxruntime to nix package

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   pkg-config,
   openssl,
+  onnxruntime,
   stdenv,
   darwin,
 }:
@@ -23,6 +24,7 @@ rustPlatform.buildRustPackage {
   buildInputs =
     [
       openssl
+      onnxruntime
     ]
     ++ lib.optionals stdenv.isDarwin [
       darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
Without it, the nix build fails on trying to fetch pyke:ort-rs in a sandboxed build

Logs from running `nix run github:nicosuave/memex`:
<details>

```log
error: Cannot build '/nix/store/0j7yabjlxrvh80baxg1gf9ybhdqzqik7-memex-0.9.1.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/acw1nvdjcwbh2qniwcjw9hcj6svfphpr-memex-0.9.1
       Last 25 log lines:
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
       >   cargo:rerun-if-env-changed=PKG_CONFIG_PATH
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
       >   onnxruntime not found using pkg-config, falling back to manual setup.
       >   cargo:rerun-if-env-changed=ORT_LIB_LOCATION
       >   cargo:rerun-if-env-changed=ORT_LIB_PROFILE
       >   cargo:rerun-if-env-changed=ORT_PREFER_DYNAMIC_LINK
       >   cargo:rerun-if-env-changed=ORT_SKIP_DOWNLOAD
       >   cargo:rerun-if-env-changed=ORT_CXX_STDLIB
       >   cargo:rerun-if-env-changed=CXXSTDLIB
       >   selected feature set: none
       >
       >   --- stderr
       >
       >   thread 'main' (7636) panicked at /build/cargo-vendor-dir/ort-sys-2.0.0-rc.10/build.rs:53:27:
       >   Failed to GET `https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz`: io: failed to lookup address information: Temporary failure in name resolution
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
         nix log /nix/store/0j7yabjlxrvh80baxg1gf9ybhdqzqik7-memex-0.9.1.drv
```
</details>