### PR TITLE
feat: add Hermes token usage source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, OpenClaw, and GitHub Copilot CLI logs. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi Coding Agent, OpenClaw, GitHub Copilot CLI, and Hermes usage records. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -210,11 +210,12 @@ Token tracking is disabled by default because it scans and caches local agent lo
 token_usage = true
 ```
 
-Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot logs:
+Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, OpenClaw, Copilot, and Hermes records:
 
 ```
 memex usage
 memex usage --source codex --since 2026-07-01
+memex usage --source hermes --since 2026-07-01
 memex usage --json --events
 ```
 
@@ -222,7 +223,7 @@ memex usage --json --events
 
 Each source also reports prompt-cache efficiency: the cache hit rate, plus an estimate of cache waste — prompt tokens that were in the previous request's prompt but were re-billed at input rates instead of read from cache, priced at catalog rates and attributed to idle gaps past the cache TTL or model switches where those apply. Waste is estimated per transcript file chain and errs toward undercounting: subagent sidechains, ambiguous dedupe deltas, and prompts that shrink past compaction are not counted.
 
-Local token history is reconstructed usage. It is deliberately kept separate from authoritative subscription quota percentages and reset windows.
+Local token history is reconstructed usage. It is deliberately kept separate from authoritative subscription quota percentages and reset windows. Hermes usage is read from `state.db` in the Hermes root and immediate profile directories (`HERMES_PROFILE_ROOTS`, `HERMES_HOME`, or `HERMES_STATE_DIR`, with safe local defaults), opened read-only and WAL-compatible. The `sessions` aggregate is used for legacy databases; newer `session_model_usage` delta rows are emitted by model/task and reconciled against the session aggregate so historical seeded rows count once and positive residuals are retained. Snapshots, backups, arbitrary nested databases, JSON/JSONL transcripts, and auth, config, memory, skills, plugins, and cron paths are excluded. Hermes queries never read message, system-prompt, tool, reasoning-text, or credential tables. Usage output contains counters and metadata only. Any API-equivalent cost estimate is analytical and is not a Hermes subscription quota measurement; source-stored API costs are not quota percentages. Hermes parser-version changes invalidate only Hermes usage cache rows.
 
 When token tracking is enabled, press `Ctrl+T` on the TUI home screen to toggle the 30-day activity chart between session count and token volume. Token activity is loaded lazily and cached when first shown.
 
@@ -266,7 +267,7 @@ This detects which tools are installed (Claude/Codex/OpenCode/Pi) and presents a
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|cursor|opencode|pi|openclaw|copilot`
+- `--source claude|codex|cursor|opencode|pi|openclaw|copilot|hermes`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, OpenClaw, and Copilot",
+    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, OpenClaw, Copilot, and Hermes",
     after_help = "\
 QUICK START:
     memex                           # Browse sessions interactively
@@ -183,7 +183,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, copilot, or hermes
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -301,7 +301,7 @@ EXAMPLES:
         /// Filter by project (repository grouping)
         #[arg(long)]
         project: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, copilot, or hermes
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include sessions active on or after this date/timestamp
@@ -336,7 +336,7 @@ EXAMPLES:
     memex usage --source codex --since 2026-07-01
     memex usage --json")]
     Usage {
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, copilot, or hermes
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include events on or after this date/timestamp
@@ -452,7 +452,7 @@ enum HerdrCommand {
         /// Prefer sessions from this directory (falls back to the global latest)
         #[arg(long)]
         cwd: Option<PathBuf>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, or copilot
+        /// Filter by source: claude, codex, cursor, opencode, pi, openclaw, copilot, or hermes
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Path to memex data directory [default: ~/.memex]
@@ -2544,6 +2544,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Pi => "pi",
         crate::types::SourceKind::OpenClaw => "openclaw",
         crate::types::SourceKind::Copilot => "copilot",
+        crate::types::SourceKind::Hermes => "hermes",
     };
     let source_path = &record.source_path;
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -743,6 +743,7 @@ pub fn ingest_all(
                 SourceKind::Copilot => {
                     parse_copilot_session(task, &tx_record, &tx_update, &next_doc_id, &progress)
                 }
+                SourceKind::Hermes => Err(anyhow!("Hermes indexing is not supported")),
             };
             finish_file_task(task, &progress, &parse_skipped, result)
         })
@@ -2926,8 +2927,8 @@ mod tests {
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
         let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, meta.len()],
-            [0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, meta.len(), 0],
+            [0, 0, 0, 0, 0, 0, 1, 0],
             false,
         ));
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -245,6 +245,7 @@ fn progress_label(source: SourceKind) -> &'static str {
         SourceKind::Pi => "pi",
         SourceKind::OpenClaw => "openclaw",
         SourceKind::Copilot => "copilot",
+        SourceKind::Hermes => "hermes",
     }
 }
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -30,6 +30,7 @@ pub fn resume_template(config: &UserConfig, source: SourceKind, remote: bool) ->
         SourceKind::Pi => config.pi_resume_cmd.clone(),
         SourceKind::OpenClaw => return None,
         SourceKind::Copilot => config.copilot_resume_cmd.clone(),
+        SourceKind::Hermes => None,
     };
     configured.or_else(|| default_resume_template(source.label(), remote))
 }

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -72,6 +72,13 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
             .map(|file| file.path)
             .collect(),
     );
+    push(
+        SourceKind::Hermes,
+        super::hermes::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
 
     groups
         .into_iter()
@@ -100,6 +107,12 @@ pub fn audit_files(source: SourceKind, files: &[PathBuf]) -> Result<SourceAudit>
 }
 
 fn audit_file(source: SourceKind, path: &Path, audit: &mut SourceAudit) -> Result<()> {
+    if source == SourceKind::Hermes {
+        // Hermes usage truth is SQLite aggregate data.  Audit must not reinterpret the
+        // database as JSON, and in particular must not read transcript/message columns.
+        std::fs::File::open(path)?;
+        return Ok(());
+    }
     let reader = std::io::BufReader::new(std::fs::File::open(path)?);
     for line in reader.lines() {
         let line = line?;
@@ -190,6 +203,11 @@ fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &
                 increment(&mut audit.semantic_types, role);
             }
             record_content_blocks(value.get("content"), audit);
+        }
+        SourceKind::Hermes => {
+            if value.get("records").and_then(Value::as_array).is_some() {
+                increment(&mut audit.semantic_types, "records");
+            }
         }
     }
 }

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -628,8 +628,10 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
                         .map(str::to_string),
                     tokens,
                     source_cost_usd: value.get("costUSD").and_then(|value| value.as_f64()),
+                    cost_authoritative: false,
                     dedupe_confidence: if exact_dedupe { "exact" } else { "heuristic" },
                     conservative_undercount: false,
+                    cache_chain_excluded: false,
                     sidechain: value
                         .get("isSidechain")
                         .and_then(|value| value.as_bool())

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -1236,9 +1236,11 @@ pub(crate) fn parse_usage_file(
                         delta.reasoning,
                     ),
                     source_cost_usd: None,
+                    cost_authoritative: false,
                     dedupe_confidence: "strong",
                     conservative_undercount: counter.interleaved
                         || (parent.is_some() && !fork_resolved),
+                    cache_chain_excluded: false,
                     sidechain: false,
                     source_order,
                 });
@@ -1281,8 +1283,10 @@ pub(crate) fn parse_usage_file(
                         tokens.reasoning,
                     ),
                     source_cost_usd: None,
+                    cost_authoritative: false,
                     dedupe_confidence: "strong",
                     conservative_undercount: false,
+                    cache_chain_excluded: false,
                     sidechain: false,
                     source_order,
                 });

--- a/src/sources/copilot.rs
+++ b/src/sources/copilot.rs
@@ -680,8 +680,10 @@ fn extract_usage(
                         .max(attribute_u64(attributes, "gen_ai.usage.reasoning_tokens")),
                 ),
                 source_cost_usd: None,
+                cost_authoritative: false,
                 dedupe_confidence: "exact",
                 conservative_undercount: false,
+                cache_chain_excluded: false,
                 sidechain: false,
                 source_order: index,
             });

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -488,12 +488,14 @@ fn extract_usage(
                     }),
                 tokens: TokenBuckets::disjoint(input, 0, 0, output),
                 source_cost_usd: None,
+                cost_authoritative: false,
                 dedupe_confidence: if table == "cursorDiskKV" {
                     "exact"
                 } else {
                     "strong"
                 },
                 conservative_undercount: false,
+                cache_chain_excluded: false,
                 sidechain: false,
                 source_order: 0,
             });

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
     index: 1,
