### PR TITLE
Fix federated session activity chart

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -421,11 +421,51 @@ impl AnalyticsStore {
     }
 
     pub fn query_source_timestamps(&self, since_ms: Option<u64>) -> Result<Vec<(SourceKind, u64)>> {
+        self.query_source_timestamps_filtered(None, since_ms, None, None, ProjectGrouping::Flat)
+    }
+
+    pub fn query_source_timestamps_filtered(
+        &self,
+        source: Option<SourceFilter>,
+        since_ms: Option<u64>,
+        until_ms: Option<u64>,
+        project: Option<&str>,
+        grouping: ProjectGrouping,
+    ) -> Result<Vec<(SourceKind, u64)>> {
         let mut sql = String::from("SELECT source, last_at FROM sessions");
+        let mut clauses = Vec::new();
         let mut values: Vec<rusqlite::types::Value> = Vec::new();
+        if let Some(source) = source {
+            let labels = source.storage_labels();
+            let placeholders = std::iter::repeat_n("?", labels.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            clauses.push(format!("source IN ({placeholders})"));
+            values.extend(
+                labels
+                    .iter()
+                    .map(|label| rusqlite::types::Value::Text((*label).to_string())),
+            );
+        }
         if let Some(since_ms) = since_ms {
-            sql.push_str(" WHERE last_at >= ?");
+            clauses.push("last_at >= ?".to_string());
             values.push(rusqlite::types::Value::Integer(since_ms as i64));
+        }
+        if let Some(until_ms) = until_ms {
+            clauses.push("last_at <= ?".to_string());
+            values.push(rusqlite::types::Value::Integer(until_ms as i64));
+        }
+        if let Some(project) = project {
+            let project_expr = match grouping {
+                ProjectGrouping::Flat => "project",
+                ProjectGrouping::Repository => "COALESCE(NULLIF(repo_project, ''), project)",
+            };
+            clauses.push(format!("{project_expr} = ?"));
+            values.push(rusqlite::types::Value::Text(project.to_string()));
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
         }
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(params_from_iter(values), |row| {
@@ -1233,6 +1273,37 @@ mod tests {
                 .query_project_timestamps(None, Some(15), ProjectGrouping::Flat)
                 .expect("timestamps"),
             vec![("alpha".to_string(), 20)]
+        );
+    }
+
+    #[test]
+    fn source_timestamps_apply_activity_filters_without_a_result_limit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db = tmp.path().join("analytics.sqlite");
+        let records = [("alpha", "s1", 10), ("alpha", "s2", 20), ("beta", "s3", 30)]
+            .into_iter()
+            .map(|(project, session, ts)| {
+                record(
+                    project,
+                    session,
+                    &tmp.path().join(format!("{session}.jsonl")),
+                    ts,
+                )
+            });
+        rebuild_from_records(&db, records).expect("rebuild");
+        let store = AnalyticsStore::open_read_only(&db).expect("open read only");
+
+        assert_eq!(
+            store
+                .query_source_timestamps_filtered(
+                    Some(SourceFilter::Codex),
+                    Some(15),
+                    Some(25),
+                    Some("alpha"),
+                    ProjectGrouping::Flat,
+                )
+                .expect("filtered activity"),
+            vec![(SourceKind::Codex, 20)]
         );
     }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -117,6 +117,22 @@ pub struct UsageActivityPointWire {
     pub total_tokens: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionActivitySpec {
+    pub source: Option<SourceFilter>,
+    pub project: Option<String>,
+    pub project_grouping: ProjectGrouping,
+    pub since_ms: Option<u64>,
+    pub until_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionActivityPointWire {
+    pub machine: String,
+    pub source: String,
+    pub timestamp_ms: u64,
+}
+
 #[derive(Debug)]
 pub struct Federated<T> {
     pub items: Vec<T>,
@@ -144,6 +160,9 @@ enum RpcOperation {
     },
     UsageActivity {
         spec: UsageSpec,
+    },
+    SessionActivity {
+        spec: SessionActivitySpec,
     },
 }
 
@@ -177,6 +196,9 @@ enum RpcPayload {
     UsageActivity {
         points: Vec<UsageActivityPointWire>,
         partial: bool,
+    },
+    SessionActivity {
+        points: Vec<SessionActivityPointWire>,
     },
     Error {
         message: String,
@@ -587,6 +609,73 @@ pub fn federated_usage_activity(
     Ok((points, partial))
 }
 
+pub fn federated_session_activity(
+    paths: &Paths,
+    config: &UserConfig,
+    requested: &[String],
+    spec: &SessionActivitySpec,
+) -> Result<(Vec<SessionActivityPointWire>, bool)> {
+    let ids = selected_machine_ids(config, requested)?;
+    let timeout = Duration::from_secs(config.multi_machine.timeout_seconds());
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let tx = tx.clone();
+            let spec = spec.clone();
+            if id == LOCAL_MACHINE_ID {
+                let paths = paths.clone();
+                scope.spawn(move || {
+                    let result = session_activity_local(&paths, &spec);
+                    let _ = tx.send((LOCAL_MACHINE_ID.to_string(), result));
+                });
+            } else {
+                let machine = config
+                    .machines
+                    .iter()
+                    .find(|machine| machine.id == *id)
+                    .expect("selected machines were validated")
+                    .clone();
+                scope.spawn(move || {
+                    let result =
+                        match rpc(&machine, RpcOperation::SessionActivity { spec }, timeout) {
+                            Ok(RpcPayload::SessionActivity { points }) => Ok(points),
+                            Ok(RpcPayload::Error { message }) => Err(anyhow!(message)),
+                            Ok(other) => {
+                                Err(anyhow!("unexpected session activity response: {other:?}"))
+                            }
+                            Err(err) => Err(err),
+                        };
+                    let _ = tx.send((machine.id.clone(), result));
+                });
+            }
+        }
+        drop(tx);
+    });
+    let mut points = Vec::new();
+    let mut successes = 0usize;
+    let mut errors = Vec::new();
+    for (machine, result) in rx {
+        match result {
+            Ok(mut machine_points) => {
+                successes += 1;
+                for point in &mut machine_points {
+                    point.machine.clone_from(&machine);
+                }
+                points.extend(machine_points);
+            }
+            Err(err) => errors.push(format!("{machine}: {err}")),
+        }
+    }
+    if successes == 0 {
+        bail!(
+            "all machine session activity queries failed: {}",
+            errors.join("; ")
+        );
+    }
+    points.sort_by_key(|point| point.timestamp_ms);
+    Ok((points, !errors.is_empty()))
+}
+
 pub fn remote_shell_command(machine: &MachineConfig, command: &str) -> Result<String> {
     validate_machine(machine)?;
     let target = machine
@@ -674,6 +763,9 @@ fn handle_rpc(paths: &Paths, config: &UserConfig, request: RpcOperation) -> Resu
             let (points, partial) = usage_activity_local(paths, config, &spec)?;
             Ok(RpcPayload::UsageActivity { points, partial })
         }
+        RpcOperation::SessionActivity { spec } => Ok(RpcPayload::SessionActivity {
+            points: session_activity_local(paths, &spec)?,
+        }),
     }
 }
 
@@ -727,6 +819,29 @@ fn usage_activity_local(
             .collect(),
         partial,
     ))
