### PR TITLE
Support Jcode, Muse, and OpenCode SQLite database sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memex
 
-Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, GitHub Copilot CLI, and Grok. Also supports Hermes usage records. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
+Fast local history search for Claude, Codex CLI, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, GitHub Copilot CLI, Grok, Jcode, and Muse. Also supports Hermes usage records. Uses BM-25 and optionally embeds your transcripts locally for hybrid search.
 
 Mostly intended for agents to use via skill. The intended workflow is to ask agent about a previous session & then the agent can narrow things down & retrieve history as needed.
 
@@ -258,7 +258,7 @@ Token tracking is disabled by default because it scans and caches local agent lo
 token_usage = true
 ```
 
-Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, and Hermes records:
+Then reconstruct historical token usage from local Claude Code, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, Hermes, Jcode, and Muse records:
 
 ```
 memex usage
@@ -316,7 +316,7 @@ Omit `--target` for an interactive menu of detected Claude/Codex/OpenCode/Pi/Oh 
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|grok|hermes`
+- `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|grok|hermes|jcode|muse`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--limit <n>`
 - `--min-score <float>`
@@ -507,6 +507,8 @@ opencode_resume_cmd = "opencode resume {session_id}"
 pi_resume_cmd = "pi --session {source_path_shell}"
 # copilot_resume_cmd = "your-copilot-resume-command {session_id}"
 grok_resume_cmd = "cd {cwd_shell} && grok --resume {session_id}"