-    usage: 4,
+    usage: 5,
 };
 
 pub fn matches_path(path: &str) -> bool {
@@ -125,26 +125,6 @@ fn add_profile_children(root: &Path, out: &mut Vec<PathBuf>) {
 
 fn is_state_db(path: &Path) -> bool {
     path.file_name().and_then(|v| v.to_str()) == Some("state.db")
-        && !path.components().any(|component| {
-            matches!(
-                component.as_os_str().to_str(),
-                Some(
-                    "snapshots"
-                        | "snapshot"
-                        | "backups"
-                        | "backup"
-                        | "upgrades"
-                        | "upgrade"
-                        | "sandbox"
-                        | "sandboxes"
-                        | "repo"
-                        | "repos"
-                        | "cron"
-                        | "kanban"
-                        | "verification"
-                )
-            )
-        })
 }
 
 type Row = HashMap<String, Value>;
@@ -154,12 +134,15 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
     let wal_before = crate::sources::UsageDependency::from_path_or_absent(&wal);
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
-    let tables = table_names(&conn)?;
+    // Keep session totals and their model/task breakdowns on the same SQLite snapshot. Hermes
+    // may append to both tables while a scan is in progress.
+    let transaction = conn.unchecked_transaction()?;
+    let tables = table_names(&transaction)?;
     if !tables.contains("sessions") {
         return Err(anyhow!("Hermes database has no sessions table"));
     }
     let sessions = rows(
-        &conn,
+        &transaction,
         "sessions",
         &[
             "id",
@@ -185,7 +168,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
     )?;
     let model_rows = if tables.contains("session_model_usage") {
         rows(
-            &conn,
+            &transaction,
             "session_model_usage",
             &[
                 "session_id",
@@ -219,6 +202,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
     } else {
         Vec::new()
     };
+    transaction.rollback()?;
     let mut by_session: HashMap<String, Vec<&Row>> = HashMap::new();
     for row in &model_rows {
         if let Some(id) = text(row, "session_id") {
@@ -294,9 +278,14 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
             authoritative_cost.is_some_and(|authoritative| attributed_model_cost > authoritative);
         let reconcile_with_authority =
             authoritative_cost.is_some() && (invalid_model || model_cost_exceeds_authority);
-        if reconcile_with_authority {
+        if authoritative_cost.is_some() {
             for event in &mut events[model_event_start..] {
-                event.source_cost_usd = None;
+                if reconcile_with_authority || event.source_cost_usd.is_none() {
+                    // An explicit zero suppresses CostMode::Auto's catalog fallback. The
+                    // authoritative session residual carries the portion not attributed to a
+                    // model row, so repricing this event would double count it.
+                    event.source_cost_usd = Some(0.0);
+                }
             }
         }
         let source_cost = if reconcile_with_authority {
@@ -618,6 +607,28 @@ mod tests {
     }
 
     #[test]
+    fn discovery_allows_reserved_names_outside_and_inside_profile_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("backups/.hermes");
+        for path in [root.join("state.db"), root.join("profiles/repo/state.db")] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+
+        let files = discover_from_roots(std::slice::from_ref(&root));
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.path.strip_prefix(&root).unwrap().to_path_buf())
+                .collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("profiles/repo/state.db"),
+                PathBuf::from("state.db")
+            ]
+        );
+    }
+
+    #[test]
     fn legacy_sessions_are_aggregates_and_ignore_transcript_tables() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("state.db");
@@ -722,7 +733,7 @@ mod tests {
                     .as_deref()
                     .unwrap()
                     .starts_with("model:")
-                    || event.source_cost_usd.is_none()
+                    || event.source_cost_usd == Some(0.0)
             }));
             assert_eq!(
                 events
@@ -793,11 +804,11 @@ mod tests {
     fn authoritative_session_cost_reconciles_model_cost_matrix() {
         for (index, (session_cost, model_cost, expected_model_cost, expected_residual)) in [
             (None, Some(6.0), Some(6.0), None),
-            (Some(0.0), Some(6.0), None, Some(0.0)),
-            (Some(5.0), Some(6.0), None, Some(5.0)),
+            (Some(0.0), Some(6.0), Some(0.0), Some(0.0)),
+            (Some(5.0), Some(6.0), Some(0.0), Some(5.0)),
             (Some(6.0), Some(6.0), Some(6.0), None),
             (Some(10.0), Some(6.0), Some(6.0), Some(4.0)),
-            (Some(10.0), None, None, Some(10.0)),
+            (Some(10.0), None, Some(0.0), Some(10.0)),
         ]
         .into_iter()
         .enumerate()

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -233,7 +233,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
         };
         let aggregate = buckets(session);
         let Some(model_rows) = by_session.get(&id) else {
-            if !is_zero(&aggregate) {
+            if !is_zero(&aggregate) || cost(session).is_some() {
                 events.push(event(
                     &source_path,
                     &id,
@@ -242,6 +242,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                     aggregate,
                     cost(session),
                     true,
+                    timestamp(session),
                     0,
                 ));
             }
@@ -249,6 +250,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
         };
         let mut summed = TokenBuckets::default();
         let mut invalid_model = false;
+        let mut attributed_model_cost = 0.0;
         let model_event_start = events.len();
         for row in model_rows {
             let raw_current = buckets(row);
@@ -267,6 +269,10 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                 ))
                 .expect("tuple serialization cannot fail");
                 let id = format!("model:{identity}");
+                let source_cost = (!inconsistent).then(|| cost(row)).flatten();
+                if let Some(cost) = source_cost {
+                    attributed_model_cost += cost;
+                }
                 events.push(model_event(
                     &source_path,
                     &id,
@@ -275,24 +281,33 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                     session,
                     model,
                     current,
-                    (!inconsistent).then(|| cost(row)).flatten(),
+                    source_cost,
                     inconsistent,
+                    timestamp(row).max(timestamp(session)),
                     timestamp(row).max(timestamp(session)),
                 ));
             }
         }
         let residual = subtract(aggregate, summed);
-        if invalid_model {
+        let authoritative_cost = cost(session);
+        let model_cost_exceeds_authority =
+            authoritative_cost.is_some_and(|authoritative| attributed_model_cost > authoritative);
+        let reconcile_with_authority =
+            authoritative_cost.is_some() && (invalid_model || model_cost_exceeds_authority);
+        if reconcile_with_authority {
             for event in &mut events[model_event_start..] {
                 event.source_cost_usd = None;
             }
         }
-        let source_cost = if invalid_model {
-            cost(session)
+        let source_cost = if reconcile_with_authority {
+            authoritative_cost
         } else {
-            residual_cost(session, model_rows)
+            authoritative_cost.and_then(|authoritative| {
+                (authoritative > attributed_model_cost)
+                    .then_some(authoritative - attributed_model_cost)
+            })
         };
-        if !is_zero(&residual) || invalid_model && source_cost.is_some() {
+        if !is_zero(&residual) || source_cost.is_some() {
             events.push(event(
                 &source_path,
                 &format!("session:{id}:residual"),
@@ -301,6 +316,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                 residual,
                 source_cost,
                 true,
+                timestamp(session),
                 timestamp(session),
             ));
         }
@@ -488,12 +504,6 @@ fn cap_to_remaining(
         reasoning: cap(aggregate.reasoning, used.reasoning, value.reasoning),
     }
 }
-fn residual_cost(session: &Row, rows: &[&Row]) -> Option<f64> {
-    let total = cost(session)?;
-    let used: f64 = rows.iter().filter_map(|row| cost(row)).sum();
-    (total > used).then_some(total - used)
-}
-
 fn cacheable_after_wal_read(
     wal_before: &crate::sources::UsageDependency,
     wal_after: &crate::sources::UsageDependency,
@@ -509,6 +519,7 @@ fn event(
     tokens: TokenBuckets,
     source_cost_usd: Option<f64>,
     conservative: bool,
+    timestamp_ms: u64,
     order: u64,
 ) -> UsageEvent {
     UsageEvent {
@@ -518,7 +529,7 @@ fn event(
         session_id: session_id.map(str::to_string),
         request_id: None,
         message_id: None,
-        timestamp_ms: timestamp(row),
+        timestamp_ms,
         project: text(row, "cwd").or_else(|| text(row, "git_repo_root")),
         provider: text(row, "billing_provider"),
         model: text(row, "model"),
@@ -541,6 +552,7 @@ fn model_event(
     tokens: TokenBuckets,
     source_cost_usd: Option<f64>,
     conservative: bool,
+    timestamp_ms: u64,
     order: u64,
 ) -> UsageEvent {
     let mut event = event(
@@ -551,6 +563,7 @@ fn model_event(
         tokens,
         source_cost_usd,
         conservative,
+        timestamp_ms,
         order,
     );
     event.model = model;
@@ -738,6 +751,329 @@ mod tests {
     }
 
     #[test]
+    fn exact_model_tokens_emit_cost_only_residual_for_uncovered_source_cost() {
+        for (index, model_cost) in [None, Some(6.0)].into_iter().enumerate() {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(format!("exact-cost-{index}.db"));
+            db(&path, true);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',10.0,'/work','/repo','prof')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,?1,1000)",
+                [model_cost],
+            )
+            .unwrap();
+            drop(conn);
+
+            let events = parse_usage_file(&path).unwrap().events;
+            let residual = events
+                .iter()
+                .find(|event| event.source_record_id.as_deref() == Some("session:s:residual"))
+                .expect("cost-only residual");
+            assert!(is_zero(&residual.tokens));
+            assert_eq!(
+                residual.source_cost_usd,
+                Some(model_cost.map_or(10.0, |_| 4.0))
+            );
+            assert_eq!(
+                events
+                    .iter()
+                    .filter_map(|event| event.source_cost_usd)
+                    .sum::<f64>(),
+                10.0
+            );
+        }
+    }
+
+    #[test]
+    fn authoritative_session_cost_reconciles_model_cost_matrix() {
+        for (index, (session_cost, model_cost, expected_model_cost, expected_residual)) in [
+            (None, Some(6.0), Some(6.0), None),
+            (Some(0.0), Some(6.0), None, Some(0.0)),
+            (Some(5.0), Some(6.0), None, Some(5.0)),
+            (Some(6.0), Some(6.0), Some(6.0), None),
+            (Some(10.0), Some(6.0), Some(6.0), Some(4.0)),
+            (Some(10.0), None, None, Some(10.0)),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(format!("cost-matrix-{index}.db"));
+            db(&path, true);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',?1,'/work','/repo','prof')",
+                [session_cost],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,?1,1000)",
+                [model_cost],
+            )
+            .unwrap();
+            drop(conn);
+
+            let events = parse_usage_file(&path).unwrap().events;
+            let model = events
+                .iter()
+                .find(|event| {
+                    event
+                        .source_record_id
+                        .as_deref()
+                        .unwrap()
+                        .starts_with("model:")
+                })
+                .unwrap();
+            let residual = events
+                .iter()
+                .find(|event| event.source_record_id.as_deref() == Some("session:s:residual"));
+            assert_eq!(model.tokens.raw_input, 10);
+            assert_eq!(model.source_cost_usd, expected_model_cost);
+            assert_eq!(
+                residual.and_then(|event| event.source_cost_usd),
+                expected_residual
+            );
+            assert_eq!(
+                events
+                    .iter()
+                    .filter_map(|event| event.source_cost_usd)
+                    .sum::<f64>(),
+                session_cost.or(model_cost).unwrap_or(0.0)
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_model_without_authoritative_cost_preserves_valid_model_costs() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("uncosted-invalid-model.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','a-valid','p','valid',4,0,0,0,0,2.0,1000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','z-capped','p','capped',10,0,0,0,0,3.0,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = parse_usage_file(&path).unwrap().events;
+        let model_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event
+                    .source_record_id
+                    .as_deref()
+                    .is_some_and(|id| id.starts_with("model:"))
+            })
+            .collect();
+        assert_eq!(model_events.len(), 2);
+        let model_costs: Vec<_> = model_events
+            .iter()
+            .filter_map(|event| event.source_cost_usd)
+            .collect();
+        assert_eq!(model_costs, vec![2.0]);
+        assert!(
+            model_events
+                .iter()
+                .any(|event| event.tokens.raw_input == 6 && event.source_cost_usd.is_none())
+        );
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.tokens.raw_input)
+                .sum::<u64>(),
+            10
+        );
+    }
+
+    #[test]
+    fn zero_token_session_with_authoritative_cost_emits_cost_only_event() {
+        for (index, session_cost) in [Some(0.0), Some(3.0)].into_iter().enumerate() {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(format!("zero-token-cost-{index}.db"));
+            db(&path, false);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s','fallback',1000,0,0,0,0,0,'p',?1,'/work','/repo','prof')",
+                [session_cost],
+            )
+            .unwrap();
+            drop(conn);
+
+            let events = parse_usage_file(&path).unwrap().events;
+            assert_eq!(events.len(), 1);
+            assert!(is_zero(&events[0].tokens));
+            assert_eq!(events[0].source_cost_usd, session_cost);
+        }
+    }
+
+    #[test]
+    fn cost_over_authority_preserves_positive_token_residual() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("cost-over-authority-residual.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',5.0,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',4,0,0,0,0,6.0,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = parse_usage_file(&path).unwrap().events;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.tokens.raw_input)
+                .sum::<u64>(),
+            10
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| event.source_cost_usd)
+                .sum::<f64>(),
+            5.0
+        );
+    }
+
+    #[test]
+    fn zero_token_model_cost_is_not_attributed() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("zero-token-model-cost.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',10.0,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m1','p','emitted',10,0,0,0,0,6.0,1000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m2','p','zero',0,0,0,0,0,3.0,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = parse_usage_file(&path).unwrap().events;
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| event.source_cost_usd)
+                .sum::<f64>(),
+            10.0
+        );
+        assert_eq!(
+            events
+                .iter()
+                .find(|event| event.source_record_id.as_deref() == Some("session:s:residual"))
+                .unwrap()
+                .source_cost_usd,
+            Some(4.0)
+        );
+    }
+
+    #[test]
+    fn model_event_timestamp_falls_back_to_session_timestamp() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("model-timestamp.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1720000000,10,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,NULL,NULL)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let event = &parse_usage_file(&path).unwrap().events[0];
+        assert_eq!(event.timestamp_ms, 1_720_000_000_000);
+        assert_eq!(event.source_order, 1_720_000_000_000);
+    }
+
+    #[test]
+    fn model_event_timestamp_falls_back_when_first_and_last_seen_are_omitted() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("model-timestamp-omitted.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT); CREATE TABLE session_model_usage (session_id TEXT, model TEXT, billing_provider TEXT, task TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, estimated_cost_usd REAL);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1720000000,10,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,NULL)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let event = &parse_usage_file(&path).unwrap().events[0];
+        assert_eq!(event.timestamp_ms, 1_720_000_000_000);
+        assert_eq!(event.source_order, 1_720_000_000_000);
+    }
+
+    #[test]
+    fn model_event_timestamp_falls_back_when_first_and_last_seen_are_null() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("model-timestamp-null.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT); CREATE TABLE session_model_usage (session_id TEXT, model TEXT, billing_provider TEXT, task TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, estimated_cost_usd REAL, first_seen INTEGER, last_seen INTEGER);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1720000000,10,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,NULL,NULL,NULL)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let event = &parse_usage_file(&path).unwrap().events[0];
+        assert_eq!(event.timestamp_ms, 1_720_000_000_000);
+        assert_eq!(event.source_order, 1_720_000_000_000);
+    }
+
+    #[test]
     fn malformed_database_is_an_error_and_jsonl_is_not_discovered() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("state.db");
@@ -798,7 +1134,7 @@ mod tests {
         conn.execute("INSERT INTO session_model_usage VALUES ('s','model:a','p','task:a',5,1,0,0,0,1.0,1720000000)", []).unwrap();
         drop(conn);
         let events = parse_usage_file(&path).unwrap().events;
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 3);
         assert!(
             events[0]
                 .source_record_id
@@ -813,6 +1149,12 @@ mod tests {
                 .unwrap()
                 .contains("task:b")
         );
+        assert_eq!(
+            events[2].source_record_id.as_deref(),
+            Some("session:s:residual")
+        );
+        assert!(is_zero(&events[2].tokens));
+        assert_eq!(events[2].source_cost_usd, Some(1.0));
         assert_ne!(events[0].source_record_id, events[1].source_record_id);
     }
 

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -130,7 +130,9 @@ fn is_state_db(path: &Path) -> bool {
 type Row = HashMap<String, Value>;
 
 pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParseOutput> {
-    let wal = PathBuf::from(format!("{}-wal", path.to_string_lossy()));
+    let mut wal = path.as_os_str().to_os_string();
+    wal.push("-wal");
+    let wal = PathBuf::from(wal);
     let wal_before = crate::sources::UsageDependency::from_path_or_absent(&wal);
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
@@ -570,6 +572,8 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
     fn db(path: &Path, model_usage: bool) {
         let conn = Connection::open(path).unwrap();
@@ -722,6 +726,38 @@ mod tests {
         let parsed = parse_usage_file(&path).unwrap();
         assert_eq!(parsed.events.len(), 1);
         assert_eq!(parsed.events[0].tokens.raw_input, 1);
+        drop(conn);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wal_dependency_preserves_invalid_utf8_path_bytes_and_invalidates_on_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let invalid_directory = std::ffi::OsString::from_vec(b"profile-\xFF".to_vec());
+        let directory = temp.path().join(invalid_directory);
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("state.db");
+        db(&path, false);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','m',1000,1,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+
+        let parsed = parse_usage_file(&path).unwrap();
+        let dependency = parsed.deps.first().unwrap();
+        let mut wal_name = path.file_name().unwrap().to_os_string();
+        wal_name.push("-wal");
+        let wal = path.with_file_name(wal_name);
+        assert!(wal.as_os_str().as_bytes().contains(&0xFF));
+        assert_eq!(dependency.native_path, wal.as_os_str().as_bytes());
+        assert!(dependency.is_current());
+
+        fs::write(&wal, b"changed").unwrap();
+        assert!(!dependency.is_current());
         drop(conn);
     }
 
@@ -1383,6 +1419,7 @@ mod tests {
     fn wal_change_during_read_makes_parse_output_non_cacheable() {
         let before = crate::sources::UsageDependency {
             path: "state.db-wal".to_string(),
+            native_path: b"state.db-wal".to_vec(),
             size: 10,
             mtime_ns: 1,
             exists: true,

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
     index: 1,
-    usage: 5,
+    usage: 6,
 };
 
 pub fn matches_path(path: &str) -> bool {
@@ -124,7 +124,7 @@ fn add_profile_children(root: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn is_state_db(path: &Path) -> bool {
-    path.file_name().and_then(|v| v.to_str()) == Some("state.db")
+    path.is_file() && path.file_name().and_then(|v| v.to_str()) == Some("state.db")
 }
 
 type Row = HashMap<String, Value>;
@@ -292,8 +292,13 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
             authoritative_cost
         } else {
             authoritative_cost.and_then(|authoritative| {
-                (authoritative > attributed_model_cost)
-                    .then_some(authoritative - attributed_model_cost)
+                if authoritative > attributed_model_cost {
+                    Some(authoritative - attributed_model_cost)
+                } else {
+                    // A positive token residual is still covered by the authoritative session
+                    // cost. Preserve an explicit zero so Auto mode does not reprice it.
+                    (!is_zero(&residual)).then_some(0.0)
+                }
             })
         };
         if !is_zero(&residual) || source_cost.is_some() {
@@ -626,6 +631,15 @@ mod tests {
                 PathBuf::from("state.db")
             ]
         );
+    }
+
+    #[test]
+    fn discovery_ignores_roots_and_profiles_without_state_databases() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join(".hermes");
+        fs::create_dir_all(root.join("profiles/empty")).unwrap();
+
+        assert!(discover_from_roots(&[root]).is_empty());
     }
 
     #[test]

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
     index: 1,
-    usage: 4,
+    usage: 5,
 };
 
 pub fn matches_path(path: &str) -> bool {
@@ -125,26 +125,6 @@ fn add_profile_children(root: &Path, out: &mut Vec<PathBuf>) {
 
 fn is_state_db(path: &Path) -> bool {
     path.file_name().and_then(|v| v.to_str()) == Some("state.db")
-        && !path.components().any(|component| {
-            matches!(
-                component.as_os_str().to_str(),
-                Some(
-                    "snapshots"
-                        | "snapshot"
-                        | "backups"
-                        | "backup"
-                        | "upgrades"
-                        | "upgrade"
-                        | "sandbox"
-                        | "sandboxes"
-                        | "repo"
-                        | "repos"
-                        | "cron"
-                        | "kanban"
-                        | "verification"
-                )
-            )
-        })
 }
 
 type Row = HashMap<String, Value>;
@@ -154,12 +134,13 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
     let wal_before = crate::sources::UsageDependency::from_path_or_absent(&wal);
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
-    let tables = table_names(&conn)?;
+    let transaction = conn.unchecked_transaction()?;
+    let tables = table_names(&transaction)?;
     if !tables.contains("sessions") {
         return Err(anyhow!("Hermes database has no sessions table"));
     }
     let sessions = rows(
-        &conn,
+        &transaction,
         "sessions",
         &[
             "id",
@@ -185,7 +166,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
     )?;
     let model_rows = if tables.contains("session_model_usage") {
         rows(
-            &conn,
+            &transaction,
             "session_model_usage",
             &[
                 "session_id",
@@ -241,6 +222,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                     session,
                     aggregate,
                     cost(session),
+                    cost(session).is_some(),
                     true,
                     timestamp(session),
                     0,
@@ -251,6 +233,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
         let mut summed = TokenBuckets::default();
         let mut invalid_model = false;
         let mut attributed_model_cost = 0.0;
+        let authoritative_cost = cost(session);
         let model_event_start = events.len();
         for row in model_rows {
             let raw_current = buckets(row);
@@ -282,6 +265,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                     model,
                     current,
                     source_cost,
+                    authoritative_cost.is_some() && source_cost.is_none(),
                     inconsistent,
                     timestamp(row).max(timestamp(session)),
                     timestamp(row).max(timestamp(session)),
@@ -289,7 +273,6 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
             }
         }
         let residual = subtract(aggregate, summed);
-        let authoritative_cost = cost(session);
         let model_cost_exceeds_authority =
             authoritative_cost.is_some_and(|authoritative| attributed_model_cost > authoritative);
         let reconcile_with_authority =
@@ -297,6 +280,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
         if reconcile_with_authority {
             for event in &mut events[model_event_start..] {
                 event.source_cost_usd = None;
+                event.cost_authoritative = true;
             }
         }
         let source_cost = if reconcile_with_authority {
@@ -315,12 +299,16 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                 session,
                 residual,
                 source_cost,
+                authoritative_cost.is_some(),
                 true,
                 timestamp(session),
                 timestamp(session),
             ));
         }
     }
+    // Keep sessions and model usage on the same SQLite snapshot. This matters in WAL mode,
+    // where Hermes can commit the aggregate and detail rows independently while we read.
+    transaction.commit()?;
     let wal_after = crate::sources::UsageDependency::from_path_or_absent(&wal);
     Ok(crate::sources::UsageParseOutput {
         events,
@@ -518,6 +506,7 @@ fn event(
     row: &Row,
     tokens: TokenBuckets,
     source_cost_usd: Option<f64>,
+    cost_authoritative: bool,
     conservative: bool,
     timestamp_ms: u64,
     order: u64,
@@ -535,8 +524,10 @@ fn event(
         model: text(row, "model"),
         tokens,
         source_cost_usd,
+        cost_authoritative,
         dedupe_confidence: "strong",
         conservative_undercount: conservative,
+        cache_chain_excluded: true,
         sidechain: false,
         source_order: order,
     }
@@ -551,6 +542,7 @@ fn model_event(
     model: Option<String>,
     tokens: TokenBuckets,
     source_cost_usd: Option<f64>,
+    cost_authoritative: bool,
     conservative: bool,
     timestamp_ms: u64,
     order: u64,
@@ -562,6 +554,7 @@ fn model_event(
         row,
         tokens,
         source_cost_usd,
+        cost_authoritative,
         conservative,
         timestamp_ms,
         order,
@@ -618,6 +611,83 @@ mod tests {
     }
 
     #[test]
+    fn discovery_allows_backup_ancestors_and_repo_profile_names() {
+        let temp = tempfile::tempdir().unwrap();
+        let backup_root = temp.path().join("backup/.hermes");
+        let repo_profile = backup_root.join("profiles/repo");
+        for path in [backup_root.join("state.db"), repo_profile.join("state.db")] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+
+        let files = discover_from_roots(&[backup_root]);
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn discovery_allows_any_profile_name_but_not_artifact_slots() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join(".hermes");
+        let blocked_names = [
+            "backup",
+            "cron",
+            "kanban",
+            "repo",
+            "repos",
+            "sandbox",
+            "sandboxes",
+            "snapshot",
+            "snapshots",
+            "upgrade",
+            "upgrades",
+            "verification",
+        ];
+        for name in blocked_names {
+            for path in [
+                root.join("profiles").join(name).join("state.db"),
+                root.join(name).join("state.db"),
+            ] {
+                fs::create_dir_all(path.parent().unwrap()).unwrap();
+                fs::write(path, b"x").unwrap();
+            }
+        }
+
+        let files = discover_from_roots(std::slice::from_ref(&root));
+        assert_eq!(files.len(), blocked_names.len() + 1);
+        assert!(files.iter().all(|file| {
+            file.path.file_name().and_then(|name| name.to_str()) == Some("state.db")
+                && (file.path == root.join("state.db")
+                    || file
+                        .path
+                        .parent()
+                        .and_then(Path::parent)
+                        .and_then(Path::file_name)
+                        .and_then(|name| name.to_str())
+                        == Some("profiles"))
+        }));
+    }
+
+    #[test]
+    fn explicit_profile_root_discovers_only_that_profile_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path().join("profiles/verification");
+        let sibling = temp.path().join("profiles/backup");
+        for path in [profile.join("state.db"), sibling.join("state.db")] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+
+        let files = discover_from_roots(std::slice::from_ref(&profile));
+        assert_eq!(
+            files,
+            vec![SourceFile {
+                source: SourceKind::Hermes,
+                path: profile.join("state.db")
+            }]
+        );
+    }
+
+    #[test]
     fn legacy_sessions_are_aggregates_and_ignore_transcript_tables() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("state.db");
@@ -654,6 +724,136 @@ mod tests {
         assert_eq!(parsed.events.len(), 1);
         assert_eq!(parsed.events[0].tokens.raw_input, 1);
         drop(conn);
+    }
+
+    #[test]
+    fn session_only_aggregate_without_cost_can_use_catalog_pricing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session-only.db");
+        db(&path, false);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','claude-sonnet-4-6',1000,100,0,0,0,0,'anthropic',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let event = &parse_usage_file(&path).unwrap().events[0];
+        assert!(!event.cost_authoritative);
+        assert_eq!(
+            crate::usage::event_cost_nanos(event, crate::usage::CostMode::Source),
+            None
+        );
+        assert!(crate::usage::event_cost_nanos(event, crate::usage::CostMode::Auto).is_some());
+    }
+
+    #[test]
+    fn positive_residual_without_session_cost_can_use_catalog_pricing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("residual.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','claude-sonnet-4-6',1000,100,0,0,0,0,'anthropic',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','claude-sonnet-4-6','anthropic','task',40,0,0,0,0,NULL,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let residual = parse_usage_file(&path)
+            .unwrap()
+            .events
+            .into_iter()
+            .find(|event| event.source_record_id.as_deref() == Some("session:s:residual"))
+            .unwrap();
+        assert!(!residual.cost_authoritative);
+        assert_eq!(
+            crate::usage::event_cost_nanos(&residual, crate::usage::CostMode::Source),
+            None
+        );
+        assert!(crate::usage::event_cost_nanos(&residual, crate::usage::CostMode::Auto).is_some());
+    }
+
+    #[test]
+    fn capped_mixed_rows_without_session_cost_can_use_catalog_pricing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("capped-mixed.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','claude-sonnet-4-6',1000,100,0,0,0,0,'anthropic',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','claude-sonnet-4-6','anthropic','priced',80,0,0,0,0,1.0,1000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','claude-sonnet-4-6','anthropic','capped',80,0,0,0,0,NULL,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = parse_usage_file(&path).unwrap().events;
+        let capped = events
+            .iter()
+            .find(|event| event.conservative_undercount)
+            .unwrap();
+        assert!(!capped.cost_authoritative);
+        assert_eq!(
+            crate::usage::event_cost_nanos(capped, crate::usage::CostMode::Source),
+            None
+        );
+        assert!(crate::usage::event_cost_nanos(capped, crate::usage::CostMode::Auto).is_some());
+    }
+
+    #[test]
+    fn read_transaction_keeps_aggregate_tables_on_one_wal_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, true);
+        let writer = Connection::open(&path).unwrap();
+        writer
+            .execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;")
+            .unwrap();
+        let reader = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+        let transaction = reader.unchecked_transaction().unwrap();
+        assert_eq!(
+            transaction
+                .query_row("SELECT COUNT(*) FROM sessions", [], |row| row
+                    .get::<_, u64>(0))
+                .unwrap(),
+            0
+        );
+        writer
+            .execute(
+                "INSERT INTO sessions VALUES ('s','m',1000,1,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+                [],
+            )
+            .unwrap();
+        writer
+            .execute(
+                "INSERT INTO session_model_usage VALUES ('s','m','p','task',1,0,0,0,0,NULL,1000)",
+                [],
+            )
+            .unwrap();
+        assert_eq!(
+            transaction
+                .query_row("SELECT COUNT(*) FROM session_model_usage", [], |row| row
+                    .get::<_, u64>(0))
+                .unwrap(),
+            0
+        );
+        transaction.commit().unwrap();
     }
 
     #[test]
@@ -747,6 +947,23 @@ mod tests {
                     .sum::<f64>(),
                 10.0
             );
+            for mode in [crate::usage::CostMode::Auto, crate::usage::CostMode::Source] {
+                let total = events
+                    .iter()
+                    .filter_map(|event| crate::usage::event_cost_nanos(event, mode))
+                    .sum::<u64>();
+                assert_eq!(total, 10_000_000_000, "{mode:?}");
+            }
+            assert!(
+                events
+                    .iter()
+                    .filter(|event| event
+                        .source_record_id
+                        .as_deref()
+                        .unwrap()
+                        .starts_with("model:"))
+                    .all(|event| event.cost_authoritative)
+            );
         }
     }
 
@@ -758,12 +975,12 @@ mod tests {
             db(&path, true);
             let conn = Connection::open(&path).unwrap();
             conn.execute(
-                "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',10.0,'/work','/repo','prof')",
+                "INSERT INTO sessions VALUES ('s','claude-sonnet-4-6',1000,10,0,0,0,0,'anthropic',10.0,'/work','/repo','prof')",
                 [],
             )
             .unwrap();
             conn.execute(
-                "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,0,0,0,0,?1,1000)",
+                "INSERT INTO session_model_usage VALUES ('s','claude-sonnet-4-6','anthropic','task',10,0,0,0,0,?1,1000)",
                 [model_cost],
             )
             .unwrap();
@@ -835,6 +1052,10 @@ mod tests {
             assert_eq!(model.tokens.raw_input, 10);
             assert_eq!(model.source_cost_usd, expected_model_cost);
             assert_eq!(
+                model.cost_authoritative,
+                session_cost.is_some() && expected_model_cost.is_none()
+            );
+            assert_eq!(
                 residual.and_then(|event| event.source_cost_usd),
                 expected_residual
             );
@@ -845,6 +1066,58 @@ mod tests {
                     .sum::<f64>(),
                 session_cost.or(model_cost).unwrap_or(0.0)
             );
+            if let Some(session_cost) = session_cost {
+                for mode in [crate::usage::CostMode::Auto, crate::usage::CostMode::Source] {
+                    let total = events
+                        .iter()
+                        .filter_map(|event| crate::usage::event_cost_nanos(event, mode))
+                        .sum::<u64>();
+                    assert_eq!(total, (session_cost * 1_000_000_000.0) as u64, "{mode:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn valid_priced_model_followed_by_capped_row_reconciles_authoritative_cost() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("valid-priced-capped.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','fallback',1000,10,0,0,0,0,'p',5.0,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m1','p','priced',8,0,0,0,0,2.0,1000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m2','p','capped',8,0,0,0,0,NULL,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = parse_usage_file(&path).unwrap().events;
+        assert!(
+            events
+                .iter()
+                .filter(|event| event
+                    .source_record_id
+                    .as_deref()
+                    .unwrap()
+                    .starts_with("model:"))
+                .all(|event| event.cost_authoritative)
+        );
+        for mode in [crate::usage::CostMode::Auto, crate::usage::CostMode::Source] {
+            let total = events
+                .iter()
+                .filter_map(|event| crate::usage::event_cost_nanos(event, mode))
+                .sum::<u64>();
+            assert_eq!(total, 5_000_000_000, "{mode:?}");
         }
     }
 

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -1,0 +1,853 @@
+use super::{ParserVersions, SourceFile};
+use crate::types::SourceKind;
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::{Context, Result, anyhow};
+use chrono::DateTime;
+use rusqlite::{Connection, OpenFlags, types::Value};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    index: 1,
+    usage: 4,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    path.ends_with("/.hermes/state.db")
+        || path.contains("/.hermes/profiles/") && path.ends_with("/state.db")
+        || path.ends_with("\\.hermes\\state.db")
+        || path.contains("\\.hermes\\profiles\\") && path.ends_with("\\state.db")
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    discover_from_roots(&profile_roots())
+}
+
+pub fn profile_roots() -> Vec<PathBuf> {
+    let home = super::common::home();
+    let explicit_roots = std::env::var_os("HERMES_PROFILE_ROOTS");
+    let hermes_home = std::env::var_os("HERMES_HOME").map(PathBuf::from);
+    let state_dir = std::env::var_os("HERMES_STATE_DIR").map(PathBuf::from);
+    let xdg_state_home = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+    profile_roots_for(
+        &home,
+        explicit_roots.as_deref(),
+        hermes_home.as_deref(),
+        state_dir.as_deref(),
+        xdg_state_home.as_deref(),
+    )
+}
+
+fn profile_roots_for(
+    home: &Path,
+    explicit_roots: Option<&std::ffi::OsStr>,
+    hermes_home: Option<&Path>,
+    state_dir: Option<&Path>,
+    xdg_state_home: Option<&Path>,
+) -> Vec<PathBuf> {
+    if let Some(roots) = explicit_roots {
+        return split_roots(roots);
+    }
+    let mut roots = vec![home.join(".hermes"), home.join(".local/state/hermes")];
+    if let Some(xdg) = xdg_state_home {
+        roots.push(xdg.join("hermes"));
+    }
+    if let Some(hermes_home) = hermes_home {
+        roots.push(hermes_home.to_path_buf());
+    }
+    if let Some(state_dir) = state_dir {
+        roots.push(state_dir.to_path_buf());
+    }
+    roots
+}
+
+fn split_roots(roots: &std::ffi::OsStr) -> Vec<PathBuf> {
+    roots
+        .to_string_lossy()
+        .split(',')
+        .filter_map(|root| {
+            let root = root.trim();
+            (!root.is_empty()).then(|| PathBuf::from(root))
+        })
+        .collect()
+}
+
+pub fn discover_from_roots(roots: &[PathBuf]) -> Vec<SourceFile> {
+    let mut candidates = Vec::new();
+    for root in roots {
+        if root.is_file() {
+            if is_state_db(root) {
+                candidates.push(root.clone());
+            }
+            continue;
+        }
+        if !root.is_dir() {
+            continue;
+        }
+        if root.file_name().and_then(|v| v.to_str()) == Some("profiles") {
+            add_profile_children(root, &mut candidates);
+        } else {
+            add_state(root, &mut candidates);
+            add_profile_children(&root.join("profiles"), &mut candidates);
+        }
+    }
+    let mut seen = HashSet::new();
+    candidates.retain(|path| seen.insert(path.canonicalize().unwrap_or_else(|_| path.clone())));
+    candidates.sort();
+    candidates
+        .into_iter()
+        .map(|path| SourceFile {
+            source: SourceKind::Hermes,
+            path,
+        })
+        .collect()
+}
+
+fn add_state(root: &Path, out: &mut Vec<PathBuf>) {
+    let path = root.join("state.db");
+    if is_state_db(&path) {
+        out.push(path);
+    }
+}
+
+fn add_profile_children(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            add_state(&entry.path(), out);
+        }
+    }
+}
+
+fn is_state_db(path: &Path) -> bool {
+    path.file_name().and_then(|v| v.to_str()) == Some("state.db")
+        && !path.components().any(|component| {
+            matches!(
+                component.as_os_str().to_str(),
+                Some(
+                    "snapshots"
+                        | "snapshot"
+                        | "backups"
+                        | "backup"
+                        | "upgrades"
+                        | "upgrade"
+                        | "sandbox"
+                        | "sandboxes"
+                        | "repo"
+                        | "repos"
+                        | "cron"
+                        | "kanban"
+                        | "verification"
+                )
+            )
+        })
+}
+
+type Row = HashMap<String, Value>;
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParseOutput> {
+    let uri = format!(
+        "file:{}?mode=ro",
+        path.to_string_lossy().replace('?', "%3f")
+    );
+    let conn = Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
+    let tables = table_names(&conn)?;
+    if !tables.contains("sessions") {
+        return Err(anyhow!("Hermes database has no sessions table"));
+    }
+    let sessions = rows(
+        &conn,
+        "sessions",
+        &[
+            "id",
+            "model",
+            "started_at",
+            "ended_at",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+            "billing_provider",
+            "billing_mode",
+            "estimated_cost_usd",
+            "actual_cost_usd",
+            "cost_status",
+            "cost_source",
+            "cwd",
+            "git_repo_root",
+            "profile_name",
+        ],
+        &["id", "started_at", "ended_at", "model", "profile_name"],
+    )?;
+    let model_rows = if tables.contains("session_model_usage") {
+        rows(
+            &conn,
+            "session_model_usage",
+            &[
+                "session_id",
+                "model",
+                "billing_provider",
+                "billing_base_url",
+                "billing_mode",
+                "task",
+                "api_call_count",
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cache_write_tokens",
+                "reasoning_tokens",
+                "estimated_cost_usd",
+                "actual_cost_usd",
+                "cost_status",
+                "cost_source",
+                "first_seen",
+                "last_seen",
+            ],
+            &[
+                "session_id",
+                "model",
+                "task",
+                "billing_provider",
+                "first_seen",
+                "last_seen",
+            ],
+        )?
+    } else {
+        Vec::new()
+    };
+    let mut by_session: HashMap<String, Vec<&Row>> = HashMap::new();
+    for row in &model_rows {
+        if let Some(id) = text(row, "session_id") {
+            by_session.entry(id).or_default().push(row);
+        }
+    }
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut events = Vec::new();
+    for session in &sessions {
+        let Some(id) = text(session, "id") else {
+            continue;
+        };
+        let aggregate = buckets(session);
+        let Some(model_rows) = by_session.get(&id) else {
+            if !is_zero(&aggregate) {
+                events.push(event(
+                    &source_path,
+                    &id,
+                    None,
+                    session,
+                    aggregate,
+                    cost(session),
+                    true,
+                    0,
+                ));
+            }
+            continue;
+        };
+        let mut summed = TokenBuckets::default();
+        for row in model_rows {
+            let raw_current = buckets(row);
+            let current = cap_to_remaining(raw_current.clone(), aggregate.clone(), summed.clone());
+            let inconsistent = current != raw_current;
+            summed = add(summed, &current);
+            if !is_zero(&current) {
+                let model = text(row, "model").or_else(|| text(session, "model"));
+                let task = text(row, "task").unwrap_or_else(|| "default".to_string());
+                let identity = serde_json::to_string(&(
+                    id.as_str(),
+                    model.as_deref().unwrap_or("unknown"),
+                    task.as_str(),
+                    text(session, "profile_name").unwrap_or_default(),
+                ))
+                .expect("tuple serialization cannot fail");
+                let id = format!("model:{identity}");
+                events.push(model_event(
+                    &source_path,
+                    &id,
+                    &text(row, "session_id"),
+                    row,
+                    session,
+                    model,
+                    current,
+                    (!inconsistent).then(|| cost(row)).flatten(),
+                    inconsistent,
+                    timestamp(row).max(timestamp(session)),
+                ));
+            }
+        }
+        let residual = subtract(aggregate, summed);
+        if !is_zero(&residual) {
+            events.push(event(
+                &source_path,
+                &format!("session:{id}:residual"),
+                Some(&id),
+                session,
+                residual,
+                residual_cost(session, model_rows),
+                true,
+                timestamp(session),
+            ));
+        }
+    }
+    let wal = PathBuf::from(format!("{}-wal", path.to_string_lossy()));
+    Ok(crate::sources::UsageParseOutput {
+        events,
+        cacheable: true,
+        // SQLite WAL pages can contain committed data not yet checkpointed into the main
+        // database. The SHM file is coordination metadata and must not make scans stale.
+        deps: vec![crate::sources::UsageDependency::from_path_or_absent(&wal)],
+    })
+}
+
+fn table_names(conn: &Connection) -> Result<HashSet<String>> {
+    let mut statement = conn.prepare("SELECT name FROM sqlite_master WHERE type='table'")?;
+    Ok(statement
+        .query_map([], |row| row.get::<_, String>(0))?
+        .filter_map(Result::ok)
+        .collect())
+}
+
+fn rows(conn: &Connection, table: &str, wanted: &[&str], order_by: &[&str]) -> Result<Vec<Row>> {
+    let columns = table_columns(conn, table)?;
+    let selected: Vec<&str> = wanted
+        .iter()
+        .copied()
+        .filter(|column| columns.contains(*column))
+        .collect();
+    if selected.is_empty() {
+        return Ok(Vec::new());
+    }
+    let order = order_by
+        .iter()
+        .filter(|column| columns.contains(**column))
+        .map(|column| format!("\"{column}\""));
+    let order = order.collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT {} FROM {}{}",
+        selected
+            .iter()
+            .map(|column| format!("\"{column}\""))
+            .collect::<Vec<_>>()
+            .join(","),
+        table,
+        if order.is_empty() {
+            String::new()
+        } else {
+            format!(" ORDER BY {order}")
+        }
+    );
+    let mut statement = conn.prepare(&sql)?;
+    let mut result = Vec::new();
+    let mut query = statement.query([])?;
+    while let Some(row) = query.next()? {
+        let mut values = Row::new();
+        for (index, column) in selected.iter().enumerate() {
+            values.insert((*column).to_string(), row.get(index)?);
+        }
+        result.push(values);
+    }
+    Ok(result)
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Result<HashSet<String>> {
+    let sql = format!("PRAGMA table_info(\"{table}\")");
+    let mut statement = conn.prepare(&sql)?;
+    Ok(statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .collect())
+}
+
+fn number(row: &Row, key: &str) -> u64 {
+    match row.get(key) {
+        Some(Value::Integer(value)) => (*value).max(0) as u64,
+        Some(Value::Real(value)) if *value >= 0.0 => *value as u64,
+        _ => 0,
+    }
+}
+fn text(row: &Row, key: &str) -> Option<String> {
+    match row.get(key) {
+        Some(Value::Text(value)) => Some(value.clone()),
+        Some(Value::Integer(value)) => Some(value.to_string()),
+        _ => None,
+    }
+}
+fn cost(row: &Row) -> Option<f64> {
+    let valid = |value: Option<&Value>| match value {
+        Some(Value::Real(value)) if value.is_finite() && *value >= 0.0 => Some(*value),
+        Some(Value::Integer(value)) if *value >= 0 => Some(*value as f64),
+        _ => None,
+    };
+    valid(row.get("actual_cost_usd")).or_else(|| valid(row.get("estimated_cost_usd")))
+}
+fn timestamp(row: &Row) -> u64 {
+    let numeric_timestamp = |key: &str| match row.get(key) {
+        Some(Value::Integer(value)) => timestamp_number(*value as f64),
+        Some(Value::Real(value)) => timestamp_number(*value),
+        _ => 0,
+    };
+    let text_timestamp = |key: &str| {
+        text(row, key).and_then(|value| {
+            DateTime::parse_from_rfc3339(&value)
+                .ok()
+                .map(|date| date.timestamp_millis().max(0) as u64)
+        })
+    };
+    numeric_timestamp("last_seen")
+        .max(numeric_timestamp("first_seen"))
+        .max(numeric_timestamp("ended_at"))
+        .max(numeric_timestamp("started_at"))
+        .max(text_timestamp("last_seen").unwrap_or(0))
+        .max(text_timestamp("first_seen").unwrap_or(0))
+        .max(text_timestamp("ended_at").unwrap_or(0))
+        .max(text_timestamp("started_at").unwrap_or(0))
+}
+fn timestamp_number(value: f64) -> u64 {
+    if !value.is_finite() || value < 0.0 {
+        return 0;
+    }
+    let millis = if value < 10_000_000_000.0 {
+        value * 1000.0
+    } else {
+        value
+    };
+    millis.round().min(u64::MAX as f64) as u64
+}
+fn buckets(row: &Row) -> TokenBuckets {
+    let input = number(row, "input_tokens");
+    let cache_read = number(row, "cache_read_tokens");
+    let cache_write = number(row, "cache_write_tokens");
+    let output = number(row, "output_tokens");
+    let mut buckets = TokenBuckets::disjoint(input, cache_read, cache_write, output);
+    buckets.reasoning = number(row, "reasoning_tokens").min(output);
+    buckets
+}
+fn add(a: TokenBuckets, b: &TokenBuckets) -> TokenBuckets {
+    TokenBuckets {
+        raw_input: a.raw_input.saturating_add(b.raw_input),
+        uncached_input: a.uncached_input.saturating_add(b.uncached_input),
+        cache_read: a.cache_read.saturating_add(b.cache_read),
+        cache_write: a.cache_write.saturating_add(b.cache_write),
+        cache_write_1h: 0,
+        output: a.output.saturating_add(b.output),
+        reasoning: a.reasoning.saturating_add(b.reasoning),
+    }
+}
+fn is_zero(value: &TokenBuckets) -> bool {
+    value.raw_input == 0
+        && value.uncached_input == 0
+        && value.output == 0
+        && value.cache_write == 0
+        && value.cache_read == 0
+        && value.reasoning == 0
+}
+fn subtract(a: TokenBuckets, b: TokenBuckets) -> TokenBuckets {
+    TokenBuckets {
+        raw_input: a.raw_input.saturating_sub(b.raw_input),
+        uncached_input: a.uncached_input.saturating_sub(b.uncached_input),
+        cache_read: a.cache_read.saturating_sub(b.cache_read),
+        cache_write: a.cache_write.saturating_sub(b.cache_write),
+        cache_write_1h: 0,
+        output: a.output.saturating_sub(b.output),
+        reasoning: a.reasoning.saturating_sub(b.reasoning),
+    }
+}
+fn cap_to_remaining(
+    value: TokenBuckets,
+    aggregate: TokenBuckets,
+    used: TokenBuckets,
+) -> TokenBuckets {
+    let cap = |total: u64, already: u64, current: u64| current.min(total.saturating_sub(already));
+    TokenBuckets {
+        raw_input: cap(aggregate.raw_input, used.raw_input, value.raw_input),
+        uncached_input: cap(
+            aggregate.uncached_input,
+            used.uncached_input,
+            value.uncached_input,
+        ),
+        cache_read: cap(aggregate.cache_read, used.cache_read, value.cache_read),
+        cache_write: cap(aggregate.cache_write, used.cache_write, value.cache_write),
+        cache_write_1h: 0,
+        output: cap(aggregate.output, used.output, value.output),
+        reasoning: cap(aggregate.reasoning, used.reasoning, value.reasoning),
+    }
+}
+fn residual_cost(session: &Row, rows: &[&Row]) -> Option<f64> {
+    let total = cost(session)?;
+    let used: f64 = rows.iter().filter_map(|row| cost(row)).sum();
+    (total > used).then_some(total - used)
+}
+#[allow(clippy::too_many_arguments)]
+fn event(
+    path: &Arc<str>,
+    record: &str,
+    session_id: Option<&str>,
+    row: &Row,
+    tokens: TokenBuckets,
+    source_cost_usd: Option<f64>,
+    conservative: bool,
+    order: u64,
+) -> UsageEvent {
+    UsageEvent {
+        source: "hermes",
+        source_path: path.clone(),
+        source_record_id: Some(record.to_string()),
+        session_id: session_id.map(str::to_string),
+        request_id: None,
+        message_id: None,
+        timestamp_ms: timestamp(row),
+        project: text(row, "cwd").or_else(|| text(row, "git_repo_root")),
+        provider: text(row, "billing_provider"),
+        model: text(row, "model"),
+        tokens,
+        source_cost_usd,
+        dedupe_confidence: "strong",
+        conservative_undercount: conservative,
+        sidechain: false,
+        source_order: order,
+    }
+}
+#[allow(clippy::too_many_arguments)]
+fn model_event(
+    path: &Arc<str>,
+    record: &str,
+    session_id: &Option<String>,
+    row: &Row,
+    session: &Row,
+    model: Option<String>,
+    tokens: TokenBuckets,
+    source_cost_usd: Option<f64>,
+    conservative: bool,
+    order: u64,
+) -> UsageEvent {
+    let mut event = event(
+        path,
+        record,
+        session_id.as_deref(),
+        row,
+        tokens,
+        source_cost_usd,
+        conservative,
+        order,
+    );
+    event.model = model;
+    event.provider = text(row, "billing_provider").or_else(|| text(session, "billing_provider"));
+    event.project = text(session, "cwd").or_else(|| text(session, "git_repo_root"));
+    event
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use std::fs;
+
+    fn db(path: &Path, model_usage: bool) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch("CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT); CREATE TABLE messages (content TEXT, system_prompt TEXT);").unwrap();
+        if model_usage {
+            conn.execute_batch("CREATE TABLE session_model_usage (session_id TEXT, model TEXT, billing_provider TEXT, task TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, estimated_cost_usd REAL, first_seen INTEGER);").unwrap();
+        }
+    }
+
+    #[test]
+    fn discovery_only_returns_canonical_root_and_profile_databases() {
+        let temp = tempfile::tempdir().unwrap();
+        for path in [
+            "state.db",
+            "profiles/a/state.db",
+            "profiles/b/state.db",
+            "snapshots/state.db",
+            "nested/state.db",
+            "sessions/old.jsonl",
+        ] {
+            let path = temp.path().join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+        let files =
+            discover_from_roots(&[temp.path().to_path_buf(), temp.path().join("profiles/a")]);
+        assert_eq!(
+            files
+                .iter()
+                .map(|f| f
+                    .path
+                    .strip_prefix(temp.path())
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string())
+                .collect::<Vec<_>>(),
+            vec!["profiles/a/state.db", "profiles/b/state.db", "state.db"]
+        );
+    }
+
+    #[test]
+    fn legacy_sessions_are_aggregates_and_ignore_transcript_tables() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, false);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("INSERT INTO sessions VALUES ('s','m',1000,100,20,30,4,5,'p',1.25,'/work','/repo','prof')", []).unwrap();
+        drop(conn);
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.events.len(), 1);
+        assert_eq!(events.events[0].tokens.uncached_input, 100);
+        assert_eq!(events.events[0].tokens.cache_read, 30);
+        assert_eq!(events.events[0].tokens.reasoning, 5);
+        assert_eq!(events.events[0].source_cost_usd, Some(1.25));
+    }
+
+    #[test]
+    fn model_rows_count_once_and_residuals_are_non_negative() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("INSERT INTO sessions VALUES ('s','fallback',1000,100,20,30,4,5,'p',10.0,'/work','/repo','prof')", []).unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',60,10,20,2,3,6.0,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.events.len(), 2);
+        assert_eq!(
+            events.events[0].tokens.raw_input + events.events[1].tokens.raw_input,
+            100
+        );
+        assert!(
+            events
+                .events
+                .iter()
+                .any(|event| event.conservative_undercount)
+        );
+    }
+
+    #[test]
+    fn malformed_database_is_an_error_and_jsonl_is_not_discovered() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        fs::write(&path, b"not sqlite").unwrap();
+        assert!(parse_usage_file(&path).is_err());
+        fs::write(temp.path().join("usage.jsonl"), b"{}\n").unwrap();
+        assert_eq!(discover_from_roots(&[temp.path().to_path_buf()]).len(), 1);
+    }
+
+    #[test]
+    fn numeric_timestamps_are_epoch_milliseconds_and_sidecar_absence_is_tracked() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, false);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("INSERT INTO sessions VALUES ('s','m',1720000000.125,1,1,0,0,0,'p',NULL,'/private','/private','profile')", []).unwrap();
+        drop(conn);
+        let parsed = parse_usage_file(&path).unwrap();
+        assert_eq!(parsed.events[0].timestamp_ms, 1_720_000_000_125);
+        assert_eq!(parsed.deps.len(), 1);
+        assert!(parsed.deps.iter().all(|dependency| !dependency.exists));
+        let wal = PathBuf::from(format!("{}-wal", path.to_string_lossy()));
+        fs::write(&wal, b"wal").unwrap();
+        let current = crate::sources::UsageDependency::from_path_or_absent(&wal);
+        assert!(current.exists);
+        assert!(
+            !parsed
+                .deps
+                .iter()
+                .any(|dependency| dependency.path == current.path && dependency.is_current())
+        );
+    }
+
+    #[test]
+    fn model_identity_is_encoded_and_ordered_by_logical_dimensions() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("INSERT INTO sessions VALUES ('s','fallback',1720000000,10,2,0,0,0,'p',3.0,'/private','/private','profile')", []).unwrap();
+        conn.execute("INSERT INTO session_model_usage VALUES ('s','model:z','p','task:b',5,1,0,0,0,1.0,1720000000)", []).unwrap();
+        conn.execute("INSERT INTO session_model_usage VALUES ('s','model:a','p','task:a',5,1,0,0,0,1.0,1720000000)", []).unwrap();
+        drop(conn);
+        let events = parse_usage_file(&path).unwrap().events;
+        assert_eq!(events.len(), 2);
+        assert!(
+            events[0]
+                .source_record_id
+                .as_deref()
+                .unwrap()
+                .contains("model:a")
+        );
+        assert!(
+            events[1]
+                .source_record_id
+                .as_deref()
+                .unwrap()
+                .contains("task:b")
+        );
+        assert_ne!(events[0].source_record_id, events[1].source_record_id);
+    }
+
+    #[test]
+    fn disjoint_buckets_preserve_cache_beyond_input_and_reconcile_every_bucket() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        db(&path, true);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("INSERT INTO sessions VALUES ('s','fallback',1000,10,3,100,7,2,'p',NULL,'/work','/repo','prof')", []).unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage VALUES ('s','m','p','task',10,3,100,7,2,NULL,1000)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let events = parse_usage_file(&path).unwrap().events;
+        assert_eq!(events.len(), 1);
+        let tokens = &events[0].tokens;
+        assert_eq!(tokens.raw_input, 10);
+        assert_eq!(tokens.uncached_input, 10);
+        assert_eq!(tokens.cache_read, 100);
+        assert_eq!(tokens.cache_write, 7);
+        assert_eq!(tokens.output, 3);
+        assert_eq!(tokens.reasoning, 2);
+        assert_eq!(tokens.total(), 120);
+    }
+
+    #[test]
+    fn default_discovery_keeps_all_profiles_when_home_points_at_one_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        for relative in [
+            ".hermes/state.db",
+            ".hermes/profiles/main/state.db",
+            ".hermes/profiles/builder/state.db",
+            ".hermes/profiles/researcher/state.db",
+        ] {
+            let path = temp.path().join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+        let roots = profile_roots_for(
+            temp.path(),
+            None,
+            Some(&temp.path().join(".hermes/profiles/main")),
+            None,
+            None,
+        );
+        let files = discover_from_roots(&roots);
+        assert_eq!(files.len(), 4);
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.path.strip_prefix(temp.path()).unwrap().to_path_buf())
+                .collect::<Vec<_>>(),
+            [
+                PathBuf::from(".hermes/profiles/builder/state.db"),
+                PathBuf::from(".hermes/profiles/main/state.db"),
+                PathBuf::from(".hermes/profiles/researcher/state.db"),
+                PathBuf::from(".hermes/state.db"),
+            ]
+        );
+    }
+
+    #[test]
+    fn aggregate_fixture_matrix_matches_each_database_sessions_exactly_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let expected = [
+            (10, 100, 7, 3, 2),
+            (20, 30, 4, 5, 1),
+            (6, 8, 2, 9, 4),
+            (11, 13, 1, 2, 0),
+        ];
+        let mut total = TokenBuckets::default();
+        for (index, (input, cache_read, cache_write, output, reasoning)) in
+            expected.iter().enumerate()
+        {
+            let path = temp.path().join(format!("db-{index}.db"));
+            db(&path, true);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute("INSERT INTO sessions VALUES ('s','m',1000,?1,?2,?3,?4,?5,'p',NULL,'/work','/repo','prof')", rusqlite::params![input, output, cache_read, cache_write, reasoning]).unwrap();
+            conn.execute("INSERT INTO session_model_usage VALUES ('s','m','p','task',?1,?2,?3,?4,?5,NULL,1000)", rusqlite::params![input, output, cache_read, cache_write, reasoning]).unwrap();
+            drop(conn);
+            let events = parse_usage_file(&path).unwrap().events;
+            let mut actual = TokenBuckets::default();
+            for event in events {
+                actual = add(actual, &event.tokens);
+            }
+            let session = TokenBuckets::disjoint(*input, *cache_read, *cache_write, *output);
+            let mut session = session;
+            session.reasoning = *reasoning;
+            assert_eq!(actual, session);
+            total = add(total, &actual);
+        }
+        assert_eq!(total.raw_input, 47);
+        assert_eq!(total.uncached_input, 47);
+        assert_eq!(total.cache_read, 151);
+        assert_eq!(total.cache_write, 14);
+        assert_eq!(total.output, 19);
+        assert_eq!(total.reasoning, 7);
+        assert_eq!(total.total(), 231);
+    }
+
+    #[test]
+    fn reconciliation_has_independent_positive_residual_and_overaggregate_caps() {
+        let cases = [
+            ((10, 100, 7, 3, 2), (4, 60, 2, 1, 1), (6, 40, 5, 2, 1)),
+            ((10, 100, 7, 3, 2), (20, 200, 10, 5, 4), (0, 0, 0, 0, 0)),
+        ];
+        for (index, (session, model, residual)) in cases.into_iter().enumerate() {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(format!("case-{index}.db"));
+            db(&path, true);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute("INSERT INTO sessions VALUES ('s','m',1000,?1,?2,?3,?4,?5,'p',NULL,'/work','/repo','prof')", rusqlite::params![session.0, session.3, session.1, session.2, session.4]).unwrap();
+            conn.execute("INSERT INTO session_model_usage VALUES ('s','m','p','task',?1,?2,?3,?4,?5,NULL,1000)", rusqlite::params![model.0, model.3, model.1, model.2, model.4]).unwrap();
+            drop(conn);
+            let events = parse_usage_file(&path).unwrap().events;
+            assert_eq!(events.len(), if residual.0 == 0 { 1 } else { 2 });
+            let mut actual = TokenBuckets::default();
+            for event in events {
+                actual = add(actual, &event.tokens);
+            }
+            let expected = TokenBuckets {
+                raw_input: session.0,
+                uncached_input: session.0,
+                cache_read: session.1,
+                cache_write: session.2,
+                cache_write_1h: 0,
+                output: session.3,
+                reasoning: session.4,
+            };
+            assert_eq!(actual, expected);
+            assert_eq!(
+                actual.total(),
+                session.0 + session.1 + session.2 + session.3
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_profile_roots_are_the_only_discovery_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        let explicit = temp.path().join("explicit");
+        let other = temp.path().join("other");
+        for path in [explicit.join("state.db"), other.join("state.db")] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"x").unwrap();
+        }
+        let roots = profile_roots_for(
+            temp.path(),
+            Some(explicit.as_os_str()),
+            Some(&other),
+            Some(&other),
+            Some(&other),
+        );
+        assert_eq!(roots, vec![explicit]);
+    }
+}

