### PR TITLE
Add automatic ingestion of modern OpenCode SQLite transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Index (incremental):
 memex index
 ```
 
+Modern OpenCode sessions stored in `opencode*.db` under
+`~/.local/share/opencode` are discovered automatically, alongside OpenCode's
+legacy JSON storage. To use one or more alternate data roots, set
+`OPENCODE_DATA_DIR` to a comma-separated list of directories before running
+the installed `memex` binary.
+
 The default scan indexes Pi sessions from `~/.pi/agent/sessions` and Oh My Pi sessions
 separately from `~/.omp/agent/sessions` plus named profile session directories.
 

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,3 +1,4 @@
+use crate::state::SessionScope;
 use crate::types::{Record, SourceFilter, SourceKind};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params, params_from_iter};
@@ -57,6 +58,7 @@ pub struct AnalyticsWriter {
     sessions: HashMap<SessionKey, SessionAccumulator>,
     metadata_cache: HashMap<SessionKey, SessionMetadata>,
     git_cache: HashMap<String, GitMetadata>,
+    cwd_overrides: HashMap<SessionKey, String>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -212,6 +214,18 @@ impl AnalyticsStore {
         self.conn.execute(
             "DELETE FROM sessions WHERE source_path = ?1",
             params![source_path],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_session_scope(&self, scope: &SessionScope) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM sessions WHERE source = ?1 AND source_path = ?2 AND session_id = ?3",
+            params![
+                SourceKind::Opencode.storage_label(),
+                scope.source_path,
+                scope.session_id
+            ],
         )?;
         Ok(())
     }
@@ -632,6 +646,7 @@ impl AnalyticsWriter {
             sessions: HashMap::new(),
             metadata_cache: HashMap::new(),
             git_cache: HashMap::new(),
+            cwd_overrides: HashMap::new(),
         })
     }
 
@@ -641,6 +656,27 @@ impl AnalyticsWriter {
 
     pub fn delete_source_path(&self, source_path: &str) -> Result<()> {
         self.store.delete_source_path(source_path)
+    }
+
+    pub fn delete_session_scope(&self, scope: &SessionScope) -> Result<()> {
+        self.store.delete_session_scope(scope)
+    }
+
+    pub fn set_session_cwd(
+        &mut self,
+        source: SourceKind,
+        source_path: &str,
+        session_id: &str,
+        cwd: &str,
+    ) {
+        self.cwd_overrides.insert(
+            SessionKey {
+                source,
+                session_id: session_id.to_string(),
+                source_path: source_path.to_string(),
+            },
+            cwd.to_string(),
+        );
     }
 
     pub fn record(&mut self, record: &Record) -> Result<()> {
@@ -737,7 +773,9 @@ impl AnalyticsWriter {
     }
 
     fn resolve_uncached_metadata(&mut self, key: &SessionKey) -> SessionMetadata {
-        let cwd = resolve_session_cwd_from_parts(key.source, &key.source_path, &key.session_id);
+        let cwd = self.cwd_overrides.get(key).cloned().or_else(|| {
+            resolve_session_cwd_from_parts(key.source, &key.source_path, &key.session_id)
+        });
         let Some(cwd) = cwd else {
             return SessionMetadata {
                 resolution_status: "no-cwd".to_string(),
@@ -964,6 +1002,13 @@ fn resolve_session_cwd_from_parts(
     source_path: &str,
     session_id: &str,
 ) -> Option<String> {
+    if source == SourceKind::Opencode && crate::sources::opencode::is_database_path(source_path) {
+        return crate::sources::opencode::enumerate_sessions(Path::new(source_path))
+            .ok()?
+            .into_iter()
+            .find(|session| session.id == session_id)
+            .map(|session| session.directory);
+    }
     if source == SourceKind::Copilot
         && let Some(cwd) = resolve_copilot_workspace_cwd(source_path)
     {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4961,34 +4961,59 @@ mod tests {
 
     #[test]
     fn web_ui_readiness_requires_memex_health_response() {
-        let (listen, server) = serve_one_test_response(
+        let server = serve_test_responses(
             "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
         );
 
-        wait_for_web_ui(&listen, Duration::from_secs(1)).unwrap();
-        server.join().unwrap();
+        wait_for_web_ui(&server.listen, Duration::from_secs(1)).unwrap();
+        server.shutdown();
     }
 
     #[test]
     fn web_ui_readiness_rejects_unrelated_tcp_listener() {
-        let (listen, server) = serve_one_test_response(
+        let server = serve_test_responses(
             "HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\nnope",
         );
 
-        assert!(!web_ui_is_healthy(&listen));
-        server.join().unwrap();
+        assert!(!web_ui_is_healthy(&server.listen));
+        server.shutdown();
     }
 
-    fn serve_one_test_response(response: &'static str) -> (String, std::thread::JoinHandle<()>) {
+    struct TestResponseServer {
+        listen: String,
+        shutdown: std::sync::mpsc::Sender<()>,
+        server: std::thread::JoinHandle<()>,
+    }
+
+    impl TestResponseServer {
+        fn shutdown(self) {
+            self.shutdown.send(()).unwrap();
+            TcpStream::connect(&self.listen).unwrap();
+            self.server.join().unwrap();
+        }
+    }
+
+    fn serve_test_responses(response: &'static str) -> TestResponseServer {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let listen = listener.local_addr().unwrap().to_string();
+        let (shutdown, shutdown_rx) = std::sync::mpsc::channel();
         let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 1024];
-            let _ = stream.read(&mut request).unwrap();
-            stream.write_all(response.as_bytes()).unwrap();
+            loop {
+                let (mut stream, _) = listener.accept().unwrap();
+                if shutdown_rx.try_recv().is_ok() {
+                    break;
+                }
+                let mut request = [0_u8; 1024];
+                if stream.read(&mut request).is_ok() {
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            }
         });
-        (listen, server)
+        TestResponseServer {
+            listen,
+            shutdown,
+            server,
+        }
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,3 +1,4 @@
+use crate::state::SessionScope;
 use crate::types::{Record, RecordLinks, SourceFilter};
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
@@ -500,6 +501,46 @@ impl SearchIndex {
         writer.delete_term(term);
     }
 
+    pub fn doc_ids_by_source_scope(&self, scope: &SessionScope) -> Result<Vec<u64>> {
+        self.doc_ids_matching_query(Box::new(source_scope_query(&self.fields, scope)))
+    }
+
+    pub fn doc_ids_by_source_path(&self, path: &str) -> Result<Vec<u64>> {
+        let query = TermQuery::new(
+            Term::from_field_text(self.fields.source_path, path),
+            IndexRecordOption::Basic,
+        );
+        self.doc_ids_matching_query(Box::new(query))
+    }
+
+    fn doc_ids_matching_query(&self, query: Box<dyn Query>) -> Result<Vec<u64>> {
+        let reader = self.reader()?;
+        let searcher = reader.searcher();
+        let limit = (searcher.num_docs() as usize).max(1);
+        let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(limit))?;
+        let mut doc_ids = Vec::with_capacity(top_docs.len());
+        for (_, address) in top_docs {
+            let doc = searcher.doc::<TantivyDocument>(address)?;
+            if let Some(doc_id) = doc
+                .get_first(self.fields.doc_id)
+                .and_then(|value| value.as_u64())
+            {
+                doc_ids.push(doc_id);
+            }
+        }
+        doc_ids.sort_unstable();
+        Ok(doc_ids)
+    }
+
+    pub fn delete_by_source_scope(
+        &self,
+        writer: &mut IndexWriter,
+        scope: &SessionScope,
+    ) -> Result<()> {
+        writer.delete_query(Box::new(source_scope_query(&self.fields, scope)))?;
+        Ok(())
+    }
+
     pub fn add_record(&self, writer: &mut IndexWriter, record: &Record) -> Result<()> {
         let mut doc = TantivyDocument::default();
         doc.add_u64(self.fields.doc_id, record.doc_id);
@@ -746,6 +787,25 @@ impl SearchIndex {
         }
         Ok(())
     }
+}
+
+fn source_scope_query(fields: &IndexFields, scope: &SessionScope) -> BooleanQuery {
+    BooleanQuery::new(vec![
+        (
+            Occur::Must,
+            Box::new(TermQuery::new(
+                Term::from_field_text(fields.source_path, &scope.source_path),
+                IndexRecordOption::Basic,
+            )),
+        ),
+        (
+            Occur::Must,
+            Box::new(TermQuery::new(
+                Term::from_field_text(fields.session_id, &scope.session_id),
+                IndexRecordOption::Basic,
+            )),
+        ),
+    ])
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1240,7 +1240,7 @@ pub fn ingest_all(
 
     let recover_vectors = pending_recovery
         .as_ref()
-        .is_some_and(|pending| pending.vector_publication && pending.session_scopes.is_empty());
+        .is_some_and(|pending| pending.vector_publication);
     let pending_ready_scope_recovery = pending_recovery.as_ref().is_some_and(|pending| {
         pending.session_scopes.iter().any(|scope| {
             matches!(
@@ -2932,6 +2932,47 @@ mod tests {
     }
 
     #[test]
+    fn vector_recovery_runs_when_pending_session_scopes_are_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        paths.ensure_dirs().expect("ensure dirs");
+        let index = save_search_records(
+            &paths,
+            &[record(1, "user", "first"), record(2, "assistant", "second")],
+        );
+        index
+            .publish_generation_if_uninitialized()
+            .expect("publish initial lexical generation");
+        let mut vectors = VectorIndex::open_or_create(&paths.vectors, 256, Some("potion"))
+            .expect("create interrupted vectors");
+        vectors.add(1, &vec![0.0; 256]).expect("add live vector");
+        vectors.add(99, &vec![0.0; 256]).expect("add stale vector");
+        vectors.save().expect("save interrupted vectors");
+        PendingIngest {
+            next_doc_id: 3,
+            source_paths: Vec::new(),
+            session_scopes: vec![SessionScope {
+                source_path: "/unavailable/opencode.db".to_string(),
+                session_id: "deferred-session".to_string(),
+            }],
+            vector_publication: true,
+        }
+        .save(&pending_ingest_path(&paths))
+        .expect("save pending vector publication with deferred scope");
+
+        let index =
+            SearchIndex::open_or_create_for_ingest(&paths.index).expect("recovery generation");
+        let lease = ingest_lease(&paths);
+        let options = ingest_options(false, ModelChoice::Potion);
+        ingest_all(&paths, &index, &options, &lease).expect("finish vector recovery");
+
+        let vectors = VectorIndex::inventory(&paths.vectors)
+            .expect("vector inventory")
+            .expect("vectors");
+        assert_eq!(vectors.doc_ids, HashSet::from([1, 2]));
+    }
+
+    #[test]
     fn parser_pool_leaves_global_rayon_available_under_backpressure() {
         let parser_pool = build_parser_thread_pool(2).expect("build parser pool");
         let (tx, rx) = bounded::<usize>(1);
@@ -3587,7 +3628,7 @@ mod tests {
 "#,
         )
         .expect("write unrelated source");
-        options.claude_source = unrelated_source;
+        options.claude_sources = vec![unrelated_source];
         PendingIngest {
             next_doc_id: 1,
             source_paths: Vec::new(),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -5,7 +5,7 @@ use crate::index::SearchIndex;
 use crate::lease::IngestLease;
 use crate::progress::{Progress, SOURCE_COUNT};
 use crate::state::{
-    FileIdentity, FileState, IngestState, PendingIngest, PendingToolCall, ScanCache,
+    FileIdentity, FileState, IngestState, PendingIngest, PendingToolCall, ScanCache, SessionScope,
 };
 #[cfg(test)]
 use crate::types::RecordLinks;
@@ -16,7 +16,7 @@ use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -79,6 +79,51 @@ struct FileUpdate {
     state: FileState,
     session_id: Option<String>,
     diagnostics: crate::sources::ParseDiagnostics,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedOpencodeDatabase {
+    path: PathBuf,
+    scan: crate::sources::opencode::DatabaseScan,
+}
+
+struct PreparedOpencodeDatabase {
+    path: PathBuf,
+    scan: crate::sources::opencode::DatabaseScan,
+    spool: tempfile::NamedTempFile,
+    diagnostics: crate::sources::ParseDiagnostics,
+}
+
+const OPENCODE_SPOOL_PREFIX: &str = ".memex-opencode-spool-";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpencodeDatabaseOutcome {
+    Planned,
+    Ready,
+    ConfirmedAbsent,
+    Failed,
+}
+
+fn classify_opencode_database_outcome(
+    outcome: Option<OpencodeDatabaseOutcome>,
+    discovered: bool,
+    inventory_completed: bool,
+) -> OpencodeDatabaseOutcome {
+    outcome.unwrap_or(if inventory_completed && !discovered {
+        OpencodeDatabaseOutcome::ConfirmedAbsent
+    } else {
+        OpencodeDatabaseOutcome::Failed
+    })
+}
+
+fn claim_opencode_session_owner(
+    owners: &mut HashMap<String, String>,
+    session_id: String,
+    database_path: &str,
+) {
+    owners
+        .entry(session_id)
+        .or_insert_with(|| database_path.to_string());
 }
 
 const FILE_IDENTITY_PREFIX_BYTES: usize = 4096;
@@ -320,6 +365,95 @@ impl RecordSender {
     }
 }
 
+fn prehydrate_opencode_database(
+    path: &Path,
+    scan: &crate::sources::opencode::DatabaseScan,
+    session_ids: &[String],
+    next_doc_id: &AtomicU64,
+    state_dir: &Path,
+) -> Result<PreparedOpencodeDatabase> {
+    let mut spool = tempfile::Builder::new()
+        .prefix(OPENCODE_SPOOL_PREFIX)
+        .tempfile_in(state_dir)
+        .with_context(|| format!("create OpenCode hydration spool in {}", state_dir.display()))?;
+    let mut diagnostics = crate::sources::ParseDiagnostics::default();
+    for session_id in session_ids {
+        let output = crate::sources::opencode::parse_database_records(
+            path,
+            session_id,
+            crate::sources::IndexParseState::default(),
+            next_doc_id,
+            |record| {
+                serde_json::to_writer(spool.as_file_mut(), &record)?;
+                spool.as_file_mut().write_all(b"\n")?;
+                Ok(())
+            },
+        )
+        .with_context(|| {
+            format!(
+                "hydrate OpenCode session `{session_id}` from {}",
+                path.display()
+            )
+        })?;
+        diagnostics.merge(output.diagnostics);
+    }
+    spool.as_file_mut().flush()?;
+    Ok(PreparedOpencodeDatabase {
+        path: path.to_path_buf(),
+        scan: scan.clone(),
+        spool,
+        diagnostics,
+    })
+}
+
+fn cleanup_opencode_spools(state_dir: &Path) -> Result<()> {
+    let entries = match std::fs::read_dir(state_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(OPENCODE_SPOOL_PREFIX)
+            && entry.file_type()?.is_file()
+        {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn replay_opencode_spool(
+    spool: &mut tempfile::NamedTempFile,
+    tx_record: &RecordSender,
+    database_path: &Path,
+    owned_session_ids: &HashSet<String>,
+) -> Result<()> {
+    spool.as_file_mut().seek(SeekFrom::Start(0))?;
+    let reader = BufReader::new(spool.as_file_mut());
+    for line in reader.lines() {
+        let line = line.with_context(|| {
+            format!(
+                "read OpenCode hydration spool for {}",
+                database_path.display()
+            )
+        })?;
+        let record = serde_json::from_str::<Record>(&line).with_context(|| {
+            format!(
+                "decode OpenCode hydration spool for {}",
+                database_path.display()
+            )
+        })?;
+        if owned_session_ids.contains(&record.session_id) {
+            tx_record.send(record)?;
+        }
+    }
+    Ok(())
+}
+
 struct WriterContext {
     embeddings: bool,
     do_backfill_embeddings: bool,
@@ -331,6 +465,9 @@ struct WriterContext {
     embed_runtime: EmbedRuntimeConfig,
     tool_content_limits: IndexedToolContentLimits,
     reconcile_vector_ids: bool,
+    scope_targets: Vec<SessionScope>,
+    opencode_session_cwds: HashMap<SessionScope, String>,
+    vector_delete_paths: HashSet<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -459,6 +596,41 @@ fn pending_ingest_path(paths: &Paths) -> PathBuf {
     paths.state.join("ingest.pending.json")
 }
 
+fn finalize_pending_ingest(
+    pending_path: &Path,
+    deferred_scopes: &[SessionScope],
+    next_doc_id: u64,
+) -> Result<()> {
+    if deferred_scopes.is_empty() {
+        return PendingIngest::clear(pending_path);
+    }
+    PendingIngest {
+        next_doc_id,
+        source_paths: Vec::new(),
+        session_scopes: deferred_scopes.to_vec(),
+        vector_publication: false,
+    }
+    .save(pending_path)
+}
+
+fn pending_scope_union(
+    active_scopes: &[SessionScope],
+    deferred_scopes: &[SessionScope],
+) -> Vec<SessionScope> {
+    let mut scopes = active_scopes
+        .iter()
+        .chain(deferred_scopes)
+        .cloned()
+        .collect::<Vec<_>>();
+    scopes.sort_by(|left, right| {
+        left.source_path
+            .cmp(&right.source_path)
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    scopes.dedup();
+    scopes
+}
+
 fn prepare_pending_ingest_recovery(
     paths: &Paths,
     state: &mut IngestState,
@@ -472,6 +644,9 @@ fn prepare_pending_ingest_recovery(
 
     for source_path in &pending.source_paths {
         state.files.remove(source_path);
+        if crate::sources::opencode::is_database_path(source_path) {
+            state.opencode_databases.remove(source_path);
+        }
     }
     state.next_doc_id = state.next_doc_id.max(pending.next_doc_id);
     Ok(Some(pending))
@@ -489,8 +664,17 @@ pub fn ingest_all(
     let mut state = IngestState::load(&state_path)?;
     let pending_recovery = prepare_pending_ingest_recovery(paths, &mut state)?;
     let recovering_pending_ingest = pending_recovery.is_some();
-    if index.doc_count()? == 0 && !state.files.is_empty() {
+    let mut deferred_pending_scopes = pending_recovery
+        .as_ref()
+        .map(|pending| pending.session_scopes.clone())
+        .unwrap_or_default();
+    cleanup_opencode_spools(&paths.state)?;
+    let mut empty_index_rebuild = false;
+    if index.doc_count()? == 0 && (!state.files.is_empty() || !state.opencode_databases.is_empty())
+    {
+        empty_index_rebuild = true;
         state.files.clear();
+        state.opencode_databases.clear();
         if paths.vectors.exists() {
             std::fs::remove_dir_all(&paths.vectors)?;
             std::fs::create_dir_all(&paths.vectors)?;
@@ -515,6 +699,16 @@ pub fn ingest_all(
     let mut files_scanned = 0usize;
     let mut files_skipped = 0usize;
     let mut total_bytes = 0u64;
+    let mut opencode_ready_databases = Vec::new();
+    let mut opencode_ready_owned_sessions = HashMap::new();
+    let mut opencode_diagnostics = crate::sources::ParseDiagnostics::default();
+    let mut opencode_scope_targets = Vec::new();
+    let mut opencode_session_cwds = HashMap::new();
+    let mut opencode_database_states = HashMap::new();
+    let mut opencode_database_paths_to_delete = Vec::new();
+    let mut opencode_database_outcomes = HashMap::new();
+    let mut opencode_discovered_database_paths = HashSet::new();
+    let mut opencode_legacy_paths_to_delete = Vec::new();
 
     for claude_source in &options.claude_sources {
         if !claude_source.exists() {
@@ -612,10 +806,214 @@ pub fn ingest_all(
     }
 
     if options.include_opencode {
+        let database_files = crate::sources::opencode::discover_databases()?;
+        let mut planned_databases = Vec::new();
+        for source_file in database_files {
+            let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
+            let key = path.to_string_lossy().to_string();
+            opencode_discovered_database_paths.insert(key.clone());
+            let Some(meta) = (match discovered_metadata(&path) {
+                Ok(meta) => meta,
+                Err(_) => {
+                    opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
+                    files_skipped += 1;
+                    continue;
+                }
+            }) else {
+                opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
+                files_skipped += 1;
+                continue;
+            };
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let previous = state.opencode_databases.get(&key);
+            match crate::sources::opencode::scan_database(&path, previous) {
+                Ok(scan) => {
+                    opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Planned);
+                    planned_databases.push(PlannedOpencodeDatabase { path, scan });
+                }
+                Err(_) => {
+                    // A bad/locked modern database must not hide the compatible JSON store.
+                    opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
+                    files_skipped += 1;
+                }
+            }
+        }
+        planned_databases.sort_by(|left, right| left.path.cmp(&right.path));
+
+        for database in planned_databases {
+            let path = database.path.to_string_lossy().to_string();
+            let mut hydration_session_ids = database.scan.dirty_session_ids.clone();
+            if let Some(pending) = &pending_recovery {
+                hydration_session_ids.extend(
+                    pending
+                        .session_scopes
+                        .iter()
+                        .filter(|scope| scope.source_path == path)
+                        .map(|scope| scope.session_id.clone()),
+                );
+                hydration_session_ids.sort();
+                hydration_session_ids.dedup();
+            }
+            match prehydrate_opencode_database(
+                &database.path,
+                &database.scan,
+                &hydration_session_ids,
+                &next_doc_id,
+                &paths.state,
+            ) {
+                Ok(prepared) => {
+                    opencode_database_outcomes.insert(path, OpencodeDatabaseOutcome::Ready);
+                    opencode_diagnostics.merge(prepared.diagnostics.clone());
+                    opencode_ready_databases.push(prepared);
+                }
+                Err(_) => {
+                    opencode_database_outcomes.insert(path, OpencodeDatabaseOutcome::Failed);
+                    files_skipped += 1;
+                }
+            }
+        }
+        opencode_ready_databases.sort_by(|left, right| left.path.cmp(&right.path));
+
+        let mut owner_by_session = HashMap::<String, String>::new();
+        let mut failed_previous = state
+            .opencode_databases
+            .iter()
+            .filter(|(path, _)| {
+                matches!(
+                    classify_opencode_database_outcome(
+                        opencode_database_outcomes.get(*path).copied(),
+                        opencode_discovered_database_paths.contains(*path),
+                        true,
+                    ),
+                    OpencodeDatabaseOutcome::Failed
+                )
+            })
+            .collect::<Vec<_>>();
+        failed_previous.sort_by_key(|(path, _)| *path);
+        for (path, previous) in failed_previous {
+            for session_id in &previous.owned_session_ids {
+                claim_opencode_session_owner(&mut owner_by_session, session_id.clone(), path);
+            }
+        }
+        for database in &opencode_ready_databases {
+            let path = database.path.to_string_lossy().to_string();
+            for session in &database.scan.sessions {
+                claim_opencode_session_owner(&mut owner_by_session, session.id.clone(), &path);
+            }
+        }
+        for (path, previous) in &state.opencode_databases {
+            let outcome = classify_opencode_database_outcome(
+                opencode_database_outcomes.get(path).copied(),
+                opencode_discovered_database_paths.contains(path),
+                true,
+            );
+            if outcome != OpencodeDatabaseOutcome::Ready {
+                if outcome == OpencodeDatabaseOutcome::ConfirmedAbsent {
+                    opencode_database_paths_to_delete.push(path.clone());
+                }
+                continue;
+            }
+            for session_id in &previous.owned_session_ids {
+                if owner_by_session.get(session_id) != Some(path) {
+                    opencode_scope_targets.push(SessionScope {
+                        source_path: path.clone(),
+                        session_id: session_id.clone(),
+                    });
+                }
+            }
+        }
+
+        for database in &opencode_ready_databases {
+            let path = database.path.to_string_lossy().to_string();
+            let owned_sessions = database
+                .scan
+                .sessions
+                .iter()
+                .filter(|session| owner_by_session.get(&session.id) == Some(&path))
+                .collect::<Vec<_>>();
+            let owned_session_ids = owned_sessions
+                .iter()
+                .map(|session| session.id.clone())
+                .collect::<HashSet<_>>();
+            opencode_ready_owned_sessions.insert(path.clone(), owned_session_ids.clone());
+            for session in &owned_sessions {
+                opencode_session_cwds.insert(
+                    SessionScope {
+                        source_path: path.clone(),
+                        session_id: session.id.clone(),
+                    },
+                    session.directory.clone(),
+                );
+            }
+            for session_id in &database.scan.dirty_session_ids {
+                if owner_by_session.get(session_id) == Some(&path) {
+                    opencode_scope_targets.push(SessionScope {
+                        source_path: path.clone(),
+                        session_id: session_id.clone(),
+                    });
+                }
+            }
+            opencode_database_states.insert(
+                path,
+                crate::state::OpencodeDatabaseState {
+                    parser_version: crate::sources::opencode::DATABASE_STATE_VERSION,
+                    event_rowid: database.scan.cursor.event_rowid,
+                    event_id: database.scan.cursor.event_id.clone(),
+                    owned_session_ids,
+                },
+            );
+        }
+        if let Some(pending) = &pending_recovery {
+            deferred_pending_scopes = pending
+                .session_scopes
+                .iter()
+                .filter(|scope| {
+                    classify_opencode_database_outcome(
+                        opencode_database_outcomes.get(&scope.source_path).copied(),
+                        opencode_discovered_database_paths.contains(&scope.source_path),
+                        true,
+                    ) == OpencodeDatabaseOutcome::Failed
+                })
+                .cloned()
+                .collect();
+            for scope in &pending.session_scopes {
+                if matches!(
+                    opencode_database_outcomes.get(&scope.source_path),
+                    Some(OpencodeDatabaseOutcome::Ready)
+                ) {
+                    opencode_scope_targets.push(scope.clone());
+                }
+            }
+        }
+        opencode_scope_targets.sort_by(|left, right| {
+            left.source_path
+                .cmp(&right.source_path)
+                .then_with(|| left.session_id.cmp(&right.session_id))
+        });
+        opencode_scope_targets.dedup();
+        opencode_database_paths_to_delete.sort();
+        opencode_database_paths_to_delete.dedup();
+
         let opencode_files = crate::sources::opencode::discover_sessions()?;
         for source_file in opencode_files {
             let path = source_file.path;
             if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
+            let session_id = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            if owner_by_session.contains_key(session_id) {
+                let path_key = path.to_string_lossy().to_string();
+                state.files.remove(&path_key);
+                opencode_legacy_paths_to_delete.push(path_key);
                 files_skipped += 1;
                 continue;
             }
@@ -842,15 +1240,49 @@ pub fn ingest_all(
 
     let recover_vectors = pending_recovery
         .as_ref()
-        .is_some_and(|pending| pending.vector_publication);
+        .is_some_and(|pending| pending.vector_publication && pending.session_scopes.is_empty());
+    let pending_ready_scope_recovery = pending_recovery.as_ref().is_some_and(|pending| {
+        pending.session_scopes.iter().any(|scope| {
+            matches!(
+                opencode_database_outcomes.get(&scope.source_path),
+                Some(OpencodeDatabaseOutcome::Ready)
+            )
+        })
+    });
+    let recover_vector_cleanup = pending_ready_scope_recovery
+        || pending_recovery.as_ref().is_some_and(|pending| {
+            pending
+                .source_paths
+                .iter()
+                .any(|path| crate::sources::opencode::is_database_path(path))
+        });
     let mut delete_paths = pending_recovery
         .as_ref()
         .map(|pending| pending.source_paths.clone())
         .unwrap_or_default();
+    delete_paths.extend(opencode_database_paths_to_delete.clone());
+    delete_paths.extend(opencode_legacy_paths_to_delete.clone());
     delete_paths.extend(excluded_state_paths);
     delete_paths.extend(excluded_index_paths);
     delete_paths.sort();
     delete_paths.dedup();
+    let pending_database_paths_to_delete = pending_recovery
+        .as_ref()
+        .map(|pending| {
+            pending
+                .source_paths
+                .iter()
+                .filter(|path| crate::sources::opencode::is_database_path(path))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut installed_opencode_states = state.opencode_databases.clone();
+    for path in &opencode_database_paths_to_delete {
+        installed_opencode_states.remove(path);
+    }
+    installed_opencode_states.extend(opencode_database_states.clone());
+    let opencode_database_state_changed = installed_opencode_states != state.opencode_databases;
 
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
@@ -860,18 +1292,30 @@ pub fn ingest_all(
     if !recover_vectors
         && tasks.is_empty()
         && delete_paths.is_empty()
+        && opencode_scope_targets.is_empty()
+        && opencode_ready_databases
+            .iter()
+            .all(|database| database.scan.dirty_session_ids.is_empty())
         && can_skip_noop_index(paths, index, options)?
     {
         if analytics_needs_backfill {
             backfill_from_index(&analytics_db, index)?;
         }
         index.publish_generation_if_uninitialized()?;
-        if recovering_pending_ingest {
+        state.opencode_databases = installed_opencode_states;
+        if recovering_pending_ingest || empty_index_rebuild {
+            state.save(&state_path)?;
+        }
+        if opencode_database_state_changed {
             state.save(&state_path)?;
         }
         update_scan_cache(paths, files_scanned, total_bytes)?;
         if recovering_pending_ingest {
-            PendingIngest::clear(&pending_ingest_path(paths))?;
+            finalize_pending_ingest(
+                &pending_ingest_path(paths),
+                &deferred_pending_scopes,
+                state.next_doc_id,
+            )?;
         }
         return Ok(IngestReport {
             records_added: 0,
@@ -893,10 +1337,19 @@ pub fn ingest_all(
         vector_migration.model = model;
     }
     let embeddings = options.embeddings || vector_migration.rebuild || recover_vectors;
+    let vector_publication = embeddings
+        || ((recover_vector_cleanup
+            || !opencode_scope_targets.is_empty()
+            || !opencode_database_paths_to_delete.is_empty())
+            && crate::vector::VectorIndex::exists(&paths.vectors));
     let progress = Arc::new(Progress::new(totals, file_totals, embeddings));
 
     let (raw_tx_record, rx_record) = record_channel();
     let shared_diagnostics = Arc::new(Mutex::new(crate::sources::ParseDiagnostics::default()));
+    shared_diagnostics
+        .lock()
+        .unwrap()
+        .merge(opencode_diagnostics);
     let tx_record = RecordSender::with_diagnostics(
         raw_tx_record,
         options.tool_content_limits,
@@ -921,10 +1374,12 @@ pub fn ingest_all(
     );
     affected_paths.sort();
     affected_paths.dedup();
+    let pending_scopes = pending_scope_union(&opencode_scope_targets, &deferred_pending_scopes);
     let mut pending_ingest = PendingIngest {
         next_doc_id: state.next_doc_id,
         source_paths: affected_paths,
-        vector_publication: embeddings,
+        session_scopes: pending_scopes,
+        vector_publication,
     };
     let pending_path = pending_ingest_path(paths);
     pending_ingest
@@ -948,6 +1403,14 @@ pub fn ingest_all(
         embed_runtime: options.embed_runtime.clone(),
         tool_content_limits: options.tool_content_limits,
         reconcile_vector_ids: recover_vectors,
+        scope_targets: opencode_scope_targets.clone(),
+        opencode_session_cwds: opencode_session_cwds.clone(),
+        vector_delete_paths: opencode_database_paths_to_delete
+            .iter()
+            .chain(pending_database_paths_to_delete.iter())
+            .chain(opencode_legacy_paths_to_delete.iter())
+            .cloned()
+            .collect(),
     };
     let (decision_tx, decision_rx) = bounded(1);
     let writer_handle = std::thread::spawn(move || {
@@ -1047,6 +1510,22 @@ pub fn ingest_all(
             finish_file_task(task, &progress, &parse_skipped, result)
         })
     });
+    let parser_result = parser_result.and_then(|_| {
+        for database in &mut opencode_ready_databases {
+            let path = database.path.to_string_lossy().to_string();
+            let owned_session_ids = opencode_ready_owned_sessions
+                .get(&path)
+                .cloned()
+                .unwrap_or_default();
+            replay_opencode_spool(
+                &mut database.spool,
+                &tx_record,
+                &database.path,
+                &owned_session_ids,
+            )?;
+        }
+        Ok(())
+    });
 
     drop(tx_record);
     drop(tx_update);
@@ -1102,11 +1581,12 @@ pub fn ingest_all(
     for (path, update) in updated_files {
         state.files.insert(path, update);
     }
+    state.opencode_databases = installed_opencode_states;
     state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
     state.save(&state_path)?;
 
     update_scan_cache(paths, files_scanned, total_bytes)?;
-    PendingIngest::clear(&pending_path)?;
+    finalize_pending_ingest(&pending_path, &deferred_pending_scopes, state.next_doc_id)?;
 
     Ok(IngestReport {
         records_added,
@@ -1137,6 +1617,15 @@ fn can_skip_fresh_scan(
         .with_context(|| format!("check pending ingest at {}", pending_path.display()))?
     {
         return Ok(false);
+    }
+    if options.include_opencode {
+        let databases = match crate::sources::opencode::discover_databases() {
+            Ok(databases) => databases,
+            Err(_) => return Ok(false),
+        };
+        if !databases.is_empty() {
+            return Ok(false);
+        }
     }
     if index.doc_count()? == 0 {
         return Ok(false);
@@ -1224,10 +1713,33 @@ fn writer_loop(
         embed_runtime,
         tool_content_limits,
         reconcile_vector_ids,
+        scope_targets,
+        opencode_session_cwds,
+        vector_delete_paths,
     } = ctx;
     let mut analytics = AnalyticsWriter::open(&analytics_path)?;
+    let mut scoped_doc_ids = HashSet::new();
+    for scope in &scope_targets {
+        for doc_id in index.doc_ids_by_source_scope(scope)? {
+            scoped_doc_ids.insert(doc_id);
+        }
+        index.delete_by_source_scope(&mut writer, scope)?;
+    }
     for path in &delete_paths {
+        if vector_delete_paths.contains(path) {
+            for doc_id in index.doc_ids_by_source_path(path)? {
+                scoped_doc_ids.insert(doc_id);
+            }
+        }
         index.delete_by_source_path(&mut writer, path);
+    }
+    for (scope, cwd) in &opencode_session_cwds {
+        analytics.set_session_cwd(
+            SourceKind::Opencode,
+            &scope.source_path,
+            &scope.session_id,
+            cwd,
+        );
     }
 
     let mut count = 0usize;
@@ -1247,6 +1759,13 @@ fn writer_loop(
         )?);
         embedder = Some(handle);
         progress.set_embed_ready();
+    } else if (reconcile_vector_ids || !scoped_doc_ids.is_empty())
+        && crate::vector::VectorIndex::exists(&vector_dir)
+    {
+        vector_index = Some(crate::vector::VectorIndex::open(&vector_dir)?);
+    }
+    if let Some(vindex) = vector_index.as_mut() {
+        vindex.remove_doc_ids(&scoped_doc_ids)?;
     }
 
     for mut record in rx.iter() {
@@ -1304,6 +1823,9 @@ fn writer_loop(
         }
     }
 
+    for scope in &scope_targets {
+        analytics.delete_session_scope(scope)?;
+    }
     for path in delete_paths {
         analytics.delete_source_path(&path)?;
     }
@@ -1311,20 +1833,19 @@ fn writer_loop(
     writer.commit()?;
     index.maybe_compact_continuous_segments(&mut writer)?;
     let mut staged_vectors = None;
-    if embeddings {
-        if reconcile_vector_ids {
-            let mut live_doc_ids = HashSet::new();
-            index.for_each_record(|record| {
-                if is_embedding_role(&record.role) && !record.text.is_empty() {
-                    live_doc_ids.insert(record.doc_id);
-                }
-                Ok(())
-            })?;
-            vector_index
-                .as_mut()
-                .expect("vector index initialized")
-                .retain_doc_ids(&live_doc_ids)?;
+    if reconcile_vector_ids {
+        let mut live_doc_ids = HashSet::new();
+        index.for_each_record(|record| {
+            if is_embedding_role(&record.role) && !record.text.is_empty() {
+                live_doc_ids.insert(record.doc_id);
+            }
+            Ok(())
+        })?;
+        if let Some(vindex) = vector_index.as_mut() {
+            vindex.retain_doc_ids(&live_doc_ids)?;
         }
+    }
+    if embeddings {
         if !embed_buffer.is_empty() {
             embedded_count += flush_embeddings(
                 &mut embed_buffer,
@@ -1348,12 +1869,12 @@ fn writer_loop(
                 &progress,
             )?;
         }
-        if let Some(vindex) = vector_index.as_ref() {
-            staged_vectors = Some(vindex.stage()?);
-        }
-        if let Some(handle) = embedder.take() {
-            std::mem::forget(handle);
-        }
+    }
+    if let Some(vindex) = vector_index.as_ref() {
+        staged_vectors = Some(vindex.stage()?);
+    }
+    if let Some(handle) = embedder.take() {
+        std::mem::forget(handle);
     }
     writer.wait_merging_threads()?;
     index.publish_generation()?;
@@ -2121,6 +2642,7 @@ mod tests {
         PendingIngest {
             next_doc_id: 100,
             source_paths: vec![source_path.clone()],
+            session_scopes: Vec::new(),
             vector_publication: false,
         }
         .save(&pending_ingest_path(&paths))
@@ -2251,6 +2773,7 @@ mod tests {
         PendingIngest {
             next_doc_id: 100,
             source_paths: vec![source_path.clone()],
+            session_scopes: Vec::new(),
             vector_publication: true,
         }
         .save(&pending_ingest_path(&paths))
@@ -2386,6 +2909,7 @@ mod tests {
         PendingIngest {
             next_doc_id: 3,
             source_paths: Vec::new(),
+            session_scopes: Vec::new(),
             vector_publication: true,
         }
         .save(&pending_ingest_path(&paths))
@@ -2605,6 +3129,9 @@ mod tests {
             embed_runtime: EmbedRuntimeConfig::default(),
             tool_content_limits: IndexedToolContentLimits::default(),
             reconcile_vector_ids: false,
+            scope_targets: Vec::new(),
+            opencode_session_cwds: HashMap::new(),
+            vector_delete_paths: HashSet::new(),
         };
         let writer = index.writer().expect("writer");
 
@@ -2669,6 +3196,9 @@ mod tests {
             embed_runtime: EmbedRuntimeConfig::default(),
             tool_content_limits: IndexedToolContentLimits::default(),
             reconcile_vector_ids: false,
+            scope_targets: Vec::new(),
+            opencode_session_cwds: HashMap::new(),
+            vector_delete_paths: HashSet::new(),
         };
         let writer = index.writer().expect("writer");
 
@@ -2774,6 +3304,369 @@ mod tests {
             file_count: 0,
             total_bytes: 0,
         }
+    }
+
+    #[test]
+    fn database_races_are_failed_but_successful_inventory_absence_is_confirmed() {
+        assert_eq!(
+            classify_opencode_database_outcome(None, true, true),
+            OpencodeDatabaseOutcome::Failed
+        );
+        assert_eq!(
+            classify_opencode_database_outcome(None, false, true),
+            OpencodeDatabaseOutcome::ConfirmedAbsent
+        );
+        assert_eq!(
+            classify_opencode_database_outcome(None, false, false),
+            OpencodeDatabaseOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn failed_database_owner_has_priority_over_ready_duplicate() {
+        let mut owners = HashMap::new();
+        claim_opencode_session_owner(&mut owners, "session".to_string(), "/failed.db");
+        claim_opencode_session_owner(&mut owners, "session".to_string(), "/ready.db");
+        assert_eq!(
+            owners.get("session").map(String::as_str),
+            Some("/failed.db")
+        );
+    }
+
+    #[test]
+    fn prepublication_pending_intent_keeps_active_and_deferred_scopes() {
+        let active = SessionScope {
+            source_path: "/ready.db".to_string(),
+            session_id: "active".to_string(),
+        };
+        let deferred = SessionScope {
+            source_path: "/failed.db".to_string(),
+            session_id: "deferred".to_string(),
+        };
+        let scopes = pending_scope_union(
+            std::slice::from_ref(&active),
+            &[deferred.clone(), active.clone()],
+        );
+        assert_eq!(scopes, vec![deferred, active]);
+    }
+
+    #[test]
+    fn pending_session_scopes_retain_database_state_for_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let database_path = temp
+            .path()
+            .join("opencode.db")
+            .to_string_lossy()
+            .to_string();
+        let scope = SessionScope {
+            source_path: database_path.clone(),
+            session_id: "session".to_string(),
+        };
+        let mut state = IngestState::default();
+        state.opencode_databases.insert(
+            database_path.clone(),
+            crate::state::OpencodeDatabaseState {
+                owned_session_ids: ["session".to_string()].into_iter().collect(),
+                ..Default::default()
+            },
+        );
+        PendingIngest {
+            next_doc_id: 1,
+            source_paths: Vec::new(),
+            session_scopes: vec![scope],
+            vector_publication: false,
+        }
+        .save(&pending_ingest_path(&paths))
+        .unwrap();
+        prepare_pending_ingest_recovery(&paths, &mut state)
+            .unwrap()
+            .expect("pending recovery");
+        assert!(state.opencode_databases.contains_key(&database_path));
+
+        PendingIngest::clear(&pending_ingest_path(&paths)).unwrap();
+        PendingIngest {
+            next_doc_id: 1,
+            source_paths: vec![database_path.clone()],
+            session_scopes: Vec::new(),
+            vector_publication: false,
+        }
+        .save(&pending_ingest_path(&paths))
+        .unwrap();
+        prepare_pending_ingest_recovery(&paths, &mut state)
+            .unwrap()
+            .expect("full-path pending recovery");
+        assert!(!state.opencode_databases.contains_key(&database_path));
+    }
+
+    #[test]
+    fn stale_opencode_spools_are_cleaned_without_touching_other_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let stale = paths.state.join(format!("{OPENCODE_SPOOL_PREFIX}stale"));
+        let unrelated = paths.state.join("unrelated");
+        fs::write(&stale, b"stale").unwrap();
+        fs::write(&unrelated, b"keep").unwrap();
+        let index = SearchIndex::open_or_create(&paths.index).unwrap();
+        ingest_all(
+            &paths,
+            &index,
+            &ingest_options(false, ModelChoice::default()),
+            &ingest_lease(&paths),
+        )
+        .unwrap();
+        assert!(!stale.exists());
+        assert_eq!(fs::read(unrelated).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn empty_index_rebuild_persists_cleared_database_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let database_path = temp
+            .path()
+            .join("opencode.db")
+            .to_string_lossy()
+            .to_string();
+        let mut state = IngestState::default();
+        state.opencode_databases.insert(
+            database_path,
+            crate::state::OpencodeDatabaseState::default(),
+        );
+        state.save(&paths.state.join("ingest.json")).unwrap();
+        let index = SearchIndex::open_or_create(&paths.index).unwrap();
+        ingest_all(
+            &paths,
+            &index,
+            &ingest_options(false, ModelChoice::default()),
+            &ingest_lease(&paths),
+        )
+        .unwrap();
+        let state = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        assert!(state.opencode_databases.is_empty());
+    }
+
+    #[test]
+    fn modern_opencode_database_ingests_once_and_skips_noop_hydration() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("opencode.db");
+        let db = rusqlite::Connection::open(&db_path).expect("open OpenCode fixture");
+        db.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT,
+                time_created INTEGER, time_updated INTEGER
+             );
+             CREATE TABLE message (
+                id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+             );
+             CREATE TABLE part (
+                id TEXT PRIMARY KEY, message_id TEXT, data TEXT
+             );
+             CREATE TABLE event (id TEXT NOT NULL, aggregate_id TEXT NOT NULL);
+             INSERT INTO session VALUES ('ses_db-session', NULL, '/tmp', 1, 2);
+             INSERT INTO message VALUES ('db-message', 'ses_db-session', 3, '{\"role\":\"assistant\"}');
+             INSERT INTO part VALUES ('db-part', 'db-message', '{\"type\":\"text\",\"text\":\"before\"}');
+             INSERT INTO event VALUES ('db-event-1', 'ses_db-session');",
+        )
+        .expect("write OpenCode fixture");
+        drop(db);
+        let _env = EnvVarGuard::set_os(&[("OPENCODE_DATA_DIR", Some(tmp.path().as_os_str()))]);
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        paths.ensure_dirs().expect("ensure paths");
+        let index = open_search_index(&paths);
+        let legacy_path = tmp.path().join("storage/message/ses_db-session");
+        fs::create_dir_all(&legacy_path).expect("create legacy session");
+        let mut legacy_record = record(900, "user", "legacy copy");
+        legacy_record.source = SourceKind::Opencode;
+        legacy_record.session_id = "ses_db-session".to_string();
+        legacy_record.source_path = legacy_path.to_string_lossy().to_string();
+        let mut seed_writer = index.writer().expect("open seed writer");
+        index
+            .add_record(&mut seed_writer, &legacy_record)
+            .expect("seed legacy record");
+        seed_writer.commit().expect("commit legacy record");
+        drop(seed_writer);
+        let mut vectors = VectorIndex::open_or_create(&paths.vectors, 4, Some("fixture"))
+            .expect("create legacy vector");
+        vectors
+            .add(legacy_record.doc_id, &[1.0, 0.0, 0.0, 0.0])
+            .expect("seed legacy vector");
+        vectors.save().expect("save legacy vector");
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.include_opencode = true;
+
+        let first = ingest_all(&paths, &index, &options, &ingest_lease(&paths));
+        assert_eq!(first.expect("initial database ingest").records_added, 1);
+        let source_path = db_path.to_string_lossy().to_string();
+        let records = index
+            .records_by_session_id("ses_db-session")
+            .expect("database records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].source_path, source_path);
+        assert_eq!(records[0].text, "before");
+        assert!(
+            !VectorIndex::inventory(&paths.vectors)
+                .expect("inspect legacy vector removal")
+                .expect("legacy vectors")
+                .doc_ids
+                .contains(&legacy_record.doc_id)
+        );
+        let analytics =
+            crate::analytics::AnalyticsStore::open_read_only(analytics_path(&paths.state))
+                .expect("open analytics");
+        let sessions = analytics
+            .query_sessions(
+                Some(crate::types::SourceFilter::Opencode),
+                None,
+                None,
+                crate::analytics::ProjectGrouping::Flat,
+                None,
+            )
+            .expect("query analytics");
+        assert_eq!(sessions[0].cwd.as_deref(), Some("/tmp"));
+
+        let second = ingest_all(&paths, &index, &options, &ingest_lease(&paths));
+        assert_eq!(second.expect("no-op database ingest").records_added, 0);
+
+        let db = rusqlite::Connection::open(&db_path).expect("reopen OpenCode fixture");
+        db.execute(
+            "UPDATE part SET data = '{\"type\":\"text\",\"text\":\"without event\"}'",
+            [],
+        )
+        .expect("update part without event");
+        drop(db);
+        let third = ingest_all(&paths, &index, &options, &ingest_lease(&paths));
+        assert_eq!(
+            third.expect("unchanged event cursor ingest").records_added,
+            0
+        );
+        assert_eq!(
+            index.records_by_session_id("ses_db-session").unwrap()[0].text,
+            "before"
+        );
+        let doc_id = index.records_by_session_id("ses_db-session").unwrap()[0].doc_id;
+        let mut vectors = VectorIndex::open_or_create(&paths.vectors, 4, Some("fixture"))
+            .expect("create fixture vectors");
+        vectors
+            .add(doc_id, &[1.0, 0.0, 0.0, 0.0])
+            .expect("seed fixture vector");
+        vectors.save().expect("save fixture vector");
+
+        let db = rusqlite::Connection::open(&db_path).expect("reopen OpenCode fixture");
+        db.execute_batch(
+            "UPDATE part SET data = '{\"type\":\"text\",\"text\":\"after event\"}';
+             INSERT INTO event VALUES ('db-event-2', 'ses_db-session');",
+        )
+        .expect("update OpenCode fixture");
+        drop(db);
+        let fourth = ingest_all(&paths, &index, &options, &ingest_lease(&paths));
+        assert_eq!(fourth.expect("event database ingest").records_added, 1);
+        let records = index
+            .records_by_session_id("ses_db-session")
+            .expect("updated records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].text, "after event");
+        assert!(
+            VectorIndex::inventory(&paths.vectors)
+                .expect("inspect updated vectors")
+                .expect("fixture vectors")
+                .doc_ids
+                .is_empty()
+        );
+
+        fs::remove_dir_all(&legacy_path).expect("remove legacy fallback");
+        let unrelated_source = tmp.path().join("claude");
+        fs::create_dir_all(&unrelated_source).expect("create unrelated source");
+        fs::write(
+            unrelated_source.join("unrelated.jsonl"),
+            r#"{"type":"user","uuid":"unrelated","sessionId":"unrelated-session","timestamp":"2026-08-08T11:00:00Z","message":{"content":"unrelated source"}}
+"#,
+        )
+        .expect("write unrelated source");
+        options.claude_source = unrelated_source;
+        PendingIngest {
+            next_doc_id: 1,
+            source_paths: Vec::new(),
+            session_scopes: vec![SessionScope {
+                source_path: source_path.clone(),
+                session_id: "ses_db-session".to_string(),
+            }],
+            vector_publication: false,
+        }
+        .save(&pending_ingest_path(&paths))
+        .expect("save pending database scope");
+        fs::write(&db_path, b"corrupt OpenCode database").expect("corrupt OpenCode database");
+        ingest_all(&paths, &index, &options, &ingest_lease(&paths))
+            .expect("failed database falls back safely");
+        assert_eq!(index.doc_count().expect("remaining document count"), 2);
+        assert_eq!(
+            index.records_by_session_id("ses_db-session").unwrap()[0].text,
+            "after event"
+        );
+        let state = IngestState::load(&paths.state.join("ingest.json")).expect("load ingest state");
+        assert!(
+            state.opencode_databases.contains_key(&source_path),
+            "failed database state must be preserved"
+        );
+        let pending = PendingIngest::load(&pending_ingest_path(&paths))
+            .expect("load deferred scope")
+            .expect("deferred scope marker");
+        assert_eq!(pending.source_paths, Vec::<String>::new());
+        assert_eq!(pending.session_scopes.len(), 1);
+
+        fs::remove_file(&db_path).expect("remove corrupt database");
+        let db = rusqlite::Connection::open(&db_path).expect("recreate OpenCode fixture");
+        db.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT,
+                time_created INTEGER, time_updated INTEGER
+             );
+             CREATE TABLE message (
+                id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+             );
+             CREATE TABLE part (
+                id TEXT PRIMARY KEY, message_id TEXT, data TEXT
+             );
+             CREATE TABLE event (id TEXT NOT NULL, aggregate_id TEXT NOT NULL);
+             INSERT INTO session VALUES ('ses_db-session', NULL, '/recovered', 2, 3);
+             INSERT INTO message VALUES ('recovered-message', 'ses_db-session', 4, '{\"role\":\"assistant\"}');
+             INSERT INTO part VALUES ('recovered-part', 'recovered-message', '{\"type\":\"text\",\"text\":\"recovered\"}');
+             INSERT INTO session VALUES ('ses_reappeared', NULL, '/reappeared', 4, 5);
+             INSERT INTO message VALUES ('reappeared-message', 'ses_reappeared', 6, '{\"role\":\"assistant\"}');
+             INSERT INTO part VALUES ('reappeared-part', 'reappeared-message', '{\"type\":\"text\",\"text\":\"reappeared\"}');
+             INSERT INTO event VALUES ('reappeared-event', 'ses_reappeared');",
+        )
+        .expect("write reappeared OpenCode fixture");
+        drop(db);
+        ingest_all(&paths, &index, &options, &ingest_lease(&paths))
+            .expect("reappeared database cold hydration");
+        let records = index
+            .records_by_session_id("ses_reappeared")
+            .expect("reappeared database records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].text, "reappeared");
+        assert_eq!(
+            index.records_by_session_id("ses_db-session").unwrap()[0].text,
+            "recovered"
+        );
+        let state = IngestState::load(&paths.state.join("ingest.json")).expect("load ingest state");
+        assert!(state.opencode_databases.contains_key(&source_path));
+        assert!(
+            PendingIngest::load(&pending_ingest_path(&paths))
+                .expect("load resolved scope")
+                .is_none()
+        );
+
+        fs::remove_file(&db_path).expect("remove unavailable database");
+        ingest_all(&paths, &index, &options, &ingest_lease(&paths))
+            .expect("confirmed-absent database cleanup");
+        assert_eq!(index.doc_count().expect("remaining document count"), 1);
+        let state = IngestState::load(&paths.state.join("ingest.json")).expect("load ingest state");
+        assert!(!state.opencode_databases.contains_key(&source_path));
     }
 
     #[test]
@@ -3533,12 +4426,32 @@ mod tests {
         PendingIngest {
             next_doc_id: 2,
             source_paths: vec!["source-1.jsonl".to_string()],
+            session_scopes: Vec::new(),
             vector_publication: false,
         }
         .save(&pending_ingest_path(&paths))
         .expect("save pending ingest");
 
         assert!(!can_skip_fresh_scan(&cache, &paths, &index, &options, 60).unwrap());
+    }
+
+    #[test]
+    fn database_discovery_error_never_allows_fresh_scan_skip() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bad_root = tmp.path().join("not-a-directory");
+        fs::write(&bad_root, "fixture").expect("write invalid data root");
+        let _env = EnvVarGuard::set_os(&[("OPENCODE_DATA_DIR", Some(bad_root.as_os_str()))]);
+        let paths = Paths::new(Some(tmp.path().join("memex"))).expect("paths");
+        let index = save_search_records(&paths, &[record(1, "user", "hello")]);
+        let options = ingest_options(false, ModelChoice::BGESmall);
+        let mut options = options;
+        options.include_opencode = true;
+        mark_analytics_complete(&paths);
+
+        assert!(!can_skip_fresh_scan(&fresh_scan_cache(), &paths, &index, &options, 60).unwrap());
+        assert!(ingest_all(&paths, &index, &options, &ingest_lease(&paths)).is_err());
+        assert_eq!(index.doc_count().expect("preserved documents"), 1);
     }
 
     #[test]
@@ -4242,6 +5155,9 @@ mod tests {
             embed_runtime: EmbedRuntimeConfig::default(),
             tool_content_limits: IndexedToolContentLimits::default(),
             reconcile_vector_ids: false,
+            scope_targets: Vec::new(),
+            opencode_session_cwds: HashMap::new(),
+            vector_delete_paths: HashSet::new(),
         };
 
         let writer = index.writer().expect("open writer");

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -1,8 +1,9 @@
-use super::{IndexParseOutput, IndexParseState, ParserVersions, SourceFile};
+use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
+use crate::state::OpencodeDatabaseState;
 use crate::types::{Record, RecordLinks, SourceKind};
 use crate::usage::{TokenBuckets, UsageEvent};
-use anyhow::Result;
-use rusqlite::{Connection, OpenFlags};
+use anyhow::{Context, Result, bail};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use simd_json::BorrowedValue;
 use simd_json::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -18,8 +19,19 @@ pub const VERSIONS: ParserVersions = ParserVersions {
     usage: 3,
 };
 
+/// Version for the SQLite event cursor and owned-session reconciliation rules.  This is
+/// intentionally independent of the shared source identity/index versions: legacy JSON parsing
+/// has not changed merely because database planning was added.
+pub const DATABASE_STATE_VERSION: u32 = 1;
+
 pub fn matches_path(path: &str) -> bool {
-    path.contains("opencode/storage/message") || path.contains("opencode\\storage\\message")
+    (path.contains("opencode/storage/message") || path.contains("opencode\\storage\\message"))
+        || is_database_path(path)
+}
+
+pub(crate) fn is_database_path(path: &str) -> bool {
+    let name = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    name.starts_with("opencode") && name.ends_with(".db")
 }
 
 pub fn data_roots() -> Vec<PathBuf> {
@@ -50,8 +62,26 @@ pub fn parts_root() -> PathBuf {
     storage_root().join("part")
 }
 
+fn parts_root_for_session(session_dir: &Path) -> PathBuf {
+    session_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(|storage| storage.join("part"))
+        .unwrap_or_else(parts_root)
+}
+
 pub fn discover_sessions() -> anyhow::Result<Vec<SourceFile>> {
-    discover_sessions_from_root(&message_root())
+    discover_sessions_from_roots(&data_roots())
+}
+
+pub fn discover_sessions_from_roots(roots: &[PathBuf]) -> anyhow::Result<Vec<SourceFile>> {
+    let mut files = Vec::new();
+    for root in roots {
+        files.extend(discover_sessions_from_root(&root.join("storage/message"))?);
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files.dedup_by(|left, right| left.path == right.path);
+    Ok(files)
 }
 
 pub fn discover_sessions_from_root(root: &Path) -> anyhow::Result<Vec<SourceFile>> {
@@ -75,6 +105,384 @@ pub fn discover_sessions_from_root(root: &Path) -> anyhow::Result<Vec<SourceFile
     }
     files.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(files)
+}
+
+/// Discover modern OpenCode databases without changing the legacy session-directory scan.
+///
+/// OpenCode's data directory may be configured as a comma-separated list, so discovery is
+/// deliberately performed against every configured root and sorted globally for stable output.
+pub fn discover_databases() -> anyhow::Result<Vec<SourceFile>> {
+    discover_databases_from_roots(&data_roots())
+}
+
+pub(crate) fn discover_databases_from_roots(roots: &[PathBuf]) -> anyhow::Result<Vec<SourceFile>> {
+    let mut paths = HashSet::new();
+    for root in roots {
+        let entries = match std::fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("read OpenCode data root {}", root.display()));
+            }
+        };
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with("opencode") && name.ends_with(".db"))
+            {
+                paths.insert(entry.path());
+            }
+        }
+    }
+    let mut files = paths
+        .into_iter()
+        .map(|path| SourceFile {
+            source: SourceKind::Opencode,
+            path,
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(files)
+}
+
+/// Open an OpenCode database in a strictly read-only, WAL-compatible mode.
+///
+/// In particular, this helper does not set journal mode or run checkpoints: those operations
+/// can write beside a database even when the main connection is read-only.
+pub(crate) fn open_read_only_database(path: &Path) -> Result<Connection> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("open OpenCode database read-only: {}", path.display()))?;
+    connection
+        .busy_timeout(Duration::from_millis(1_000))
+        .with_context(|| format!("set OpenCode database busy timeout: {}", path.display()))?;
+    connection
+        .execute_batch("PRAGMA query_only = ON")
+        .with_context(|| format!("enable SQLite query_only for {}", path.display()))?;
+    Ok(connection)
+}
+
+const MODERN_SESSION_COLUMNS: &[&str] = &[
+    "id",
+    "parent_id",
+    "directory",
+    "time_created",
+    "time_updated",
+];
+const MODERN_MESSAGE_COLUMNS: &[&str] = &["id", "session_id", "time_created", "data"];
+const MODERN_PART_COLUMNS: &[&str] = &["id", "message_id", "data"];
+
+fn require_modern_schema(connection: &Connection, path: &Path) -> Result<()> {
+    for (table, columns) in [
+        ("session", MODERN_SESSION_COLUMNS),
+        ("message", MODERN_MESSAGE_COLUMNS),
+        ("part", MODERN_PART_COLUMNS),
+    ] {
+        let exists = connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+                [table],
+                |row| row.get::<_, i64>(0),
+            )
+            .with_context(|| format!("inspect OpenCode schema in {}", path.display()))?;
+        if exists == 0 {
+            bail!(
+                "unrecognized OpenCode SQLite schema in {}: missing table `{table}`",
+                path.display()
+            );
+        }
+        let pragma = format!("PRAGMA table_info({table})");
+        let mut statement = connection
+            .prepare(&pragma)
+            .with_context(|| format!("inspect OpenCode `{table}` table in {}", path.display()))?;
+        let found = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .with_context(|| format!("read OpenCode `{table}` columns in {}", path.display()))?
+            .collect::<rusqlite::Result<HashSet<_>>>()
+            .with_context(|| format!("read OpenCode `{table}` columns in {}", path.display()))?;
+        for column in columns {
+            if !found.contains(*column) {
+                bail!(
+                    "unrecognized OpenCode SQLite schema in {}: `{table}` lacks `{column}`",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpencodeSession {
+    pub id: String,
+    pub parent_id: Option<String>,
+    pub directory: String,
+    pub time_created: u64,
+    pub time_updated: u64,
+}
+
+/// Enumerate the modern session inventory from one OpenCode database.
+pub fn enumerate_sessions(path: &Path) -> Result<Vec<OpencodeSession>> {
+    let connection = open_read_only_database(path)?;
+    require_modern_schema(&connection, path)?;
+    enumerate_sessions_from_connection(&connection, path)
+}
+
+fn enumerate_sessions_from_connection(
+    connection: &Connection,
+    path: &Path,
+) -> Result<Vec<OpencodeSession>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT id, parent_id, directory, time_created, time_updated
+             FROM session ORDER BY id",
+        )
+        .with_context(|| format!("prepare OpenCode session query for {}", path.display()))?;
+    let rows = statement
+        .query_map([], |row| {
+            let id = row.get::<_, String>(0)?;
+            let time_created = row.get::<_, i64>(3)?;
+            let time_updated = row.get::<_, i64>(4)?;
+            Ok((
+                id,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, String>(2)?,
+                time_created,
+                time_updated,
+            ))
+        })
+        .with_context(|| format!("query OpenCode sessions in {}", path.display()))?;
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (id, parent_id, directory, time_created, time_updated) = row?;
+        sessions.push(OpencodeSession {
+            id: id.clone(),
+            parent_id,
+            directory,
+            time_created: nonnegative_timestamp(time_created)
+                .with_context(|| format!("session `{id}` has invalid time_created"))?,
+            time_updated: nonnegative_timestamp(time_updated)
+                .with_context(|| format!("session `{id}` has invalid time_updated"))?,
+        });
+    }
+    Ok(sessions)
+}
+
+fn nonnegative_timestamp(value: i64) -> Result<u64> {
+    u64::try_from(value).map_err(|_| anyhow::anyhow!("negative timestamp"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatabaseCursor {
+    pub event_rowid: i64,
+    pub event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatabaseScan {
+    pub sessions: Vec<OpencodeSession>,
+    pub dirty_session_ids: Vec<String>,
+    pub removed_session_ids: Vec<String>,
+    pub cursor: DatabaseCursor,
+}
+
+fn require_event_schema(connection: &Connection, path: &Path) -> Result<()> {
+    let exists = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'event')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .with_context(|| format!("inspect OpenCode event schema in {}", path.display()))?;
+    if exists == 0 {
+        bail!(
+            "unrecognized OpenCode SQLite schema in {}: missing table `event`",
+            path.display()
+        );
+    }
+
+    let mut statement = connection
+        .prepare("PRAGMA table_info(event)")
+        .with_context(|| format!("inspect OpenCode event table in {}", path.display()))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .with_context(|| format!("read OpenCode event columns in {}", path.display()))?
+        .collect::<rusqlite::Result<HashSet<_>>>()
+        .with_context(|| format!("read OpenCode event columns in {}", path.display()))?;
+    for column in ["id", "aggregate_id"] {
+        if !columns.contains(column) {
+            bail!(
+                "unrecognized OpenCode SQLite schema in {}: `event` lacks `{column}`",
+                path.display()
+            );
+        }
+    }
+    connection
+        .prepare("SELECT rowid, id, aggregate_id FROM event LIMIT 0")
+        .with_context(|| {
+            format!(
+                "OpenCode `event` table in {} does not provide rowid/id/aggregate_id",
+                path.display()
+            )
+        })?;
+    Ok(())
+}
+
+fn current_event_cursor(connection: &Connection, path: &Path) -> Result<DatabaseCursor> {
+    connection
+        .query_row(
+            "SELECT rowid, id FROM event ORDER BY rowid DESC LIMIT 1",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()
+        .with_context(|| format!("read OpenCode event high-water mark in {}", path.display()))
+        .map(|row| match row {
+            Some((event_rowid, event_id)) => DatabaseCursor {
+                event_rowid,
+                event_id: Some(event_id),
+            },
+            None => DatabaseCursor {
+                event_rowid: 0,
+                event_id: None,
+            },
+        })
+}
+
+fn full_reconcile(
+    sessions: &[OpencodeSession],
+    previous: Option<&OpencodeDatabaseState>,
+) -> (Vec<String>, Vec<String>) {
+    let current_ids = sessions
+        .iter()
+        .map(|session| session.id.clone())
+        .collect::<HashSet<_>>();
+    let mut dirty = current_ids.iter().cloned().collect::<Vec<_>>();
+    dirty.sort();
+    let mut removed = previous
+        .into_iter()
+        .flat_map(|state| state.owned_session_ids.iter())
+        .filter(|id| !current_ids.contains(*id))
+        .cloned()
+        .collect::<Vec<_>>();
+    removed.sort();
+    (dirty, removed)
+}
+
+/// Scan the short-lived inventory/event snapshot used to plan database hydration.
+///
+/// The connection is opened and all inventory/event reads are completed before this function
+/// returns.  Hydration must happen afterwards using a separate connection: keeping this read
+/// snapshot open while parsing messages would unnecessarily pin a WAL checkpoint and enlarge the
+/// consistency window.
+pub fn scan_database(
+    path: &Path,
+    previous: Option<&OpencodeDatabaseState>,
+) -> Result<DatabaseScan> {
+    let connection = open_read_only_database(path)?;
+    connection
+        .execute_batch("BEGIN")
+        .with_context(|| format!("begin OpenCode planning snapshot in {}", path.display()))?;
+    // Planning must reject databases that hydration cannot read, so ingest can apply its
+    // per-database fallback consistently.
+    require_modern_schema(&connection, path)?;
+    require_event_schema(&connection, path)?;
+    let sessions = enumerate_sessions_from_connection(&connection, path)?;
+    let cursor = current_event_cursor(&connection, path)?;
+    let (mut dirty, removed) = full_reconcile(&sessions, previous);
+    let current_ids = sessions
+        .iter()
+        .map(|session| session.id.as_str())
+        .collect::<HashSet<_>>();
+
+    let valid_previous = match previous {
+        Some(previous)
+            if previous.parser_version == DATABASE_STATE_VERSION
+                && previous.event_rowid >= 0
+                && cursor.event_rowid >= previous.event_rowid =>
+        {
+            if previous.event_rowid == 0 && previous.event_id.is_none() {
+                true
+            } else if previous.event_rowid > 0 {
+                connection
+                    .query_row(
+                        "SELECT id FROM event WHERE rowid = ?1",
+                        [previous.event_rowid],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .with_context(|| format!("verify OpenCode event cursor in {}", path.display()))?
+                    .is_some_and(|event_id| Some(event_id) == previous.event_id)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    };
+
+    if valid_previous {
+        let mut statement = connection
+            .prepare(
+                "SELECT aggregate_id FROM event
+                 WHERE rowid > ?1 ORDER BY rowid",
+            )
+            .with_context(|| {
+                format!("prepare OpenCode event delta query for {}", path.display())
+            })?;
+        let rows = statement
+            .query_map(
+                [previous.expect("valid previous exists").event_rowid],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .with_context(|| format!("query OpenCode event delta in {}", path.display()))?;
+        let previous = previous.expect("valid previous exists");
+        let mut dirty_ids = current_ids
+            .iter()
+            .filter(|id| !previous.owned_session_ids.contains(**id))
+            .map(|id| (*id).to_string())
+            .collect::<HashSet<_>>();
+        for row in rows {
+            if let Some(session_id) = row?.filter(|id| current_ids.contains(id.as_str())) {
+                dirty_ids.insert(session_id);
+            }
+        }
+        dirty = dirty_ids.into_iter().collect();
+        dirty.sort();
+    }
+
+    let scan = DatabaseScan {
+        sessions,
+        dirty_session_ids: dirty,
+        removed_session_ids: removed,
+        cursor,
+    };
+    connection
+        .execute_batch("COMMIT")
+        .with_context(|| format!("finish OpenCode planning snapshot in {}", path.display()))?;
+    Ok(scan)
+}
+
+enum ModernJson<T> {
+    Valid(T),
+    Malformed,
+}
+
+fn parse_modern_value<T>(
+    data: String,
+    parse: impl FnOnce(&BorrowedValue<'_>) -> Result<T>,
+) -> Result<ModernJson<T>> {
+    let mut bytes = data.into_bytes();
+    let value = match simd_json::to_borrowed_value(&mut bytes) {
+        Ok(value) => value,
+        Err(_) => return Ok(ModernJson::Malformed),
+    };
+    Ok(ModernJson::Valid(parse(&value)?))
 }
 
 #[derive(Clone, Default)]
@@ -103,20 +511,40 @@ fn default_session_links() -> SessionLinks {
 }
 
 pub(crate) fn session_links_by_id() -> HashMap<String, SessionLinks> {
-    session_links_by_id_from_root(&storage_root().join("session"))
+    session_links_by_id_from_roots(&data_roots())
 }
 
+#[allow(dead_code)]
 pub(crate) fn session_links_by_id_from_root(root: &Path) -> HashMap<String, SessionLinks> {
-    let mut links_by_id = HashMap::new();
-    if !root.exists() {
-        return links_by_id;
+    session_links_by_id_from_paths(&[root.to_path_buf()])
+}
+
+pub(crate) fn session_links_by_id_from_roots(roots: &[PathBuf]) -> HashMap<String, SessionLinks> {
+    let storage_roots = roots
+        .iter()
+        .map(|root| root.join("storage/session"))
+        .collect::<Vec<_>>();
+    session_links_by_id_from_paths(&storage_roots)
+}
+
+fn session_links_by_id_from_paths(roots: &[PathBuf]) -> HashMap<String, SessionLinks> {
+    let mut paths = Vec::new();
+    for root in roots {
+        paths.extend(
+            WalkDir::new(root)
+                .into_iter()
+                .flatten()
+                .filter(|entry| {
+                    entry.file_type().is_file()
+                        && entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                })
+                .map(|entry| entry.path().to_path_buf()),
+        );
     }
-    for entry in WalkDir::new(root).into_iter().flatten().filter(|entry| {
-        entry.file_type().is_file()
-            && entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
-    }) {
-        let Some(session_id) = entry
-            .path()
+    paths.sort();
+    let mut links_by_id = HashMap::new();
+    for path in paths {
+        let Some(session_id) = path
             .file_stem()
             .and_then(|stem| stem.to_str())
             .filter(|id| !id.is_empty())
@@ -124,13 +552,15 @@ pub(crate) fn session_links_by_id_from_root(root: &Path) -> HashMap<String, Sess
         else {
             continue;
         };
-        let Ok(mut bytes) = std::fs::read(entry.path()) else {
+        let Ok(mut bytes) = std::fs::read(path) else {
             continue;
         };
         let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
             continue;
         };
-        links_by_id.insert(session_id, session_links_from_value(&value));
+        links_by_id
+            .entry(session_id)
+            .or_insert_with(|| session_links_from_value(&value));
     }
     links_by_id
 }
@@ -206,7 +636,7 @@ pub(crate) fn parse_index_records(
     let project = SourceKind::Opencode.label().to_string();
     let mut turn_id = state.turn_id;
     for (message_id, timestamp, role) in messages {
-        let part_dir = parts_root().join(&message_id);
+        let part_dir = parts_root_for_session(session_dir).join(&message_id);
         if !part_dir.exists() {
             continue;
         }
@@ -262,6 +692,256 @@ pub(crate) fn parse_index_records(
         session_id: Some(session_id),
         diagnostics: Default::default(),
     })
+}
+
+#[derive(Debug)]
+struct ModernMessage {
+    id: String,
+    timestamp: u64,
+    role: String,
+    text_parts: Vec<String>,
+}
+
+/// Project one modern SQLite session into records.  This is kept separate from the legacy
+/// directory parser so the latter's tolerant JSON behavior and discovery semantics remain intact.
+pub(crate) fn parse_database_records(
+    path: &Path,
+    session_id: &str,
+    state: IndexParseState,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let connection = open_read_only_database(path)?;
+    require_modern_schema(&connection, path)?;
+    let Some(session) = enumerate_session_from_connection(&connection, path, session_id)? else {
+        return Ok(IndexParseOutput {
+            offset: 0,
+            turn_id: state.turn_id,
+            pending_tool_calls: state.pending_tool_calls,
+            session_id: Some(session_id.to_string()),
+            diagnostics: Default::default(),
+        });
+    };
+    let links = SessionLinks {
+        parent_session_id: session.parent_id.clone(),
+        thread_source: session.parent_id.as_ref().map(|_| "fork".to_string()),
+        conversation_kind: Some(if session.parent_id.is_some() {
+            "fork".to_string()
+        } else {
+            "main".to_string()
+        }),
+    };
+
+    let mut statement = connection
+        .prepare(
+            "SELECT m.id, m.time_created, m.data, p.id, p.data
+             FROM message AS m
+             JOIN part AS p ON p.message_id = m.id
+             WHERE m.session_id = ?1
+             ORDER BY m.time_created, m.id, p.id",
+        )
+        .with_context(|| format!("prepare OpenCode message query for {}", path.display()))?;
+    let rows = statement
+        .query_map(params![session_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .with_context(|| format!("query OpenCode messages in {}", path.display()))?;
+
+    let mut current: Option<ModernMessage> = None;
+    let mut malformed_message_ids = HashSet::new();
+    let mut turn_id = state.turn_id;
+    let mut diagnostics = ParseDiagnostics::default();
+    for row in rows {
+        let (message_id, timestamp, message_data, _part_id, part_data) = row?;
+        if current
+            .as_ref()
+            .is_some_and(|message| message.id != message_id)
+            && let Some(message) = current.take()
+        {
+            emit_modern_message(
+                message,
+                session_id,
+                path,
+                &links,
+                &mut turn_id,
+                next_doc_id,
+                &mut emit,
+            )?;
+        }
+        if current.is_none() {
+            if malformed_message_ids.contains(&message_id) {
+                continue;
+            }
+            let timestamp = nonnegative_timestamp(timestamp)
+                .with_context(|| format!("message `{message_id}` has invalid time_created"))?;
+            let role = match parse_modern_value(message_data, |value| {
+                Ok(value
+                    .get("role")
+                    .and_then(|role| role.as_str())
+                    .filter(|role| !role.is_empty())
+                    .unwrap_or("user")
+                    .to_string())
+            })? {
+                ModernJson::Valid(role) => role,
+                ModernJson::Malformed => {
+                    diagnostics.malformed_json_lines += 1;
+                    malformed_message_ids.insert(message_id);
+                    continue;
+                }
+            };
+            current = Some(ModernMessage {
+                id: message_id.clone(),
+                timestamp,
+                role,
+                text_parts: Vec::new(),
+            });
+        }
+        let text = match parse_modern_value(part_data, |value| {
+            if value.get("type").and_then(|kind| kind.as_str()) != Some("text") {
+                return Ok(None);
+            }
+            Ok(value
+                .get("text")
+                .and_then(|text| text.as_str())
+                .filter(|text| !text.is_empty())
+                .map(str::to_string))
+        })? {
+            ModernJson::Valid(text) => text,
+            ModernJson::Malformed => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
+        };
+        let Some(text) = text else { continue };
+        current
+            .as_mut()
+            .expect("current message was initialized")
+            .text_parts
+            .push(text);
+    }
+    if let Some(message) = current {
+        emit_modern_message(
+            message,
+            session_id,
+            path,
+            &links,
+            &mut turn_id,
+            next_doc_id,
+            &mut emit,
+        )?;
+    }
+    Ok(IndexParseOutput {
+        offset: 0,
+        turn_id,
+        pending_tool_calls: state.pending_tool_calls,
+        session_id: Some(session_id.to_string()),
+        diagnostics,
+    })
+}
+
+fn enumerate_session_from_connection(
+    connection: &Connection,
+    path: &Path,
+    session_id: &str,
+) -> Result<Option<OpencodeSession>> {
+    let row = connection
+        .query_row(
+            "SELECT id, parent_id, directory, time_created, time_updated
+             FROM session WHERE id = ?1",
+            [session_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .with_context(|| {
+            format!(
+                "look up OpenCode session `{session_id}` in {}",
+                path.display()
+            )
+        })?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let (id, parent_id, directory, time_created, time_updated) = row;
+    Ok(Some(OpencodeSession {
+        id,
+        parent_id,
+        directory,
+        time_created: nonnegative_timestamp(time_created)
+            .with_context(|| format!("session `{session_id}` has invalid time_created"))?,
+        time_updated: nonnegative_timestamp(time_updated)
+            .with_context(|| format!("session `{session_id}` has invalid time_updated"))?,
+    }))
+}
+
+fn emit_modern_message(
+    message: ModernMessage,
+    session_id: &str,
+    path: &Path,
+    links: &SessionLinks,
+    turn_id: &mut u32,
+    next_doc_id: &AtomicU64,
+    emit: &mut impl FnMut(Record) -> Result<()>,
+) -> Result<()> {
+    if message.text_parts.is_empty() {
+        return Ok(());
+    }
+    let mut record_links = links.record_links();
+    record_links.event_id = Some(message.id);
+    emit(Record {
+        source: SourceKind::Opencode,
+        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+        ts: message.timestamp,
+        project: "opencode".to_string(),
+        session_id: session_id.to_string(),
+        turn_id: *turn_id,
+        role: message.role,
+        text: message.text_parts.join("\n"),
+        tool_name: None,
+        tool_input: None,
+        tool_output: None,
+        links: record_links,
+        source_path: path.to_string_lossy().to_string(),
+    })?;
+    *turn_id = turn_id.saturating_add(1);
+    Ok(())
+}
+
+/// Convenience wrapper for callers that want owned records rather than a streaming callback.
+pub fn parse_database_session(
+    path: &Path,
+    session_id: &str,
+    starting_turn_id: u32,
+    next_doc_id: &AtomicU64,
+) -> Result<Vec<Record>> {
+    let mut records = Vec::new();
+    parse_database_records(
+        path,
+        session_id,
+        IndexParseState {
+            turn_id: starting_turn_id,
+            ..IndexParseState::default()
+        },
+        next_doc_id,
+        |record| {
+            records.push(record);
+            Ok(())
+        },
+    )?;
+    Ok(records)
 }
 
 /// Databases precede message files so duplicate reconciliation retains the database copy,
@@ -327,11 +1007,7 @@ fn parse_usage_message(path: &Path) -> Result<Vec<UsageEvent>> {
 }
 
 fn parse_usage_database(path: &Path) -> Result<Vec<UsageEvent>> {
-    let connection = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )?;
-    connection.busy_timeout(Duration::from_secs(1))?;
+    let connection = open_read_only_database(path)?;
     let mut statement = connection.prepare("SELECT id, session_id, data FROM message")?;
     let rows = statement.query_map([], |row| {
         Ok((
@@ -456,6 +1132,46 @@ pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
+    use std::fs;
+    use std::sync::atomic::AtomicU64;
+
+    fn modern_fixture(path: &Path) -> Connection {
+        let connection = Connection::open(path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE session (
+                    id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT NOT NULL,
+                    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL
+                );
+                 CREATE TABLE message (
+                    id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+                    time_created INTEGER NOT NULL, data TEXT NOT NULL
+                 );
+                 CREATE TABLE part (
+                    id TEXT PRIMARY KEY, message_id TEXT NOT NULL, data TEXT NOT NULL
+                 );
+                 CREATE TABLE event (
+                    id TEXT NOT NULL, aggregate_id TEXT NOT NULL
+                 );
+                 CREATE INDEX message_session_time ON message(session_id, time_created, id);
+                 CREATE INDEX part_message_id ON part(message_id, id);",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO session VALUES (?1, NULL, ?2, ?3, ?4)",
+                params!["s_root", "/repo", 10_i64, 20_i64],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO session VALUES (?1, ?2, ?3, ?4, ?5)",
+                params!["s_child", "s_root", "/repo/child", 30_i64, 40_i64],
+            )
+            .unwrap();
+        connection
+    }
 
     #[test]
     fn reasoning_is_included_in_output_and_total() {
@@ -481,5 +1197,444 @@ mod tests {
         assert_eq!(events[0].tokens.output, 50);
         assert_eq!(events[0].tokens.total(), 200);
         assert_eq!(events[0].project.as_deref(), Some("opencode"));
+    }
+
+    #[test]
+    fn modern_inventory_and_projection_are_deterministic() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, ?2, ?3, ?4)",
+                params!["m_b", "s_child", 100_i64, r#"{}"#],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, ?2, ?3, ?4)",
+                params!["m_a", "s_child", 100_i64, r#"{"role":"assistant"}"#],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO message VALUES (?1, ?2, ?3, ?4)",
+                params!["m_empty", "s_child", 101_i64, r#"{"role":"assistant"}"#],
+            )
+            .unwrap();
+        // Part ordering is by id, not insertion order. Non-text parts are ignored.
+        for (id, message, data) in [
+            ("p_z", "m_a", r#"{"type":"text","text":"second"}"#),
+            ("p_a", "m_a", r#"{"type":"image","text":"not emitted"}"#),
+            ("p_b", "m_a", r#"{"type":"text","text":"first"}"#),
+            ("p_c", "m_b", r#"{"type":"text","text":"user fallback"}"#),
+            ("p_d", "m_empty", r#"{"type":"tool","text":"ignored"}"#),
+        ] {
+            connection
+                .execute(
+                    "INSERT INTO part VALUES (?1, ?2, ?3)",
+                    params![id, message, data],
+                )
+                .unwrap();
+        }
+        drop(connection);
+
+        let sessions = enumerate_sessions(&path).unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id, "s_child");
+        assert_eq!(sessions[0].parent_id.as_deref(), Some("s_root"));
+        assert_eq!(sessions[0].directory, "/repo/child");
+        assert_eq!(
+            (sessions[0].time_created, sessions[0].time_updated),
+            (30, 40)
+        );
+
+        let records = parse_database_session(&path, "s_child", 7, &AtomicU64::new(11)).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].links.event_id.as_deref(), Some("m_a"));
+        assert_eq!(records[0].text, "first\nsecond");
+        assert_eq!(records[0].turn_id, 7);
+        assert_eq!(records[1].links.event_id.as_deref(), Some("m_b"));
+        assert_eq!(records[1].role, "user");
+        assert_eq!(records[1].turn_id, 8);
+        assert_eq!(
+            records[0].links.parent_session_id.as_deref(),
+            Some("s_root")
+        );
+        assert_eq!(records[0].source, SourceKind::Opencode);
+        assert_eq!(records[0].source_path, path.to_string_lossy());
+        assert_eq!(records[0].project, "opencode");
+        assert_eq!(records[0].ts, 100);
+    }
+
+    #[test]
+    fn database_plan_rejects_incomplete_hydration_schema() {
+        for (mutation, expected) in [
+            ("DROP TABLE message", "message"),
+            ("DROP TABLE part", "part"),
+            (
+                "ALTER TABLE message RENAME TO message_old;
+                 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER)",
+                "message",
+            ),
+            (
+                "ALTER TABLE part RENAME TO part_old;
+                 CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT)",
+                "part",
+            ),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("opencode.db");
+            let connection = modern_fixture(&path);
+            connection.execute_batch(mutation).unwrap();
+            drop(connection);
+
+            let error =
+                scan_database(&path, None).expect_err("incomplete schema must fail planning");
+            assert!(error.to_string().contains(expected));
+        }
+    }
+
+    #[test]
+    fn malformed_database_json_isolated_with_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+        connection
+            .execute_batch(
+                "INSERT INTO message VALUES
+                    ('m_bad', 's_child', 50, '{bad json'),
+                    ('m_good', 's_child', 60, '{\"role\":\"assistant\"}'),
+                    ('m_last', 's_child', 70, '{\"role\":\"user\"}');
+                 INSERT INTO part VALUES
+                    ('p_bad_message', 'm_bad', '{\"type\":\"text\",\"text\":\"ignored\"}'),
+                    ('p_bad_part', 'm_good', '{bad json'),
+                    ('p_good_part', 'm_good', '{\"type\":\"text\",\"text\":\"valid sibling\"}'),
+                    ('p_last', 'm_last', '{\"type\":\"text\",\"text\":\"after\"}');",
+            )
+            .unwrap();
+        drop(connection);
+
+        let mut records = Vec::new();
+        let output = parse_database_records(
+            &path,
+            "s_child",
+            IndexParseState::default(),
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(output.diagnostics.malformed_json_lines, 2);
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["valid sibling", "after"]
+        );
+        assert_eq!(records[0].turn_id, 0);
+        assert_eq!(records[1].turn_id, 1);
+    }
+
+    #[test]
+    fn database_plan_handles_initial_noop_events_removals_and_cursor_reset() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+
+        let initial = scan_database(&path, None).unwrap();
+        assert_eq!(initial.dirty_session_ids, vec!["s_child", "s_root"]);
+        assert!(initial.removed_session_ids.is_empty());
+        assert_eq!(initial.cursor.event_rowid, 0);
+        let initial_state = OpencodeDatabaseState {
+            parser_version: DATABASE_STATE_VERSION,
+            event_rowid: initial.cursor.event_rowid,
+            event_id: initial.cursor.event_id.clone(),
+            owned_session_ids: initial.sessions.iter().map(|s| s.id.clone()).collect(),
+        };
+        let noop = scan_database(&path, Some(&initial_state)).unwrap();
+        assert!(noop.dirty_session_ids.is_empty());
+        assert!(noop.removed_session_ids.is_empty());
+
+        connection
+            .execute(
+                "INSERT INTO event (id, aggregate_id) VALUES (?1, ?2)",
+                params!["event-1", "s_child"],
+            )
+            .unwrap();
+        let event_scan = scan_database(&path, Some(&initial_state)).unwrap();
+        assert_eq!(event_scan.dirty_session_ids, vec!["s_child"]);
+        assert_eq!(event_scan.cursor.event_id.as_deref(), Some("event-1"));
+        let event_state = OpencodeDatabaseState {
+            parser_version: DATABASE_STATE_VERSION,
+            event_rowid: event_scan.cursor.event_rowid,
+            event_id: event_scan.cursor.event_id.clone(),
+            owned_session_ids: event_scan.sessions.iter().map(|s| s.id.clone()).collect(),
+        };
+
+        connection
+            .execute("DELETE FROM session WHERE id = 's_root'", [])
+            .unwrap();
+        let removed = scan_database(&path, Some(&event_state)).unwrap();
+        assert!(removed.dirty_session_ids.is_empty());
+        assert_eq!(removed.removed_session_ids, vec!["s_root"]);
+
+        connection
+            .execute("UPDATE event SET id = 'event-replaced'", [])
+            .unwrap();
+        let sentinel_reset = scan_database(&path, Some(&event_state)).unwrap();
+        assert_eq!(sentinel_reset.dirty_session_ids, vec!["s_child"]);
+        assert_eq!(
+            sentinel_reset.cursor.event_id.as_deref(),
+            Some("event-replaced")
+        );
+
+        connection.execute("DELETE FROM event", []).unwrap();
+        let regression = scan_database(&path, Some(&event_state)).unwrap();
+        assert_eq!(regression.dirty_session_ids, vec!["s_child"]);
+    }
+
+    #[test]
+    fn newly_inventoried_session_is_dirty_without_a_new_event() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+        drop(connection);
+
+        let initial = scan_database(&path, None).unwrap();
+        let previous = OpencodeDatabaseState {
+            parser_version: DATABASE_STATE_VERSION,
+            event_rowid: initial.cursor.event_rowid,
+            event_id: initial.cursor.event_id,
+            owned_session_ids: initial
+                .sessions
+                .iter()
+                .map(|session| session.id.clone())
+                .collect(),
+        };
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO session VALUES (?1, NULL, ?2, ?3, ?4)",
+                params!["s_new", "/repo/new", 50_i64, 60_i64],
+            )
+            .unwrap();
+        drop(connection);
+
+        let scan = scan_database(&path, Some(&previous)).unwrap();
+        assert_eq!(scan.dirty_session_ids, vec!["s_new"]);
+    }
+
+    #[test]
+    fn production_indexes_are_used_by_message_and_part_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+        let mut statement = connection
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT m.id, p.id FROM message AS m
+                 JOIN part AS p ON p.message_id = m.id
+                 WHERE m.session_id = 's_child'
+                 ORDER BY m.time_created, m.id, p.id",
+            )
+            .unwrap();
+        let details = statement
+            .query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect::<Vec<_>>();
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("message_session_time"))
+        );
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("part_message_id"))
+        );
+    }
+
+    #[test]
+    fn deleted_session_during_hydration_is_a_nonfatal_empty_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = modern_fixture(&path);
+        drop(connection);
+
+        let output = parse_database_records(
+            &path,
+            "deleted-before-hydration",
+            IndexParseState {
+                turn_id: 23,
+                ..IndexParseState::default()
+            },
+            &AtomicU64::new(1),
+            |_| Ok(()),
+        )
+        .unwrap();
+        assert_eq!(output.turn_id, 23);
+        assert_eq!(
+            output.session_id.as_deref(),
+            Some("deleted-before-hydration")
+        );
+    }
+
+    #[test]
+    fn database_discovery_covers_all_roots_and_legacy_paths_stay_classified() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+        fs::write(first.join("opencode.db"), []).unwrap();
+        fs::write(second.join("opencode-work.db"), []).unwrap();
+        fs::write(second.join("other.db"), []).unwrap();
+        let databases = discover_databases_from_roots(&[second.clone(), first.clone()]).unwrap();
+        assert_eq!(
+            databases
+                .iter()
+                .map(|file| file.path.clone())
+                .collect::<Vec<_>>(),
+            vec![first.join("opencode.db"), second.join("opencode-work.db")]
+        );
+
+        let message_root = temp.path().join("opencode/storage/message");
+        fs::create_dir_all(message_root.join("ses_legacy")).unwrap();
+        let legacy = message_root.join("ses_legacy/msg.json");
+        fs::write(&legacy, "{}").unwrap();
+        assert_eq!(discover_sessions_from_root(&message_root).unwrap().len(), 1);
+        assert_eq!(
+            crate::sources::classify_path(&legacy.to_string_lossy()),
+            SourceKind::Opencode
+        );
+        assert!(matches_path(&first.join("opencode.db").to_string_lossy()));
+    }
+
+    #[test]
+    fn legacy_sessions_and_parts_are_discovered_per_data_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let root_a = temp.path().join("a");
+        let root_b = temp.path().join("b");
+        for (root, session, message, text) in [
+            (&root_a, "ses_a", "msg_a", "from a"),
+            (&root_b, "ses_b", "msg_b", "from b"),
+        ] {
+            let session_dir = root.join("storage/message").join(session);
+            let part_dir = root.join("storage/part").join(message);
+            fs::create_dir_all(&session_dir).unwrap();
+            fs::create_dir_all(&part_dir).unwrap();
+            fs::write(
+                session_dir.join(format!("{message}.json")),
+                format!(r#"{{"id":"{message}","role":"user","time":{{"created":1}}}}"#),
+            )
+            .unwrap();
+            fs::write(
+                part_dir.join("part.json"),
+                format!(r#"{{"text":"{text}"}}"#),
+            )
+            .unwrap();
+            let session_meta = root.join("storage/session");
+            fs::create_dir_all(&session_meta).unwrap();
+            fs::write(
+                session_meta.join(format!("{session}.json")),
+                if session == "ses_b" {
+                    r#"{"parentID":"ses_a"}"#
+                } else {
+                    r#"{}"#
+                },
+            )
+            .unwrap();
+        }
+
+        let sessions = discover_sessions_from_roots(&[root_b.clone(), root_a.clone()]).unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert!(sessions[0].path.starts_with(&root_a));
+        assert!(sessions[1].path.starts_with(&root_b));
+        let links = session_links_by_id_from_roots(&[root_b.clone(), root_a.clone()]);
+        assert_eq!(links.len(), 2);
+        assert_eq!(links["ses_b"].parent_session_id.as_deref(), Some("ses_a"));
+        let mut records = Vec::new();
+        for session in sessions {
+            parse_index_records(
+                &session.path,
+                IndexParseState::default(),
+                &HashMap::new(),
+                &AtomicU64::new(1),
+                |record| {
+                    records.push(record);
+                    Ok(())
+                },
+            )
+            .unwrap();
+        }
+        records.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["from a", "from b"]
+        );
+    }
+
+    #[test]
+    fn read_only_reader_sees_committed_wal_data() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let writer = Connection::open(&path).unwrap();
+        writer
+            .execute_batch(
+                "PRAGMA journal_mode = WAL;
+                 PRAGMA wal_autocheckpoint = 0;
+                 CREATE TABLE session (
+                    id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT,
+                    time_created INTEGER, time_updated INTEGER
+                 );
+                 CREATE TABLE message (
+                    id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+                 );
+                 CREATE TABLE part (
+                    id TEXT PRIMARY KEY, message_id TEXT, data TEXT
+                 );
+                 CREATE TABLE event (
+                    id TEXT NOT NULL, aggregate_id TEXT NOT NULL
+                 );
+                 CREATE INDEX message_session_time ON message(session_id, time_created, id);
+                 CREATE INDEX part_message_id ON part(message_id, id);
+                 INSERT INTO session VALUES ('wal', NULL, '/wal', 1, 2);
+                 INSERT INTO message VALUES ('wal-msg', 'wal', 3, '{\"role\":\"assistant\"}');
+                 INSERT INTO part VALUES ('wal-part', 'wal-msg', '{\"type\":\"text\",\"text\":\"visible\"}');
+                 INSERT INTO event VALUES ('wal-event-1', 'wal');",
+            )
+            .unwrap();
+        let sessions = enumerate_sessions(&path).unwrap();
+        assert_eq!(sessions[0].id, "wal");
+        let initial = scan_database(&path, None).unwrap();
+        let previous = OpencodeDatabaseState {
+            parser_version: DATABASE_STATE_VERSION,
+            event_rowid: initial.cursor.event_rowid,
+            event_id: initial.cursor.event_id.clone(),
+            owned_session_ids: initial.sessions.iter().map(|s| s.id.clone()).collect(),
+        };
+        writer
+            .execute_batch(
+                "BEGIN;
+                 UPDATE part SET data = '{\"type\":\"text\",\"text\":\"changed while open\"}'
+                   WHERE id = 'wal-part';
+                 INSERT INTO event VALUES ('wal-event-2', 'wal');
+                 COMMIT;",
+            )
+            .unwrap();
+        let delta = scan_database(&path, Some(&previous)).unwrap();
+        assert_eq!(delta.dirty_session_ids, vec!["wal"]);
+        let records = parse_database_session(&path, "wal", 0, &AtomicU64::new(0)).unwrap();
+        assert_eq!(records[0].text, "changed while open");
+        drop(writer);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -110,10 +110,27 @@ impl ScanCache {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpencodeDatabaseState {
+    pub parser_version: u32,
+    pub event_rowid: i64,
+    pub event_id: Option<String>,
+    pub owned_session_ids: HashSet<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IngestState {
     pub next_doc_id: u64,
     pub files: HashMap<String, FileState>,
+    #[serde(default)]
+    pub opencode_databases: HashMap<String, OpencodeDatabaseState>,
+}
+
+/// A precise source/session target for replacement and deletion work.
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionScope {
+    pub source_path: String,
+    pub session_id: String,
 }
 
 /// Durable intent for an ingest batch that may have crossed one publication boundary.
@@ -125,6 +142,8 @@ pub struct PendingIngest {
     pub next_doc_id: u64,
     pub source_paths: Vec<String>,
     #[serde(default)]
+    pub session_scopes: Vec<SessionScope>,
+    #[serde(default)]
     pub vector_publication: bool,
 }
 
@@ -133,6 +152,7 @@ impl Default for IngestState {
         Self {
             next_doc_id: 1,
             files: HashMap::new(),
+            opencode_databases: HashMap::new(),
         }
     }
 }
@@ -222,6 +242,7 @@ mod tests {
         let state = IngestState {
             next_doc_id: 42,
             files: HashMap::new(),
+            opencode_databases: HashMap::new(),
         };
         state.save(&path).expect("save state");
 
@@ -272,6 +293,7 @@ mod tests {
         let pending = PendingIngest {
             next_doc_id: 17,
             source_paths: vec!["session.jsonl".to_string()],
+            session_scopes: Vec::new(),
             vector_publication: true,
         };
 
@@ -296,5 +318,25 @@ mod tests {
                 .expect("load legacy pending ingest");
 
         assert!(!pending.vector_publication);
+    }
+
+    #[test]
+    fn ingest_state_without_opencode_databases_remains_compatible() {
+        let state: IngestState =
+            serde_json::from_str(r#"{"next_doc_id":9,"files":{}}"#).expect("legacy state");
+        assert_eq!(state.next_doc_id, 9);
+        assert!(state.opencode_databases.is_empty());
+
+        let database = OpencodeDatabaseState {
+            parser_version: 1,
+            event_rowid: 12,
+            event_id: Some("event".to_string()),
+            owned_session_ids: HashSet::from(["session".to_string()]),
+        };
+        let round_trip = serde_json::to_string(&database).expect("serialize database state");
+        assert_eq!(
+            serde_json::from_str::<OpencodeDatabaseState>(&round_trip).unwrap(),
+            database
+        );
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -340,6 +340,15 @@ impl VectorIndex {
         Ok(())
     }
 
+    pub(crate) fn remove_doc_ids(&mut self, doc_ids: &HashSet<u64>) -> Result<()> {
+        for doc_id in doc_ids {
+            if self.doc_id_set.remove(doc_id) {
+                self.index.remove(*doc_id)?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn exists(dir: &Path) -> bool {
         dir.join(CURRENT_GENERATION_FILE).exists() || dir.join("usearch.index").exists()
     }


### PR DESCRIPTION
## Summary
- Discover modern OpenCode SQLite transcript databases alongside legacy JSON storage.
- Read SQLite in WAL-aware, query-only mode and incrementally replace affected sessions.
- Preserve existing indexed data through transient database failures and recover safely from interrupted publication.
- Capture OpenCode session directories for analytics and document automatic discovery plus `OPENCODE_DATA_DIR`.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release`

The feature is included in the next packaged release; end users do not need to run Cargo.