+jcode_resume_cmd = "cd {cwd_shell} && jcode --resume {session_id}"
+muse_resume_cmd = "cd {cwd_shell} && muse resume {session_id}"
 herdr_resume = "tab"  # inside a herdr pane: "tab" (default), "split", or "off"
 ```
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # memex as a herdr plugin: a session desk for your agent history.
 #
 # memex indexes the transcripts every coding agent on this machine leaves behind (Claude Code,
-# Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot). Inside herdr it becomes a native
+# Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, Jcode, Muse). Inside herdr it becomes a native
 # pane: browse and search past sessions, then resume one straight into a new herdr tab.
 #
 # The version here must match Cargo.toml — herdr/install.sh downloads the release tarball tagged

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -399,7 +399,7 @@ Useful filters and controls:
 - `--role <user|assistant|tool_use|tool_result>`
 - `--tool <tool_name>`
 - `--session <session_id>`
-- `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|grok|hermes`
+- `--source claude|codex|cursor|opencode|pi|omp|openclaw|copilot|grok|hermes|jcode|muse`
 - `--since <iso|unix>` / `--until <iso|unix>`
 - `--machine <id>` (repeatable)
 - `--query <query>` (repeatable additional query view, fused with the positional query)

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1494,7 +1494,8 @@ mod tests {
         fs::write(
             &transcript,
             format!(
-                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                "{{\"cwd\":\"{}\",\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                repo.display(),
                 repo.display()
             ),
         )

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1019,6 +1019,16 @@ fn resolve_session_cwd_from_parts(
     {
         return Some(cwd);
     }
+    if source == SourceKind::Jcode
+        && let Some(cwd) = crate::sources::jcode::cwd_from_jcode_session(Path::new(source_path))
+    {
+        return Some(cwd.to_string_lossy().to_string());
+    }
+    if source == SourceKind::Muse
+        && let Some(cwd) = crate::sources::muse::cwd_from_muse_session(Path::new(source_path))
+    {
+        return Some(cwd.to_string_lossy().to_string());
+    }
     let file = std::fs::File::open(source_path).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut fallback: Option<String> = None;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ static TRACE_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[command(
     name = "memex",
     version,
-    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, and Hermes",
+    about = "Fast local history search for Claude, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, Hermes, Jcode, and Muse",
     after_help = "\
 QUICK START:
     memex                           # Browse sessions interactively
@@ -118,6 +118,18 @@ struct IndexArgs {
     /// Skip indexing Grok sessions
     #[arg(long = "no-grok", default_value_t = false)]
     no_grok: bool,
+    /// Index Jcode sessions from ~/.jcode/sessions [default: true]
+    #[arg(long, default_value_t = true)]
+    jcode: bool,
+    /// Skip indexing Jcode sessions
+    #[arg(long = "no-jcode", default_value_t = false)]
+    no_jcode: bool,
+    /// Index Muse sessions from ~/.local/share/muse/sessions [default: true]
+    #[arg(long, default_value_t = true)]
+    muse: bool,
+    /// Skip indexing Muse sessions
+    #[arg(long = "no-muse", default_value_t = false)]
+    no_muse: bool,
     /// Generate embeddings for semantic search during indexing
     #[arg(long)]
     embeddings: bool,
@@ -143,7 +155,7 @@ struct IndexArgs {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Index Claude, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, and Grok conversation history
+    /// Index Claude, Codex, Cursor, OpenCode, Pi, Oh My Pi, OpenClaw, Copilot, Grok, Jcode, and Muse conversation history
     #[command(after_help = "\
 EXAMPLES:
     memex index                         # Index all supported local history
@@ -231,7 +243,7 @@ OUTPUT FIELDS (--fields):
         /// Filter by session ID
         #[arg(long)]
         session: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, or hermes
+        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, hermes, jcode, or muse
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Use semantic (embedding-based) search instead of keyword search
@@ -432,7 +444,7 @@ EXAMPLES:
         /// Filter by project (repository grouping)
         #[arg(long)]
         project: Option<String>,
-        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, or hermes
+        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, hermes, jcode, or muse
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include sessions active on or after this date/timestamp
@@ -467,7 +479,7 @@ EXAMPLES:
     memex usage --source codex --since 2026-07-01
     memex usage --json")]
     Usage {
-        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, or hermes
+        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, hermes, jcode, or muse
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Only include events on or after this date/timestamp
@@ -631,7 +643,7 @@ enum HerdrCommand {
         /// Refuse when no resumable session exists in --cwd instead of using another project
         #[arg(long)]
         strict_cwd: bool,
-        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, or hermes
+        /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, hermes, jcode, or muse
         #[arg(long)]
         source: Option<SourceFilter>,
         /// Path to memex data directory [default: ~/.memex]
@@ -1184,6 +1196,8 @@ fn run_index_args(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<
         index.openclaw && !index.no_openclaw,
         index.copilot && !index.no_copilot,
         index.grok && !index.no_grok,
+        index.jcode && !index.no_jcode,
+        index.muse && !index.no_muse,
         index.embeddings,
         index.no_embeddings,
         index.model.clone(),
@@ -1208,6 +1222,8 @@ fn run_index(
     openclaw: bool,
     copilot: bool,
     grok: bool,
+    jcode: bool,
+    muse: bool,
     embeddings_flag: bool,
     no_embeddings: bool,
     model: Option<String>,
@@ -1260,6 +1276,8 @@ fn run_index(
         include_openclaw: openclaw,
         include_copilot: copilot,
         include_grok: grok,
+        include_jcode: jcode,
+        include_muse: muse,
         exclude_patterns: excludes,
         embeddings,
         backfill_embeddings: false,
@@ -1410,7 +1428,7 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
     vector.save()?;
     progress.finish();
     println!(
-        "embedded {} vectors (claude {}, codex {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {})",
+        "embedded {} vectors (claude {}, codex {}, opencode {}, cursor {}, pi {}, openclaw {}, copilot {}, jcode {}, muse {}, grok {})",
         embedded_total,
         embedded_counts[crate::types::SourceKind::Claude.idx()],
         embedded_counts[crate::types::SourceKind::Codex.idx()],
@@ -1419,6 +1437,9 @@ fn run_embed(model: Option<String>, root: Option<PathBuf>) -> Result<()> {
         embedded_counts[crate::types::SourceKind::Pi.idx()],
         embedded_counts[crate::types::SourceKind::OpenClaw.idx()],
         embedded_counts[crate::types::SourceKind::Copilot.idx()],
+        embedded_counts[crate::types::SourceKind::Jcode.idx()],
+        embedded_counts[crate::types::SourceKind::Muse.idx()],
+        embedded_counts[crate::types::SourceKind::Grok.idx()],
     );
 
     std::io::stdout().flush().ok();
@@ -3122,6 +3143,8 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Grok => "grok",
         crate::types::SourceKind::Omp => "omp",
         crate::types::SourceKind::Hermes => "hermes",
+        crate::types::SourceKind::Jcode => "jcode",
+        crate::types::SourceKind::Muse => "muse",
     };
     let source_path = &record.source_path;
 
@@ -4142,6 +4165,12 @@ fn build_index_command_args(
     if !index.grok || index.no_grok {
         args.push("--no-grok".to_string());
     }
+    if !index.jcode || index.no_jcode {
+        args.push("--no-jcode".to_string());
+    }
+    if !index.muse || index.no_muse {
+        args.push("--no-muse".to_string());
+    }
     if index.embeddings {
         args.push("--embeddings".to_string());
     }
@@ -4838,6 +4867,8 @@ mod tests {
             openclaw: false,
             copilot: false,
             grok: false,
+            jcode: false,
+            muse: false,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -4845,6 +4876,8 @@ mod tests {
             no_openclaw: false,
             no_copilot: false,
             no_grok: false,
+            no_jcode: false,
+            no_muse: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -4862,6 +4895,8 @@ mod tests {
         assert!(args.contains(&"--no-omp".to_string()));
         assert!(args.contains(&"--no-copilot".to_string()));
         assert!(args.contains(&"--no-grok".to_string()));
+        assert!(args.contains(&"--no-jcode".to_string()));
+        assert!(args.contains(&"--no-muse".to_string()));
     }
 
     #[test]
@@ -4879,6 +4914,8 @@ mod tests {
             openclaw: true,
             copilot: true,
             grok: true,
+            jcode: true,
+            muse: true,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -4886,6 +4923,8 @@ mod tests {
             no_openclaw: false,
             no_copilot: false,
             no_grok: false,
+            no_jcode: false,
+            no_muse: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -4916,6 +4955,8 @@ mod tests {
             openclaw: true,
             copilot: true,
             grok: true,
+            jcode: true,
+            muse: true,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -4923,6 +4964,8 @@ mod tests {
             no_openclaw: false,
             no_copilot: false,
             no_grok: false,
+            no_jcode: false,
+            no_muse: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -5184,6 +5227,8 @@ arguments = {
             "--no-pi",
             "--no-copilot",
             "--no-grok",
+            "--no-jcode",
+            "--no-muse",
         ])
         .unwrap();
 
@@ -5195,6 +5240,8 @@ arguments = {
         assert!(index.no_pi);
         assert!(index.no_copilot);
         assert!(index.no_grok);
+        assert!(index.no_jcode);
+        assert!(index.no_muse);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,10 @@ pub struct UserConfig {
     pub omp_resume_cmd: Option<String>,
     /// Resume command template for GitHub Copilot CLI sessions.
     pub copilot_resume_cmd: Option<String>,
+    /// Resume command template for Jcode sessions.
+    pub jcode_resume_cmd: Option<String>,
+    /// Resume command template for Muse sessions.
+    pub muse_resume_cmd: Option<String>,
     /// Resume command template for Grok sessions.
     pub grok_resume_cmd: Option<String>,
     /// How resume behaves inside a herdr pane: "tab" (default), "split", or "off".

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -240,6 +240,13 @@ fn prepare_file_task(
             previous.pending_tool_calls.clone(),
             true,
         ),
+        // Jcode sessions are whole JSON documents, not appendable JSONL: any change
+        // must delete existing records and re-index from scratch, otherwise the
+        // parser (which replays the full messages array) would duplicate history.
+        Some(previous) if source == SourceKind::Jcode => {
+            let _ = previous;
+            (0, 0, true, HashMap::new(), false)
+        }
         Some(previous) => (
             previous.offset,
             previous.turn_id,
@@ -4344,6 +4351,39 @@ mod tests {
                 .and_then(|call| call.tool_name.as_deref()),
             Some("Read")
         );
+    }
+
+    #[test]
+    fn jcode_append_forces_whole_file_replacement() {
+        use std::io::Write;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("session_test.json");
+        fs::write(&path, r#"{"id":"s1","messages":[]}"#).expect("write session");
+        let metadata = path.metadata().expect("session metadata");
+        let (first, _) = prepare_file_task(path.clone(), SourceKind::Jcode, false, &metadata, None);
+        let previous =
+            completed_file_state(&first, metadata.len(), 1, first.pending_tool_calls.clone());
+
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(br#", "appended": true}"#)
+            .expect("append");
+        let appended_metadata = path.metadata().expect("appended metadata");
+        let (appended, skip) = prepare_file_task(
+            path,
+            SourceKind::Jcode,
+            false,
+            &appended_metadata,
+            Some(&previous),
+        );
+
+        assert!(!skip);
+        assert!(appended.delete_first);
+        assert_eq!(appended.offset, 0);
+        assert!(appended.pending_tool_calls.is_empty());
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -41,6 +41,8 @@ pub struct IngestOptions {
     pub include_openclaw: bool,
     pub include_copilot: bool,
     pub include_grok: bool,
+    pub include_jcode: bool,
+    pub include_muse: bool,
     pub exclude_patterns: Vec<String>,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
@@ -1217,6 +1219,66 @@ pub fn ingest_all(
         }
     }
 
+    if options.include_jcode {
+        let jcode_files = crate::sources::jcode::discover();
+        for source_file in jcode_files {
+            let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
+            let Some(meta) = discovered_metadata(&path)? else {
+                files_skipped += 1;
+                continue;
+            };
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = path.to_string_lossy().to_string();
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Jcode,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(task);
+        }
+    }
+
+    if options.include_muse {
+        let muse_files = crate::sources::muse::discover();
+        for source_file in muse_files {
+            let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
+            let Some(meta) = discovered_metadata(&path)? else {
+                files_skipped += 1;
+                continue;
+            };
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = path.to_string_lossy().to_string();
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Muse,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(task);
+        }
+    }
+
     // Previously indexed records under now-excluded paths must be deleted even
     // when there is no ingest state entry for them (e.g. state loss or legacy runs).
     let mut excluded_index_paths: Vec<String> = Vec::new();
@@ -1506,6 +1568,22 @@ pub fn ingest_all(
                     &progress,
                 ),
                 SourceKind::Hermes => Err(anyhow!("Hermes indexing is not supported")),
+                SourceKind::Jcode => parse_jcode_file(
+                    task,
+                    options.include_reasoning,
+                    &tx_record,
+                    &tx_update,
+                    &next_doc_id,
+                    &progress,
+                ),
+                SourceKind::Muse => parse_muse_file(
+                    task,
+                    options.include_reasoning,
+                    &tx_record,
+                    &tx_update,
+                    &next_doc_id,
+                    &progress,
+                ),
             };
             finish_file_task(task, &progress, &parse_skipped, result)
         })
@@ -2079,6 +2157,72 @@ fn parse_opencode_file(
     )
 }
 
+fn parse_jcode_file(
+    task: &FileTask,
+    include_reasoning: bool,
+    tx_record: &RecordSender,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::jcode::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        include_reasoning,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Jcode, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Jcode,
+        source_path,
+        parsed,
+    )
+}
+
+fn parse_muse_file(
+    task: &FileTask,
+    include_reasoning: bool,
+    tx_record: &RecordSender,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::muse::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        include_reasoning,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Muse, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Muse,
+        source_path,
+        parsed,
+    )
+}
+
 fn parse_cursor_file(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -2443,6 +2587,8 @@ mod tests {
             include_openclaw: false,
             include_copilot: false,
             include_grok: false,
+            include_jcode: false,
+            include_muse: false,
             embeddings,
             backfill_embeddings: false,
             model,
@@ -4323,6 +4469,8 @@ mod tests {
             include_openclaw: false,
             include_copilot: false,
             include_grok: false,
+            include_jcode: false,
+            include_muse: false,
             embeddings: false,
             backfill_embeddings: false,
             model: ModelChoice::default(),
@@ -4763,6 +4911,8 @@ mod tests {
             include_openclaw: false,
             include_copilot: false,
             include_grok: false,
+            include_jcode: false,
+            include_muse: false,
             embeddings: false,
             backfill_embeddings: false,
             model: ModelChoice::default(),
@@ -5105,11 +5255,11 @@ mod tests {
         let tx_record = RecordSender::new(raw_tx_record, IndexedToolContentLimits::default());
         let (tx_update, rx_update) = unbounded();
         let next_doc_id = AtomicU64::new(1);
-        let progress = Arc::new(Progress::new(
-            [0, 0, 0, 0, 0, 0, meta.len(), 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-            false,
-        ));
+        let mut total_bytes = [0; SOURCE_COUNT];
+        total_bytes[SourceKind::Copilot.idx()] = meta.len();
+        let mut files_total = [0; SOURCE_COUNT];
+        files_total[SourceKind::Copilot.idx()] = 1;
+        let progress = Arc::new(Progress::new(total_bytes, files_total, false));
 
         parse_copilot_session(&task, &tx_record, &tx_update, &next_doc_id, &progress)
             .expect("parse copilot session");

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1516,6 +1516,8 @@ fn index_local(paths: &Paths, config: &UserConfig, stale_only: bool) -> Result<I
         include_openclaw: true,
         include_copilot: true,
         include_grok: true,
+        include_jcode: true,
+        include_muse: true,
         exclude_patterns: config.exclude_path_patterns(),
         embeddings: config.embeddings_default(),
         backfill_embeddings: false,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -248,6 +248,8 @@ fn progress_label(source: SourceKind) -> &'static str {
         SourceKind::Omp => "omp",
         SourceKind::Grok => "grok",
         SourceKind::Hermes => "hermes",
+        SourceKind::Jcode => "jcode",
+        SourceKind::Muse => "muse",
     }
 }
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -33,6 +33,8 @@ pub fn resume_template(config: &UserConfig, source: SourceKind, remote: bool) ->
         SourceKind::Copilot => config.copilot_resume_cmd.clone(),
         SourceKind::Grok => config.grok_resume_cmd.clone(),
         SourceKind::Hermes => None,
+        SourceKind::Jcode => config.jcode_resume_cmd.clone(),
+        SourceKind::Muse => config.muse_resume_cmd.clone(),
     };
     configured.or_else(|| default_resume_template(source.label(), remote))
 }
@@ -58,6 +60,12 @@ pub fn default_resume_template(cmd: &str, remote: bool) -> Option<String> {
         }
         "copilot" if remote || find_in_path("copilot").is_some() => {
             Some("copilot --resume {session_id}".to_string())
+        }
+        "jcode" if remote || find_in_path("jcode").is_some() => {
+            Some("cd {cwd_shell} && jcode --resume {session_id}".to_string())
+        }
+        "muse" if remote || find_in_path("muse").is_some() => {
+            Some("cd {cwd_shell} && muse resume {session_id}".to_string())
         }
         "grok" if remote || find_in_path("grok").is_some() => {
             Some("cd {cwd_shell} && grok --resume {session_id}".to_string())

--- a/src/retrieval_eval.rs
+++ b/src/retrieval_eval.rs
@@ -809,7 +809,14 @@ mod tests {
     fn invalid_direct_metric_grades_do_not_produce_nan() {
         let first = located("local", SourceKind::Codex, "s", "s.jsonl", 1, 1.0, 1);
         let invalid = relevance(&first, f32::INFINITY);
-        assert_eq!(recall_at_k(&[first.clone()], &[invalid.clone()], 1), 0.0);
+        assert_eq!(
+            recall_at_k(
+                std::slice::from_ref(&first),
+                std::slice::from_ref(&invalid),
+                1
+            ),
+            0.0
+        );
         assert_eq!(ndcg_at_k(&[first], &[invalid], 1), 0.0);
     }
 

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -132,6 +132,16 @@ fn audit_files(source: SourceKind, files: &[PathBuf]) -> SourceAudit {
         let Ok(file) = std::fs::File::open(file) else {
             continue;
         };
+        if source == SourceKind::Hermes {
+            // Hermes usage truth is SQLite aggregate data. Audit must not
+            // reinterpret the database as JSON, and in particular must not
+            // buffer it as lines or read transcript/message columns.
+            continue;
+        }
+        if source == SourceKind::Jcode {
+            audit_jcode_file(file, &mut audit);
+            continue;
+        }
         let reader = std::io::BufReader::new(file);
         for line in reader.lines() {
             let Ok(line) = line else {
@@ -164,6 +174,54 @@ fn audit_files(source: SourceKind, files: &[PathBuf]) -> SourceAudit {
         }
     }
     audit
+}
+
+/// Audit a Jcode session file as a single JSON document. Jcode sessions are
+/// whole objects with roles/content under `messages`, not JSONL transcripts,
+/// so per-line parsing would report no semantics (compact files) or mostly
+/// malformed lines (pretty-printed files).
+fn audit_jcode_file(file: std::fs::File, audit: &mut SourceAudit) {
+    let mut bytes = Vec::new();
+    let mut file = file;
+    if std::io::Read::read_to_end(&mut file, &mut bytes).is_err() {
+        audit.malformed_json_lines += 1;
+        return;
+    }
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        audit.malformed_json_lines += 1;
+        return;
+    };
+    let Some(doc) = value.as_object() else {
+        audit.non_object_json_lines += 1;
+        return;
+    };
+    audit.valid_json_lines += 1;
+    let top_level = doc
+        .get("type")
+        .or_else(|| doc.get("kind"))
+        .and_then(Value::as_str)
+        .unwrap_or("document");
+    increment(&mut audit.top_level_types, top_level);
+    if let Some(version) = extract_producer_version(&value, SourceKind::Jcode) {
+        increment(&mut audit.producer_versions, &version);
+    }
+    if let Some(messages) = doc.get("messages").and_then(|v| v.as_array()) {
+        for message in messages {
+            let Some(object) = message.as_object() else {
+                audit.non_object_json_lines += 1;
+                continue;
+            };
+            if let Some(role) = object.get("role").and_then(Value::as_str) {
+                increment(&mut audit.semantic_types, role);
+            }
+            record_content_blocks(object.get("content"), audit);
+        }
+    } else {
+        if let Some(role) = doc.get("role").and_then(Value::as_str) {
+            increment(&mut audit.semantic_types, role);
+        }
+        record_content_blocks(doc.get("content"), audit);
+    }
 }
 
 fn extract_producer_version(value: &Value, source: SourceKind) -> Option<String> {
@@ -228,12 +286,15 @@ fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &
                 record_content_blocks(message.get("content"), audit);
             }
         }
-        SourceKind::Opencode | SourceKind::Cursor | SourceKind::Copilot | SourceKind::Jcode => {
+        SourceKind::Opencode | SourceKind::Cursor | SourceKind::Copilot => {
             if let Some(role) = value.get("role").and_then(Value::as_str) {
                 increment(&mut audit.semantic_types, role);
             }
             record_content_blocks(value.get("content"), audit);
         }
+        // Jcode files are audited whole-document in `audit_jcode_file` and never
+        // reach the per-line path.
+        SourceKind::Jcode => {}
         SourceKind::Muse => {
             if let Some(payload) = value.get("payload").and_then(Value::as_object) {
                 let kind = payload

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashSet};
 use std::io::BufRead;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct SourceAudit {
@@ -86,6 +86,20 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
             .map(|file| file.path)
             .collect(),
     );
+    push(
+        SourceKind::Jcode,
+        super::jcode::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
+    push(
+        SourceKind::Muse,
+        super::muse::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
 
     push(
         SourceKind::Omp,
@@ -94,10 +108,10 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
             .map(|file| file.path)
             .collect(),
     );
-    groups
+    Ok(groups
         .into_iter()
         .map(|(kind, files)| audit_files(kind, &deduplicate(files)))
-        .collect()
+        .collect())
 }
 
 fn deduplicate(files: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -108,62 +122,64 @@ fn deduplicate(files: Vec<PathBuf>) -> Vec<PathBuf> {
         .collect()
 }
 
-pub fn audit_files(source: SourceKind, files: &[PathBuf]) -> Result<SourceAudit> {
+fn audit_files(source: SourceKind, files: &[PathBuf]) -> SourceAudit {
     let mut audit = SourceAudit {
         source: source.storage_label().to_string(),
         files: files.len() as u64,
         ..SourceAudit::default()
     };
-    for path in files {
-        audit_file(source, path, &mut audit)?;
-    }
-    Ok(audit)
-}
-
-fn audit_file(source: SourceKind, path: &Path, audit: &mut SourceAudit) -> Result<()> {
-    if source == SourceKind::Hermes {
-        // Hermes usage truth is SQLite aggregate data.  Audit must not reinterpret the
-        // database as JSON, and in particular must not read transcript/message columns.
-        std::fs::File::open(path)?;
-        return Ok(());
-    }
-    let reader = std::io::BufReader::new(std::fs::File::open(path)?);
-    for line in reader.lines() {
-        let line = line?;
-        if line.trim().is_empty() {
+    for file in files {
+        let Ok(file) = std::fs::File::open(file) else {
             continue;
-        }
-        let value: Value = match serde_json::from_str(&line) {
-            Ok(value) => value,
-            Err(_) => {
+        };
+        let reader = std::io::BufReader::new(file);
+        for line in reader.lines() {
+            let Ok(line) = line else {
                 audit.malformed_json_lines += 1;
                 continue;
+            };
+            if line.trim().is_empty() {
+                continue;
             }
-        };
-        let Some(object) = value.as_object() else {
-            audit.non_object_json_lines += 1;
-            continue;
-        };
-        audit.valid_json_lines += 1;
-        let top_level = object
-            .get("type")
-            .and_then(Value::as_str)
-            .unwrap_or("<missing>");
-        increment(&mut audit.top_level_types, top_level);
-
-        if let Some(version) = producer_version(source, &value) {
-            increment(&mut audit.producer_versions, &version);
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                audit.malformed_json_lines += 1;
+                continue;
+            };
+            let Some(object) = value.as_object() else {
+                audit.non_object_json_lines += 1;
+                continue;
+            };
+            audit.valid_json_lines += 1;
+            let top_level = object
+                .get("type")
+                .or_else(|| object.get("kind"))
+                .or_else(|| object.get("role"))
+                .and_then(Value::as_str)
+                .unwrap_or("<missing>");
+            increment(&mut audit.top_level_types, top_level);
+            if let Some(version) = extract_producer_version(&value, source) {
+                increment(&mut audit.producer_versions, &version);
+            }
+            record_semantics(source, &value, top_level, &mut audit);
         }
-        record_semantics(source, &value, top_level, audit);
     }
-    Ok(())
+    audit
 }
 
-fn producer_version(source: SourceKind, value: &Value) -> Option<String> {
+fn extract_producer_version(value: &Value, source: SourceKind) -> Option<String> {
     let version = match source {
         SourceKind::Codex => value
             .get("payload")
-            .and_then(|payload| payload.get("cli_version")),
+            .and_then(|payload| payload.get("cli_version"))
+            .or_else(|| value.get("version")),
+        SourceKind::Cursor => value.get("clientVersion").or_else(|| value.get("version")),
+        SourceKind::Copilot => value.get("copilotVersion").or_else(|| value.get("version")),
+        SourceKind::Hermes => value.get("profileVersion").or_else(|| value.get("version")),
+        SourceKind::Jcode => value.get("version").or_else(|| value.get("jcode_version")),
+        SourceKind::Muse => value
+            .get("protocol_version")
+            .or_else(|| value.get("version")),
+        SourceKind::Grok => value.get("grok_version").or_else(|| value.get("version")),
         _ => value.get("version"),
     }?;
     match version {
@@ -212,11 +228,28 @@ fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &
                 record_content_blocks(message.get("content"), audit);
             }
         }
-        SourceKind::Opencode | SourceKind::Cursor | SourceKind::Copilot => {
+        SourceKind::Opencode | SourceKind::Cursor | SourceKind::Copilot | SourceKind::Jcode => {
             if let Some(role) = value.get("role").and_then(Value::as_str) {
                 increment(&mut audit.semantic_types, role);
             }
             record_content_blocks(value.get("content"), audit);
+        }
+        SourceKind::Muse => {
+            if let Some(payload) = value.get("payload").and_then(Value::as_object) {
+                let kind = payload
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<missing>");
+                if let Some(event) = payload.get("event").and_then(Value::as_object) {
+                    let ekind = event
+                        .get("kind")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<missing>");
+                    increment(&mut audit.semantic_types, &format!("{kind}/{ekind}"));
+                } else {
+                    increment(&mut audit.semantic_types, kind);
+                }
+            }
         }
         SourceKind::Grok => {
             if let Some(kind) = value
@@ -280,7 +313,7 @@ mod tests {
         )
         .unwrap();
 
-        let audit = audit_files(SourceKind::Codex, &[path]).unwrap();
+        let audit = audit_files(SourceKind::Codex, &[path]);
         assert_eq!(audit.files, 1);
         assert_eq!(audit.valid_json_lines, 2);
         assert_eq!(audit.malformed_json_lines, 1);
@@ -296,7 +329,7 @@ mod tests {
         let path = temp.path().join("pi.jsonl");
         fs::write(&path, "{\"type\":\"session\",\"version\":3}\n").unwrap();
 
-        let audit = audit_files(SourceKind::Pi, &[path]).unwrap();
+        let audit = audit_files(SourceKind::Pi, &[path]);
         assert_eq!(audit.producer_versions.get("3"), Some(&1));
     }
 }

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -134,6 +134,9 @@ pub(crate) fn parse_index_records(
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
+    // Whole-document format: `prepare_file_task` forces whole-file replacement
+    // (delete + reparse from scratch) on any change, so `state.offset` is
+    // intentionally ignored here and every record is re-emitted.
     let mut bytes = std::fs::read(path)?;
     let bytes_len = bytes.len() as u64;
     let mut diagnostics = ParseDiagnostics::default();

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -1,0 +1,646 @@
+use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    index: 1,
+    usage: 1,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.contains(".jcode/sessions")
+        || normalized.contains("jcode/sessions")
+        || (normalized.contains(".jcode") && normalized.ends_with(".json"))
+}
+
+pub fn sessions_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("JCODE_SESSIONS_DIR") {
+        return PathBuf::from(root);
+    }
+    let base = std::env::var_os("JCODE_HOME")
+        .or_else(|| std::env::var_os("JCODE_DIR"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::common::home().join(".jcode"));
+    base.join("sessions")
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    let root = sessions_root();
+    if !root.exists() {
+        return Vec::new();
+    }
+    let mut files = WalkDir::new(root)
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .path()
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| name.starts_with("session_") && name.ends_with(".json"))
+        })
+        .map(|entry| SourceFile {
+            source: SourceKind::Jcode,
+            path: entry.path().to_path_buf(),
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    files
+}
+
+pub fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn cwd_from_jcode_session(path: &Path) -> Option<PathBuf> {
+    let Ok(mut bytes) = std::fs::read(path) else {
+        return None;
+    };
+    let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+        return None;
+    };
+    value
+        .get("working_dir")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+fn content_text(content: Option<&BorrowedValue<'_>>) -> String {
+    let Some(content) = content else {
+        return String::new();
+    };
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    if let Some(array) = content.as_array() {
+        let mut parts = Vec::new();
+        for item in array {
+            if let Some(text) = item.as_str() {
+                parts.push(text.to_string());
+                continue;
+            }
+            let Some(object) = item.as_object() else {
+                continue;
+            };
+            if let Some(text) = object.get("text").and_then(|v| v.as_str()) {
+                parts.push(text.to_string());
+            } else if let Some(text) = object.get("content").and_then(|v| v.as_str()) {
+                parts.push(text.to_string());
+            }
+        }
+        return parts.join("\n");
+    }
+    String::new()
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| value as u64)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let mut bytes = std::fs::read(path)?;
+    let bytes_len = bytes.len() as u64;
+    let mut diagnostics = ParseDiagnostics::default();
+    let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+        diagnostics.malformed_json_lines += 1;
+        return Ok(IndexParseOutput {
+            offset: 0,
+            turn_id: state.turn_id,
+            pending_tool_calls: state.pending_tool_calls,
+            session_id: Some(session_id_from_path(path)),
+            diagnostics,
+        });
+    };
+
+    let session_id = value
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| session_id_from_path(path));
+
+    let parent_session_id = value
+        .get("parent_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let conversation_kind = if parent_session_id.is_some() {
+        "subagent"
+    } else {
+        "main"
+    };
+
+    let working_dir = value
+        .get("working_dir")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let project = if !working_dir.is_empty() {
+        super::common::project_from_path(working_dir)
+    } else {
+        SourceKind::Jcode.label().to_string()
+    };
+
+    let default_timestamp = value.get("created_at").map(timestamp_millis).unwrap_or(0);
+
+    let source_path = path.to_string_lossy().to_string();
+    let mut turn_id = state.turn_id;
+    let mut pending_tool_calls = state.pending_tool_calls;
+
+    let base_links = RecordLinks {
+        parent_session_id,
+        conversation_kind: Some(conversation_kind.to_string()),
+        thread_source: (conversation_kind != "main").then(|| conversation_kind.to_string()),
+        ..RecordLinks::default()
+    };
+
+    let messages = value.get("messages").and_then(|v| v.as_array());
+    if let Some(messages) = messages {
+        for message in messages {
+            let Some(msg_obj) = message.as_object() else {
+                continue;
+            };
+            let role = msg_obj.get("role").and_then(|v| v.as_str()).unwrap_or("");
+            let msg_id = msg_obj
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let timestamp = msg_obj
+                .get("timestamp")
+                .map(timestamp_millis)
+                .filter(|t| *t > 0)
+                .unwrap_or(default_timestamp);
+
+            let mut msg_links = base_links.clone();
+            if let Some(ref id) = msg_id {
+                msg_links.event_id = Some(id.clone());
+            }
+
+            match role {
+                "user" => {
+                    let content = msg_obj.get("content");
+                    let mut text_parts = Vec::new();
+                    if let Some(arr) = content.and_then(|v| v.as_array()) {
+                        for block in arr {
+                            let Some(block_obj) = block.as_object() else {
+                                if let Some(s) = block.as_str() {
+                                    text_parts.push(s.to_string());
+                                }
+                                continue;
+                            };
+                            let block_type =
+                                block_obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                            if block_type == "tool_result" {
+                                let tool_call_id = block_obj
+                                    .get("tool_use_id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                let tool_name = if !tool_call_id.is_empty() {
+                                    pending_tool_calls
+                                        .remove(tool_call_id)
+                                        .and_then(|call| call.tool_name)
+                                } else {
+                                    None
+                                };
+                                let mut output = content_text(block_obj.get("content"));
+                                if output.is_empty()
+                                    && let Some(text) =
+                                        block_obj.get("text").and_then(|v| v.as_str())
+                                {
+                                    output = text.to_string();
+                                }
+                                if block_obj
+                                    .get("is_error")
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(false)
+                                    && !output.to_ascii_lowercase().starts_with("error")
+                                {
+                                    output = format!("Error: {output}");
+                                }
+                                if !output.trim().is_empty() {
+                                    let mut links = msg_links.clone();
+                                    if !tool_call_id.is_empty() {
+                                        links.parent_tool_use_id = Some(tool_call_id.to_string());
+                                    }
+                                    emit(Record {
+                                        source: SourceKind::Jcode,
+                                        doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                        ts: timestamp,
+                                        project: project.clone(),
+                                        session_id: session_id.clone(),
+                                        turn_id,
+                                        role: "tool_result".to_string(),
+                                        text: output.clone(),
+                                        tool_name,
+                                        tool_input: None,
+                                        tool_output: Some(output),
+                                        links,
+                                        source_path: source_path.clone(),
+                                    })?;
+                                    turn_id += 1;
+                                }
+                            } else if let Some(text) =
+                                block_obj.get("text").and_then(|v| v.as_str())
+                            {
+                                text_parts.push(text.to_string());
+                            }
+                        }
+                    } else if let Some(text) = content.and_then(|v| v.as_str()) {
+                        text_parts.push(text.to_string());
+                    }
+
+                    let full_text = text_parts.join("\n").trim().to_string();
+                    if !full_text.is_empty() {
+                        emit(Record {
+                            source: SourceKind::Jcode,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "user".to_string(),
+                            text: full_text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output: None,
+                            links: msg_links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+                "assistant" => {
+                    let content = msg_obj.get("content");
+                    let mut text_parts = Vec::new();
+                    if let Some(arr) = content.and_then(|v| v.as_array()) {
+                        for block in arr {
+                            let Some(block_obj) = block.as_object() else {
+                                if let Some(s) = block.as_str() {
+                                    text_parts.push(s.to_string());
+                                }
+                                continue;
+                            };
+                            let block_type =
+                                block_obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                            match block_type {
+                                "text" => {
+                                    if let Some(text) =
+                                        block_obj.get("text").and_then(|v| v.as_str())
+                                    {
+                                        text_parts.push(text.to_string());
+                                    }
+                                }
+                                "tool_use" => {
+                                    let tool_name = block_obj
+                                        .get("name")
+                                        .and_then(|v| v.as_str())
+                                        .map(str::to_string);
+                                    let tool_call_id = block_obj
+                                        .get("id")
+                                        .and_then(|v| v.as_str())
+                                        .map(str::to_string);
+                                    let tool_input = block_obj.get("input").map(|v| v.to_string());
+
+                                    let mut links = msg_links.clone();
+                                    if let Some(ref id) = tool_call_id {
+                                        links.event_id = Some(id.clone());
+                                        links.parent_event_id = msg_id.clone();
+                                    }
+                                    let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                                    if let Some(ref call_id) = tool_call_id {
+                                        let replaced = pending_tool_calls.insert(
+                                            call_id.clone(),
+                                            super::common::pending_tool_call(
+                                                tool_name.clone(),
+                                                Some(call_id.clone()),
+                                                doc_id,
+                                                timestamp,
+                                                tool_input.as_deref(),
+                                                &links,
+                                                &session_id,
+                                            ),
+                                        );
+                                        if replaced.is_some() {
+                                            diagnostics.duplicate_tool_calls += 1;
+                                        }
+                                    }
+                                    emit(Record {
+                                        source: SourceKind::Jcode,
+                                        doc_id,
+                                        ts: timestamp,
+                                        project: project.clone(),
+                                        session_id: session_id.clone(),
+                                        turn_id,
+                                        role: "tool_use".to_string(),
+                                        text: tool_input.clone().unwrap_or_default(),
+                                        tool_name,
+                                        tool_input,
+                                        tool_output: None,
+                                        links,
+                                        source_path: source_path.clone(),
+                                    })?;
+                                    turn_id += 1;
+                                }
+                                "thinking" => {
+                                    if include_reasoning
+                                        && let Some(thinking) = block_obj
+                                            .get("thinking")
+                                            .and_then(|v| v.as_str())
+                                            .filter(|t| !t.trim().is_empty())
+                                    {
+                                        let mut links = msg_links.clone();
+                                        if let Some(ref id) = msg_id {
+                                            links.event_id = Some(format!("{id}:reasoning"));
+                                        }
+                                        emit(Record {
+                                            source: SourceKind::Jcode,
+                                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                            ts: timestamp,
+                                            project: project.clone(),
+                                            session_id: session_id.clone(),
+                                            turn_id,
+                                            role: "reasoning".to_string(),
+                                            text: thinking.to_string(),
+                                            tool_name: None,
+                                            tool_input: None,
+                                            tool_output: None,
+                                            links,
+                                            source_path: source_path.clone(),
+                                        })?;
+                                        turn_id += 1;
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    } else if let Some(text) = content.and_then(|v| v.as_str()) {
+                        text_parts.push(text.to_string());
+                    }
+
+                    let full_text = text_parts.join("\n").trim().to_string();
+                    if !full_text.is_empty() {
+                        emit(Record {
+                            source: SourceKind::Jcode,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "assistant".to_string(),
+                            text: full_text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output: None,
+                            links: msg_links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: bytes_len,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+        diagnostics,
+    })
+}
+
+pub fn usage_files() -> Vec<PathBuf> {
+    discover().into_iter().map(|f| f.path).collect()
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    let mut bytes = std::fs::read(path)?;
+    let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
+        return Ok(Vec::new());
+    };
+    let session_id = value
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| Some(session_id_from_path(path)));
+
+    let working_dir = value
+        .get("working_dir")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let project = if !working_dir.is_empty() {
+        Some(super::common::project_from_path(working_dir))
+    } else {
+        Some(SourceKind::Jcode.label().to_string())
+    };
+
+    let model = value
+        .get("model")
+        .and_then(|v| v.as_str())
+        .filter(|m| *m != "unknown")
+        .map(str::to_string);
+
+    let provider = value
+        .get("provider_key")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut events = Vec::new();
+    let messages = value.get("messages").and_then(|v| v.as_array());
+
+    if let Some(messages) = messages {
+        for message in messages {
+            let Some(msg_obj) = message.as_object() else {
+                continue;
+            };
+            if msg_obj.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+                continue;
+            }
+            let usage = msg_obj.get("token_usage").or_else(|| msg_obj.get("usage"));
+            let Some(usage) = usage else {
+                continue;
+            };
+            let number = |key: &str| usage.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+            let input = number("input_tokens").max(number("input"));
+            let output = number("output_tokens").max(number("output"));
+            let cache_read = number("cache_read_input_tokens").max(number("cache_read"));
+            let cache_write = number("cache_creation_input_tokens")
+                .max(number("cache_creation_tokens"))
+                .max(number("cache_write"));
+            let reasoning = number("reasoning_tokens").max(number("reasoning"));
+
+            let mut tokens = TokenBuckets::disjoint(
+                input,
+                cache_read,
+                cache_write,
+                output.saturating_add(reasoning),
+            );
+            tokens.reasoning = reasoning;
+            if tokens.additive_total() == 0 {
+                continue;
+            }
+
+            let msg_id = msg_obj
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let timestamp_ms = msg_obj.get("timestamp").map(timestamp_millis).unwrap_or(0);
+
+            events.push(UsageEvent {
+                source: "jcode",
+                source_path: source_path.clone(),
+                source_record_id: msg_id.clone(),
+                session_id: session_id.clone(),
+                request_id: None,
+                message_id: msg_id,
+                timestamp_ms,
+                project: project.clone(),
+                provider: provider.clone(),
+                model: model.clone(),
+                tokens,
+                source_cost_usd: None,
+                cost_authoritative: false,
+                dedupe_confidence: "exact",
+                conservative_undercount: false,
+                cache_chain_excluded: false,
+                sidechain: false,
+                source_order: 0,
+            });
+        }
+    }
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_jcode_session_record_and_usage() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session_test_123.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "id": "session_test_123",
+                "parent_id": null,
+                "title": "Test Jcode Session",
+                "working_dir": "/Users/joe/Developer/memex",
+                "provider_key": "meta-muse",
+                "model": "muse-spark-1.2-contributor",
+                "messages": [
+                    {
+                        "id": "msg_001",
+                        "role": "user",
+                        "timestamp": 1788338812928,
+                        "content": [
+                            {"type": "text", "text": "Hello Jcode"}
+                        ]
+                    },
+                    {
+                        "id": "msg_002",
+                        "role": "assistant",
+                        "timestamp": 1788338819456,
+                        "content": [
+                            {"type": "text", "text": "I can help with that."},
+                            {"type": "tool_use", "id": "call_001", "name": "bash", "input": {"command": "ls -la"}},
+                            {"type": "thinking", "thinking": "Let's check directory"}
+                        ],
+                        "token_usage": {
+                            "input_tokens": 1500,
+                            "output_tokens": 80,
+                            "cache_read_input_tokens": 500
+                        }
+                    },
+                    {
+                        "id": "msg_003",
+                        "role": "user",
+                        "timestamp": 1788338821616,
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": "call_001", "content": "total 0\n"}
+                        ]
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut records = Vec::new();
+        let next_doc_id = AtomicU64::new(1);
+        let out = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &next_doc_id,
+            |rec| {
+                records.push(rec);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.session_id.as_deref(), Some("session_test_123"));
+        assert_eq!(records.len(), 5); // user text, tool_use, reasoning, assistant text, tool_result
+        assert_eq!(records[0].role, "user");
+        assert_eq!(records[0].text, "Hello Jcode");
+        assert_eq!(records[0].project, "memex");
+        assert_eq!(records[1].role, "tool_use");
+        assert_eq!(records[1].tool_name.as_deref(), Some("bash"));
+        assert_eq!(records[2].role, "reasoning");
+        assert_eq!(records[2].text, "Let's check directory");
+        assert_eq!(records[3].role, "assistant");
+        assert_eq!(records[3].text, "I can help with that.");
+        assert_eq!(records[4].role, "tool_result");
+        assert_eq!(records[4].tool_name.as_deref(), Some("bash"));
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tokens.uncached_input, 1500);
+        assert_eq!(events[0].tokens.output, 80);
+        assert_eq!(events[0].tokens.cache_read, 500);
+        assert_eq!(
+            events[0].model.as_deref(),
+            Some("muse-spark-1.2-contributor")
+        );
+        assert_eq!(events[0].provider.as_deref(), Some("meta-muse"));
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -12,6 +12,8 @@ pub mod copilot;
 pub mod cursor;
 pub mod grok;
 pub mod hermes;
+pub mod jcode;
+pub mod muse;
 pub mod omp;
 pub mod openclaw;
 pub mod opencode;
@@ -249,6 +251,8 @@ pub fn versions(source: SourceKind) -> ParserVersions {
         SourceKind::Copilot => copilot::VERSIONS,
         SourceKind::Grok => grok::VERSIONS,
         SourceKind::Hermes => hermes::VERSIONS,
+        SourceKind::Jcode => jcode::VERSIONS,
+        SourceKind::Muse => muse::VERSIONS,
     }
 }
 
@@ -266,6 +270,9 @@ pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u
                 | SourceKind::Pi
                 | SourceKind::Omp
                 | SourceKind::OpenClaw
+                | SourceKind::Opencode
+                | SourceKind::Jcode
+                | SourceKind::Muse
                 | SourceKind::Grok
         );
     (versions.identity.saturating_mul(10_000) + versions.index)
@@ -280,6 +287,12 @@ pub fn classify_path(path: &str) -> SourceKind {
         source
     } else if opencode::matches_path(path) {
         SourceKind::Opencode
+    } else if jcode::matches_path(path) {
+        SourceKind::Jcode
+    } else if muse::matches_path(path) {
+        SourceKind::Muse
+    } else if grok::matches_path(path) {
+        SourceKind::Grok
     } else if cursor::matches_path(path) {
         SourceKind::Cursor
     } else if omp::matches_path(path) {
@@ -290,8 +303,6 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::OpenClaw
     } else if copilot::matches_path(path) {
         SourceKind::Copilot
-    } else if grok::matches_path(path) {
-        SourceKind::Grok
     } else if hermes::matches_path(path) {
         SourceKind::Hermes
     } else {
@@ -311,6 +322,10 @@ mod tests {
             SourceKind::Pi,
             SourceKind::Omp,
             SourceKind::OpenClaw,
+            SourceKind::Opencode,
+            SourceKind::Jcode,
+            SourceKind::Muse,
+            SourceKind::Grok,
         ] {
             assert_ne!(
                 index_state_version_for(source, false),

--- a/src/sources/muse.rs
+++ b/src/sources/muse.rs
@@ -1,0 +1,621 @@
+use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::{TokenBuckets, UsageEvent};
+use anyhow::Result;
+use memchr::memchr;
+use memmap2::Mmap;
+use simd_json::BorrowedValue;
+use simd_json::prelude::*;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    index: 1,
+    usage: 1,
+};
+
+pub fn matches_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.contains("muse/sessions")
+        || normalized.contains(".local/share/muse")
+        || (normalized.contains("muse") && normalized.ends_with("session.jsonl"))
+}
+
+pub fn sessions_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("MUSE_SESSIONS_DIR") {
+        return PathBuf::from(root);
+    }
+    std::env::var_os("MUSE_DATA_DIR")
+        .or_else(|| std::env::var_os("MUSE_HOME"))
+        .map(|p| PathBuf::from(p).join("sessions"))
+        .unwrap_or_else(|| super::common::home().join(".local/share/muse/sessions"))
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    let root = sessions_root();
+    if !root.exists() {
+        return Vec::new();
+    }
+    let mut files = WalkDir::new(root)
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().file_name().and_then(|n| n.to_str()) == Some("session.jsonl")
+        })
+        .map(|entry| SourceFile {
+            source: SourceKind::Muse,
+            path: entry.path().to_path_buf(),
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    files
+}
+
+pub fn session_id_from_path(path: &Path) -> String {
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub fn cwd_from_muse_session(path: &Path) -> Option<PathBuf> {
+    let Ok(file) = File::open(path) else {
+        return None;
+    };
+    let Ok(mmap) = (unsafe { Mmap::map(&file) }) else {
+        return None;
+    };
+    let mut start = 0;
+    let mut buf = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + usize::from(rel < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buf) else {
+            continue;
+        };
+        if let Some(payload) = value.get("payload")
+            && let Some(record) = payload.get("record")
+        {
+            if let Some(cwd) = record.get("cwd").and_then(|v| v.as_str())
+                && !cwd.is_empty()
+            {
+                return Some(PathBuf::from(cwd));
+            }
+            if let Some(root) = record.get("workspace_root").and_then(|v| v.as_str())
+                && !root.is_empty()
+            {
+                return Some(PathBuf::from(root));
+            }
+        }
+        if start > 64 * 1024 {
+            break;
+        }
+    }
+    None
+}
+
+fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
+    value
+        .as_u64()
+        .map(|number| {
+            if number > 1_000_000_000_000_000 {
+                number / 1000
+            } else if number < 10_000_000_000 {
+                number.saturating_mul(1000)
+            } else {
+                number
+            }
+        })
+        .or_else(|| {
+            value
+                .as_i64()
+                .filter(|value| *value >= 0)
+                .map(|value| (value as u64) / 1000)
+        })
+        .or_else(|| value.as_str().and_then(super::common::parse_iso_millis))
+        .unwrap_or(0)
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let mut start = state.offset as usize;
+    let mut turn_id = state.turn_id;
+    let mut pending_tool_calls = state.pending_tool_calls;
+    let mut diagnostics = ParseDiagnostics::default();
+
+    let source_path = path.to_string_lossy().to_string();
+    let normalized_path = source_path.replace('\\', "/");
+    let is_subagent = normalized_path.contains("/subagent/");
+
+    let mut session_id = session_id_from_path(path);
+    let mut parent_session_id = None;
+    if is_subagent
+        && let Some(parent_dir) = path
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.parent())
+        && let Some(pid) = parent_dir.file_name().and_then(|n| n.to_str())
+    {
+        parent_session_id = Some(pid.to_string());
+    }
+
+    let conversation_kind = if is_subagent { "subagent" } else { "main" };
+    let mut project = SourceKind::Muse.label().to_string();
+    let mut default_timestamp = 0;
+
+    let mut buf = Vec::new();
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + usize::from(rel < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let value: BorrowedValue = match simd_json::to_borrowed_value(&mut buf) {
+            Ok(v) => v,
+            Err(_) => {
+                diagnostics.malformed_json_lines += 1;
+                continue;
+            }
+        };
+
+        if let Some(stream) = value.get("stream")
+            && let Some(sid) = stream.get("id").and_then(|v| v.as_str())
+            && !sid.is_empty()
+        {
+            session_id = sid.to_string();
+        }
+
+        let recorded_at = value.get("recorded_at").map(timestamp_millis).unwrap_or(0);
+        if recorded_at > 0 && default_timestamp == 0 {
+            default_timestamp = recorded_at;
+        }
+
+        let payload = match value.get("payload") {
+            Some(p) => p,
+            None => continue,
+        };
+        let p_kind = payload.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+
+        if p_kind == "metadata" || p_kind == "route_facts" {
+            if let Some(record) = payload.get("record") {
+                if let Some(root) = record.get("workspace_root").and_then(|v| v.as_str()) {
+                    if !root.is_empty() {
+                        project = super::common::project_from_path(root);
+                    }
+                } else if let Some(cwd) = record.get("cwd").and_then(|v| v.as_str())
+                    && !cwd.is_empty()
+                {
+                    project = super::common::project_from_path(cwd);
+                }
+            }
+            continue;
+        }
+
+        let event = match payload.get("event") {
+            Some(e) => e,
+            None => continue,
+        };
+        let ekind = event.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        let timestamp = if recorded_at > 0 {
+            recorded_at
+        } else {
+            default_timestamp
+        };
+
+        let base_links = RecordLinks {
+            parent_session_id: parent_session_id.clone(),
+            conversation_kind: Some(conversation_kind.to_string()),
+            thread_source: (conversation_kind != "main").then(|| conversation_kind.to_string()),
+            ..RecordLinks::default()
+        };
+
+        match ekind {
+            "started" => {
+                if let Some(prompt) = event.get("prompt").and_then(|v| v.as_str()) {
+                    let text = prompt.trim().to_string();
+                    if !text.is_empty() {
+                        emit(Record {
+                            source: SourceKind::Muse,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "user".to_string(),
+                            text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output: None,
+                            links: base_links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+            }
+            "assistant_message_committed" => {
+                if let Some(text) = event.get("text").and_then(|v| v.as_str()) {
+                    let text = text.trim().to_string();
+                    if !text.is_empty() {
+                        let mut links = base_links;
+                        if let Some(msg_id) = event.get("message_id").and_then(|v| v.as_str()) {
+                            links.event_id = Some(msg_id.to_string());
+                        }
+                        emit(Record {
+                            source: SourceKind::Muse,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "assistant".to_string(),
+                            text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output: None,
+                            links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+            }
+            "assistant_tool_calls_committed" => {
+                let msg_id = event
+                    .get("message_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                if let Some(tool_calls) = event.get("tool_calls").and_then(|v| v.as_array()) {
+                    for call in tool_calls {
+                        let tool_name = call
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                        let tool_call_id = call
+                            .get("call_id")
+                            .or_else(|| call.get("id"))
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                        let tool_input = call.get("args").map(|v| {
+                            if let Some(s) = v.as_str() {
+                                s.to_string()
+                            } else {
+                                v.to_string()
+                            }
+                        });
+
+                        let mut links = base_links.clone();
+                        if let Some(ref id) = tool_call_id {
+                            links.event_id = Some(id.clone());
+                            links.parent_event_id = msg_id.clone();
+                        }
+                        let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
+                        if let Some(ref call_id) = tool_call_id {
+                            let replaced = pending_tool_calls.insert(
+                                call_id.clone(),
+                                super::common::pending_tool_call(
+                                    tool_name.clone(),
+                                    Some(call_id.clone()),
+                                    doc_id,
+                                    timestamp,
+                                    tool_input.as_deref(),
+                                    &links,
+                                    &session_id,
+                                ),
+                            );
+                            if replaced.is_some() {
+                                diagnostics.duplicate_tool_calls += 1;
+                            }
+                        }
+                        emit(Record {
+                            source: SourceKind::Muse,
+                            doc_id,
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "tool_use".to_string(),
+                            text: tool_input.clone().unwrap_or_default(),
+                            tool_name,
+                            tool_input,
+                            tool_output: None,
+                            links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+            }
+            "tool_result_batch_committed" => {
+                if let Some(results) = event.get("results").and_then(|v| v.as_array()) {
+                    for res in results {
+                        let tool_call_id = res
+                            .get("tool_call_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let tool_name = if !tool_call_id.is_empty() {
+                            pending_tool_calls
+                                .remove(tool_call_id)
+                                .and_then(|call| call.tool_name)
+                        } else {
+                            None
+                        };
+                        let output = res
+                            .get("text")
+                            .or_else(|| res.get("output"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !output.trim().is_empty() {
+                            let mut links = base_links.clone();
+                            if !tool_call_id.is_empty() {
+                                links.parent_tool_use_id = Some(tool_call_id.to_string());
+                            }
+                            emit(Record {
+                                source: SourceKind::Muse,
+                                doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                                ts: timestamp,
+                                project: project.clone(),
+                                session_id: session_id.clone(),
+                                turn_id,
+                                role: "tool_result".to_string(),
+                                text: output.clone(),
+                                tool_name,
+                                tool_input: None,
+                                tool_output: Some(output),
+                                links,
+                                source_path: source_path.clone(),
+                            })?;
+                            turn_id += 1;
+                        }
+                    }
+                }
+            }
+            "reasoning_committed" => {
+                if include_reasoning
+                    && let Some(text) = event
+                        .get("text")
+                        .or_else(|| event.get("reasoning"))
+                        .and_then(|v| v.as_str())
+                {
+                    let text = text.trim().to_string();
+                    if !text.is_empty() {
+                        let mut links = base_links;
+                        if let Some(msg_id) = event.get("message_id").and_then(|v| v.as_str()) {
+                            links.event_id = Some(format!("{msg_id}:reasoning"));
+                        }
+                        emit(Record {
+                            source: SourceKind::Muse,
+                            doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                            ts: timestamp,
+                            project: project.clone(),
+                            session_id: session_id.clone(),
+                            turn_id,
+                            role: "reasoning".to_string(),
+                            text,
+                            tool_name: None,
+                            tool_input: None,
+                            tool_output: None,
+                            links,
+                            source_path: source_path.clone(),
+                        })?;
+                        turn_id += 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(IndexParseOutput {
+        offset: mmap.len() as u64,
+        turn_id,
+        pending_tool_calls,
+        session_id: Some(session_id),
+        diagnostics,
+    })
+}
+
+pub fn usage_files() -> Vec<PathBuf> {
+    discover().into_iter().map(|f| f.path).collect()
+}
+
+pub(crate) fn parse_usage_file(path: &Path) -> Result<Vec<UsageEvent>> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let source_path: Arc<str> = Arc::from(path.to_string_lossy());
+    let mut session_id = session_id_from_path(path);
+    let mut project = SourceKind::Muse.label().to_string();
+    let mut current_model = None;
+    let mut current_provider = None;
+
+    let mut start = 0;
+    let mut buf = Vec::new();
+    let mut events = Vec::new();
+
+    while start < mmap.len() {
+        let slice = &mmap[start..];
+        let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+        let line = &slice[..rel];
+        start += rel + usize::from(rel < slice.len());
+        if line.is_empty() {
+            continue;
+        }
+        buf.clear();
+        buf.extend_from_slice(line);
+        let Ok(value) = simd_json::to_borrowed_value(&mut buf) else {
+            continue;
+        };
+
+        if let Some(stream) = value.get("stream")
+            && let Some(sid) = stream.get("id").and_then(|v| v.as_str())
+            && !sid.is_empty()
+        {
+            session_id = sid.to_string();
+        }
+
+        let recorded_at = value.get("recorded_at").map(timestamp_millis).unwrap_or(0);
+        let payload = match value.get("payload") {
+            Some(p) => p,
+            None => continue,
+        };
+
+        if let Some(record) = payload.get("record") {
+            if let Some(root) = record.get("workspace_root").and_then(|v| v.as_str())
+                && !root.is_empty()
+            {
+                project = super::common::project_from_path(root);
+            }
+            if let Some(model) = record.get("model_id").and_then(|v| v.as_str()) {
+                current_model = Some(model.to_string());
+            }
+            if let Some(provider) = record.get("provider_id").and_then(|v| v.as_str()) {
+                current_provider = Some(provider.to_string());
+            }
+        }
+
+        let event = match payload.get("event") {
+            Some(e) => e,
+            None => continue,
+        };
+        let ekind = event.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+
+        if ekind == "model_completed" {
+            let usage = match event.get("usage") {
+                Some(u) => u,
+                None => continue,
+            };
+            let number = |key: &str| usage.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+            let input = number("input_tokens").max(number("input"));
+            let output = number("output_tokens").max(number("output"));
+            let cache_read = number("cache_read_tokens").max(number("cached_tokens"));
+            let cache_write = number("cache_write_tokens");
+            let reasoning = number("reasoning_tokens");
+
+            let mut tokens = TokenBuckets::disjoint(
+                input,
+                cache_read,
+                cache_write,
+                output.saturating_add(reasoning),
+            );
+            tokens.reasoning = reasoning;
+            if tokens.additive_total() == 0 {
+                continue;
+            }
+
+            let model = event
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .or_else(|| current_model.clone());
+
+            events.push(UsageEvent {
+                source: "muse",
+                source_path: source_path.clone(),
+                source_record_id: None,
+                session_id: Some(session_id.clone()),
+                request_id: None,
+                message_id: None,
+                timestamp_ms: recorded_at,
+                project: Some(project.clone()),
+                provider: current_provider.clone(),
+                model,
+                tokens,
+                source_cost_usd: None,
+                cost_authoritative: false,
+                dedupe_confidence: "exact",
+                conservative_undercount: false,
+                cache_chain_excluded: false,
+                sidechain: false,
+                source_order: 0,
+            });
+        }
+    }
+
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_muse_session_record_and_usage() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308372342264,"payload":{"kind":"metadata","record":{"workspace_root":"/Users/joe/Developer/memex","provider_id":"meta","model_id":"muse-spark-1.2"}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308372900000,"payload":{"kind":"run","event":{"kind":"started","prompt":"Hello Muse"}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373000000,"payload":{"kind":"run","event":{"kind":"reasoning_committed","message_id":"m1","text":"Let me think"}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373100000,"payload":{"kind":"run","event":{"kind":"assistant_tool_calls_committed","message_id":"m1","tool_calls":[{"call_id":"call1","name":"bash","args":"{\"command\":\"pwd\"}"}]}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373200000,"payload":{"kind":"run","event":{"kind":"tool_result_batch_committed","results":[{"tool_call_id":"call1","text":"/Users/joe/Developer/memex"}]}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373300000,"payload":{"kind":"run","event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"input_tokens":100,"output_tokens":20,"cached_tokens":10,"reasoning_tokens":5}}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373400000,"payload":{"kind":"run","event":{"kind":"assistant_message_committed","message_id":"m2","text":"I checked the current directory."}}}"#, "\n"
+            ),
+        )
+        .unwrap();
+
+        let mut records = Vec::new();
+        let next_doc_id = AtomicU64::new(1);
+        let out = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &next_doc_id,
+            |rec| {
+                records.push(rec);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.session_id.as_deref(), Some("01a05f7c-3b49-77a1"));
+        assert_eq!(records.len(), 5); // user started, reasoning, tool_use, tool_result, assistant text
+        assert_eq!(records[0].role, "user");
+        assert_eq!(records[0].text, "Hello Muse");
+        assert_eq!(records[0].project, "memex");
+        assert_eq!(records[1].role, "reasoning");
+        assert_eq!(records[1].text, "Let me think");
+        assert_eq!(records[2].role, "tool_use");
+        assert_eq!(records[2].tool_name.as_deref(), Some("bash"));
+        assert_eq!(records[3].role, "tool_result");
+        assert_eq!(records[3].tool_name.as_deref(), Some("bash"));
+        assert_eq!(records[4].role, "assistant");
+        assert_eq!(records[4].text, "I checked the current directory.");
+
+        let events = parse_usage_file(&path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tokens.uncached_input, 100);
+        assert_eq!(events[0].tokens.output, 25);
+        assert_eq!(events[0].tokens.cache_read, 10);
+        assert_eq!(events[0].tokens.reasoning, 5);
+        assert_eq!(events[0].model.as_deref(), Some("muse-spark-1.2"));
+        assert_eq!(events[0].provider.as_deref(), Some("meta"));
+    }
+}

--- a/src/sources/muse.rs
+++ b/src/sources/muse.rs
@@ -129,6 +129,45 @@ fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
         .unwrap_or(0)
 }
 
+/// Recover session id, project, and base timestamp from an already-indexed
+/// prefix row. Used before resuming at a saved offset so appended-only parses
+/// keep the metadata established by the leading rows.
+fn recover_muse_header(
+    value: &BorrowedValue<'_>,
+    session_id: &mut String,
+    project: &mut String,
+    default_timestamp: &mut u64,
+) {
+    if let Some(stream) = value.get("stream")
+        && let Some(sid) = stream.get("id").and_then(|v| v.as_str())
+        && !sid.is_empty()
+    {
+        *session_id = sid.to_string();
+    }
+    let recorded_at = value.get("recorded_at").map(timestamp_millis).unwrap_or(0);
+    if recorded_at > 0 && *default_timestamp == 0 {
+        *default_timestamp = recorded_at;
+    }
+    let Some(payload) = value.get("payload") else {
+        return;
+    };
+    let kind = payload.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if kind != "metadata" && kind != "route_facts" {
+        return;
+    }
+    if let Some(record) = payload.get("record") {
+        if let Some(root) = record.get("workspace_root").and_then(|v| v.as_str())
+            && !root.is_empty()
+        {
+            *project = super::common::project_from_path(root);
+        } else if let Some(cwd) = record.get("cwd").and_then(|v| v.as_str())
+            && !cwd.is_empty()
+        {
+            *project = super::common::project_from_path(cwd);
+        }
+    }
+}
+
 pub(crate) fn parse_index_records(
     path: &Path,
     state: IndexParseState,
@@ -164,6 +203,35 @@ pub(crate) fn parse_index_records(
     let mut default_timestamp = 0;
 
     let mut buf = Vec::new();
+    // On incremental appends parsing resumes at `state.offset`, skipping the
+    // leading metadata/route-facts rows that carry workspace_root/cwd. Recover
+    // them (plus session id and base timestamp) from the already-indexed prefix
+    // first, mirroring the Pi session-header recovery.
+    if start > 0 && !mmap.is_empty() {
+        let prefix_end = start.min(mmap.len());
+        let mut scan = 0;
+        while scan < prefix_end {
+            let slice = &mmap[scan..prefix_end];
+            let rel = memchr(b'\n', slice).unwrap_or(slice.len());
+            let line = &slice[..rel];
+            scan += rel + usize::from(rel < slice.len());
+            if line.is_empty() {
+                continue;
+            }
+            buf.clear();
+            buf.extend_from_slice(line);
+            let Ok(value) = simd_json::to_borrowed_value(&mut buf) else {
+                continue;
+            };
+            recover_muse_header(
+                &value,
+                &mut session_id,
+                &mut project,
+                &mut default_timestamp,
+            );
+        }
+        buf.clear();
+    }
     while start < mmap.len() {
         let slice = &mmap[start..];
         let rel = memchr(b'\n', slice).unwrap_or(slice.len());
@@ -617,5 +685,75 @@ mod tests {
         assert_eq!(events[0].tokens.reasoning, 5);
         assert_eq!(events[0].model.as_deref(), Some("muse-spark-1.2"));
         assert_eq!(events[0].provider.as_deref(), Some("meta"));
+    }
+
+    #[test]
+    fn appended_rows_keep_metadata_project() {
+        use std::io::Write;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"stream":{"kind":"session","id":"sess-1"},"recorded_at":1788308372342264,"payload":{"kind":"metadata","record":{"workspace_root":"/Users/joe/Developer/memex"}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"sess-1"},"recorded_at":1788308372900000,"payload":{"kind":"run","event":{"kind":"started","prompt":"Hello"}}}"#, "\n",
+            ),
+        )
+        .unwrap();
+
+        let next_doc_id = AtomicU64::new(1);
+        let mut first_records = Vec::new();
+        let out = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &next_doc_id,
+            |rec| {
+                first_records.push(rec);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(first_records.len(), 1);
+        assert_eq!(first_records[0].project, "memex");
+
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(
+                br#"{"stream":{"kind":"session","id":"sess-1"},"recorded_at":1788308373400000,"payload":{"kind":"run","event":{"kind":"assistant_message_committed","message_id":"m9","text":"Follow-up"}}}"#,
+            )
+            .unwrap();
+        // Newline-terminate the appended row so the resumed parse sees a full line.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"\n")
+            .unwrap();
+
+        let mut resumed = Vec::new();
+        let resumed_out = parse_index_records(
+            &path,
+            IndexParseState {
+                offset: out.offset,
+                turn_id: out.turn_id,
+                ..IndexParseState::default()
+            },
+            false,
+            &next_doc_id,
+            |rec| {
+                resumed.push(rec);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resumed.len(), 1);
+        assert_eq!(resumed[0].project, "memex");
+        assert_eq!(resumed[0].session_id, "sess-1");
+        assert_eq!(resumed_out.turn_id, out.turn_id + 1);
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1540,6 +1540,12 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
             crate::sources::grok::session_cwd(Path::new(&first.source_path)).map(PathBuf::from)
         }
         SourceKind::Hermes => None,
+        SourceKind::Jcode => {
+            crate::sources::jcode::cwd_from_jcode_session(Path::new(&first.source_path))
+        }
+        SourceKind::Muse => {
+            crate::sources::muse::cwd_from_muse_session(Path::new(&first.source_path))
+        }
     }
     .filter(|path| path.is_dir())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -412,6 +412,8 @@ enum SourceChoice {
     Copilot,
     Grok,
     Hermes,
+    Jcode,
+    Muse,
 }
 
 impl SourceChoice {
@@ -427,7 +429,9 @@ impl SourceChoice {
             SourceChoice::OpenClaw => SourceChoice::Copilot,
             SourceChoice::Copilot => SourceChoice::Grok,
             SourceChoice::Grok => SourceChoice::Hermes,
-            SourceChoice::Hermes => SourceChoice::All,
+            SourceChoice::Hermes => SourceChoice::Jcode,
+            SourceChoice::Jcode => SourceChoice::Muse,
+            SourceChoice::Muse => SourceChoice::All,
         }
     }
 
@@ -444,6 +448,8 @@ impl SourceChoice {
             SourceChoice::Copilot => Some(SourceFilter::Copilot),
             SourceChoice::Grok => Some(SourceFilter::Grok),
             SourceChoice::Hermes => Some(SourceFilter::Hermes),
+            SourceChoice::Jcode => Some(SourceFilter::Jcode),
+            SourceChoice::Muse => Some(SourceFilter::Muse),
         }
     }
 
@@ -460,6 +466,8 @@ impl SourceChoice {
             SourceChoice::Copilot => "copilot",
             SourceChoice::Grok => "grok",
             SourceChoice::Hermes => "hermes",
+            SourceChoice::Jcode => "jcode",
+            SourceChoice::Muse => "muse",
         }
     }
 
@@ -475,6 +483,8 @@ impl SourceChoice {
             SourceKind::Copilot => SourceChoice::Copilot,
             SourceKind::Grok => SourceChoice::Grok,
             SourceKind::Hermes => SourceChoice::Hermes,
+            SourceKind::Jcode => SourceChoice::Jcode,
+            SourceKind::Muse => SourceChoice::Muse,
         }
     }
 }
@@ -1117,6 +1127,8 @@ impl App {
                     include_openclaw: true,
                     include_copilot: true,
                     include_grok: true,
+                    include_jcode: true,
+                    include_muse: true,
                     exclude_patterns: config.exclude_path_patterns(),
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
@@ -2510,6 +2522,8 @@ impl App {
             SourceKind::Grok => "grok",
             SourceKind::Omp => "omp",
             SourceKind::Hermes => "hermes",
+            SourceKind::Jcode => "jcode",
+            SourceKind::Muse => "muse",
         };
         let source_path = session.source_path.clone();
 
@@ -3958,6 +3972,8 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
         SourceChoice::Copilot => label == "copilot",
         SourceChoice::Grok => label == "grok",
         SourceChoice::Hermes => label == "hermes",
+        SourceChoice::Jcode => label == "jcode",
+        SourceChoice::Muse => label == "muse",
         SourceChoice::All => false,
     }
 }
@@ -3974,6 +3990,8 @@ fn source_color(source: SourceKind) -> Color {
         SourceKind::Copilot => Color::Rgb(140, 160, 220),
         SourceKind::Grok => Color::Rgb(255, 120, 90),
         SourceKind::Hermes => Color::Rgb(190, 150, 220),
+        SourceKind::Jcode => Color::Rgb(220, 140, 180),
+        SourceKind::Muse => Color::Rgb(180, 130, 240),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,10 +15,12 @@ pub enum SourceKind {
     Omp,
     Grok,
     Hermes,
+    Jcode,
+    Muse,
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 10] = [
+    pub const ALL: [SourceKind; 12] = [
         SourceKind::Claude,
         SourceKind::Codex,
         SourceKind::Opencode,
@@ -29,6 +31,8 @@ impl SourceKind {
         SourceKind::Omp,
         SourceKind::Grok,
         SourceKind::Hermes,
+        SourceKind::Jcode,
+        SourceKind::Muse,
     ];
     pub const COUNT: usize = Self::ALL.len();
 
@@ -44,6 +48,8 @@ impl SourceKind {
             SourceKind::Omp => 7,
             SourceKind::Grok => 8,
             SourceKind::Hermes => 9,
+            SourceKind::Jcode => 10,
+            SourceKind::Muse => 11,
         }
     }
 
@@ -59,6 +65,8 @@ impl SourceKind {
             7 => Some(SourceKind::Omp),
             8 => Some(SourceKind::Grok),
             9 => Some(SourceKind::Hermes),
+            10 => Some(SourceKind::Jcode),
+            11 => Some(SourceKind::Muse),
             _ => None,
         }
     }
@@ -75,6 +83,8 @@ impl SourceKind {
             SourceKind::Omp => "omp",
             SourceKind::Grok => "grok",
             SourceKind::Hermes => "hermes",
+            SourceKind::Jcode => "jcode",
+            SourceKind::Muse => "muse",
         }
     }
 
@@ -90,6 +100,8 @@ impl SourceKind {
             SourceKind::Omp => "omp",
             SourceKind::Grok => "grok",
             SourceKind::Hermes => "hermes",
+            SourceKind::Jcode => "jcode",
+            SourceKind::Muse => "muse",
         }
     }
 
@@ -109,6 +121,8 @@ impl SourceKind {
             "omp" => Some(SourceKind::Omp),
             "grok" => Some(SourceKind::Grok),
             "hermes" => Some(SourceKind::Hermes),
+            "jcode" => Some(SourceKind::Jcode),
+            "muse" => Some(SourceKind::Muse),
             _ => None,
         }
     }
@@ -129,6 +143,8 @@ pub enum SourceFilter {
     Omp,
     Grok,
     Hermes,
+    Jcode,
+    Muse,
 }
 
 impl SourceFilter {
@@ -144,6 +160,8 @@ impl SourceFilter {
             SourceFilter::Omp => source == SourceKind::Omp,
             SourceFilter::Grok => source == SourceKind::Grok,
             SourceFilter::Hermes => source == SourceKind::Hermes,
+            SourceFilter::Jcode => source == SourceKind::Jcode,
+            SourceFilter::Muse => source == SourceKind::Muse,
         }
     }
 
@@ -159,6 +177,8 @@ impl SourceFilter {
             SourceFilter::Omp => &["omp"],
             SourceFilter::Grok => &["grok"],
             SourceFilter::Hermes => &["hermes"],
+            SourceFilter::Jcode => &["jcode"],
+            SourceFilter::Muse => &["muse"],
         }
     }
 
@@ -174,6 +194,8 @@ impl SourceFilter {
             SourceFilter::Omp => "omp",
             SourceFilter::Grok => "grok",
             SourceFilter::Hermes => "hermes",
+            SourceFilter::Jcode => "jcode",
+            SourceFilter::Muse => "muse",
         }
     }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -513,7 +513,7 @@ fn assemble_usage_events(
     };
     type SourceScanner =
         fn(&mut Vec<UsageEvent>, &mut Vec<String>, Option<&mut UsageCache>) -> Result<()>;
-    const SCANNERS: [(SourceFilter, SourceScanner); 10] = [
+    const SCANNERS: [(SourceFilter, SourceScanner); 12] = [
         (SourceFilter::Claude, scan_claude),
         (SourceFilter::Codex, scan_codex),
         (SourceFilter::Opencode, scan_opencode),
@@ -524,6 +524,8 @@ fn assemble_usage_events(
         (SourceFilter::Copilot, scan_copilot),
         (SourceFilter::Grok, scan_grok),
         (SourceFilter::Hermes, scan_hermes),
+        (SourceFilter::Jcode, scan_jcode),
+        (SourceFilter::Muse, scan_muse),
     ];
     for (filter, scanner) in SCANNERS {
         if source.is_none_or(|selected| selected == filter) {
@@ -1424,6 +1426,48 @@ fn scan_hermes(
         warnings,
         out,
         crate::sources::hermes::parse_usage_file,
+    );
+    Ok(())
+}
+
+fn scan_jcode(
+    out: &mut Vec<UsageEvent>,
+    warnings: &mut Vec<String>,
+    cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    let files = crate::sources::jcode::usage_files();
+    scan_files_cached(
+        SourceScan {
+            source: "jcode",
+            parser_version: crate::sources::jcode::VERSIONS.usage,
+            volatile_reuse_ms: |_| None,
+        },
+        &files,
+        cache,
+        warnings,
+        out,
+        |path| crate::sources::jcode::parse_usage_file(path).map(FileParse::cacheable),
+    );
+    Ok(())
+}
+
+fn scan_muse(
+    out: &mut Vec<UsageEvent>,
+    warnings: &mut Vec<String>,
+    cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    let files = crate::sources::muse::usage_files();
+    scan_files_cached(
+        SourceScan {
+            source: "muse",
+            parser_version: crate::sources::muse::VERSIONS.usage,
+            volatile_reuse_ms: |_| None,
+        },
+        &files,
+        cache,
+        warnings,
+        out,
+        |path| crate::sources::muse::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -585,6 +585,8 @@ fn parse_source(value: &str) -> Result<SourceFilter> {
         "copilot" => Ok(SourceFilter::Copilot),
         "grok" => Ok(SourceFilter::Grok),
         "hermes" => Ok(SourceFilter::Hermes),
+        "jcode" => Ok(SourceFilter::Jcode),
+        "muse" => Ok(SourceFilter::Muse),
         _ => Err(anyhow!("unknown source: {value}")),
     }
 }
@@ -896,6 +898,20 @@ mod tests {
         let request = SearchRequest::from_url(&url).unwrap();
 
         assert_eq!(request.source, Some(SourceFilter::Omp));
+    }
+
+    #[test]
+    fn search_request_accepts_jcode_and_muse_sources() {
+        let url_jcode = parse_url("/api/search?source=jcode").unwrap();
+        assert_eq!(
+            SearchRequest::from_url(&url_jcode).unwrap().source,
+            Some(SourceFilter::Jcode)
+        );
+        let url_muse = parse_url("/api/search?source=muse").unwrap();
+        assert_eq!(
+            SearchRequest::from_url(&url_muse).unwrap().source,
+            Some(SourceFilter::Muse)
+        );
     }
 
     #[test]

--- a/tests/concurrent_search.rs
+++ b/tests/concurrent_search.rs
@@ -38,8 +38,12 @@ fn concurrent_searches_coalesce_stale_auto_indexing() {
             "--no-opencode",
             "--no-cursor",
             "--no-pi",
+            "--no-omp",
+            "--no-openclaw",
             "--no-copilot",
             "--no-grok",
+            "--no-jcode",
+            "--no-muse",
             "--no-embeddings",
         ])
         .arg("--root")

--- a/tests/multi_machine.rs
+++ b/tests/multi_machine.rs
@@ -72,6 +72,8 @@ fn federated_search_uses_the_configured_ssh_rpc_backend() {
             "--no-openclaw",
             "--no-copilot",
             "--no-grok",
+            "--no-jcode",
+            "--no-muse",
             "--no-embeddings",
             "--root",
         ])


### PR DESCRIPTION
## Summary
Adds indexing, search, token-usage reconstruction, and resume support for Jcode, Muse, and SQLite-backed OpenCode sessions.

Base of the session-label (#117) / origin-classification (#118) stack.

## Changes
- OpenCode (`src/sources/opencode.rs`): parse the SQLite database (`session`, `message`, `part`, `project` tables) alongside the legacy per-message JSON files. Preserves reasoning blocks, tool use/results, and project associations.
- Jcode (`src/sources/jcode.rs`): index user/assistant turns, reasoning blocks, tool calls/results, and token metrics from session files.
- Muse (`src/sources/muse.rs`): index message/tool event streams, including worker transcripts, reasoning blocks, and token usage events.
- Plumbing: new `SourceKind`/`SourceFilter` variants, index flags to include or skip the new sources, usage-scanner registration, resume templates and working-directory resolution, TUI source filtering, and docs.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`