--- a/src/sources/hermes.rs
+++ b/src/sources/hermes.rs
@@ -150,15 +150,10 @@ fn is_state_db(path: &Path) -> bool {
 type Row = HashMap<String, Value>;
 
 pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParseOutput> {
-    let uri = format!(
-        "file:{}?mode=ro",
-        path.to_string_lossy().replace('?', "%3f")
-    );
-    let conn = Connection::open_with_flags(
-        &uri,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
-    )
-    .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
+    let wal = PathBuf::from(format!("{}-wal", path.to_string_lossy()));
+    let wal_before = crate::sources::UsageDependency::from_path_or_absent(&wal);
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open Hermes SQLite database {}", path.display()))?;
     let tables = table_names(&conn)?;
     if !tables.contains("sessions") {
         return Err(anyhow!("Hermes database has no sessions table"));
@@ -242,7 +237,7 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
                 events.push(event(
                     &source_path,
                     &id,
-                    None,
+                    Some(&id),
                     session,
                     aggregate,
                     cost(session),
@@ -253,10 +248,13 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
             continue;
         };
         let mut summed = TokenBuckets::default();
+        let mut invalid_model = false;
+        let model_event_start = events.len();
         for row in model_rows {
             let raw_current = buckets(row);
             let current = cap_to_remaining(raw_current.clone(), aggregate.clone(), summed.clone());
             let inconsistent = current != raw_current;
+            invalid_model |= inconsistent;
             summed = add(summed, &current);
             if !is_zero(&current) {
                 let model = text(row, "model").or_else(|| text(session, "model"));
@@ -284,26 +282,36 @@ pub(crate) fn parse_usage_file(path: &Path) -> Result<crate::sources::UsageParse
             }
         }
         let residual = subtract(aggregate, summed);
-        if !is_zero(&residual) {
+        if invalid_model {
+            for event in &mut events[model_event_start..] {
+                event.source_cost_usd = None;
+            }
+        }
+        let source_cost = if invalid_model {
+            cost(session)
+        } else {
+            residual_cost(session, model_rows)
+        };
+        if !is_zero(&residual) || invalid_model && source_cost.is_some() {
             events.push(event(
                 &source_path,
                 &format!("session:{id}:residual"),
                 Some(&id),
                 session,
                 residual,
-                residual_cost(session, model_rows),
+                source_cost,
                 true,
                 timestamp(session),
             ));
         }
     }
-    let wal = PathBuf::from(format!("{}-wal", path.to_string_lossy()));
+    let wal_after = crate::sources::UsageDependency::from_path_or_absent(&wal);
     Ok(crate::sources::UsageParseOutput {
         events,
-        cacheable: true,
+        cacheable: cacheable_after_wal_read(&wal_before, &wal_after),
         // SQLite WAL pages can contain committed data not yet checkpointed into the main
         // database. The SHM file is coordination metadata and must not make scans stale.
-        deps: vec![crate::sources::UsageDependency::from_path_or_absent(&wal)],
+        deps: vec![wal_after],
     })
 }
 
@@ -485,6 +493,13 @@ fn residual_cost(session: &Row, rows: &[&Row]) -> Option<f64> {
     let used: f64 = rows.iter().filter_map(|row| cost(row)).sum();
     (total > used).then_some(total - used)
 }
+
+fn cacheable_after_wal_read(
+    wal_before: &crate::sources::UsageDependency,
+    wal_after: &crate::sources::UsageDependency,
+) -> bool {
+    wal_before == wal_after
+}
 #[allow(clippy::too_many_arguments)]
 fn event(
     path: &Arc<str>,
@@ -602,7 +617,30 @@ mod tests {
         assert_eq!(events.events[0].tokens.uncached_input, 100);
         assert_eq!(events.events[0].tokens.cache_read, 30);
         assert_eq!(events.events[0].tokens.reasoning, 5);
+        assert_eq!(events.events[0].session_id.as_deref(), Some("s"));
         assert_eq!(events.events[0].source_cost_usd, Some(1.25));
+    }
+
+    #[test]
+    fn database_paths_with_uri_metacharacters_open_read_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("profile#100%");
+        fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("state?db");
+        db(&path, false);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s','m',1000,1,0,0,0,0,'p',NULL,'/work','/repo','prof')",
+            [],
+        )
+        .unwrap();
+
+        let parsed = parse_usage_file(&path).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+        assert_eq!(parsed.events[0].tokens.raw_input, 1);
+        drop(conn);
     }
 
     #[test]
@@ -630,6 +668,73 @@ mod tests {
                 .iter()
                 .any(|event| event.conservative_undercount)
         );
+    }
+
+    #[test]
+    fn inconsistent_model_costs_use_one_authoritative_session_fallback() {
+        for (index, (aggregate_input, first_input, second_input, first_cost, residual)) in [
+            (10, 4, 10, 12.0, 0), // zero residual, retained model cost over aggregate
+            (10, 4, 10, 6.0, 0),  // zero residual, retained model cost under aggregate
+            (10, 4, 1, 12.0, 5),  // positive residual, retained model cost over aggregate
+            (10, 4, 1, 6.0, 5),   // positive residual, retained model cost under aggregate
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(format!("cost-{index}.db"));
+            db(&path, true);
+            let conn = Connection::open(&path).unwrap();
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s','fallback',1000,?1,0,0,0,0,'p',10.0,'/work','/repo','prof')",
+                [aggregate_input],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO session_model_usage VALUES ('s','m1','p','task-1',?1,0,0,0,0,?2,1000)",
+                rusqlite::params![first_input, first_cost],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO session_model_usage VALUES ('s','m2','p','task-2',?1,?2,0,0,0,3.0,1000)",
+                rusqlite::params![second_input, 1],
+            )
+            .unwrap();
+            drop(conn);
+
+            let events = parse_usage_file(&path).unwrap().events;
+            assert!(events.iter().all(|event| {
+                !event
+                    .source_record_id
+                    .as_deref()
+                    .unwrap()
+                    .starts_with("model:")
+                    || event.source_cost_usd.is_none()
+            }));
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| event.source_record_id.as_deref() == Some("session:s:residual"))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                events
+                    .iter()
+                    .find(|event| event.source_record_id.as_deref() == Some("session:s:residual"))
+                    .unwrap()
+                    .tokens
+                    .raw_input,
+                residual
+            );
+            assert_eq!(
+                events
+                    .iter()
+                    .filter_map(|event| event.source_cost_usd)
+                    .sum::<f64>(),
+                10.0
+            );
+        }
     }
 
     #[test]
