### PR TITLE
Exclude reasoning records from search unless requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Omit `--target` for an interactive menu of detected Claude/Codex/OpenCode/Pi/Oh 
 - `--project <name>`
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
+- `--include-reasoning` — reasoning records are excluded from results by default; `--role reasoning` still returns only them
 - `--session <session_id>`
 - `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|hermes`
 - `--since <iso|unix>` / `--until <iso|unix>`

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -398,6 +398,7 @@ Useful filters and controls:
 - `--project <name>`
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
+- `--include-reasoning` — reasoning records are excluded from results by default; `--role reasoning` still returns only them
 - `--session <session_id>`
 - `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|hermes`
 - `--since <iso|unix>` / `--until <iso|unix>`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,6 +219,9 @@ OUTPUT FIELDS (--fields):
         /// Filter by role (user, assistant, tool_use, tool_result)
         #[arg(long)]
         role: Option<String>,
+        /// Include reasoning records, which are excluded from results by default
+        #[arg(long)]
+        include_reasoning: bool,
         /// Filter by tool name (e.g., Read, Edit, Bash)
         #[arg(long)]
         tool: Option<String>,
@@ -851,6 +854,7 @@ pub fn run() -> Result<()> {
             cwd,
             project,
             role,
+            include_reasoning,
             tool,
             session,
             source,
@@ -878,6 +882,7 @@ pub fn run() -> Result<()> {
                 cwd,
                 project,
                 role,
+                include_reasoning,
                 tool,
                 session,
                 source,
@@ -1421,6 +1426,7 @@ fn run_search(
     cwd: Option<PathBuf>,
     project: Option<String>,
     role: Option<String>,
+    include_reasoning: bool,
     tool: Option<String>,
     session: Option<String>,
     source: Option<SourceFilter>,
@@ -1469,6 +1475,7 @@ fn run_search(
         since: parse_ts_millis(since)?,
         until: parse_ts_millis(until)?,
         limit,
+        include_reasoning,
     };
     let matchers = build_matchers(&options.query)?;
     let fields = parse_fields(fields)?;
@@ -1527,6 +1534,7 @@ fn run_search(
             recency_half_life_days,
             min_score,
             project_grouping: None,
+            include_reasoning: options.include_reasoning,
         };
         let federated =
             federated_search(&paths, &config, &selected_machines, &spec, query_index == 0)?;
@@ -2052,6 +2060,7 @@ fn run_eval_retrieval(dataset_path: PathBuf, k: usize, root: Option<PathBuf>) ->
                 since: None,
                 until: None,
                 limit: k.max(20),
+                include_reasoning: false,
             };
             ranked.push(
                 index

--- a/src/index.rs
+++ b/src/index.rs
@@ -142,6 +142,8 @@ impl Directory for SealedDirectory {
     }
 }
 
+const REASONING_ROLE: &str = "reasoning";
+
 #[derive(Debug, Clone)]
 pub struct QueryOptions {
     pub query: String,
@@ -156,6 +158,7 @@ pub struct QueryOptions {
     pub since: Option<u64>,
     pub until: Option<u64>,
     pub limit: usize,
+    pub include_reasoning: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1182,6 +1185,15 @@ fn build_query(
         ));
     }
 
+    let reasoning_requested = options.role.as_deref() == Some(REASONING_ROLE);
+    if !options.include_reasoning && !reasoning_requested {
+        let term = Term::from_field_text(fields.role, REASONING_ROLE);
+        clauses.push((
+            Occur::MustNot,
+            Box::new(TermQuery::new(term, IndexRecordOption::Basic)),
+        ));
+    }
+
     if let Some(tool) = &options.tool {
         let term = Term::from_field_text(fields.tool_name, tool);
         clauses.push((
@@ -1409,6 +1421,7 @@ mod tests {
             since: None,
             until: None,
             limit: 10,
+            include_reasoning: false,
         };
         let scoped = index.search(&options).expect("scoped search");
         assert_eq!(scoped.len(), 1);
@@ -1421,6 +1434,60 @@ mod tests {
             })
             .expect("empty scope");
         assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn reasoning_records_are_excluded_unless_requested() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let index = SearchIndex::open_or_create(tmp.path()).expect("index");
+        let spoken = test_record(1, "shared needle");
+        let mut thought = test_record(2, "shared needle");
+        thought.role = REASONING_ROLE.to_string();
+        let mut writer = index.writer().expect("writer");
+        index.add_record(&mut writer, &spoken).expect("spoken");
+        index.add_record(&mut writer, &thought).expect("thought");
+        writer.commit().expect("commit");
+
+        let options = QueryOptions {
+            query: "shared needle".to_string(),
+            project: None,
+            role: None,
+            tool: None,
+            session_id: None,
+            session_scope: None,
+            source: None,
+            since: None,
+            until: None,
+            limit: 10,
+            include_reasoning: false,
+        };
+
+        let default = index.search(&options).expect("default search");
+        assert_eq!(
+            default.iter().map(|(_, r)| r.doc_id).collect::<Vec<_>>(),
+            vec![spoken.doc_id],
+        );
+
+        let included = index
+            .search(&QueryOptions {
+                include_reasoning: true,
+                ..options.clone()
+            })
+            .expect("include reasoning");
+        let mut ids = included.iter().map(|(_, r)| r.doc_id).collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![spoken.doc_id, thought.doc_id]);
+
+        let only = index
+            .search(&QueryOptions {
+                role: Some(REASONING_ROLE.to_string()),
+                ..options
+            })
+            .expect("explicit role overrides the exclusion");
+        assert_eq!(
+            only.iter().map(|(_, r)| r.doc_id).collect::<Vec<_>>(),
+            vec![thought.doc_id],
+        );
     }
 
     #[test]
@@ -1831,6 +1898,7 @@ mod tests {
                 since: None,
                 until: None,
                 limit: 10,
+                include_reasoning: false,
             })
             .expect("search")
             .len()
@@ -1925,6 +1993,7 @@ mod tests {
                         since: None,
                         until: None,
                         limit: 10,
+                        include_reasoning: false,
                     })
                     .expect("search merged segment")
                     .len(),