+}
+
+fn session_activity_local(
+    paths: &Paths,
+    spec: &SessionActivitySpec,
+) -> Result<Vec<SessionActivityPointWire>> {
+    let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
+    let rows = store.query_source_timestamps_filtered(
+        spec.source,
+        spec.since_ms,
+        spec.until_ms,
+        spec.project.as_deref(),
+        spec.project_grouping,
+    )?;
+    Ok(rows
+        .into_iter()
+        .filter(|(_, timestamp_ms)| *timestamp_ms > 0)
+        .map(|(source, timestamp_ms)| SessionActivityPointWire {
+            machine: LOCAL_MACHINE_ID.to_string(),
+            source: source.storage_label().to_string(),
+            timestamp_ms,
+        })
+        .collect())
 }
 
 fn usage_query(paths: &Paths, spec: &UsageSpec) -> UsageQuery {
@@ -1316,6 +1431,7 @@ fn shell_quote(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analytics::AnalyticsWriter;
     use crate::config::{ControlConfig, IndexBackendConfig, MultiMachineConfig};
     use crate::types::{RecordLinks, SourceKind};
     use tempfile::TempDir;
@@ -1484,6 +1600,51 @@ mod tests {
         assert_eq!(other.session_keys, Some(Vec::new()));
         assert!(local.machine_session_keys.is_none());
         assert!(mini.machine_session_keys.is_none());
+    }
+
+    #[test]
+    fn session_activity_rpc_reads_complete_analytics_history() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut analytics =
+            AnalyticsWriter::open(analytics_path(&paths.state)).expect("analytics writer");
+        for (session_id, ts) in [("old", 10), ("new", 20)] {
+            analytics
+                .record(&Record {
+                    source: SourceKind::Codex,
+                    doc_id: ts,
+                    ts,
+                    project: "memex".to_string(),
+                    session_id: session_id.to_string(),
+                    turn_id: 1,
+                    role: "user".to_string(),
+                    text: "hello".to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: format!("{session_id}.jsonl"),
+                })
+                .expect("record session");
+        }
+        analytics.flush().expect("flush analytics");
+
+        let points = session_activity_local(
+            &paths,
+            &SessionActivitySpec {
+                source: Some(SourceFilter::Codex),
+                project: Some("memex".to_string()),
+                project_grouping: ProjectGrouping::Flat,
+                since_ms: None,
+                until_ms: None,
+            },
+        )
+        .expect("session activity");
+
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].timestamp_ms, 10);
+        assert_eq!(points[1].timestamp_ms, 20);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,9 +4,9 @@ use crate::index::{QueryOptions, SearchIndex};
 use crate::ingest::{IngestOptions, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease, LeaseAttempt};
 use crate::machine::{
-    LOCAL_MACHINE_ID, SearchMode, SearchSpec, UsageSpec, federated_recent, federated_search,
-    federated_usage_activity, machine_by_id, remote_shell_command, session_context,
-    session_records,
+    LOCAL_MACHINE_ID, SearchMode, SearchSpec, SessionActivitySpec, UsageSpec, federated_recent,
+    federated_search, federated_session_activity, federated_usage_activity, machine_by_id,
+    remote_shell_command, session_context, session_records,
 };
 use crate::resume::{find_in_path, resume_template, shell_quote};
 use crate::types::{Record, SourceFilter, SourceKind};