@@ -664,6 +769,22 @@ mod tests {
                 .iter()
                 .any(|dependency| dependency.path == current.path && dependency.is_current())
         );
+    }
+
+    #[test]
+    fn wal_change_during_read_makes_parse_output_non_cacheable() {
+        let before = crate::sources::UsageDependency {
+            path: "state.db-wal".to_string(),
+            size: 10,
+            mtime_ns: 1,
+            exists: true,
+        };
+        let after = crate::sources::UsageDependency {
+            size: 20,
+            ..before.clone()
+        };
+        assert!(!cacheable_after_wal_read(&before, &after));
+        assert!(cacheable_after_wal_read(&before, &before));
     }
 
     #[test]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -10,6 +10,7 @@ pub mod codex;
 pub mod common;
 pub mod copilot;
 pub mod cursor;
+pub mod hermes;
 pub mod openclaw;
 pub mod opencode;
 pub mod pi;
@@ -154,6 +155,7 @@ pub(crate) struct UsageDependency {
     pub path: String,
     pub size: u64,
     pub mtime_ns: i64,
+    pub exists: bool,
 }
 
 impl UsageDependency {
@@ -169,12 +171,21 @@ impl UsageDependency {
             path: path.to_string_lossy().to_string(),
             size: metadata.len(),
             mtime_ns,
+            exists: true,
+        })
+    }
+
+    pub fn from_path_or_absent(path: &Path) -> Self {
+        Self::from_path(path).unwrap_or_else(|_| Self {
+            path: path.to_string_lossy().to_string(),
+            size: 0,
+            mtime_ns: 0,
+            exists: false,
         })
     }
 
     pub fn is_current(&self) -> bool {
-        Self::from_path(Path::new(&self.path))
-            .is_ok_and(|current| current.size == self.size && current.mtime_ns == self.mtime_ns)
+        Self::from_path_or_absent(Path::new(&self.path)) == *self
     }
 }
 