@@ -1964,6 +2033,7 @@ mod tests {
                     since: None,
                     until: None,
                     limit: 10,
+                    include_reasoning: false,
                 })
                 .expect("search adopted generation")
                 .len(),
@@ -2003,6 +2073,7 @@ mod tests {
                 since: None,
                 until: None,
                 limit: 10,
+                include_reasoning: false,
             })
             .expect("search sealed generation");
         fs::set_permissions(&generation, original_permissions).expect("restore permissions");

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -57,6 +57,8 @@ pub struct SearchSpec {
     pub recency_half_life_days: f32,
     pub min_score: Option<f32>,
     pub project_grouping: Option<ProjectGrouping>,
+    #[serde(default)]
+    pub include_reasoning: bool,
 }
 
 impl SearchSpec {
@@ -72,6 +74,7 @@ impl SearchSpec {
             since: self.since,
             until: self.until,
             limit: self.limit,
+            include_reasoning: self.include_reasoning,
         }
     }
 }
@@ -1841,6 +1844,7 @@ mod tests {
             recency_half_life_days: 30.0,
             min_score: None,
             project_grouping: None,
+            include_reasoning: false,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4995,6 +4995,7 @@ fn sessions_from_query(
         since,
         until: None,
         limit: limit.max(20),
+        include_reasoning: false,
     };
     let results = index.search(&options)?;
     let mut sessions: HashMap<String, SessionSummary> = HashMap::new();
@@ -5350,6 +5351,7 @@ fn run_search_request(
                     recency_half_life_days: 30.0,
                     min_score: None,
                     project_grouping: Some(request.grouping),
+                    include_reasoning: false,
                 },
                 false,
             )?

--- a/src/web.rs
+++ b/src/web.rs
@@ -645,6 +645,7 @@ fn search_payload(paths: &Paths, params: &SearchRequest) -> Result<SearchPayload
                     since: None,
                     until: None,
                     limit: candidate_limit,
+                    include_reasoning: false,
                 })?
                 .into_iter()
                 .map(|(score, record)| (Some(score), record))


### PR DESCRIPTION
Reasoning records are indexed only with `--include-reasoning`, are BM25-only (is_embedding_role covers user and assistant, so they are never embedded), and are verbose enough to crowd out conversational hits in lexical and hybrid results. There was no way to search everything-except-reasoning: the role filter compiles to a single Occur::Must term, so `--role reasoning` returns only reasoning and no combination returns the complement.

Add `include_reasoning` to QueryOptions and SearchSpec, defaulting to false, and push an Occur::MustNot role clause when it is unset. An explicit `--role reasoning` still takes precedence, so the existing way to read reasoning back is unchanged.

SearchSpec's field is #[serde(default)], so the RPC surface stays compatible with peers on the current protocol version.