@@ -97,6 +97,7 @@ enum SearchUpdate {
     HomeActivity {
         request_id: u64,
         points: Vec<HomeChartPoint>,
+        partial: bool,
     },
     HomeActivityError {
         request_id: u64,
@@ -540,6 +541,7 @@ struct App {
     timeline_state: LoadState,
     active_timeline_request: u64,
     home_activity: Vec<HomeChartPoint>,
+    home_activity_partial: bool,
     home_result_activity: Vec<HomeChartPoint>,
     home_activity_range: TimelineRange,
     home_activity_state: LoadState,
@@ -929,6 +931,7 @@ impl App {
             machine: String::new(),
             home_machines,
             home_activity: Vec::new(),
+            home_activity_partial: false,
             home_result_activity: Vec::new(),
             home_activity_range: TimelineRange::Month,
             home_activity_state: LoadState::Idle,
@@ -1025,17 +1028,22 @@ impl App {
     }
 
     fn home_chart_is_filtered(&self) -> bool {
-        !self.config.machines.is_empty()
-            || !self.query.trim().is_empty()
+        !self.query.trim().is_empty()
             || !self.machine.is_empty()
             || self.source != SourceChoice::All
             || !self.project.trim().is_empty()
     }
 
+    fn home_chart_uses_search_results(&self) -> bool {
+        !self.query.trim().is_empty()
+    }
+
     fn home_chart_activity(&self) -> &[HomeChartPoint] {
         match self.home_chart_mode {
             HomeChartMode::Tokens => &self.home_token_activity,
-            HomeChartMode::Sessions if self.home_chart_is_filtered() => &self.home_result_activity,
+            HomeChartMode::Sessions if self.home_chart_uses_search_results() => {
+                &self.home_result_activity
+            }
             HomeChartMode::Sessions => &self.home_activity,
         }
     }
@@ -1346,25 +1354,74 @@ impl App {
         let request_id = self.next_request_id();
         self.active_home_activity_request = request_id;
         self.home_activity_state = LoadState::Loading;
+        self.home_activity_partial = false;
         let paths = self.paths.clone();
+        let config = self.config.clone();
+        let machines = self.selected_machines();
+        let source = self.source.as_filter();
+        let project = (!self.project.trim().is_empty()).then(|| self.project.trim().to_string());
+        let project_grouping = self.project_display.grouping();
         let tx = self.search_tx.clone();
         let range = self.home_activity_range;
         std::thread::spawn(move || {
-            let result = (|| -> Result<Vec<HomeChartPoint>> {
-                let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
-                let rows = store.query_source_timestamps(range.since_ms(now_ms()))?;
-                Ok(rows
-                    .into_iter()
-                    .filter(|(_, timestamp_ms)| *timestamp_ms > 0)
-                    .map(|(source, timestamp_ms)| HomeChartPoint {
+            let since_ms = range.since_ms(now_ms());
+            let result = if config.machines.is_empty() {
+                (|| -> Result<(Vec<HomeChartPoint>, bool)> {
+                    let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
+                    let rows = store.query_source_timestamps_filtered(
                         source,
-                        timestamp_ms,
-                        value: 1,
-                    })
-                    .collect())
-            })();
+                        since_ms,
+                        None,
+                        project.as_deref(),
+                        project_grouping,
+                    )?;
+                    Ok((
+                        rows.into_iter()
+                            .filter(|(_, timestamp_ms)| *timestamp_ms > 0)
+                            .map(|(source, timestamp_ms)| HomeChartPoint {
+                                source,
+                                timestamp_ms,
+                                value: 1,
+                            })
+                            .collect(),
+                        false,
+                    ))
+                })()
+            } else {
+                federated_session_activity(
+                    &paths,
+                    &config,
+                    &machines,
+                    &SessionActivitySpec {
+                        source,
+                        project,
+                        project_grouping,
+                        since_ms,
+                        until_ms: None,
+                    },
+                )
+                .map(|(points, partial)| {
+                    (
+                        points
+                            .into_iter()
+                            .filter_map(|point| {
+                                Some(HomeChartPoint {
+                                    source: SourceKind::from_label(&point.source)?,
+                                    timestamp_ms: point.timestamp_ms,
+                                    value: 1,
+                                })
+                            })
+                            .collect(),
+                        partial,
+                    )
+                })
+            };
             let _ = match result {
-                Ok(points) => tx.send(SearchUpdate::HomeActivity { request_id, points }),
+                Ok((points, partial)) => tx.send(SearchUpdate::HomeActivity {
+                    request_id,
+                    points,
+                    partial,
+                }),
                 Err(error) => tx.send(SearchUpdate::HomeActivityError {
                     request_id,
                     message: error.to_string(),
@@ -1662,6 +1719,9 @@ impl App {
         }
         if refresh_search {
             self.kickoff_search();
+            if token_filter_changed {
+                self.kickoff_home_activity();
+            }
         } else if refresh_activity {
             self.kickoff_home_activity();
         }
@@ -1703,7 +1763,9 @@ impl App {
 
     fn home_chart_state(&self) -> &LoadState {
         match self.home_chart_mode {
-            HomeChartMode::Sessions if self.home_chart_is_filtered() => &self.sessions_state,
+            HomeChartMode::Sessions if self.home_chart_uses_search_results() => {
+                &self.sessions_state
+            }
             HomeChartMode::Sessions => &self.home_activity_state,
             HomeChartMode::Tokens => &self.home_token_activity_state,
         }
@@ -1957,10 +2019,13 @@ impl App {
                 self.detail_line_offsets.clear();
                 self.detail_scroll = 0;
             }
-            SearchUpdate::HomeActivity { request_id, points }
-                if request_id == self.active_home_activity_request =>
-            {
+            SearchUpdate::HomeActivity {
+                request_id,
+                points,
+                partial,
+            } if request_id == self.active_home_activity_request => {
                 self.home_activity = points;
+                self.home_activity_partial = partial;
                 self.home_activity_state = if self.home_activity.is_empty() {
                     LoadState::Empty
                 } else {
@@ -2156,6 +2221,7 @@ impl App {
             self.kickoff_timeline_load();
         } else {
             self.refresh_results();
+            self.kickoff_home_activity();
             if self.project_source == self.source {
                 self.kickoff_project_load();
             }
@@ -2815,6 +2881,7 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
                 app.kickoff_timeline_load();
             } else {
                 app.refresh_results();
+                app.kickoff_home_activity();
             }
         }
         KeyCode::Char('[') => {
@@ -3153,9 +3220,23 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
             LoadState::Loaded | LoadState::Empty => {
                 let metric = match app.home_chart_mode {
                     HomeChartMode::Sessions if filtered_chart => {
-                        format!("{plotted_count}/{total_count} matches")
+                        format!(
+                            "{plotted_count}/{total_count} matches{}",
+                            if app.home_activity_partial && !app.home_chart_uses_search_results() {
+                                " · partial"
+                            } else {
+                                ""
+                            }
+                        )
                     }
-                    HomeChartMode::Sessions => format!("{plotted_count} sessions"),
+                    HomeChartMode::Sessions => format!(
+                        "{plotted_count} sessions{}",
+                        if app.home_activity_partial && !app.home_chart_uses_search_results() {
+                            " · partial"
+                        } else {
+                            ""
+                        }
+                    ),
                     HomeChartMode::Tokens => {
                         let total = activity_value_in_bounds(chart_activity, bounds);
                         format!(
@@ -7008,7 +7089,7 @@ mod tests {
     }
 
     #[test]
-    fn home_chart_uses_accepted_results_while_searching() {
+    fn home_chart_uses_full_activity_unless_a_text_query_is_active() {
         let (_tmp, mut app) = test_app();
         app.home_activity = vec![HomeChartPoint {
             source: SourceKind::Claude,
@@ -7031,10 +7112,20 @@ mod tests {
 
         app.query.clear();
         app.source = SourceChoice::Codex;
-        assert_eq!(
-            app.home_chart_activity(),
-            app.home_result_activity.as_slice()
-        );
+        assert_eq!(app.home_chart_activity(), app.home_activity.as_slice());
+
+        app.source = SourceChoice::All;
+        app.config.machines.push(crate::config::MachineConfig {
+            id: "mini".to_string(),
+            label: None,
+            ssh: Some("mini".to_string()),
+            command: None,
+            enabled: None,
+            control: None,
+            index: None,
+        });
+        assert!(!app.home_chart_is_filtered());
+        assert_eq!(app.home_chart_activity(), app.home_activity.as_slice());
     }
 
     #[test]


### PR DESCRIPTION
Use a dedicated analytics RPC for session activity so multi-machine charts cover the full selected range instead of the capped recent-results list. Keep text-query charts result-based, refresh activity for every filter path, and report partial machine failures.