### PR TITLE
Add index-time path exclusion via config and --exclude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1327,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2209,7 @@ dependencies = [
  "directories",
  "fastembed",
  "getrandom 0.3.4",
+ "globset",
  "hmac",
  "indicatif",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tantivy = "0.22"
 usearch = "2"
 toml = "0.8"
 walkdir = "2.5"
+globset = "0.4"
 indicatif = "0.17"
 ratatui = { version = "0.30", default-features = false, features = [
     "crossterm_0_29",

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ compute_units = "ane"  # CoreML only: ane, gpu, cpu, all
 scan_cache_ttl = 3600  # seconds (default 1 hour)
 max_indexed_tool_input_bytes = 65536  # 64 KiB default
 max_indexed_tool_output_bytes = 262144  # 256 KiB default
+exclude_paths = ["~/.claude/projects/*-client-*", "~/work/**"]  # never index matched transcripts
 index_service_mode = "interval"  # interval or continuous
 index_service_interval = 3600  # seconds (ignored when mode = "continuous")
 index_service_poll_interval = 30  # seconds
@@ -454,6 +455,10 @@ and redacted reasoning payloads are always excluded.
 unchanged. memex keeps roughly the first three quarters and final quarter, with a marker reporting
 the omitted middle. Each value must be at least 1024 bytes. Run `memex index --reindex` to apply
 new limits to records that are already indexed.
+`exclude_paths` takes glob patterns matched against transcript source paths at index time, so
+matched transcripts never enter the index (a leading `~/` is expanded to your home directory).
+Adding a pattern also removes records previously indexed from matched paths — no `--reindex`
+required. For one-off runs, pass `--exclude GLOB` (repeatable) to `memex index`.
 `execution_provider` applies to ONNX-backed models; `potion` uses the model2vec backend.
 `cuda_library_paths` and `cudnn_library_paths` accept path lists and are only used
 when `execution_provider = "cuda"`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,11 @@ struct IndexArgs {
     /// Print aggregate parser diagnostics without transcript content
     #[arg(long)]
     diagnostics: bool,
+    /// Exclude transcripts whose source path matches this glob (repeatable).
+    /// Matched transcripts are never indexed. Also configurable via
+    /// `exclude_paths` in ~/.memex/config.toml.
+    #[arg(long = "exclude", value_name = "GLOB")]
+    exclude: Vec<String>,
 }
 
 #[derive(Subcommand)]
@@ -945,6 +950,7 @@ fn run_index_args(index: &IndexArgs, reindex: bool) -> Result<()> {
         index.no_embeddings,
         index.model.clone(),
         index.root.clone(),
+        index.exclude.clone(),
         reindex,
         index.diagnostics,
     )
@@ -966,11 +972,15 @@ fn run_index(
     no_embeddings: bool,
     model: Option<String>,
     root: Option<PathBuf>,
+    mut excludes: Vec<String>,
     reindex: bool,
     print_diagnostics: bool,
 ) -> Result<()> {
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
+
+    // Config exclusions apply to every index run; CLI --exclude adds one-off patterns.
+    excludes.extend(config.exclude_path_patterns());
 
     // Model priority: CLI flag > config file > env var > default
     let model_choice = config.resolve_model(model)?;
@@ -1002,6 +1012,7 @@ fn run_index(
         include_omp: omp,
         include_openclaw: openclaw,
         include_copilot: copilot,
+        exclude_patterns: excludes,
         embeddings,
         backfill_embeddings: false,
         model: model_choice,
@@ -1249,6 +1260,7 @@ fn run_search(
             include_omp: true,
             include_openclaw: true,
             include_copilot: true,
+            exclude_patterns: config.exclude_path_patterns(),
             embeddings: config.embeddings_default(),
             backfill_embeddings: false,
             model: model_choice,
@@ -3537,6 +3549,10 @@ fn build_index_command_args(
     if index.include_reasoning {
         args.push("--include-reasoning".to_string());
     }
+    for pattern in &index.exclude {
+        args.push("--exclude".to_string());
+        args.push(pattern.clone());
+    }
     if !index.codex || index.no_codex {
         args.push("--no-codex".to_string());
     }
@@ -4304,6 +4320,7 @@ mod tests {
             source: None,
             include_agents: false,
             include_reasoning: false,
+            exclude: Vec::new(),
             codex: false,
             opencode: false,
             cursor: false,
@@ -4336,11 +4353,47 @@ mod tests {
     }
 
     #[test]
+    fn build_index_command_args_forwards_exclude_patterns() {
+        let index = IndexArgs {
+            source: None,
+            include_agents: false,
+            include_reasoning: false,
+            exclude: vec!["~/work/**".to_string(), "/tmp/secret/*.jsonl".to_string()],
+            codex: true,
+            opencode: true,
+            cursor: true,
+            pi: true,
+            omp: true,
+            openclaw: true,
+            copilot: true,
+            no_codex: false,
+            no_opencode: false,
+            no_pi: false,
+            no_omp: false,
+            no_openclaw: false,
+            no_copilot: false,
+            embeddings: false,
+            no_embeddings: false,
+            model: None,
+            root: None,
+            diagnostics: false,
+        };
+
+        let args = build_index_command_args(&index, false, 30, false, "127.0.0.1:7777");
+
+        let mut pairs = args.windows(2);
+        assert!(pairs.any(|w| w == ["--exclude", "~/work/**"]));
+        let mut pairs = args.windows(2);
+        assert!(pairs.any(|w| w == ["--exclude", "/tmp/secret/*.jsonl"]));
+    }
+
+    #[test]
     fn build_index_command_args_includes_web_ui_options() {
         let index = IndexArgs {
             source: None,
             include_agents: false,
             include_reasoning: false,
+            exclude: Vec::new(),
             codex: true,
             opencode: true,
             cursor: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,9 @@ pub struct UserConfig {
     pub copilot_resume_cmd: Option<String>,
     /// How resume behaves inside a herdr pane: "tab" (default), "split", or "off".
     pub herdr_resume: Option<String>,
+    /// Glob patterns matched against transcript source paths; matched files are
+    /// never indexed. Applied during source discovery, not at query time.
+    pub exclude_paths: Option<Vec<String>>,
     /// Multi-machine search and control defaults.
     #[serde(default)]
     pub multi_machine: MultiMachineConfig,
@@ -233,6 +236,12 @@ impl UserConfig {
 
     pub fn token_usage_enabled(&self) -> bool {
         self.token_usage.unwrap_or(false)
+    }
+
+    /// Exclusion patterns from config, with a leading `~/` expanded to the
+    /// user's home directory so patterns match absolute transcript paths.
+    pub fn exclude_path_patterns(&self) -> Vec<String> {
+        expand_exclude_patterns(self.exclude_paths.clone().unwrap_or_default())
     }
 
     pub fn resolve_model(&self, cli_model: Option<String>) -> Result<ModelChoice> {
@@ -361,6 +370,29 @@ impl UserConfig {
     }
 }
 
+/// Expand a leading `~/` (or bare `~`) in exclusion patterns to the current
+/// home directory. Other patterns are returned unchanged.
+pub fn expand_exclude_patterns(patterns: Vec<String>) -> Vec<String> {
+    let home = directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf());
+    patterns
+        .into_iter()
+        .map(|pattern| {
+            if pattern == "~" {
+                home.as_ref()
+                    .map(|h| h.to_string_lossy().to_string())
+                    .unwrap_or(pattern)
+            } else if let Some(rest) = pattern.strip_prefix("~/") {
+                match &home {
+                    Some(h) => format!("{}/{rest}", h.to_string_lossy()),
+                    None => pattern,
+                }
+            } else {
+                pattern
+            }
+        })
+        .collect()
+}
+
 fn indexed_tool_content_limit(value: Option<usize>, default: usize, key: &str) -> Result<usize> {
     let value = value.unwrap_or(default);
     if value < MIN_INDEXED_TOOL_CONTENT_BYTES {
@@ -375,6 +407,30 @@ fn indexed_tool_content_limit(value: Option<usize>, default: usize, key: &str) -
 mod tests {
     use super::*;
     use crate::test_support::{EnvVarGuard, env_lock};
+
+    #[test]
+    fn exclude_paths_parse_and_expand_tilde() {
+        let config: UserConfig = toml::from_str(
+            r#"
+                exclude_paths = ["~/.claude/projects/*-client-*", "/opt/work/**"]
+            "#,
+        )
+        .expect("parse config");
+        let patterns = config.exclude_path_patterns();
+        assert_eq!(patterns.len(), 2);
+        let home = directories::BaseDirs::new()
+            .expect("home dir")
+            .home_dir()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(patterns[0], format!("{home}/.claude/projects/*-client-*"));
+        assert_eq!(patterns[1], "/opt/work/**");
+    }
+
+    #[test]
+    fn exclude_paths_default_to_empty() {
+        assert!(UserConfig::default().exclude_path_patterns().is_empty());
+    }
 
     #[test]
     fn token_usage_is_disabled_by_default() {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -38,6 +38,7 @@ pub struct IngestOptions {
     pub include_omp: bool,
     pub include_openclaw: bool,
     pub include_copilot: bool,
+    pub exclude_patterns: Vec<String>,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
     pub model: ModelChoice,
@@ -383,6 +384,49 @@ pub fn ingest_if_stale(
     Ok(Some(report))
 }
 
+/// Glob-based path exclusion applied at discovery time so matched
+/// transcripts never enter the index. Empty pattern sets disable matching.
+#[derive(Debug, Clone)]
+struct PathExcluder {
+    set: Option<globset::GlobSet>,
+}
+
+impl PathExcluder {
+    fn build(patterns: &[String]) -> Result<Self> {
+        if patterns.is_empty() {
+            return Ok(Self { set: None });
+        }
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            builder.add(
+                globset::GlobBuilder::new(pattern)
+                    .literal_separator(false)
+                    .build()
+                    .with_context(|| format!("invalid exclude pattern: {pattern}"))?,
+            );
+        }
+        let set = builder
+            .build()
+            .context("failed to compile exclude patterns")?;
+        Ok(Self { set: Some(set) })
+    }
+
+    fn is_excluded(&self, path: &Path) -> bool {
+        let Some(set) = &self.set else {
+            return false;
+        };
+        set.is_match(path)
+            || path
+                .canonicalize()
+                .is_ok_and(|canonical| canonical != path && set.is_match(&canonical))
+    }
+}
+
+fn build_path_excluder(options: &IngestOptions) -> Result<PathExcluder> {
+    let expanded = crate::config::expand_exclude_patterns(options.exclude_patterns.clone());
+    PathExcluder::build(&expanded)
+}
+
 pub fn ingest_all(
     paths: &Paths,
     index: &SearchIndex,
@@ -400,6 +444,19 @@ pub fn ingest_all(
             std::fs::create_dir_all(&paths.vectors)?;
         }
     }
+
+    // Index-time exclusion: matched transcripts never enter the index, and
+    // records previously indexed from now-excluded paths are removed.
+    let excluder = build_path_excluder(options)?;
+    let mut excluded_state_paths: Vec<String> = Vec::new();
+    state.files.retain(|key, _| {
+        if excluder.is_excluded(Path::new(key)) {
+            excluded_state_paths.push(key.clone());
+            false
+        } else {
+            true
+        }
+    });
     let next_doc_id = Arc::new(AtomicU64::new(state.next_doc_id));
 
     let mut tasks = Vec::new();
@@ -412,6 +469,10 @@ pub fn ingest_all(
             crate::sources::claude::discover(&options.claude_source, options.include_agents)?;
         for source_file in claude_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -439,6 +500,10 @@ pub fn ingest_all(
         let codex_files = crate::sources::codex::discover_rollouts();
         for source_file in codex_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             if let Some(id) = crate::sources::codex::session_id_from_path(&path) {
                 session_ids.insert(id);
             }
@@ -466,6 +531,10 @@ pub fn ingest_all(
 
     if options.include_codex {
         for history_path in crate::sources::codex::history_paths() {
+            if excluder.is_excluded(&history_path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&history_path)? else {
                 files_skipped += 1;
                 continue;
@@ -492,6 +561,10 @@ pub fn ingest_all(
         let opencode_files = crate::sources::opencode::discover_sessions()?;
         for source_file in opencode_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -518,6 +591,10 @@ pub fn ingest_all(
         let cursor_files = crate::sources::cursor::discover_transcripts();
         for source_file in cursor_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -544,6 +621,10 @@ pub fn ingest_all(
         let pi_files = crate::sources::pi::discover();
         for source_file in pi_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -570,6 +651,10 @@ pub fn ingest_all(
         let omp_files = crate::sources::omp::discover();
         for source_file in omp_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -595,6 +680,10 @@ pub fn ingest_all(
     if options.include_openclaw {
         for source_file in crate::sources::openclaw::discover() {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -621,6 +710,10 @@ pub fn ingest_all(
         let copilot_files = crate::sources::copilot::discover_sessions();
         for source_file in copilot_files {
             let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
             let Some(meta) = discovered_metadata(&path)? else {
                 files_skipped += 1;
                 continue;
@@ -643,18 +736,44 @@ pub fn ingest_all(
         }
     }
 
+    // Previously indexed records under now-excluded paths must be deleted even
+    // when there is no ingest state entry for them (e.g. state loss or legacy runs).
+    let mut excluded_index_paths: Vec<String> = Vec::new();
+    if excluder.set.is_some() {
+        index.for_each_record(|record| {
+            if excluder.is_excluded(Path::new(&record.source_path)) {
+                excluded_index_paths.push(record.source_path.clone());
+            }
+            Ok(())
+        })?;
+        excluded_index_paths.sort();
+        excluded_index_paths.dedup();
+    }
+    files_skipped += excluded_state_paths.len();
+
     let opencode_session_links = if tasks.iter().any(|task| task.source == SourceKind::Opencode) {
         crate::sources::opencode::session_links_by_id()
     } else {
         HashMap::new()
     };
 
+    if !excluded_state_paths.is_empty() {
+        state.save(&state_path)?;
+    }
+
+    let mut delete_paths: Vec<String> = excluded_state_paths;
+    for path in excluded_index_paths {
+        if !delete_paths.contains(&path) {
+            delete_paths.push(path);
+        }
+    }
+
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     let analytics_db = analytics_path(&paths.state);
     let analytics_needs_backfill =
         !AnalyticsStore::is_complete(&analytics_db) && index.doc_count()? > 0;
-    if tasks.is_empty() && can_skip_noop_index(paths, index, options)? {
+    if tasks.is_empty() && delete_paths.is_empty() && can_skip_noop_index(paths, index, options)? {
         if analytics_needs_backfill {
             backfill_from_index(&analytics_db, index)?;
         }
@@ -681,11 +800,12 @@ pub fn ingest_all(
     );
     let (tx_update, rx_update) = unbounded::<FileUpdate>();
 
-    let delete_paths: Vec<String> = tasks
-        .iter()
-        .filter(|t| t.delete_first)
-        .map(|t| t.path.to_string_lossy().to_string())
-        .collect();
+    delete_paths.extend(
+        tasks
+            .iter()
+            .filter(|t| t.delete_first)
+            .map(|t| t.path.to_string_lossy().to_string()),
+    );
     let writer = index
         .writer()
         .context("failed to initialize the Tantivy index writer")?;
@@ -1533,6 +1653,7 @@ mod tests {
     fn ingest_options(embeddings: bool, model: ModelChoice) -> IngestOptions {
         IngestOptions {
             claude_source: PathBuf::from("/does/not/exist"),
+            exclude_patterns: Vec::new(),
             include_agents: false,
             include_reasoning: false,
             include_codex: false,
@@ -1548,6 +1669,91 @@ mod tests {
             embed_runtime: EmbedRuntimeConfig::default(),
             tool_content_limits: IndexedToolContentLimits::default(),
         }
+    }
+
+    #[test]
+    fn exclusion_filters_new_and_previously_indexed_transcripts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_root = tmp.path().join("claude-projects");
+        let keep_dir = claude_root.join("-Users-nico-Code-personal");
+        let drop_dir = claude_root.join("-Users-nico-Code-client-x");
+        fs::create_dir_all(&keep_dir).expect("create keep dir");
+        fs::create_dir_all(&drop_dir).expect("create drop dir");
+        let keep_file = keep_dir.join("keep.jsonl");
+        let drop_file = drop_dir.join("drop.jsonl");
+        let line = br#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]},"uuid":"u1","timestamp":"2024-01-01T00:00:00Z"}
+"#;
+        fs::write(&keep_file, line).expect("write keep");
+        fs::write(&drop_file, line).expect("write drop");
+
+        let paths = Paths::new(Some(tmp.path().join("memex-root"))).expect("paths");
+        paths.ensure_dirs().expect("ensure dirs");
+        let index = open_search_index(&paths);
+
+        // First run with no exclusions indexes both transcripts.
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.claude_source = claude_root.clone();
+        let lease = ingest_lease(&paths);
+        let report = ingest_all(&paths, &index, &options, &lease).expect("first ingest");
+        assert_eq!(report.records_added, 2);
+        assert!(index.doc_count().expect("doc count") >= 2);
+
+        // Adding an exclusion removes the previously indexed transcript and
+        // never indexes newly discovered files under matched paths.
+        let drop_pattern = format!("{}/*-client-*/*.jsonl", claude_root.to_string_lossy());
+        options.exclude_patterns = vec![drop_pattern];
+        let new_drop = drop_dir.join("new-drop.jsonl");
+        fs::write(&new_drop, line).expect("write new drop");
+        let report = ingest_all(&paths, &index, &options, &lease).expect("second ingest");
+        assert_eq!(
+            report.records_added, 0,
+            "excluded files must not be indexed"
+        );
+
+        let mut remaining = Vec::new();
+        index
+            .for_each_record(|record| {
+                remaining.push(record.source_path.clone());
+                Ok(())
+            })
+            .expect("collect remaining records");
+        assert!(
+            remaining.iter().all(|p| !p.contains("-client-")),
+            "excluded transcripts must be purged from the index, got: {remaining:?}"
+        );
+        assert!(
+            remaining.iter().any(|p| p.contains("keep.jsonl")),
+            "non-excluded transcripts must remain indexed, got: {remaining:?}"
+        );
+
+        // Ingest state must not retain entries for excluded paths.
+        let state = IngestState::load(&paths.state.join("ingest.json")).expect("load state");
+        assert!(
+            state.files.keys().all(|k| !k.contains("-client-")),
+            "excluded paths must be pruned from ingest state"
+        );
+    }
+
+    #[test]
+    fn exclusion_glob_star_matches_path_separators() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp.path().join("work/deep/project/session.jsonl");
+        let patterns = vec![format!("{}/work/**", tmp.path().to_string_lossy())];
+        let excluder = PathExcluder::build(&patterns).expect("build excluder");
+        assert!(excluder.is_excluded(&nested));
+        assert!(!excluder.is_excluded(&tmp.path().join("other/session.jsonl")));
+    }
+
+    #[test]
+    fn exclusion_invalid_pattern_is_rejected() {
+        let result = PathExcluder::build(&["[unclosed".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn exclusion_empty_patterns_match_nothing() {
+        let excluder = PathExcluder::build(&[]).expect("build excluder");
+        assert!(!excluder.is_excluded(Path::new("/anything/at/all.jsonl")));
     }
 
     fn save_vector_store(paths: &Paths, model: &str, dimensions: usize) {
@@ -2388,6 +2594,7 @@ mod tests {
         let index = SearchIndex::open_or_create(&paths.index).expect("index");
         let options = IngestOptions {
             claude_source: claude_root,
+            exclude_patterns: Vec::new(),
             include_agents: false,
             include_reasoning: false,
             include_codex: false,
@@ -2787,6 +2994,7 @@ mod tests {
         let index = SearchIndex::open_or_create(&paths.index).expect("index");
         let options = IngestOptions {
             claude_source: tmp.path().join("missing-claude"),
+            exclude_patterns: Vec::new(),
             include_agents: false,
             include_reasoning: false,
             include_codex: false,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1057,6 +1057,7 @@ fn index_local(paths: &Paths, config: &UserConfig, stale_only: bool) -> Result<I
         include_omp: true,
         include_openclaw: true,
         include_copilot: true,
+        exclude_patterns: config.exclude_path_patterns(),
         embeddings: config.embeddings_default(),
         backfill_embeddings: false,
         model: config.resolve_model(None)?,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1102,6 +1102,7 @@ impl App {
                     include_omp: true,
                     include_openclaw: true,
                     include_copilot: true,
+                    exclude_patterns: config.exclude_path_patterns(),
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
                     model: model_choice,


### PR DESCRIPTION
Closes #93.

## Problem

memex indexes each supported tool's session store wholesale. When a transcript tree mixes work with different confidentiality obligations (client, employer, personal projects as sibling directories under `~/.claude/projects`), indexing is all-or-nothing: whole-source toggles exclude entire tools, and `--source` takes a single path. Since the Tantivy schema stores `text`/`tool_input`/`tool_output`, and `memex transfer`/`share` can move indexed content off-machine, the current answer is to decline the whole tool.

## Change

An index-time exclusion list, applied during source discovery so matched transcripts never enter the index:

```toml
exclude_paths = ["~/.claude/projects/*-client-*", "~/work/**"]
```

plus a repeatable `--exclude GLOB` flag on `memex index` for one-off runs (merged on top of config patterns).

- Matching is done with `globset` (`literal_separator(false)` so `*` crosses path separators, and `**` works as expected). A leading `~/` is expanded to the home directory.
- Applied at discovery — before metadata access — for every source: Claude, Codex (rollouts + history), OpenCode, Cursor, Pi, OMP, OpenClaw, Copilot. Not at query time, so stored-text and `transfer`/`share` reachability is unchanged for excluded content.
- Adding a pattern after content was already indexed removes those records from the index and analytics store on the next run, and prunes them from ingest state — no `--reindex` required.
- The background index service command builder forwards `--exclude`; auto-index paths (search, TUI, machine RPC) honor config exclusions.
- `is_excluded` also matches symlink-resolved canonical paths, so patterns work with either spelling where temp/home dirs are symlinked (e.g. macOS `/var` → `/private/var`).

## Verification

- `cargo fmt --check` and `cargo clippy -- -D warnings` pass.
- New tests: discovery filtering + purge of previously indexed excluded transcripts, `**` separator behavior, invalid-pattern rejection, `~` expansion, empty-pattern no-op, and service command forwarding.
- Full `cargo test --lib`: 356 passed, 2 failures that reproduce identically on clean `main` (`sources::hermes::wal_dependency_preserves_invalid_utf8_path_bytes_and_invalidates_on_change` fails in isolation; `analytics::repository_grouping_uses_git_common_dir_project` is order-dependent and passes alone). Neither touches this change.