@@ -204,6 +215,7 @@ pub fn versions(source: SourceKind) -> ParserVersions {
         SourceKind::Pi => pi::VERSIONS,
         SourceKind::OpenClaw => openclaw::VERSIONS,
         SourceKind::Copilot => copilot::VERSIONS,
+        SourceKind::Hermes => hermes::VERSIONS,
     }
 }
 
@@ -258,6 +270,8 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::OpenClaw
     } else if copilot::matches_path(path) {
         SourceKind::Copilot
+    } else if hermes::matches_path(path) {
+        SourceKind::Hermes
     } else {
         SourceKind::Claude
     }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -20,6 +20,10 @@ use crate::types::SourceKind;
 use crate::usage::UsageEvent;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -153,12 +157,35 @@ impl ParseDiagnostics {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct UsageDependency {
     pub path: String,
+    pub native_path: Vec<u8>,
     pub size: u64,
     pub mtime_ns: i64,
     pub exists: bool,
 }
 
 impl UsageDependency {
+    fn native_path(path: &Path) -> Vec<u8> {
+        #[cfg(unix)]
+        {
+            path.as_os_str().as_bytes().to_vec()
+        }
+        #[cfg(not(unix))]
+        {
+            path.to_string_lossy().as_bytes().to_vec()
+        }
+    }
+
+    fn path_from_native(&self) -> PathBuf {
+        #[cfg(unix)]
+        {
+            PathBuf::from(OsString::from_vec(self.native_path.clone()))
+        }
+        #[cfg(not(unix))]
+        {
+            PathBuf::from(String::from_utf8_lossy(&self.native_path).into_owned())
+        }
+    }
+
     pub fn from_path(path: &Path) -> std::io::Result<Self> {
         let metadata = path.metadata()?;
         let mtime_ns = metadata
@@ -169,6 +196,7 @@ impl UsageDependency {
             .min(i64::MAX as u128) as i64;
         Ok(Self {
             path: path.to_string_lossy().to_string(),
+            native_path: Self::native_path(path),
             size: metadata.len(),
             mtime_ns,
             exists: true,
@@ -178,6 +206,7 @@ impl UsageDependency {
     pub fn from_path_or_absent(path: &Path) -> Self {
         Self::from_path(path).unwrap_or_else(|_| Self {
             path: path.to_string_lossy().to_string(),
+            native_path: Self::native_path(path),
             size: 0,
             mtime_ns: 0,
             exists: false,
@@ -185,7 +214,7 @@ impl UsageDependency {
     }
 
     pub fn is_current(&self) -> bool {
-        Self::from_path_or_absent(Path::new(&self.path)) == *self
+        Self::from_path_or_absent(&self.path_from_native()) == *self
     }
 }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -223,26 +223,6 @@ pub fn index_state_version(source: SourceKind) -> u32 {
     index_state_version_for(source, false)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn reasoning_mode_is_part_of_index_state_version() {
-        for source in [
-            SourceKind::Claude,
-            SourceKind::Codex,
-            SourceKind::Pi,
-            SourceKind::OpenClaw,
-        ] {
-            assert_ne!(
-                index_state_version_for(source, false),
-                index_state_version_for(source, true)
-            );
-        }
-    }
-}
-
 pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u32 {
     let versions = versions(source);
     let reasoning_mode = include_reasoning
@@ -274,5 +254,25 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::Hermes
     } else {
         SourceKind::Claude
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_mode_is_part_of_index_state_version() {
+        for source in [
+            SourceKind::Claude,
+            SourceKind::Codex,
+            SourceKind::Pi,
+            SourceKind::OpenClaw,
+        ] {
+            assert_ne!(
+                index_state_version_for(source, false),
+                index_state_version_for(source, true)
+            );
+        }
     }
 }

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -405,8 +405,10 @@ fn usage_event(
         model: borrowed_string(value, &["modelID", "model"]),
         tokens,
         source_cost_usd: value.get("cost").and_then(|value| value.as_f64()),
+        cost_authoritative: false,
         dedupe_confidence: "exact",
         conservative_undercount: false,
+        cache_chain_excluded: false,
         sidechain: false,
         source_order: 0,
     })

--- a/src/sources/pi.rs
+++ b/src/sources/pi.rs
@@ -799,8 +799,10 @@ pub(crate) fn parse_usage_file_for(
                     .get("cost")
                     .and_then(|value| value.get("total"))
                     .and_then(|value| value.as_f64()),
+                cost_authoritative: false,
                 dedupe_confidence: "exact",
                 conservative_undercount: false,
+                cache_chain_excluded: false,
                 sidechain: false,
                 source_order: index,
             });

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1534,6 +1534,7 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
         SourceKind::Opencode => cwd_from_opencode_session(Path::new(&first.source_path)),
         SourceKind::Pi => cwd_from_pi_session(Path::new(&first.source_path)),
         SourceKind::OpenClaw => cwd_from_pi_session(Path::new(&first.source_path)),
+        SourceKind::Hermes => None,
     }
     .filter(|path| path.is_dir())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -408,6 +408,7 @@ enum SourceChoice {
     Pi,
     OpenClaw,
     Copilot,
+    Hermes,
 }
 
 impl SourceChoice {
@@ -420,7 +421,8 @@ impl SourceChoice {
             SourceChoice::Cursor => SourceChoice::Pi,
             SourceChoice::Pi => SourceChoice::OpenClaw,
             SourceChoice::OpenClaw => SourceChoice::Copilot,
-            SourceChoice::Copilot => SourceChoice::All,
+            SourceChoice::Copilot => SourceChoice::Hermes,
+            SourceChoice::Hermes => SourceChoice::All,
         }
     }
 
@@ -434,6 +436,7 @@ impl SourceChoice {
             SourceChoice::Pi => Some(SourceFilter::Pi),
             SourceChoice::OpenClaw => Some(SourceFilter::OpenClaw),
             SourceChoice::Copilot => Some(SourceFilter::Copilot),
+            SourceChoice::Hermes => Some(SourceFilter::Hermes),
         }
     }
 
@@ -447,6 +450,7 @@ impl SourceChoice {
             SourceChoice::Pi => "pi",
             SourceChoice::OpenClaw => "openclaw",
             SourceChoice::Copilot => "copilot",
+            SourceChoice::Hermes => "hermes",
         }
     }
 
@@ -459,6 +463,7 @@ impl SourceChoice {
             SourceKind::Pi => SourceChoice::Pi,
             SourceKind::OpenClaw => SourceChoice::OpenClaw,
             SourceKind::Copilot => SourceChoice::Copilot,
+            SourceKind::Hermes => SourceChoice::Hermes,
         }
     }
 }
@@ -2428,6 +2433,7 @@ impl App {
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "pi",
             SourceKind::Copilot => "copilot",
+            SourceKind::Hermes => "hermes",
         };
         let source_path = session.source_path.clone();
 
@@ -3858,6 +3864,7 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
         SourceChoice::Pi => label == "pi",
         SourceChoice::OpenClaw => label == "openclaw",
         SourceChoice::Copilot => label == "copilot",
+        SourceChoice::Hermes => label == "hermes",
         SourceChoice::All => false,
     }
 }
