### PR TITLE
Release memex version 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memex"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memex"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 build = "build.rs"
 description = "CLI tool for indexing and searching local agent conversation history"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -8,7 +8,7 @@
 # with exactly this version.
 id = "nicosuave.memex"
 name = "memex"
-version = "0.11.4"
+version = "0.11.5"
 min_herdr_version = "0.7.0"
 platforms = ["macos", "linux"]
 description = "Session desk for your agent history: search past Claude Code / Codex / Cursor / Pi / Oh My Pi sessions and resume one into a herdr tab."


### PR DESCRIPTION
Release the abandoned-generation cleanup and live staging ownership fixes in v0.11.5.