@@ -3871,6 +3878,7 @@ fn source_color(source: SourceKind) -> Color {
         SourceKind::Pi => Color::Rgb(120, 190, 190),
         SourceKind::OpenClaw => Color::Rgb(235, 160, 110),
         SourceKind::Copilot => Color::Rgb(140, 160, 220),
+        SourceKind::Hermes => Color::Rgb(190, 150, 220),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,10 +12,11 @@ pub enum SourceKind {
     Pi,
     OpenClaw,
     Copilot,
+    Hermes,
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 7] = [
+    pub const ALL: [SourceKind; 8] = [
         SourceKind::Claude,
         SourceKind::Codex,
         SourceKind::Opencode,
@@ -23,6 +24,7 @@ impl SourceKind {
         SourceKind::Pi,
         SourceKind::OpenClaw,
         SourceKind::Copilot,
+        SourceKind::Hermes,
     ];
     pub const COUNT: usize = Self::ALL.len();
 
@@ -35,6 +37,7 @@ impl SourceKind {
             SourceKind::Pi => 4,
             SourceKind::OpenClaw => 5,
             SourceKind::Copilot => 6,
+            SourceKind::Hermes => 7,
         }
     }
 
@@ -47,6 +50,7 @@ impl SourceKind {
             4 => Some(SourceKind::Pi),
             5 => Some(SourceKind::OpenClaw),
             6 => Some(SourceKind::Copilot),
+            7 => Some(SourceKind::Hermes),
             _ => None,
         }
     }
@@ -60,6 +64,7 @@ impl SourceKind {
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
+            SourceKind::Hermes => "hermes",
         }
     }
 
@@ -72,6 +77,7 @@ impl SourceKind {
             SourceKind::Pi => "pi",
             SourceKind::OpenClaw => "openclaw",
             SourceKind::Copilot => "copilot",
+            SourceKind::Hermes => "hermes",
         }
     }
 
@@ -88,6 +94,7 @@ impl SourceKind {
             "pi" => Some(SourceKind::Pi),
             "openclaw" => Some(SourceKind::OpenClaw),
             "copilot" => Some(SourceKind::Copilot),
+            "hermes" => Some(SourceKind::Hermes),
             _ => None,
         }
     }
@@ -105,6 +112,7 @@ pub enum SourceFilter {
     #[value(name = "openclaw", alias = "open-claw")]
     OpenClaw,
     Copilot,
+    Hermes,
 }
 
 impl SourceFilter {
@@ -117,6 +125,7 @@ impl SourceFilter {
             SourceFilter::Pi => source == SourceKind::Pi,
             SourceFilter::OpenClaw => source == SourceKind::OpenClaw,
             SourceFilter::Copilot => source == SourceKind::Copilot,
+            SourceFilter::Hermes => source == SourceKind::Hermes,
         }
     }
 
@@ -129,6 +138,7 @@ impl SourceFilter {
             SourceFilter::Pi => &["pi"],
             SourceFilter::OpenClaw => &["openclaw"],
             SourceFilter::Copilot => &["copilot"],
+            SourceFilter::Hermes => &["hermes"],
         }
     }
 
@@ -141,6 +151,7 @@ impl SourceFilter {
             SourceFilter::Pi => "pi",
             SourceFilter::OpenClaw => "openclaw",
             SourceFilter::Copilot => "copilot",
+            SourceFilter::Hermes => "hermes",
         }
     }
 }
@@ -205,6 +216,20 @@ mod tests {
             assert!(labels.insert(source.storage_label()));
             assert_eq!(SourceKind::from_label(source.storage_label()), Some(source));
         }
+    }
+
+    #[test]
+    fn hermes_is_a_stable_first_class_source() {
+        assert_eq!(SourceKind::Hermes.label(), "hermes");
+        assert_eq!(SourceKind::Hermes.storage_label(), "hermes");
+        assert_eq!(SourceKind::from_label("hermes"), Some(SourceKind::Hermes));
+        assert_eq!(
+            SourceKind::from_idx(SourceKind::Hermes.idx()),
+            Some(SourceKind::Hermes)
+        );
+        assert!(SourceFilter::Hermes.matches(SourceKind::Hermes));
+        assert_eq!(SourceFilter::Hermes.as_str(), "hermes");
+        assert_eq!(SourceFilter::Hermes.storage_labels(), &["hermes"]);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1516,12 +1516,12 @@ mod tests {
     }
 
     #[test]
-    fn hermes_disjoint_usage_parser_version_is_newer_than_repair_three() {
-        assert_eq!(crate::sources::hermes::VERSIONS.usage, 5);
+    fn hermes_disjoint_usage_parser_version_is_newer_than_repair_four() {
+        assert_eq!(crate::sources::hermes::VERSIONS.usage, 6);
     }
 
     #[test]
-    fn hermes_parser_version_change_reparses_a_repair_three_cache_row() {
+    fn hermes_parser_version_change_reparses_a_repair_four_cache_row() {
         let temp = tempfile::tempdir().expect("tempdir");
         let db_path = temp.path().join("state.db");
         let conn = Connection::open(&db_path).expect("create db");
@@ -1538,7 +1538,7 @@ mod tests {
                 "INSERT INTO usage_file_cache(
                     source, path, parser_version, size, mtime_ns, scanned_at_ms,
                     events_blob, deps_blob
-                 ) VALUES ('hermes', ?1, 4, ?2, ?3, 30, ?4, ?5)",
+                 ) VALUES ('hermes', ?1, 5, ?2, ?3, 30, ?4, ?5)",
                 params![
                     db_path.to_string_lossy(),
                     fs::metadata(&db_path).unwrap().len() as i64,
@@ -1547,7 +1547,7 @@ mod tests {
                     postcard::to_stdvec(&Vec::<UsageFileDep>::new()).unwrap()
                 ],
             )
-            .expect("seed repair-three row");
+            .expect("seed repair-four row");
         drop(cache);
 
         let mut cache = UsageCache::open(&cache_path).expect("reopen cache");
@@ -1579,7 +1579,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("reparsed row");
-        assert_eq!(version, 5);
+        assert_eq!(version, 6);
     }
 
     #[derive(Serialize)]
@@ -1849,7 +1849,10 @@ mod tests {
 
     #[test]
     fn hermes_authoritative_cost_suppresses_auto_repricing() {
-        for (index, model_input) in [10, 12].into_iter().enumerate() {
+        for (index, (model_input, model_cost)) in [(10, None), (12, None), (6, Some(10.0))]
+            .into_iter()
+            .enumerate()
+        {
             let temp = tempfile::tempdir().expect("tempdir");
             let db_path = temp.path().join(format!("authoritative-cost-{index}.db"));
             let conn = Connection::open(&db_path).expect("create db");
@@ -1864,8 +1867,8 @@ mod tests {
             )
             .expect("insert session");
             conn.execute(
-                "INSERT INTO session_model_usage VALUES ('s','gpt-5','openai','task',?1,0,0,0,0,NULL,1000)",
-                [model_input],
+                "INSERT INTO session_model_usage VALUES ('s','gpt-5','openai','task',?1,0,0,0,0,?2,1000)",
+                rusqlite::params![model_input, model_cost],
             )
             .expect("insert model usage");
             drop(conn);
@@ -1878,13 +1881,11 @@ mod tests {
                 .filter_map(|event| event_cost_nanos(event, CostMode::Auto))
                 .sum::<u64>();
             assert_eq!(auto_cost, 10_000_000_000);
-            assert!(events.iter().any(|event| {
-                event
-                    .source_record_id
-                    .as_deref()
-                    .is_some_and(|id| id.starts_with("model:"))
-                    && event.source_cost_usd == Some(0.0)
-            }));
+            assert!(
+                events
+                    .iter()
+                    .any(|event| event.source_cost_usd == Some(0.0))
+            );
         }
     }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -339,7 +339,9 @@ fn compute_cache_waste<'a>(
     let mut chains: HashMap<(&'a str, &'a str, &'a str), CacheChainState<'a>> = HashMap::new();
     let mut by_source: HashMap<&'static str, CacheWaste> = HashMap::new();
     for event in events {
-        if event.sidechain {
+        // Hermes exposes session/model aggregates rather than an ordered request stream, so
+        // chaining its rows would fabricate prompt-cache misses.
+        if event.sidechain || event.source == "hermes" {
             continue;
         }
         let Some(session_id) = event.session_id.as_deref() else {
@@ -1514,12 +1516,12 @@ mod tests {
     }
 
     #[test]
-    fn hermes_disjoint_usage_parser_version_is_newer_than_repair_two() {
-        assert_eq!(crate::sources::hermes::VERSIONS.usage, 4);
+    fn hermes_disjoint_usage_parser_version_is_newer_than_repair_three() {
+        assert_eq!(crate::sources::hermes::VERSIONS.usage, 5);
     }
 
     #[test]
-    fn hermes_parser_version_change_reparses_a_repair_two_cache_row() {
+    fn hermes_parser_version_change_reparses_a_repair_three_cache_row() {
         let temp = tempfile::tempdir().expect("tempdir");
         let db_path = temp.path().join("state.db");
         let conn = Connection::open(&db_path).expect("create db");
@@ -1536,7 +1538,7 @@ mod tests {
                 "INSERT INTO usage_file_cache(
                     source, path, parser_version, size, mtime_ns, scanned_at_ms,
                     events_blob, deps_blob
-                 ) VALUES ('hermes', ?1, 3, ?2, ?3, 30, ?4, ?5)",
+                 ) VALUES ('hermes', ?1, 4, ?2, ?3, 30, ?4, ?5)",
                 params![
                     db_path.to_string_lossy(),
                     fs::metadata(&db_path).unwrap().len() as i64,
@@ -1545,7 +1547,7 @@ mod tests {
                     postcard::to_stdvec(&Vec::<UsageFileDep>::new()).unwrap()
                 ],
             )
-            .expect("seed repair-two row");
+            .expect("seed repair-three row");
         drop(cache);
 
         let mut cache = UsageCache::open(&cache_path).expect("reopen cache");
@@ -1577,7 +1579,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("reparsed row");
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
     }
 
     #[derive(Serialize)]
@@ -1846,6 +1848,47 @@ mod tests {
     }
 
     #[test]
+    fn hermes_authoritative_cost_suppresses_auto_repricing() {
+        for (index, model_input) in [10, 12].into_iter().enumerate() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let db_path = temp.path().join(format!("authoritative-cost-{index}.db"));
+            let conn = Connection::open(&db_path).expect("create db");
+            conn.execute_batch(
+                "CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT);
+                 CREATE TABLE session_model_usage (session_id TEXT, model TEXT, billing_provider TEXT, task TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, estimated_cost_usd REAL, first_seen INTEGER);",
+            )
+            .expect("create Hermes tables");
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s','gpt-5',1000,10,0,0,0,0,'openai',10.0,'/work','/repo','prof')",
+                [],
+            )
+            .expect("insert session");
+            conn.execute(
+                "INSERT INTO session_model_usage VALUES ('s','gpt-5','openai','task',?1,0,0,0,0,NULL,1000)",
+                [model_input],
+            )
+            .expect("insert model usage");
+            drop(conn);
+
+            let events = crate::sources::hermes::parse_usage_file(&db_path)
+                .expect("parse Hermes usage")
+                .events;
+            let auto_cost = events
+                .iter()
+                .filter_map(|event| event_cost_nanos(event, CostMode::Auto))
+                .sum::<u64>();
+            assert_eq!(auto_cost, 10_000_000_000);
+            assert!(events.iter().any(|event| {
+                event
+                    .source_record_id
+                    .as_deref()
+                    .is_some_and(|id| id.starts_with("model:"))
+                    && event.source_cost_usd == Some(0.0)
+            }));
+        }
+    }
+
+    #[test]
     fn openai_cached_input_is_a_subset() {
         let tokens = TokenBuckets::codex(100, 80, 10, 4);
         assert_eq!(tokens.uncached_input, 20);
@@ -2053,6 +2096,16 @@ mod tests {
             .expect("miss counted");
         assert_eq!(waste.miss_count, 1);
         assert_eq!(waste.idle_misses, 1);
+    }
+
+    #[test]
+    fn cache_hermes_aggregates_are_excluded() {
+        let mut first = cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000);
+        first.source = "hermes";
+        let mut second = cache_event("s", 10 * 60 * 1000, "claude-sonnet-4-6", 0, 0, 100_500);
+        second.source = "hermes";
+
+        assert!(compute_cache_waste([&first, &second]).is_empty());
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use clap::ValueEnum;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params, types::Type};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -503,7 +503,7 @@ fn assemble_usage_events(
     };
     type SourceScanner =
         fn(&mut Vec<UsageEvent>, &mut Vec<String>, Option<&mut UsageCache>) -> Result<()>;
-    const SCANNERS: [(SourceFilter, SourceScanner); 7] = [
+    const SCANNERS: [(SourceFilter, SourceScanner); 8] = [
         (SourceFilter::Claude, scan_claude),
         (SourceFilter::Codex, scan_codex),
         (SourceFilter::Opencode, scan_opencode),
@@ -511,6 +511,7 @@ fn assemble_usage_events(
         (SourceFilter::OpenClaw, scan_openclaw),
         (SourceFilter::Cursor, scan_cursor),
         (SourceFilter::Copilot, scan_copilot),
+        (SourceFilter::Hermes, scan_hermes),
     ];
     for (filter, scanner) in SCANNERS {
         if source.is_none_or(|selected| selected == filter) {
@@ -804,6 +805,9 @@ impl UsageCache {
         )?;
         let rows = statement.query_map(params![source, parser_version], |row| {
             let deps_blob: Vec<u8> = row.get(5)?;
+            let deps = postcard::from_bytes(&deps_blob).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(5, Type::Blob, Box::new(error))
+            })?;
             Ok((
                 row.get::<_, String>(0)?,
                 CachedFileRow {
@@ -811,7 +815,7 @@ impl UsageCache {
                     mtime_ns: row.get(2)?,
                     scanned_at_ms: row.get(3)?,
                     events_blob: row.get(4)?,
-                    deps: postcard::from_bytes(&deps_blob).unwrap_or_default(),
+                    deps,
                 },
             ))
         })?;
@@ -1286,6 +1290,30 @@ fn scan_copilot(
     Ok(())
 }
 
+fn scan_hermes(
+    out: &mut Vec<UsageEvent>,
+    warnings: &mut Vec<String>,
+    cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    let files = crate::sources::hermes::discover()
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<_>>();
+    scan_files_cached(
+        SourceScan {
+            source: "hermes",
+            parser_version: crate::sources::hermes::VERSIONS.usage,
+            volatile_reuse_ms: |_| None,
+        },
+        &files,
+        cache,
+        warnings,
+        out,
+        crate::sources::hermes::parse_usage_file,
+    );
+    Ok(())
+}
+
 // Rates are nano-USD per million tokens. The catalog is deliberately small and versioned:
 // unknown models remain unpriced instead of silently inheriting a guessed family rate.
 const PRICE_CATALOG_ID: &str = "official-api-prices-2026-07-15";
@@ -1427,6 +1455,8 @@ fn claude_rates(input: u64, write_5m: u64, write_1h: u64, read: u64, output: u64
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn usage_parser_version_change_invalidates_cached_rows() {
@@ -1462,6 +1492,234 @@ mod tests {
             )
             .unwrap();
         assert_eq!(rows, 0);
+    }
+
+    #[test]
+    fn hermes_disjoint_usage_parser_version_is_newer_than_repair_two() {
+        assert_eq!(crate::sources::hermes::VERSIONS.usage, 4);
+        assert!(crate::sources::hermes::VERSIONS.usage > 3);
+    }
+
+    #[test]
+    fn hermes_parser_version_change_reparses_a_repair_two_cache_row() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.db");
+        let conn = Connection::open(&db_path).expect("create db");
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT);",
+        )
+        .expect("create sessions");
+        drop(conn);
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&cache_path).expect("open cache");
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('hermes', ?1, 3, ?2, ?3, 30, ?4, ?5)",
+                params![
+                    db_path.to_string_lossy(),
+                    fs::metadata(&db_path).unwrap().len() as i64,
+                    usage_file_metadata(&db_path).unwrap().1,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    postcard::to_stdvec(&Vec::<UsageFileDep>::new()).unwrap()
+                ],
+            )
+            .expect("seed repair-two row");
+        drop(cache);
+
+        let mut cache = UsageCache::open(&cache_path).expect("reopen cache");
+        let mut warnings = Vec::new();
+        let mut events = Vec::new();
+        let parses = AtomicUsize::new(0);
+        scan_files_cached(
+            SourceScan {
+                source: "hermes",
+                parser_version: crate::sources::hermes::VERSIONS.usage,
+                volatile_reuse_ms: |_| None,
+            },
+            &[db_path.clone()],
+            Some(&mut cache),
+            &mut warnings,
+            &mut events,
+            |path| {
+                parses.fetch_add(1, Ordering::SeqCst);
+                crate::sources::hermes::parse_usage_file(path)
+            },
+        );
+        assert_eq!(parses.load(Ordering::SeqCst), 1);
+        assert!(warnings.is_empty());
+        let version: i64 = cache
+            .connection
+            .query_row(
+                "SELECT parser_version FROM usage_file_cache WHERE source = 'hermes'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("reparsed row");
+        assert_eq!(version, 4);
+    }
+
+    #[derive(Serialize)]
+    struct LegacyUsageDependency {
+        path: String,
+        size: u64,
+        mtime_ns: i64,
+    }
+
+    #[test]
+    fn legacy_nonempty_dependency_blob_cannot_become_a_dependency_free_hit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source_path = temp.path().join("rollout.jsonl");
+        fs::write(&source_path, "source").expect("write source");
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&cache_path).expect("open cache");
+        let metadata = usage_file_metadata(&source_path).expect("metadata");
+        let legacy = vec![LegacyUsageDependency {
+            path: temp
+                .path()
+                .join("parent.jsonl")
+                .to_string_lossy()
+                .to_string(),
+            size: 12,
+            mtime_ns: 34,
+        }];
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, ?3, ?4, 30, ?5, ?6)",
+                params![
+                    source_path.to_string_lossy(),
+                    crate::sources::codex::VERSIONS.usage,
+                    metadata.0 as i64,
+                    metadata.1,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    postcard::to_stdvec(&legacy).unwrap()
+                ],
+            )
+            .expect("seed legacy row");
+        drop(cache);
+
+        let mut cache = UsageCache::open(&cache_path).expect("reopen cache");
+        let mut warnings = Vec::new();
+        let mut events = Vec::new();
+        let parses = AtomicUsize::new(0);
+        scan_files_cached(
+            SourceScan {
+                source: "codex",
+                parser_version: crate::sources::codex::VERSIONS.usage,
+                volatile_reuse_ms: |_| None,
+            },
+            std::slice::from_ref(&source_path),
+            Some(&mut cache),
+            &mut warnings,
+            &mut events,
+            |_| {
+                parses.fetch_add(1, Ordering::SeqCst);
+                Ok(FileParse::cacheable(Vec::new()))
+            },
+        );
+        assert_eq!(parses.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn corrupted_dependency_blob_forces_a_reparse() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source_path = temp.path().join("rollout.jsonl");
+        fs::write(&source_path, "source").expect("write source");
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&cache_path).expect("open cache");
+        let metadata = usage_file_metadata(&source_path).expect("metadata");
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, ?3, ?4, 30, ?5, ?6)",
+                params![
+                    source_path.to_string_lossy(),
+                    crate::sources::codex::VERSIONS.usage,
+                    metadata.0 as i64,
+                    metadata.1,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    vec![0xff_u8, 0x00_u8]
+                ],
+            )
+            .expect("seed corrupt row");
+        drop(cache);
+
+        let mut cache = UsageCache::open(&cache_path).expect("reopen cache");
+        let mut warnings = Vec::new();
+        let mut events = Vec::new();
+        let parses = AtomicUsize::new(0);
+        scan_files_cached(
+            SourceScan {
+                source: "codex",
+                parser_version: crate::sources::codex::VERSIONS.usage,
+                volatile_reuse_ms: |_| None,
+            },
+            std::slice::from_ref(&source_path),
+            Some(&mut cache),
+            &mut warnings,
+            &mut events,
+            |_| {
+                parses.fetch_add(1, Ordering::SeqCst);
+                Ok(FileParse::cacheable(Vec::new()))
+            },
+        );
+        assert_eq!(parses.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn hermes_wal_changes_invalidate_but_shm_changes_do_not() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.db");
+        let conn = Connection::open(&db_path).expect("create db");
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT, model TEXT, started_at INTEGER, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, reasoning_tokens INTEGER, billing_provider TEXT, estimated_cost_usd REAL, cwd TEXT, git_repo_root TEXT, profile_name TEXT);",
+        )
+        .expect("create sessions");
+        drop(conn);
+        let wal = PathBuf::from(format!("{}-wal", db_path.to_string_lossy()));
+        let shm = PathBuf::from(format!("{}-shm", db_path.to_string_lossy()));
+        fs::write(&wal, "wal-1").expect("write wal");
+        fs::write(&shm, "shm-1").expect("write shm");
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let mut cache = UsageCache::open(&cache_path).expect("open cache");
+        let mut warnings = Vec::new();
+        let mut events = Vec::new();
+        let parses = AtomicUsize::new(0);
+        let scan =
+            |cache: &mut UsageCache, warnings: &mut Vec<String>, events: &mut Vec<UsageEvent>| {
+                scan_files_cached(
+                    SourceScan {
+                        source: "hermes",
+                        parser_version: crate::sources::hermes::VERSIONS.usage,
+                        volatile_reuse_ms: |_| None,
+                    },
+                    std::slice::from_ref(&db_path),
+                    Some(cache),
+                    warnings,
+                    events,
+                    |path| {
+                        parses.fetch_add(1, Ordering::SeqCst);
+                        crate::sources::hermes::parse_usage_file(path)
+                    },
+                );
+            };
+        scan(&mut cache, &mut warnings, &mut events);
+        fs::write(&shm, "shm-2").expect("change shm");
+        scan(&mut cache, &mut warnings, &mut events);
+        assert_eq!(parses.load(Ordering::SeqCst), 1);
+        fs::write(&wal, "wal-2").expect("change wal");
+        scan(&mut cache, &mut warnings, &mut events);
+        assert_eq!(parses.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -112,8 +112,14 @@ pub struct UsageEvent {
     pub model: Option<String>,
     pub tokens: TokenBuckets,
     pub source_cost_usd: Option<f64>,
+    /// A missing source cost is intentionally covered by an authoritative aggregate.
+    #[serde(skip)]
+    pub(crate) cost_authoritative: bool,
     pub dedupe_confidence: &'static str,
     pub conservative_undercount: bool,
+    /// The source row is an aggregate rather than one request in a cache chain.
+    #[serde(skip)]
+    pub(crate) cache_chain_excluded: bool,
     #[serde(skip)]
     pub(crate) sidechain: bool,
     #[serde(skip)]
@@ -355,6 +361,10 @@ fn compute_cache_waste<'a>(
             event.source_path.as_ref()
         };
         let key = (event.source, session_id, thread);
+        if event.cache_chain_excluded {
+            chains.remove(&key);
+            continue;
+        }
         if event.conservative_undercount {
             chains.remove(&key);
             continue;
@@ -653,8 +663,10 @@ struct CachedUsageEvent {
     model: Option<String>,
     tokens: TokenBuckets,
     source_cost_usd: Option<f64>,
+    cost_authoritative: bool,
     dedupe_confidence: String,
     conservative_undercount: bool,
+    cache_chain_excluded: bool,
     sidechain: bool,
     source_order: u64,
 }
@@ -672,8 +684,10 @@ impl CachedUsageEvent {
             model: event.model.clone(),
             tokens: event.tokens.clone(),
             source_cost_usd: event.source_cost_usd,
+            cost_authoritative: event.cost_authoritative,
             dedupe_confidence: event.dedupe_confidence.to_string(),
             conservative_undercount: event.conservative_undercount,
+            cache_chain_excluded: event.cache_chain_excluded,
             sidechain: event.sidechain,
             source_order: event.source_order,
         }
@@ -693,12 +707,14 @@ impl CachedUsageEvent {
             model: self.model,
             tokens: self.tokens,
             source_cost_usd: self.source_cost_usd,
+            cost_authoritative: self.cost_authoritative,
             dedupe_confidence: match self.dedupe_confidence.as_str() {
                 "exact" => "exact",
                 "strong" => "strong",
                 _ => "heuristic",
             },
             conservative_undercount: self.conservative_undercount,
+            cache_chain_excluded: self.cache_chain_excluded,
             sidechain: self.sidechain,
             source_order: self.source_order,
         }
@@ -1350,7 +1366,7 @@ const fn usd_per_million(value_milli_usd: u64) -> u64 {
     value_milli_usd * 1_000_000
 }
 
-fn event_cost_nanos(event: &UsageEvent, mode: CostMode) -> Option<u64> {
+pub(crate) fn event_cost_nanos(event: &UsageEvent, mode: CostMode) -> Option<u64> {
     let source = event
         .source_cost_usd
         .filter(|value| value.is_finite() && *value >= 0.0)
@@ -1360,7 +1376,11 @@ fn event_cost_nanos(event: &UsageEvent, mode: CostMode) -> Option<u64> {
         });
     match mode {
         CostMode::Source => source,
-        CostMode::Auto => source.or_else(|| calculated_cost_nanos(event)),
+        CostMode::Auto => source.or_else(|| {
+            (!event.cost_authoritative)
+                .then(|| calculated_cost_nanos(event))
+                .flatten()
+        }),
         CostMode::Reprice => calculated_cost_nanos(event),
     }
 }
@@ -1515,7 +1535,7 @@ mod tests {
 
     #[test]
     fn hermes_disjoint_usage_parser_version_is_newer_than_repair_two() {
-        assert_eq!(crate::sources::hermes::VERSIONS.usage, 4);
+        assert_eq!(crate::sources::hermes::VERSIONS.usage, 5);
     }
 
     #[test]
@@ -1577,7 +1597,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("reparsed row");
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
     }
 
     #[derive(Serialize)]
@@ -1882,8 +1902,10 @@ mod tests {
                 reasoning: 0,
             },
             source_cost_usd: None,
+            cost_authoritative: false,
             dedupe_confidence: "exact",
             conservative_undercount: false,
+            cache_chain_excluded: false,
             sidechain: false,
             source_order: 0,
         }
@@ -2001,6 +2023,20 @@ mod tests {
             cache_event("s", 60_000, "claude-sonnet-4-6", 0, 100_000, 500),
         ];
         assert!(waste_for(&events).is_none());
+    }
+
+    #[test]
+    fn hermes_aggregate_rows_are_excluded_from_cache_chains() {
+        let mut first = cache_event("s", 0, "claude-sonnet-4-6", 0, 0, 100_000);
+        first.source = "hermes";
+        first.source_path = Arc::from("hermes.db");
+        first.cache_chain_excluded = true;
+        let mut second = cache_event("s", 60_000, "claude-sonnet-4-6", 0, 0, 100_500);
+        second.source = "hermes";
+        second.source_path = Arc::from("hermes.db");
+        second.cache_chain_excluded = true;
+        let waste = compute_cache_waste([&first, &second]);
+        assert!(!waste.contains_key("hermes"));
     }
 
     #[test]
@@ -3030,8 +3066,10 @@ mod tests {
             model: Some("claude-sonnet-4-6".into()),
             tokens,
             source_cost_usd: None,
+            cost_authoritative: false,
             dedupe_confidence: "exact",
             conservative_undercount: false,
+            cache_chain_excluded: false,
             sidechain: false,
             source_order: 0,
         };
@@ -3054,12 +3092,40 @@ mod tests {
             model: Some("claude-sonnet-4-6".into()),
             tokens: TokenBuckets::disjoint(100, 0, 0, 0),
             source_cost_usd: Some(0.0),
+            cost_authoritative: false,
             dedupe_confidence: "exact",
             conservative_undercount: false,
+            cache_chain_excluded: false,
             sidechain: false,
             source_order: 0,
         };
         assert_eq!(event_cost_nanos(&event, CostMode::Auto), Some(0));
         assert_eq!(event_cost_nanos(&event, CostMode::Reprice), Some(300_000));
+    }
+
+    #[test]
+    fn implementation_only_event_state_is_absent_from_public_json_and_cached_internally() {
+        let mut event = cache_event("session", 0, "claude-sonnet-4-6", 100, 0, 0);
+        event.cost_authoritative = true;
+        event.cache_chain_excluded = true;
+        event.sidechain = true;
+        event.source_order = 42;
+
+        let json = serde_json::to_value(&event).unwrap();
+        let object = json.as_object().unwrap();
+        assert!(object.contains_key("source"));
+        assert!(object.contains_key("model"));
+        assert!(!object.contains_key("cost_authoritative"));
+        assert!(!object.contains_key("cache_chain_excluded"));
+        assert!(!object.contains_key("sidechain"));
+        assert!(!object.contains_key("source_order"));
+
+        let bytes = postcard::to_stdvec(&CachedUsageEvent::from_event(&event)).unwrap();
+        let cached: CachedUsageEvent = postcard::from_bytes(&bytes).unwrap();
+        assert!(cached.cost_authoritative);
+        assert!(cached.cache_chain_excluded);
+        let restored = cached.into_event("claude", Arc::from("cached"));
+        assert!(restored.cost_authoritative);
+        assert!(restored.cache_chain_excluded);
     }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1497,7 +1497,6 @@ mod tests {
     #[test]
     fn hermes_disjoint_usage_parser_version_is_newer_than_repair_two() {
         assert_eq!(crate::sources::hermes::VERSIONS.usage, 4);
-        assert!(crate::sources::hermes::VERSIONS.usage > 3);
     }
 
     #[test]
@@ -1540,7 +1539,7 @@ mod tests {
                 parser_version: crate::sources::hermes::VERSIONS.usage,
                 volatile_reuse_ms: |_| None,
             },
-            &[db_path.clone()],
+            std::slice::from_ref(&db_path),
             Some(&mut cache),
             &mut warnings,
             &mut events,

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use clap::ValueEnum;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
-use rusqlite::{Connection, params, types::Type};
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -799,28 +799,47 @@ impl UsageCache {
             "DELETE FROM usage_file_cache WHERE source = ?1 AND parser_version != ?2",
             params![source, parser_version],
         )?;
-        let mut statement = self.connection.prepare(
-            "SELECT path, size, mtime_ns, scanned_at_ms, events_blob, deps_blob FROM usage_file_cache
-             WHERE source = ?1 AND parser_version = ?2",
-        )?;
-        let rows = statement.query_map(params![source, parser_version], |row| {
-            let deps_blob: Vec<u8> = row.get(5)?;
-            let deps = postcard::from_bytes(&deps_blob).map_err(|error| {
-                rusqlite::Error::FromSqlConversionFailure(5, Type::Blob, Box::new(error))
-            })?;
-            Ok((
-                row.get::<_, String>(0)?,
-                CachedFileRow {
-                    size: row.get::<_, i64>(1)? as u64,
-                    mtime_ns: row.get(2)?,
-                    scanned_at_ms: row.get(3)?,
-                    events_blob: row.get(4)?,
-                    deps,
-                },
-            ))
-        })?;
-        rows.collect::<std::result::Result<HashMap<_, _>, _>>()
-            .map_err(Into::into)
+        let mut cached = HashMap::new();
+        let mut invalid_paths = Vec::new();
+        {
+            let mut statement = self.connection.prepare(
+                "SELECT path, size, mtime_ns, scanned_at_ms, events_blob, deps_blob FROM usage_file_cache
+                 WHERE source = ?1 AND parser_version = ?2",
+            )?;
+            let mut rows = statement.query(params![source, parser_version])?;
+            while let Some(row) = rows.next()? {
+                let path: String = row.get(0)?;
+                let size = row.get::<_, i64>(1)? as u64;
+                let mtime_ns = row.get::<_, i64>(2)?;
+                let scanned_at_ms = row.get::<_, i64>(3)?;
+                let events_blob = row.get::<_, Vec<u8>>(4)?;
+                let Ok(deps_blob) = row.get::<_, Vec<u8>>(5) else {
+                    invalid_paths.push(path);
+                    continue;
+                };
+                let Ok(deps) = postcard::from_bytes(&deps_blob) else {
+                    invalid_paths.push(path);
+                    continue;
+                };
+                cached.insert(
+                    path,
+                    CachedFileRow {
+                        size,
+                        mtime_ns,
+                        scanned_at_ms,
+                        events_blob,
+                        deps,
+                    },
+                );
+            }
+        }
+        for path in invalid_paths {
+            self.connection.execute(
+                "DELETE FROM usage_file_cache WHERE source = ?1 AND path = ?2",
+                params![source, path],
+            )?;
+        }
+        Ok(cached)
     }
 
     fn delete_stale(&mut self, source: &str, stale_paths: &[String]) -> Result<()> {
@@ -1673,6 +1692,111 @@ mod tests {
             },
         );
         assert_eq!(parses.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn invalid_dependency_row_does_not_discard_valid_cache_rows() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let valid_path = temp.path().join("valid.jsonl");
+        fs::write(&valid_path, "valid").expect("write valid source");
+        let vanished_path = temp.path().join("vanished.jsonl");
+        let malformed_path = temp.path().join("malformed.jsonl");
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&cache_path).expect("open cache");
+        let metadata = usage_file_metadata(&valid_path).expect("metadata");
+        let empty_events = postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap();
+        let empty_deps = postcard::to_stdvec(&Vec::<UsageFileDep>::new()).unwrap();
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, ?3, ?4, 30, ?5, ?6)",
+                params![
+                    valid_path.to_string_lossy(),
+                    crate::sources::codex::VERSIONS.usage,
+                    metadata.0 as i64,
+                    metadata.1,
+                    empty_events,
+                    empty_deps
+                ],
+            )
+            .expect("seed valid row");
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, 0, 0, 30, ?3, ?4)",
+                params![
+                    vanished_path.to_string_lossy(),
+                    crate::sources::codex::VERSIONS.usage,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    vec![0xff_u8, 0x00_u8]
+                ],
+            )
+            .expect("seed invalid row");
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, 0, 0, 30, ?3, 7)",
+                params![
+                    malformed_path.to_string_lossy(),
+                    crate::sources::codex::VERSIONS.usage,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                ],
+            )
+            .expect("seed malformed dependency type row");
+
+        let mut cache = cache;
+        let mut warnings = Vec::new();
+        let mut events = Vec::new();
+        let parses = AtomicUsize::new(0);
+        scan_files_cached(
+            SourceScan {
+                source: "codex",
+                parser_version: crate::sources::codex::VERSIONS.usage,
+                volatile_reuse_ms: |_| None,
+            },
+            std::slice::from_ref(&valid_path),
+            Some(&mut cache),
+            &mut warnings,
+            &mut events,
+            |_| {
+                parses.fetch_add(1, Ordering::SeqCst);
+                Ok(FileParse::cacheable(Vec::new()))
+            },
+        );
+
+        assert_eq!(parses.load(Ordering::SeqCst), 0);
+        assert!(
+            cache
+                .load_source("codex", crate::sources::codex::VERSIONS.usage)
+                .is_ok()
+        );
+        let invalid_rows: i64 = cache
+            .connection
+            .query_row(
+                "SELECT count(*) FROM usage_file_cache WHERE source = 'codex' AND path = ?1",
+                [vanished_path.to_string_lossy().as_ref()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(invalid_rows, 0);
+        let malformed_rows: i64 = cache
+            .connection
+            .query_row(
+                "SELECT count(*) FROM usage_file_cache WHERE source = 'codex' AND path = ?1",
+                [malformed_path.to_string_lossy().as_ref()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(malformed_rows, 0);
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -736,6 +736,27 @@ struct CachedFileRow {
 type FileParse = crate::sources::UsageParseOutput;
 type UsageFileDep = crate::sources::UsageDependency;
 
+/// Dependency representation written before native path bytes were persisted.
+#[derive(Serialize, Deserialize)]
+struct LegacyUsageFileDep {
+    path: String,
+    size: u64,
+    mtime_ns: i64,
+    exists: bool,
+}
+
+impl From<LegacyUsageFileDep> for UsageFileDep {
+    fn from(dependency: LegacyUsageFileDep) -> Self {
+        Self {
+            native_path: dependency.path.as_bytes().to_vec(),
+            path: dependency.path,
+            size: dependency.size,
+            mtime_ns: dependency.mtime_ns,
+            exists: dependency.exists,
+        }
+    }
+}
+
 struct ParsedUsageFile {
     index: usize,
     path: PathBuf,
@@ -833,7 +854,12 @@ impl UsageCache {
                     invalid_paths.push(path);
                     continue;
                 };
-                let Ok(deps) = postcard::from_bytes(&deps_blob) else {
+                let deps = postcard::from_bytes::<Vec<UsageFileDep>>(&deps_blob).or_else(|_| {
+                    postcard::from_bytes::<Vec<LegacyUsageFileDep>>(&deps_blob).map(
+                        |dependencies| dependencies.into_iter().map(UsageFileDep::from).collect(),
+                    )
+                });
+                let Ok(deps) = deps else {
                     invalid_paths.push(path);
                     continue;
                 };
@@ -1598,6 +1624,51 @@ mod tests {
             )
             .expect("reparsed row");
         assert_eq!(version, 7);
+    }
+
+    #[test]
+    fn previous_dependency_postcard_format_loads_with_native_path_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source_path = temp.path().join("rollout.jsonl");
+        let dependency_path = temp.path().join("parent.jsonl");
+        fs::write(&source_path, "source").expect("write source");
+        fs::write(&dependency_path, "dependency").expect("write dependency");
+        let cache_path = temp.path().join("usage-cache.sqlite3");
+        let cache = UsageCache::open(&cache_path).expect("open cache");
+        let source_metadata = usage_file_metadata(&source_path).expect("source metadata");
+        let dependency_metadata = usage_file_metadata(&dependency_path).expect("dep metadata");
+        let source_key = source_path.to_string_lossy().to_string();
+        let dependency_key = dependency_path.to_string_lossy().to_string();
+        let legacy = vec![LegacyUsageFileDep {
+            path: dependency_key.clone(),
+            size: dependency_metadata.0,
+            mtime_ns: dependency_metadata.1,
+            exists: true,
+        }];
+        cache
+            .connection
+            .execute(
+                "INSERT INTO usage_file_cache(
+                    source, path, parser_version, size, mtime_ns, scanned_at_ms,
+                    events_blob, deps_blob
+                 ) VALUES ('codex', ?1, ?2, ?3, ?4, 30, ?5, ?6)",
+                params![
+                    source_key,
+                    crate::sources::codex::VERSIONS.usage,
+                    source_metadata.0 as i64,
+                    source_metadata.1,
+                    postcard::to_stdvec(&Vec::<CachedUsageEvent>::new()).unwrap(),
+                    postcard::to_stdvec(&legacy).unwrap()
+                ],
+            )
+            .expect("seed previous dependency format");
+
+        let loaded = cache
+            .load_source("codex", crate::sources::codex::VERSIONS.usage)
+            .expect("load previous dependency format");
+        let dependency = &loaded[&source_key].deps[0];
+        assert_eq!(dependency.native_path, dependency_key.as_bytes());
+        assert!(dependency.is_current());
     }
 
     #[derive(Serialize)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -471,6 +471,7 @@ fn parse_source(value: &str) -> Result<SourceFilter> {
         "pi" => Ok(SourceFilter::Pi),
         "openclaw" | "open-claw" => Ok(SourceFilter::OpenClaw),
         "copilot" => Ok(SourceFilter::Copilot),
+        "hermes" => Ok(SourceFilter::Hermes),
         _ => Err(anyhow!("unknown source: {value}")),
     }
 }


### PR DESCRIPTION
## Summary

Adds Hermes Agent as a first-class Memex token-usage source.

- discovers the canonical Hermes root `state.db` and immediate profile databases
- reads SQLite in read-only, WAL-compatible mode
- supports legacy `sessions` aggregates and current `session_model_usage` model/task rows
- reconciles model rows against session totals without double counting
- preserves Hermes' disjoint input/cache-read/cache-write/output accounting
- adds CLI, TUI, web, audit, source-filter, cache, and documentation integration

## Privacy and safety

The adapter reads usage counters and limited attribution metadata only. It does not query message text, system prompts, tool/reasoning content, credentials, auth, memory, skills, plugins, or cron data. JSON/JSONL transcripts are not treated as Hermes usage sources.

SQLite databases are opened read-only. WAL metadata participates in cache freshness; SHM coordination metadata does not. Parser version 4 invalidates older Hermes projections, and malformed legacy dependency cache entries fail closed by reparsing.

## Accounting model

Hermes stores disjoint buckets:

`total = input_tokens + cache_read_tokens + cache_write_tokens + output_tokens`

For databases with `session_model_usage`, per-model/task rows are emitted first and capped conservatively against the session aggregate. Any positive residual is retained once at session level. Legacy databases use the session aggregate directly.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- 11 focused Hermes source tests
- focused parser-version, WAL freshness, and fail-closed cache tests
- full `cargo test`: 301 passed, 0 failed, 2 ignored
- integration tests: 3 passed
- exact aggregate comparison against immutable snapshots of four local Hermes databases: exact bucket and total match, zero warnings

The upstream branch intentionally excludes the local installer/rollback scripts and Herdr cockpit metadata used during development.