### PR TITLE
Add auto-generated session labels (with initial origin classification)

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1272,81 +1272,85 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 #[allow(clippy::while_let_loop)]
 pub fn sanitize_label(raw: &str) -> String {
     // Comprehensive stripping of system wrappers (case-insensitive).
+    // Fast path: neither the tag stripper nor the generic unwrap can match
+    // without a '<', so skip both scans for ordinary prose. This keeps the
+    // per-record emptiness check in `record` cheap during index scans.
     let mut current = raw.to_string();
-    const DROP_TAGS: &[&str] = &[
-        "system-reminder",
-        "command-message",
-        "command-name",
-        "local-command-stdout",
-        "local-command-caveat",
-        "local-command-output",
-        "instructions",
-        "environment_context",
-        "cwd",
-        "approval_policy",
-        "shell",
-        "user_instructions",
-        "recommended_plugins",
-        "skill",
-        "user_action",
-        "context",
-        "task-notification",
-        "task-id",
-        "tool-use-id",
-        "subagent_notification",
-        "turn_aborted",
-        "current_date",
-        "timezone",
-        "epoch",
-        "collaboration_mode",
-        "apps_instructions",
-        "permissions",
-        "total_tokens",
-    ];
-    for tag in DROP_TAGS {
-        let open = format!("<{}", tag.to_lowercase());
-        let close = format!("</{}>", tag.to_lowercase());
-        loop {
-            let lower = current.to_lowercase();
-            let Some(start) = lower.find(&open) else {
-                break;
-            };
-            let open_end = match lower[start..].find('>') {
-                Some(p) => start + p + 1,
-                None => {
+    if current.contains('<') {
+        const DROP_TAGS: &[&str] = &[
+            "system-reminder",
+            "command-message",
+            "command-name",
+            "local-command-stdout",
+            "local-command-caveat",
+            "local-command-output",
+            "instructions",
+            "environment_context",
+            "cwd",
+            "approval_policy",
+            "shell",
+            "user_instructions",
+            "recommended_plugins",
+            "skill",
+            "user_action",
+            "context",
+            "task-notification",
+            "task-id",
+            "tool-use-id",
+            "subagent_notification",
+            "turn_aborted",
+            "current_date",
+            "timezone",
+            "epoch",
+            "collaboration_mode",
+            "apps_instructions",
+            "permissions",
+            "total_tokens",
+        ];
+        for tag in DROP_TAGS {
+            let open = format!("<{tag}");
+            let close = format!("</{tag}>");
+            loop {
+                let Some(start) = find_ascii_ci(&current, &open) else {
+                    break;
+                };
+                let open_end = match current[start..].find('>') {
+                    Some(p) => start + p + 1,
+                    None => {
+                        current.truncate(start);
+                        break;
+                    }
+                };
+                if let Some(end_offset) = find_ascii_ci(&current[open_end..], &close) {
+                    let abs_end = open_end + end_offset + close.len();
+                    current.replace_range(start..abs_end, " ");
+                } else {
                     current.truncate(start);
                     break;
                 }
-            };
-            if let Some(end_offset) = lower[open_end..].find(&close) {
-                let abs_end = open_end + end_offset + close.len();
-                current.replace_range(start..abs_end, " ");
-            } else {
-                current.truncate(start);
-                break;
             }
         }
-    }
-    // Generic unwrap: remove any remaining <...> tags but keep inner text.
-    let mut search_start = 0;
-    loop {
-        let Some(rel_start) = current[search_start..].find('<') else {
-            break;
-        };
-        let start = search_start + rel_start;
-        let Some(end) = current[start..].find('>') else {
-            break;
-        };
-        let abs_end = start + end + 1;
-        let after_lt = current[start + 1..].chars().next().unwrap_or(' ');
-        if after_lt.is_ascii_alphabetic() || after_lt == '/' || after_lt == '!' {
-            current.replace_range(start..abs_end, " ");
-            search_start = start;
-        } else {
-            search_start = abs_end;
-        }
-        if current.len() > 10000 {
-            break;
+        // Generic unwrap: remove any remaining <...> tags but keep inner text.
+        let mut search_start = 0;
+        loop {
+            let Some(rel_start) = current[search_start..].find('<') else {
+                break;
+            };
+            let start = search_start + rel_start;
+            let Some(end) = current[start..].find('>') else {
+                break;
+            };
+            let abs_end = start + end + 1;
+            let after_lt = current[start + 1..].chars().next().unwrap_or(' ');
+            if after_lt.is_ascii_alphabetic() || after_lt == '/' || after_lt == '!' {
+                current.replace_range(start..abs_end, " ");
+                search_start = start;
+            } else {
+                search_start = abs_end;
+            }
+            if current.len() > 10000 {
+                break;
+            }
         }
     }
     let ansi_stripped = strip_ansi(&current);
@@ -1415,7 +1419,25 @@ pub fn sanitize_label(raw: &str) -> String {
     format!("{}…{}", head, tail)
 }
 
+/// ASCII case-insensitive substring search over the original string's bytes.
+/// Tag patterns are pure ASCII, so byte-wise matching keeps every index in the
+/// original string's coordinates: Unicode `to_lowercase` can shift byte
+/// offsets (e.g. U+0130 folds 2 bytes into 3), which would make `replace_range`
+/// or `truncate` panic on a non-char-boundary. Every match starts at a `<`
+/// byte, which is always a char boundary in UTF-8.
+fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let hay = haystack.as_bytes();
+    let ndl = needle.as_bytes();
+    if ndl.is_empty() || hay.len() < ndl.len() {
+        return None;
+    }
+    (0..=hay.len() - ndl.len()).find(|&i| hay[i..i + ndl.len()].eq_ignore_ascii_case(ndl))
+}
+
 fn strip_ansi(input: &str) -> String {
+    if !input.contains('\x1b') {
+        return input.to_string();
+    }
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
@@ -1451,8 +1473,15 @@ fn strip_ansi(input: &str) -> String {
             i += 1;
             continue;
         }
-        out.push(bytes[i] as char);
-        i += 1;
+        // Copy one full UTF-8 scalar value: pushing a single byte as char
+        // would corrupt multi-byte sequences (e.g. emoji) into mojibake and
+        // inflate char counts used by truncation. `i` always rests on a char
+        // boundary here because every skipped escape sequence is pure ASCII.
+        let Some(ch) = input[i..].chars().next() else {
+            break;
+        };
+        out.push(ch);
+        i += ch.len_utf8();
     }
     out
 }
@@ -2148,6 +2177,40 @@ mod tests {
         assert!(label.chars().count() <= MAX_LABEL_CHARS);
         assert!(label.ends_with('…') || label.chars().count() < MAX_LABEL_CHARS);
         assert!(label.starts_with("Hello world red"));
+    }
+
+    #[test]
+    fn strip_ansi_preserves_multibyte_unicode() {
+        let label = sanitize_label("Fix the 🚀 deploy \x1b[31mred\x1b[0m pipeline ✅ now");
+        assert_eq!(label, "Fix the 🚀 deploy red pipeline ✅ now");
+        assert!(label.contains('🚀'));
+    }
+
+    #[test]
+    fn sanitize_label_truncates_unicode_by_chars_not_bytes() {
+        let raw = "🚀".repeat(200);
+        let label = sanitize_label(&raw);
+        assert!(label.chars().count() <= MAX_LABEL_CHARS);
+        assert!(label.contains('…'));
+        assert!(label.starts_with("🚀"));
+    }
+
+    #[test]
+    fn sanitize_label_with_unicode_case_fold_before_tag_does_not_panic() {
+        // U+0130 folds to 2 chars on lowercase; byte offsets computed on the
+        // folded copy would be wrong for the original. Must strip safely.
+        let raw = "İstanbul \u{130} <SYSTEM-REMINDER>hidden</SYSTEM-REMINDER> visible task";
+        let label = sanitize_label(raw);
+        assert!(!label.contains("hidden"));
+        assert!(!label.contains("SYSTEM-REMINDER"));
+        assert!(label.contains("visible task"));
+    }
+
+    #[test]
+    fn sanitize_label_preserves_lone_comparison_brackets() {
+        let raw = "a < b and c > d comparison";
+        let label = sanitize_label(raw);
+        assert_eq!(label, "a < b and c > d comparison");
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 const GIT_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_LABEL_CHARS: usize = 150;
 
@@ -186,6 +186,13 @@ impl AnalyticsStore {
         if previous_schema_version != Some(SCHEMA_VERSION) {
             self.conn
                 .execute("DELETE FROM meta WHERE key = 'analytics_complete'", [])?;
+            // Labels generated before the system-tag stripper was complete contained raw
+            // <system-reminder> / <command-message> wrappers. Clear them so the next
+            // backfill recomputes the real first user prompt.
+            let _ = self.conn.execute(
+                "UPDATE sessions SET label = NULL WHERE label LIKE '%<system-reminder>%' OR label LIKE '%<command-message>%' OR label LIKE '%<command-name>%'",
+                [],
+            );
         }
         self.conn.execute(
             "INSERT INTO meta(key, value) VALUES('schema_version', ?1)
@@ -799,6 +806,7 @@ impl AnalyticsWriter {
         if entry.first_user_text.is_none()
             && record.role == "user"
             && !record.text.trim().is_empty()
+            && !sanitize_label(&record.text).is_empty()
         {
             entry.first_user_text = Some(record.text.clone());
         }
@@ -1251,30 +1259,38 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 }
 
 pub fn sanitize_label(raw: &str) -> String {
-    // Strip <system-reminder> blocks (case-insensitive).
-    let mut without_reminder = String::with_capacity(raw.len());
-    let lower = raw.to_lowercase();
-    let mut idx = 0;
-    while idx < raw.len() {
-        if let Some(start) = lower[idx..].find("<system-reminder") {
-            let abs_start = idx + start;
-            without_reminder.push_str(&raw[idx..abs_start]);
-            if let Some(end) = lower[abs_start..].find("</system-reminder>") {
-                idx = abs_start + end + "</system-reminder>".len();
-                continue;
+    // Strip system-like tag blocks (case-insensitive) that wrap slash-command / reminder metadata.
+    let mut current = raw.to_string();
+    for tag in [
+        "system-reminder",
+        "command-message",
+        "command-name",
+        "local-command-stdout",
+    ] {
+        let open = format!("<{tag}");
+        let close = format!("</{tag}>");
+        let lower = current.to_lowercase();
+        let mut without = String::with_capacity(current.len());
+        let mut idx = 0;
+        while idx < current.len() {
+            if let Some(start) = lower[idx..].find(&open) {
+                let abs_start = idx + start;
+                without.push_str(&current[idx..abs_start]);
+                if let Some(end) = lower[abs_start..].find(&close) {
+                    idx = abs_start + end + close.len();
+                    continue;
+                } else {
+                    // Tag opened but not closed – drop the rest.
+                    break;
+                }
             } else {
+                without.push_str(&current[idx..]);
                 break;
             }
-        } else {
-            without_reminder.push_str(&raw[idx..]);
-            break;
         }
+        current = without;
     }
-    let stripped = if without_reminder.is_empty() {
-        raw.to_string()
-    } else {
-        without_reminder
-    };
+    let stripped = current;
     let ansi_stripped = strip_ansi(&stripped);
     let collapsed = ansi_stripped
         .split_whitespace()
@@ -1442,6 +1458,10 @@ fn jcode_label_from_file(path: &str) -> Option<String> {
         }
         let combined = texts.join("\n");
         if combined.trim().is_empty() {
+            continue;
+        }
+        // Skip pure <system-reminder> messages – look for next user message.
+        if sanitize_label(&combined).is_empty() {
             continue;
         }
         return Some(combined);

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -862,7 +862,7 @@ impl AnalyticsWriter {
                     last_at = MAX(sessions.last_at, excluded.last_at),
                     message_count = sessions.message_count + excluded.message_count,
                     resolution_status = excluded.resolution_status,
-                    label = COALESCE(excluded.label, sessions.label),
+                    label = COALESCE(sessions.label, excluded.label),
                     conversation_kind = COALESCE(excluded.conversation_kind, sessions.conversation_kind)
                 "#,
             )?;
@@ -1610,7 +1610,9 @@ fn opencode_agent_is_subagent(db_path: &str, session_id: &str) -> bool {
             .optional()
             .ok()
             .flatten();
-        Some(agent.is_some_and(|a| !a.is_empty() && a != "build"))
+        Some(!crate::sources::opencode::opencode_agent_is_primary(
+            agent.as_deref(),
+        ))
     };
     check().unwrap_or(false)
 }
@@ -2243,6 +2245,47 @@ mod tests {
             Some("Fix the login bug on the dashboard")
         );
         assert_eq!(rows[0].conversation_kind.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn analytics_preserves_label_on_incremental_append() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(
+            &transcript,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                tmp.path().display()
+            ),
+        )
+        .expect("write");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        let mut first = record("proj", "s-append", &transcript, 10);
+        first.role = "user".to_string();
+        first.text = "Fix the login bug on the dashboard".to_string();
+        first.links.conversation_kind = Some("main".to_string());
+        writer.record(&first).expect("record");
+        writer.flush().expect("flush");
+
+        // An append-only batch resumes past the original prompt, so its
+        // derived label reflects a later turn and must not replace the stored one.
+        let mut later = record("proj", "s-append", &transcript, 20);
+        later.role = "user".to_string();
+        later.text = "Also check the settings page".to_string();
+        later.links.conversation_kind = Some("main".to_string());
+        writer.record(&later).expect("record");
+        writer.flush().expect("flush");
+
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        let rows = store
+            .query_sessions_detailed(None, None, None, None, None)
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].label.as_deref(),
+            Some("Fix the login bug on the dashboard")
+        );
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 5;
 const GIT_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_LABEL_CHARS: usize = 150;
 
@@ -187,10 +187,21 @@ impl AnalyticsStore {
             self.conn
                 .execute("DELETE FROM meta WHERE key = 'analytics_complete'", [])?;
             // Labels generated before the system-tag stripper was complete contained raw
-            // <system-reminder> / <command-message> wrappers. Clear them so the next
-            // backfill recomputes the real first user prompt.
+            // system wrappers and truncated prefixes. Clear them so the next backfill
+            // recomputes with comprehensive stripping and suffix-preserving truncation.
             let _ = self.conn.execute(
-                "UPDATE sessions SET label = NULL WHERE label LIKE '%<system-reminder>%' OR label LIKE '%<command-message>%' OR label LIKE '%<command-name>%'",
+                "UPDATE sessions SET label = NULL WHERE \
+                 label LIKE '%<system-reminder>%' OR \
+                 label LIKE '%<command-message>%' OR \
+                 label LIKE '%<command-name>%' OR \
+                 label LIKE '%<INSTRUCTIONS>%' OR \
+                 label LIKE '%<environment_context>%' OR \
+                 label LIKE '%<recommended_plugins>%' OR \
+                 label LIKE '%<user_instructions>%' OR \
+                 label LIKE '%<skill>%' OR \
+                 label LIKE '%<%' OR \
+                 label LIKE '# AGENTS.md%' OR \
+                 label LIKE 'You are a reminder observer%'",
                 [],
             );
         }
@@ -1258,46 +1269,100 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
     workspace
 }
 
+#[allow(clippy::while_let_loop)]
 pub fn sanitize_label(raw: &str) -> String {
-    // Strip system-like tag blocks (case-insensitive) that wrap slash-command / reminder metadata.
+    // Comprehensive stripping of system wrappers (case-insensitive).
     let mut current = raw.to_string();
-    for tag in [
+    const DROP_TAGS: &[&str] = &[
         "system-reminder",
         "command-message",
         "command-name",
         "local-command-stdout",
-    ] {
-        let open = format!("<{tag}");
-        let close = format!("</{tag}>");
-        let lower = current.to_lowercase();
-        let mut without = String::with_capacity(current.len());
-        let mut idx = 0;
-        while idx < current.len() {
-            if let Some(start) = lower[idx..].find(&open) {
-                let abs_start = idx + start;
-                without.push_str(&current[idx..abs_start]);
-                if let Some(end) = lower[abs_start..].find(&close) {
-                    idx = abs_start + end + close.len();
-                    continue;
-                } else {
-                    // Tag opened but not closed – drop the rest.
+        "local-command-caveat",
+        "local-command-output",
+        "instructions",
+        "environment_context",
+        "cwd",
+        "approval_policy",
+        "shell",
+        "user_instructions",
+        "recommended_plugins",
+        "skill",
+        "user_action",
+        "context",
+        "task-notification",
+        "task-id",
+        "tool-use-id",
+        "subagent_notification",
+        "turn_aborted",
+        "current_date",
+        "timezone",
+        "epoch",
+        "collaboration_mode",
+        "apps_instructions",
+        "permissions",
+        "total_tokens",
+    ];
+    for tag in DROP_TAGS {
+        let open = format!("<{}", tag.to_lowercase());
+        let close = format!("</{}>", tag.to_lowercase());
+        loop {
+            let lower = current.to_lowercase();
+            let Some(start) = lower.find(&open) else {
+                break;
+            };
+            let open_end = match lower[start..].find('>') {
+                Some(p) => start + p + 1,
+                None => {
+                    current.truncate(start);
                     break;
                 }
+            };
+            if let Some(end_offset) = lower[open_end..].find(&close) {
+                let abs_end = open_end + end_offset + close.len();
+                current.replace_range(start..abs_end, " ");
             } else {
-                without.push_str(&current[idx..]);
+                current.truncate(start);
                 break;
             }
         }
-        current = without;
     }
-    let stripped = current;
-    let ansi_stripped = strip_ansi(&stripped);
+    // Generic unwrap: remove any remaining <...> tags but keep inner text.
+    let mut search_start = 0;
+    loop {
+        let Some(rel_start) = current[search_start..].find('<') else {
+            break;
+        };
+        let start = search_start + rel_start;
+        let Some(end) = current[start..].find('>') else {
+            break;
+        };
+        let abs_end = start + end + 1;
+        let after_lt = current[start + 1..].chars().next().unwrap_or(' ');
+        if after_lt.is_ascii_alphabetic() || after_lt == '/' || after_lt == '!' {
+            current.replace_range(start..abs_end, " ");
+            search_start = start;
+        } else {
+            search_start = abs_end;
+        }
+        if current.len() > 10000 {
+            break;
+        }
+    }
+    let ansi_stripped = strip_ansi(&current);
     let collapsed = ansi_stripped
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ");
     let trimmed = collapsed.trim();
     if trimmed.is_empty() {
+        return String::new();
+    }
+    let lower = trimmed.to_lowercase();
+    if lower.starts_with("# agents.md")
+        || lower.contains("global agent preferences")
+        || lower.starts_with("you are a reminder observer")
+    {
         return String::new();
     }
     // Remove non-printable control chars
@@ -1312,17 +1377,42 @@ pub fn sanitize_label(raw: &str) -> String {
     if printable.chars().count() <= MAX_LABEL_CHARS {
         return printable.to_string();
     }
-    let truncated: String = printable.chars().take(MAX_LABEL_CHARS - 1).collect();
-    if let Some(pos) = truncated.rfind(' ')
-        && pos > 80
-    {
-        let mut out: String = printable.chars().take(pos).collect();
+    // Suffix-preserving truncation: keep head and tail to preserve distinguishing suffix.
+    const TAIL_LEN: usize = 40;
+    let head_len = MAX_LABEL_CHARS.saturating_sub(TAIL_LEN + 1);
+    let head_raw: String = printable.chars().take(head_len).collect();
+    let head = if let Some(pos) = head_raw.rfind(' ') {
+        if pos > 80 {
+            head_raw[..pos].to_string()
+        } else {
+            head_raw
+        }
+    } else {
+        head_raw
+    };
+    let rev_tail: String = printable.chars().rev().take(TAIL_LEN).collect();
+    let tail_raw: String = rev_tail.chars().rev().collect();
+    let tail = if let Some(pos) = tail_raw.find(' ') {
+        tail_raw[pos + 1..].trim().to_string()
+    } else {
+        tail_raw.trim().to_string()
+    };
+    if tail.is_empty() {
+        let mut out = head;
         out.push('…');
         return out;
     }
-    let mut out = truncated;
-    out.push('…');
-    out
+    let mut tail = tail;
+    while head.chars().count() + 1 + tail.chars().count() > MAX_LABEL_CHARS {
+        if let Some(pos) = tail.find(' ') {
+            tail = tail[pos + 1..].trim().to_string();
+        } else if tail.chars().count() > 10 {
+            tail = tail.chars().skip(tail.chars().count() - 10).collect();
+        } else {
+            break;
+        }
+    }
+    format!("{}…{}", head, tail)
 }
 
 fn strip_ansi(input: &str) -> String {
@@ -2146,8 +2236,8 @@ mod tests {
 
     #[test]
     fn jcode_tmp_cwd_is_classified_as_subagent() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let transcript = tmp.path().join("session_session_tmp.json");
+        let _tmp = tempfile::tempdir().expect("tempdir");
+        let _transcript = _tmp.path().join("session_session_tmp.json");
         // Need a file that contains cwd; but we also need to test inference via cwd.
         // We'll directly test infer_session_kind helper.
         let kind = infer_session_kind(

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -8,8 +8,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 3;
 const GIT_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_LABEL_CHARS: usize = 150;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -29,6 +30,17 @@ pub struct SessionRow {
     pub cwd: Option<String>,
     pub last_at: u64,
     pub message_count: u64,
+    pub label: Option<String>,
+    pub conversation_kind: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionKindFilter {
+    Primary,
+    Subagent,
+    #[default]
+    All,
 }
 
 /// A session row with every stored column, for `memex sessions`.
@@ -47,6 +59,10 @@ pub struct SessionDetailRow {
     pub started_at: u64,
     pub last_at: u64,
     pub message_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_kind: Option<String>,
 }
 
 pub struct AnalyticsStore {
@@ -75,6 +91,8 @@ struct SessionAccumulator {
     started_at: u64,
     last_at: u64,
     message_count: u64,
+    first_user_text: Option<String>,
+    conversation_kind: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -133,6 +151,8 @@ impl AnalyticsStore {
                 last_at INTEGER NOT NULL,
                 message_count INTEGER NOT NULL DEFAULT 0,
                 resolution_status TEXT NOT NULL DEFAULT '',
+                label TEXT,
+                conversation_kind TEXT,
                 PRIMARY KEY (source, session_id, source_path)
             );
             CREATE INDEX IF NOT EXISTS sessions_last_at_idx ON sessions(last_at);
@@ -142,6 +162,17 @@ impl AnalyticsStore {
                 ON sessions(COALESCE(NULLIF(repo_project, ''), project), last_at);
             CREATE INDEX IF NOT EXISTS sessions_source_last_at_idx ON sessions(source, last_at);
             "#,
+        )?;
+        // Additive migrations for existing databases: ignore duplicate-column errors.
+        for sql in [
+            "ALTER TABLE sessions ADD COLUMN label TEXT",
+            "ALTER TABLE sessions ADD COLUMN conversation_kind TEXT",
+        ] {
+            let _ = self.conn.execute(sql, []);
+        }
+        self.conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS sessions_conversation_kind_idx ON sessions(conversation_kind);
+             CREATE INDEX IF NOT EXISTS sessions_label_idx ON sessions(label);",
         )?;
         let previous_schema_version: Option<i64> = self
             .conn
@@ -238,10 +269,22 @@ impl AnalyticsStore {
         grouping: ProjectGrouping,
         limit: Option<usize>,
     ) -> Result<Vec<SessionRow>> {
+        self.query_sessions_filtered(source, since_ms, project, grouping, None, limit)
+    }
+
+    pub fn query_sessions_filtered(
+        &self,
+        source: Option<SourceFilter>,
+        since_ms: Option<u64>,
+        project: Option<&str>,
+        grouping: ProjectGrouping,
+        kind: Option<SessionKindFilter>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SessionRow>> {
         let mut sql = String::from(
             "SELECT source, session_id, source_path, project,
                     COALESCE(NULLIF(repo_project, ''), project) AS display_project,
-                    cwd, last_at, message_count
+                    cwd, last_at, message_count, label, conversation_kind
              FROM sessions",
         );
         let mut clauses = Vec::new();
@@ -272,6 +315,21 @@ impl AnalyticsStore {
             }
             values.push(rusqlite::types::Value::Text(project.to_string()));
         }
+        if let Some(kind) = kind {
+            match kind {
+                SessionKindFilter::Primary => {
+                    clauses.push(
+                        "(conversation_kind IS NULL OR conversation_kind = 'main')".to_string(),
+                    );
+                }
+                SessionKindFilter::Subagent => {
+                    clauses.push(
+                        "conversation_kind IS NOT NULL AND conversation_kind != 'main'".to_string(),
+                    );
+                }
+                SessionKindFilter::All => {}
+            }
+        }
         if !clauses.is_empty() {
             sql.push_str(" WHERE ");
             sql.push_str(&clauses.join(" AND "));
@@ -298,9 +356,11 @@ impl AnalyticsStore {
                 source_path: row.get(2)?,
                 project,
                 display_project,
-                cwd: row.get(5)?,
+                cwd: row.get::<_, Option<String>>(5)?.filter(|v| !v.is_empty()),
                 last_at: row.get::<_, i64>(6)?.max(0) as u64,
                 message_count: row.get::<_, i64>(7)?.max(0) as u64,
+                label: row.get::<_, Option<String>>(8)?.filter(|v| !v.is_empty()),
+                conversation_kind: row.get::<_, Option<String>>(9)?.filter(|v| !v.is_empty()),
             })
         })?;
 
@@ -323,9 +383,21 @@ impl AnalyticsStore {
         since_ms: Option<u64>,
         limit: Option<usize>,
     ) -> Result<Vec<SessionDetailRow>> {
+        self.query_sessions_detailed_filtered(source, project, cwd, since_ms, None, limit)
+    }
+
+    pub fn query_sessions_detailed_filtered(
+        &self,
+        source: Option<SourceFilter>,
+        project: Option<&str>,
+        cwd: Option<&str>,
+        since_ms: Option<u64>,
+        kind: Option<SessionKindFilter>,
+        limit: Option<usize>,
+    ) -> Result<Vec<SessionDetailRow>> {
         let mut sql = String::from(
             "SELECT source, session_id, source_path, project, repo_project,
-                    cwd, git_root, started_at, last_at, message_count
+                    cwd, git_root, started_at, last_at, message_count, label, conversation_kind
              FROM sessions",
         );
         let mut clauses = Vec::new();
@@ -364,6 +436,21 @@ impl AnalyticsStore {
             clauses.push("last_at >= ?".to_string());
             values.push(rusqlite::types::Value::Integer(since_ms as i64));
         }
+        if let Some(kind) = kind {
+            match kind {
+                SessionKindFilter::Primary => {
+                    clauses.push(
+                        "(conversation_kind IS NULL OR conversation_kind = 'main')".to_string(),
+                    );
+                }
+                SessionKindFilter::Subagent => {
+                    clauses.push(
+                        "conversation_kind IS NOT NULL AND conversation_kind != 'main'".to_string(),
+                    );
+                }
+                SessionKindFilter::All => {}
+            }
+        }
         if !clauses.is_empty() {
             sql.push_str(" WHERE ");
             sql.push_str(&clauses.join(" AND "));
@@ -390,6 +477,8 @@ impl AnalyticsStore {
                 started_at: row.get::<_, i64>(7)?.max(0) as u64,
                 last_at: row.get::<_, i64>(8)?.max(0) as u64,
                 message_count: row.get::<_, i64>(9)?.max(0) as u64,
+                label: row.get::<_, Option<String>>(10)?.filter(|v| !v.is_empty()),
+                conversation_kind: row.get::<_, Option<String>>(11)?.filter(|v| !v.is_empty()),
             })
         })?;
 
@@ -694,6 +783,8 @@ impl AnalyticsWriter {
                 started_at: record.ts,
                 last_at: record.ts,
                 message_count: 0,
+                first_user_text: None,
+                conversation_kind: None,
             });
         if record.ts < entry.started_at {
             entry.started_at = record.ts;
@@ -705,6 +796,18 @@ impl AnalyticsWriter {
             }
         }
         entry.message_count = entry.message_count.saturating_add(1);
+        if entry.first_user_text.is_none()
+            && record.role == "user"
+            && !record.text.trim().is_empty()
+        {
+            entry.first_user_text = Some(record.text.clone());
+        }
+        if entry.conversation_kind.is_none()
+            && let Some(kind) = record.links.conversation_kind.clone()
+            && !kind.is_empty()
+        {
+            entry.conversation_kind = Some(kind);
+        }
         Ok(())
     }
 
@@ -726,9 +829,10 @@ impl AnalyticsWriter {
                 r#"
                 INSERT INTO sessions(
                     source, session_id, source_path, project, cwd, git_root, git_common_dir,
-                    repo_project, started_at, last_at, message_count, resolution_status
+                    repo_project, started_at, last_at, message_count, resolution_status,
+                    label, conversation_kind
                 )
-                VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
                 ON CONFLICT(source, session_id, source_path) DO UPDATE SET
                     project = excluded.project,
                     cwd = excluded.cwd,
@@ -738,10 +842,27 @@ impl AnalyticsWriter {
                     started_at = MIN(sessions.started_at, excluded.started_at),
                     last_at = MAX(sessions.last_at, excluded.last_at),
                     message_count = sessions.message_count + excluded.message_count,
-                    resolution_status = excluded.resolution_status
+                    resolution_status = excluded.resolution_status,
+                    label = COALESCE(excluded.label, sessions.label),
+                    conversation_kind = COALESCE(excluded.conversation_kind, sessions.conversation_kind)
                 "#,
             )?;
             for (session, metadata) in sessions {
+                let label = extract_session_label(
+                    session.key.source,
+                    &session.key.source_path,
+                    &session.key.session_id,
+                    session.first_user_text.as_deref(),
+                    metadata.cwd.as_deref(),
+                );
+                let conversation_kind = infer_session_kind(
+                    session.key.source,
+                    &session.key.source_path,
+                    &session.key.session_id,
+                    session.conversation_kind.as_deref(),
+                    metadata.cwd.as_deref(),
+                    session.first_user_text.as_deref(),
+                );
                 stmt.execute(params![
                     session.key.source.storage_label(),
                     session.key.session_id,
@@ -755,6 +876,8 @@ impl AnalyticsWriter {
                     session.last_at as i64,
                     session.message_count as i64,
                     metadata.resolution_status,
+                    label,
+                    conversation_kind,
                 ])?;
             }
         }
@@ -1125,6 +1248,335 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
         }
     }
     workspace
+}
+
+pub fn sanitize_label(raw: &str) -> String {
+    // Strip <system-reminder> blocks (case-insensitive).
+    let mut without_reminder = String::with_capacity(raw.len());
+    let lower = raw.to_lowercase();
+    let mut idx = 0;
+    while idx < raw.len() {
+        if let Some(start) = lower[idx..].find("<system-reminder") {
+            let abs_start = idx + start;
+            without_reminder.push_str(&raw[idx..abs_start]);
+            if let Some(end) = lower[abs_start..].find("</system-reminder>") {
+                idx = abs_start + end + "</system-reminder>".len();
+                continue;
+            } else {
+                break;
+            }
+        } else {
+            without_reminder.push_str(&raw[idx..]);
+            break;
+        }
+    }
+    let stripped = if without_reminder.is_empty() {
+        raw.to_string()
+    } else {
+        without_reminder
+    };
+    let ansi_stripped = strip_ansi(&stripped);
+    let collapsed = ansi_stripped
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let trimmed = collapsed.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    // Remove non-printable control chars
+    let printable: String = trimmed
+        .chars()
+        .filter(|c| !c.is_control() || *c == ' ')
+        .collect();
+    let printable = printable.trim();
+    if printable.is_empty() {
+        return String::new();
+    }
+    if printable.chars().count() <= MAX_LABEL_CHARS {
+        return printable.to_string();
+    }
+    let truncated: String = printable.chars().take(MAX_LABEL_CHARS - 1).collect();
+    if let Some(pos) = truncated.rfind(' ')
+        && pos > 80
+    {
+        let mut out: String = printable.chars().take(pos).collect();
+        out.push('…');
+        return out;
+    }
+    let mut out = truncated;
+    out.push('…');
+    out
+}
+
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b {
+            // CSI: ESC [ ... letter
+            if i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+                i += 2;
+                while i < bytes.len() && !bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+            // OSC: ESC ] ... BEL or ESC \
+            if i + 1 < bytes.len() && bytes[i + 1] == b']' {
+                i += 2;
+                while i < bytes.len()
+                    && bytes[i] != 0x07
+                    && !(bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\')
+                {
+                    i += 1;
+                }
+                if i < bytes.len() && bytes[i] == 0x07 {
+                    i += 1;
+                } else if i + 1 < bytes.len() && bytes[i] == 0x1b {
+                    i += 2;
+                }
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn opencode_title_for_session(db_path: &str, session_id: &str) -> Option<String> {
+    let path = Path::new(db_path);
+    if !path.is_file() {
+        return None;
+    }
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    conn.busy_timeout(Duration::from_secs(1)).ok()?;
+    let mut stmt = conn
+        .prepare("SELECT title FROM session WHERE id = ?1")
+        .ok()?;
+    let title: Option<String> = stmt
+        .query_row(params![session_id], |row| row.get(0))
+        .optional()
+        .ok()
+        .flatten()
+        .filter(|t: &String| !t.trim().is_empty());
+    title
+}
+
+fn grok_title_for_session(updates_path: &str) -> Option<String> {
+    let path = Path::new(updates_path);
+    let parent = path.parent()?;
+    let summary_path = parent.join("summary.json");
+    let contents = std::fs::read_to_string(&summary_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    for key in [
+        "generated_title",
+        "generatedTitle",
+        "title",
+        "session_summary",
+        "sessionSummary",
+        "summary",
+    ] {
+        if let Some(title) = value
+            .get(key)
+            .and_then(|v| v.as_str())
+            .filter(|s: &&str| !s.trim().is_empty())
+        {
+            return Some(title.to_string());
+        }
+        if let Some(title) = value
+            .pointer(&format!("/info/{key}"))
+            .and_then(|v| v.as_str())
+            .filter(|s: &&str| !s.trim().is_empty())
+        {
+            return Some(title.to_string());
+        }
+    }
+    value
+        .get("info")
+        .and_then(|info| info.get("generated_title").or_else(|| info.get("title")))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            value
+                .pointer("/info/cwd")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+}
+
+fn jcode_label_from_file(path: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let messages = value.get("messages")?.as_array()?;
+    for msg in messages {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role != "user" {
+            continue;
+        }
+        let content = msg.get("content")?;
+        let mut texts = Vec::new();
+        if let Some(arr) = content.as_array() {
+            for block in arr {
+                if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                    texts.push(text.to_string());
+                } else if let Some(text) = block.as_str() {
+                    texts.push(text.to_string());
+                }
+            }
+        } else if let Some(text) = content.as_str() {
+            texts.push(text.to_string());
+        }
+        let combined = texts.join("\n");
+        if combined.trim().is_empty() {
+            continue;
+        }
+        return Some(combined);
+    }
+    None
+}
+
+fn opencode_agent_is_subagent(db_path: &str, session_id: &str) -> bool {
+    let path = Path::new(db_path);
+    if !path.is_file() {
+        return false;
+    }
+    let conn = match Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let _ = conn.busy_timeout(Duration::from_secs(1));
+    let check = || -> Option<bool> {
+        let mut stmt = conn
+            .prepare("SELECT agent FROM session WHERE id = ?1")
+            .ok()?;
+        let agent: Option<String> = stmt
+            .query_row(params![session_id], |row| row.get(0))
+            .optional()
+            .ok()
+            .flatten();
+        Some(agent.is_some_and(|a| !a.is_empty() && a != "build"))
+    };
+    check().unwrap_or(false)
+}
+
+fn extract_session_label(
+    source: SourceKind,
+    source_path: &str,
+    session_id: &str,
+    first_user_text: Option<&str>,
+    _cwd: Option<&str>,
+) -> Option<String> {
+    let raw = match source {
+        SourceKind::Opencode => {
+            if let Some(title) = opencode_title_for_session(source_path, session_id)
+                && !title.trim().is_empty()
+            {
+                title
+            } else {
+                first_user_text?.to_string()
+            }
+        }
+        SourceKind::Grok => {
+            if let Some(title) = grok_title_for_session(source_path)
+                && !title.trim().is_empty()
+            {
+                title
+            } else {
+                first_user_text?.to_string()
+            }
+        }
+        SourceKind::Jcode => {
+            if let Some(text) = jcode_label_from_file(source_path) {
+                text
+            } else {
+                first_user_text?.to_string()
+            }
+        }
+        _ => first_user_text?.to_string(),
+    };
+    let label = sanitize_label(&raw);
+    if label.is_empty() { None } else { Some(label) }
+}
+
+fn infer_session_kind(
+    source: SourceKind,
+    source_path: &str,
+    session_id: &str,
+    initial_kind: Option<&str>,
+    cwd: Option<&str>,
+    first_user_text: Option<&str>,
+) -> Option<String> {
+    if let Some(kind) = initial_kind
+        && kind != "main"
+        && !kind.is_empty()
+    {
+        return Some(kind.to_string());
+    }
+    match source {
+        SourceKind::Jcode => {
+            if let Some(cwd) = cwd
+                && (cwd.starts_with("/tmp/")
+                    || cwd.starts_with("/private/tmp/")
+                    || cwd == "/tmp"
+                    || cwd == "/private/tmp")
+            {
+                return Some("subagent".to_string());
+            }
+            if let Some(text) = first_user_text {
+                let lower = text.to_lowercase();
+                if lower.contains("you are a low-effort fact-checker")
+                    || lower.contains("role: manager")
+                    || lower.contains("you are a subagent")
+                    || lower.contains("you are a low effort")
+                {
+                    return Some("subagent".to_string());
+                }
+            }
+        }
+        SourceKind::Opencode => {
+            if opencode_agent_is_subagent(source_path, session_id) {
+                return Some("subagent".to_string());
+            }
+        }
+        SourceKind::Muse => {
+            let normalized = source_path.replace('\\', "/");
+            if normalized.contains("/subagent/") {
+                return Some("subagent".to_string());
+            }
+        }
+        SourceKind::Claude => {
+            let normalized = source_path.replace('\\', "/");
+            if normalized.contains("/subagents/") || normalized.contains("/subagent/") {
+                return Some("subagent".to_string());
+            }
+        }
+        SourceKind::Cursor => {
+            let normalized = source_path.replace('\\', "/");
+            if normalized.contains("/subagents/") || normalized.contains("subagents") {
+                return Some("subagent".to_string());
+            }
+        }
+        SourceKind::Codex => {}
+        _ => {}
+    }
+    Some("main".to_string())
 }
 
 pub fn analytics_path(state_dir: &Path) -> PathBuf {
@@ -1574,5 +2026,127 @@ mod tests {
             .expect("query");
         assert_eq!(rows[0].project, "ssh-d4309b74-100f-407e-b64d-31c7160044cd");
         assert_eq!(rows[0].display_project, "atm-backend");
+    }
+
+    #[test]
+    fn sanitize_label_collapses_whitespace_and_truncates() {
+        let raw = "  Hello\n   world   \x1b[31mred\x1b[0m  <system-reminder>ignore</system-reminder>  this is a very long prompt that should be truncated at word boundary because it exceeds the one hundred fifty character limit significantly and we want to ensure ellipsis handling works correctly for display";
+        let label = sanitize_label(raw);
+        assert!(!label.contains('\n'));
+        assert!(!label.contains("\x1b"));
+        assert!(!label.contains("ignore"));
+        assert!(label.chars().count() <= MAX_LABEL_CHARS);
+        assert!(label.ends_with('…') || label.chars().count() < MAX_LABEL_CHARS);
+        assert!(label.starts_with("Hello world red"));
+    }
+
+    #[test]
+    fn analytics_stores_label_from_first_user_message() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(
+            &transcript,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
+                tmp.path().display()
+            ),
+        )
+        .expect("write");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        let mut rec = record("proj", "s-label", &transcript, 10);
+        rec.role = "user".to_string();
+        rec.text = "Fix the login bug on the dashboard".to_string();
+        rec.links.conversation_kind = Some("main".to_string());
+        writer.record(&rec).expect("record");
+        writer.flush().expect("flush");
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        let rows = store
+            .query_sessions_detailed(None, None, None, None, None)
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].label.as_deref(),
+            Some("Fix the login bug on the dashboard")
+        );
+        assert_eq!(rows[0].conversation_kind.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn analytics_filters_by_conversation_kind() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a_path = tmp.path().join("a.jsonl");
+        let b_path = tmp.path().join("b.jsonl");
+        for p in [&a_path, &b_path] {
+            fs::write(p, "").expect("write");
+        }
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        let mut primary = record("proj", "s-primary", &a_path, 10);
+        primary.role = "user".to_string();
+        primary.text = "primary task".to_string();
+        primary.links.conversation_kind = Some("main".to_string());
+        let mut sub = record("proj", "s-sub", &b_path, 20);
+        sub.role = "user".to_string();
+        sub.text = "subagent task".to_string();
+        sub.links.conversation_kind = Some("subagent".to_string());
+        writer.record(&primary).expect("record");
+        writer.record(&sub).expect("record");
+        writer.flush().expect("flush");
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        let primary_rows = store
+            .query_sessions_detailed_filtered(
+                None,
+                None,
+                None,
+                None,
+                Some(SessionKindFilter::Primary),
+                None,
+            )
+            .expect("primary");
+        assert_eq!(primary_rows.len(), 1);
+        assert_eq!(primary_rows[0].session_id, "s-primary");
+        let sub_rows = store
+            .query_sessions_detailed_filtered(
+                None,
+                None,
+                None,
+                None,
+                Some(SessionKindFilter::Subagent),
+                None,
+            )
+            .expect("sub");
+        assert_eq!(sub_rows.len(), 1);
+        assert_eq!(sub_rows[0].session_id, "s-sub");
+        let all_rows = store
+            .query_sessions_detailed(None, None, None, None, None)
+            .expect("all");
+        assert_eq!(all_rows.len(), 2);
+    }
+
+    #[test]
+    fn jcode_tmp_cwd_is_classified_as_subagent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session_session_tmp.json");
+        // Need a file that contains cwd; but we also need to test inference via cwd.
+        // We'll directly test infer_session_kind helper.
+        let kind = infer_session_kind(
+            SourceKind::Jcode,
+            "/tmp/.jcode/sessions/session_tmp.json",
+            "session_tmp",
+            Some("main"),
+            Some("/tmp/work"),
+            Some("hello"),
+        );
+        assert_eq!(kind.as_deref(), Some("subagent"));
+        let kind2 = infer_session_kind(
+            SourceKind::Jcode,
+            "/tmp/.jcode/sessions/session_main.json",
+            "session_main",
+            Some("main"),
+            Some("/Users/joe/Code/memex"),
+            Some("hello"),
+        );
+        assert_eq!(kind2.as_deref(), Some("main"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -453,6 +453,12 @@ EXAMPLES:
         /// Maximum number of sessions
         #[arg(long, default_value_t = 20)]
         limit: usize,
+        /// Filter by session kind: primary (interactive), subagent, or all
+        #[arg(long, value_enum, default_value_t = SessionKind::All)]
+        kind: SessionKind,
+        /// Only show primary (interactive) sessions (alias for --kind primary)
+        #[arg(long)]
+        primary_only: bool,
         /// Emit one JSON array instead of JSON Lines
         #[arg(long)]
         json_array: bool,
@@ -699,6 +705,24 @@ impl From<TransferMode> for CoreTransferMode {
         match value {
             TransferMode::Compact => CoreTransferMode::Compact,
             TransferMode::Strict => CoreTransferMode::Strict,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum SessionKind {
+    Primary,
+    Subagent,
+    All,
+}
+
+impl From<SessionKind> for crate::analytics::SessionKindFilter {
+    fn from(value: SessionKind) -> Self {
+        match value {
+            SessionKind::Primary => crate::analytics::SessionKindFilter::Primary,
+            SessionKind::Subagent => crate::analytics::SessionKindFilter::Subagent,
+            SessionKind::All => crate::analytics::SessionKindFilter::All,
         }
     }
 }
@@ -1069,10 +1093,17 @@ pub fn run() -> Result<()> {
             source,
             since,
             limit,
+            kind,
+            primary_only,
             json_array,
             root,
         } => {
-            run_sessions(cwd, project, source, since, limit, json_array, root)?;
+            let kind = if primary_only {
+                SessionKind::Primary
+            } else {
+                kind
+            };
+            run_sessions(cwd, project, source, since, limit, kind, json_array, root)?;
         }
         Commands::Herdr { action } => match action {
             HerdrCommand::ResumeLast {
@@ -2711,12 +2742,14 @@ fn session_resume_command(
     Some((command, cwd))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_sessions(
     cwd: Option<PathBuf>,
     project: Option<String>,
     source: Option<SourceFilter>,
     since: Option<String>,
     limit: usize,
+    kind: SessionKind,
     json_array: bool,
     root: Option<PathBuf>,
 ) -> Result<()> {
@@ -2725,11 +2758,16 @@ fn run_sessions(
     let store = open_analytics_read_only(&paths)?;
     let since_ms = parse_ts_millis(since)?;
     let cwd_filter = canonical_cwd_filter(cwd);
-    let rows = store.query_sessions_detailed(
+    let kind_filter = match kind {
+        SessionKind::All => None,
+        other => Some(other.into()),
+    };
+    let rows = store.query_sessions_detailed_filtered(
         source,
         project.as_deref(),
         cwd_filter.as_deref(),
         since_ms,
+        kind_filter,
         Some(limit),
     )?;
 

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -163,16 +163,60 @@ pub(crate) fn parse_index_records(
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
-    let conversation_kind = if parent_session_id.is_some() {
-        "subagent"
-    } else {
-        "main"
-    };
-
     let working_dir = value
         .get("working_dir")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+
+    let mut conversation_kind = if parent_session_id.is_some()
+        || working_dir.starts_with("/tmp/")
+        || working_dir.starts_with("/private/tmp/")
+        || working_dir == "/tmp"
+        || working_dir == "/private/tmp"
+    {
+        "subagent"
+    } else {
+        "main"
+    };
+    // Check directives in first user message for subagent hints
+    if conversation_kind == "main"
+        && let Some(messages) = value.get("messages").and_then(|v| v.as_array())
+    {
+        for message in messages.iter().take(3) {
+            let Some(obj) = message.as_object() else {
+                continue;
+            };
+            if obj.get("role").and_then(|v| v.as_str()) != Some("user") {
+                continue;
+            }
+            let mut first_text = String::new();
+            if let Some(content) = obj.get("content") {
+                if let Some(s) = content.as_str() {
+                    first_text = s.to_string();
+                } else if let Some(arr) = content.as_array() {
+                    for block in arr {
+                        if let Some(t) = block
+                            .as_object()
+                            .and_then(|o| o.get("text"))
+                            .and_then(|v| v.as_str())
+                        {
+                            first_text.push_str(t);
+                            first_text.push('\n');
+                        }
+                    }
+                }
+            }
+            let lower = first_text.to_lowercase();
+            if lower.contains("you are a low-effort fact-checker")
+                || lower.contains("role: manager")
+                || lower.contains("you are a subagent")
+            {
+                conversation_kind = "subagent";
+                break;
+            }
+            break;
+        }
+    }
 
     let project = if !working_dir.is_empty() {
         super::common::project_from_path(working_dir)

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -286,10 +286,7 @@ fn session_agents(connection: &Connection) -> HashMap<String, String> {
         return agents;
     };
     let Ok(rows) = statement.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, Option<String>>(1)?,
-        ))
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
     }) else {
         return agents;
     };

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -303,6 +303,13 @@ fn nonnegative_timestamp(value: i64) -> Result<u64> {
     u64::try_from(value).map_err(|_| anyhow::anyhow!("negative timestamp"))
 }
 
+/// OpenCode's interactive primary agents. `plan` is a primary interactive mode,
+/// not a subagent, even though it is not `build`. Anything else recorded in
+/// the session `agent` column runs as a subagent.
+pub(crate) fn opencode_agent_is_primary(agent: Option<&str>) -> bool {
+    matches!(agent, None | Some("") | Some("build") | Some("plan"))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseCursor {
     pub event_rowid: i64,
@@ -752,7 +759,7 @@ pub(crate) fn parse_database_records(
         thread_source: session.parent_id.as_ref().map(|_| "fork".to_string()),
         conversation_kind: Some(if session.parent_id.is_some() {
             "fork".to_string()
-        } else if session.agent.as_deref().is_some_and(|a| a != "build") {
+        } else if !opencode_agent_is_primary(session.agent.as_deref()) {
             "subagent".to_string()
         } else {
             "main".to_string()
@@ -1235,6 +1242,16 @@ mod tests {
         assert_eq!(events[0].tokens.output, 50);
         assert_eq!(events[0].tokens.total(), 200);
         assert_eq!(events[0].project.as_deref(), Some("opencode"));
+    }
+
+    #[test]
+    fn plan_and_build_agents_are_primary() {
+        assert!(opencode_agent_is_primary(None));
+        assert!(opencode_agent_is_primary(Some("")));
+        assert!(opencode_agent_is_primary(Some("build")));
+        assert!(opencode_agent_is_primary(Some("plan")));
+        assert!(!opencode_agent_is_primary(Some("explore")));
+        assert!(!opencode_agent_is_primary(Some("custom-agent")));
     }
 
     #[test]

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -225,6 +225,7 @@ pub struct OpencodeSession {
     pub directory: String,
     pub time_created: u64,
     pub time_updated: u64,
+    pub agent: Option<String>,
 }
 
 /// Enumerate the modern session inventory from one OpenCode database.
@@ -259,6 +260,7 @@ fn enumerate_sessions_from_connection(
         })
         .with_context(|| format!("query OpenCode sessions in {}", path.display()))?;
     let mut sessions = Vec::new();
+    let agents = session_agents(connection);
     for row in rows {
         let (id, parent_id, directory, time_created, time_updated) = row?;
         sessions.push(OpencodeSession {
@@ -269,9 +271,35 @@ fn enumerate_sessions_from_connection(
                 .with_context(|| format!("session `{id}` has invalid time_created"))?,
             time_updated: nonnegative_timestamp(time_updated)
                 .with_context(|| format!("session `{id}` has invalid time_updated"))?,
+            agent: agents.get(&id).cloned(),
         });
     }
     Ok(sessions)
+}
+
+/// Tolerantly load the `agent` column for subagent detection (`agent != 'build'`).
+/// Older databases may lack the column; in that case every session reports `None`
+/// and callers fall back to parent-id-only classification.
+fn session_agents(connection: &Connection) -> HashMap<String, String> {
+    let mut agents = HashMap::new();
+    let Ok(mut statement) = connection.prepare("SELECT id, agent FROM session") else {
+        return agents;
+    };
+    let Ok(rows) = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+        ))
+    }) else {
+        return agents;
+    };
+    for row in rows.flatten() {
+        let (id, agent) = row;
+        if let Some(agent) = agent.filter(|a| !a.is_empty()) {
+            agents.insert(id, agent);
+        }
+    }
+    agents
 }
 
 fn nonnegative_timestamp(value: i64) -> Result<u64> {
@@ -727,6 +755,8 @@ pub(crate) fn parse_database_records(
         thread_source: session.parent_id.as_ref().map(|_| "fork".to_string()),
         conversation_kind: Some(if session.parent_id.is_some() {
             "fork".to_string()
+        } else if session.agent.as_deref().is_some_and(|a| a != "build") {
+            "subagent".to_string()
         } else {
             "main".to_string()
         }),
@@ -876,6 +906,16 @@ fn enumerate_session_from_connection(
         return Ok(None);
     };
     let (id, parent_id, directory, time_created, time_updated) = row;
+    let agent = connection
+        .query_row(
+            "SELECT agent FROM session WHERE id = ?1",
+            [session_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .unwrap_or(None)
+        .flatten()
+        .filter(|a| !a.is_empty());
     Ok(Some(OpencodeSession {
         id,
         parent_id,
@@ -884,6 +924,7 @@ fn enumerate_session_from_connection(
             .with_context(|| format!("session `{session_id}` has invalid time_created"))?,
         time_updated: nonnegative_timestamp(time_updated)
             .with_context(|| format!("session `{session_id}` has invalid time_updated"))?,
+        agent,
     }))
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4088,7 +4088,7 @@ fn session_result_line(
         ),
         Span::raw("  "),
     ];
-<    // Show label/title when there is no search snippet (recent/home view), badge subagents
+    // Show label/title when there is no search snippet (recent/home view), badge subagents
     let is_subagent = session
         .conversation_kind
         .as_deref()
@@ -7216,6 +7216,8 @@ mod tests {
             snippet: String::new(),
             source_path: "source.jsonl".to_string(),
             source_dir: String::new(),
+            label: None,
+            conversation_kind: None,
         };
 
         let line = session_result_line(&session, &[], 8, 40, &Theme::new());

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -140,6 +140,7 @@ struct SearchRequest {
     source: SourceChoice,
     since: Option<u64>,
     grouping: ProjectGrouping,
+    kind: crate::analytics::SessionKindFilter,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -502,6 +503,8 @@ struct SessionSummary {
     snippet: String,
     source_path: String,
     source_dir: String,
+    label: Option<String>,
+    conversation_kind: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -532,6 +535,7 @@ struct App {
     machine: String,
     home_machines: Vec<String>,
     source: SourceChoice,
+    session_kind: crate::analytics::SessionKindFilter,
     all_projects: Vec<String>,
     project_options: Vec<String>,
     project_selected: usize,
@@ -970,6 +974,7 @@ impl App {
             home_projects: Vec::new(),
             active_home_filters_request: 0,
             source: SourceChoice::All,
+            session_kind: crate::analytics::SessionKindFilter::Primary,
             all_projects: Vec::new(),
             project_options: Vec::new(),
             project_selected: 0,
@@ -1256,6 +1261,7 @@ impl App {
             source: self.source,
             since: self.sessions_since,
             grouping: self.project_display.grouping(),
+            kind: self.session_kind,
         };
         if self.search_request_tx.send(request).is_err() {
             let message = "search worker stopped".to_string();
@@ -2268,6 +2274,28 @@ impl App {
         }
     }
 
+    fn cycle_session_kind(&mut self) {
+        self.session_kind = match self.session_kind {
+            crate::analytics::SessionKindFilter::Primary => {
+                crate::analytics::SessionKindFilter::All
+            }
+            crate::analytics::SessionKindFilter::All => {
+                crate::analytics::SessionKindFilter::Subagent
+            }
+            crate::analytics::SessionKindFilter::Subagent => {
+                crate::analytics::SessionKindFilter::Primary
+            }
+        };
+        let label = match self.session_kind {
+            crate::analytics::SessionKindFilter::Primary => "primary",
+            crate::analytics::SessionKindFilter::All => "all",
+            crate::analytics::SessionKindFilter::Subagent => "subagent",
+        };
+        self.set_status(format!("sessions: {label}"));
+        self.kickoff_search();
+        self.kickoff_home_activity();
+    }
+
     fn scroll_timeline(&mut self, delta: isize) {
         if self.timeline_rows.is_empty() {
             self.timeline_scroll = 0;
@@ -2906,6 +2934,9 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
                 app.kickoff_home_activity();
             }
         }
+        KeyCode::Char('K') => {
+            app.cycle_session_kind();
+        }
         KeyCode::Char('[') => {
             app.cycle_timeline_range(-1);
         }
@@ -3076,6 +3107,9 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
         }
         KeyCode::Char('p') => {
             app.open_home_dropdown(HomeDropdown::Project);
+        }
+        KeyCode::Char('K') => {
+            app.cycle_session_kind();
         }
         KeyCode::Char('S') => {
             let _ = app.share_selected();
@@ -4054,16 +4088,46 @@ fn session_result_line(
         ),
         Span::raw("  "),
     ];
-    if session.snippet.is_empty() && session.title.is_empty() {
-        spans.push(Span::styled(
-            truncate_middle(&session.session_id, detail_width),
-            theme.muted,
-        ));
-    } else if session.snippet.is_empty() {
-        let title = strip_ansi_and_controls(&session.title);
-        spans.push(Span::styled(truncate_end(&title, detail_width), theme.text));
+<    // Show label/title when there is no search snippet (recent/home view), badge subagents
+    let is_subagent = session
+        .conversation_kind
+        .as_deref()
+        .is_some_and(|k| k != "main");
+    if session.snippet.is_empty() {
+        if let Some(label) = session.label.as_deref().filter(|s| !s.is_empty()) {
+            let mut detail = truncate_middle(label, detail_width);
+            if is_subagent {
+                // Prepend a subtle subagent indicator; keep width calculation simple
+                detail = format!("[sub] {detail}");
+                if detail.chars().count() > detail_width {
+                    detail = truncate_middle(&detail, detail_width);
+                }
+            }
+            spans.push(Span::styled(detail, theme.text));
+        } else if !session.title.is_empty() {
+            let title = strip_ansi_and_controls(&session.title);
+            let mut detail = truncate_end(&title, detail_width);
+            if is_subagent {
+                detail = format!("[sub] {detail}");
+                if detail.chars().count() > detail_width {
+                    detail = truncate_middle(&detail, detail_width);
+                }
+            }
+            spans.push(Span::styled(detail, theme.text));
+        } else {
+            spans.push(Span::styled(
+                truncate_middle(&session.session_id, detail_width),
+                theme.muted,
+            ));
+        }
     } else {
         let snippet = strip_ansi_and_controls(&session.snippet);
+        if is_subagent {
+            spans.push(Span::styled(
+                "[sub] ",
+                Style::default().fg(Color::Rgb(160, 120, 80)),
+            ));
+        }
         spans.extend(match_context_spans(&snippet, terms, detail_width, theme));
     }
     Line::from(spans)
@@ -4768,6 +4832,21 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
         right_spans.push(Span::styled(app.source.label(), theme.accent));
         right_spans.push(Span::raw("   "));
     }
+    if app.session_kind != crate::analytics::SessionKindFilter::All
+        || app.layout_mode == LayoutMode::Home
+        || app.layout_mode == LayoutMode::List
+        || app.layout_mode == LayoutMode::Split
+    {
+        let kind_label = match app.session_kind {
+            crate::analytics::SessionKindFilter::Primary => "primary",
+            crate::analytics::SessionKindFilter::Subagent => "subagent",
+            crate::analytics::SessionKindFilter::All => "all",
+        };
+        right_spans.push(Span::styled("kind ", theme.muted));
+        right_spans.push(Span::styled("(K) ", theme.accent));
+        right_spans.push(Span::styled(kind_label, theme.text));
+        right_spans.push(Span::raw("   "));
+    }
     if app.layout_mode == LayoutMode::Timeline {
         right_spans.push(Span::styled("source", theme.muted));
         right_spans.push(Span::styled("(s) ", theme.accent));
@@ -4865,6 +4944,8 @@ fn footer_shortcuts<'a>(app: &App, theme: &Theme, width: u16) -> Line<'a> {
             Span::styled(" source  ", theme.muted),
             Span::styled("p", theme.accent),
             Span::styled(" projects  ", theme.muted),
+            Span::styled("K", theme.accent),
+            Span::styled(" kind  ", theme.muted),
             Span::styled("/", theme.accent),
             Span::styled(" search  ", theme.muted),
             Span::styled("tab", theme.accent),
@@ -5092,6 +5173,7 @@ fn sessions_from_recent(
     Ok(out)
 }
 
+#[allow(dead_code)]
 fn sessions_from_analytics(
     paths: &Paths,
     source: Option<SourceFilter>,
@@ -5099,18 +5181,48 @@ fn sessions_from_analytics(
     project: Option<&str>,
     grouping: ProjectGrouping,
 ) -> Result<Vec<SessionSummary>> {
+    sessions_from_analytics_filtered(paths, source, since, project, grouping, None)
+}
+
+fn sessions_from_analytics_filtered(
+    paths: &Paths,
+    source: Option<SourceFilter>,
+    since: Option<u64>,
+    project: Option<&str>,
+    grouping: ProjectGrouping,
+    kind: Option<crate::analytics::SessionKindFilter>,
+) -> Result<Vec<SessionSummary>> {
     let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
-    let rows = store.query_sessions(
-        source,
-        since,
-        project,
-        grouping,
-        Some(RECENT_SESSIONS_LIMIT),
-    )?;
+    let rows = if kind.is_some() {
+        store.query_sessions_filtered(
+            source,
+            since,
+            project,
+            grouping,
+            kind,
+            Some(RECENT_SESSIONS_LIMIT),
+        )?
+    } else {
+        store.query_sessions(
+            source,
+            since,
+            project,
+            grouping,
+            Some(RECENT_SESSIONS_LIMIT),
+        )?
+    };
     if rows.is_empty() {
         anyhow::bail!("no analytics sessions");
     }
     Ok(rows.into_iter().map(session_summary_from_row).collect())
+}
+
+fn session_matches_kind(filter: crate::analytics::SessionKindFilter, kind: Option<&str>) -> bool {
+    match filter {
+        crate::analytics::SessionKindFilter::All => true,
+        crate::analytics::SessionKindFilter::Primary => kind.is_none() || kind == Some("main"),
+        crate::analytics::SessionKindFilter::Subagent => kind.is_some() && kind != Some("main"),
+    }
 }
 
 fn session_summary_from_row(row: SessionRow) -> SessionSummary {
@@ -5124,8 +5236,13 @@ fn session_summary_from_row(row: SessionRow) -> SessionSummary {
         top_score: 0.0,
         title: String::new(),
         snippet: String::new(),
-        source_dir: row.cwd.unwrap_or_else(|| parent_dir(&row.source_path)),
+        source_dir: row
+            .cwd
+            .clone()
+            .unwrap_or_else(|| parent_dir(&row.source_path)),
         source_path: row.source_path,
+        label: row.label,
+        conversation_kind: row.conversation_kind,
     }
 }
 
@@ -5277,6 +5394,7 @@ fn add_record_to_session(
     score: f32,
     record: Record,
 ) {
+    let label = record.links.conversation_kind.clone();
     let entry = sessions
         .entry(record.session_id.clone())
         .or_insert(SessionSummary {
@@ -5291,6 +5409,8 @@ fn add_record_to_session(
             snippet: summarize(&record.text, 160),
             source_path: record.source_path.clone(),
             source_dir: parent_dir(&record.source_path),
+            label: None,
+            conversation_kind: label.clone(),
         });
     entry.hit_count += 1;
     if record.ts > entry.last_ts {
@@ -5333,6 +5453,8 @@ fn add_located_record_to_session(
         snippet: summarize(&record.text, 160),
         source_path: record.source_path.clone(),
         source_dir: parent_dir(&record.source_path),
+        label: None,
+        conversation_kind: record.links.conversation_kind.clone(),
     });
     entry.hit_count += 1;
     entry.last_ts = entry.last_ts.max(record.ts);
@@ -5458,21 +5580,36 @@ fn run_search_request(
         if let Some(project) = project {
             sessions.retain(|session| session.project == project);
         }
+        sessions.retain(|session| {
+            session_matches_kind(request.kind, session.conversation_kind.as_deref())
+        });
         sessions.truncate(RESULT_LIMIT);
         return Ok((sessions, failures));
     }
     if request.query.is_empty() {
-        let mut sessions = sessions_from_analytics(
+        let mut sessions = sessions_from_analytics_filtered(
             paths,
             request.source.as_filter(),
             request.since,
             project,
             request.grouping,
+            Some(request.kind),
         )
         .or_else(|_| {
-            sessions_from_recent(index, request.source.as_filter(), request.since, project)
+            let mut sessions =
+                sessions_from_recent(index, request.source.as_filter(), request.since, project)?;
+            sessions.retain(|session| {
+                session_matches_kind(request.kind, session.conversation_kind.as_deref())
+            });
+            if sessions.is_empty() {
+                anyhow::bail!("no analytics sessions");
+            }
+            Ok(sessions)
         })?;
         enrich_session_titles(index, &mut sessions);
+        sessions.retain(|session| {
+            session_matches_kind(request.kind, session.conversation_kind.as_deref())
+        });
         return Ok((sessions, Vec::new()));
     }
 
@@ -5493,6 +5630,8 @@ fn run_search_request(
     if let Some(project) = project {
         sessions.retain(|session| session.project == project);
     }
+    sessions
+        .retain(|session| session_matches_kind(request.kind, session.conversation_kind.as_deref()));
     Ok((sessions, Vec::new()))
 }
 
@@ -7105,6 +7244,8 @@ mod tests {
             snippet: String::new(),
             source_path: "source.jsonl".to_string(),
             source_dir: String::new(),
+            label: None,
+            conversation_kind: None,
         });
         app.enter_browse();
         assert_eq!(app.layout_mode, LayoutMode::Split);
@@ -7252,6 +7393,8 @@ mod tests {
                 snippet: String::new(),
                 source_path: "source.jsonl".to_string(),
                 source_dir: String::new(),
+                label: None,
+                conversation_kind: None,
             }],
             failures: Vec::new(),
         });
@@ -7437,6 +7580,8 @@ mod tests {
                 snippet: String::new(),
                 source_path: "codex.jsonl".into(),
                 source_dir: String::new(),
+                label: None,
+                conversation_kind: None,
             },
             SessionSummary {
                 machine: LOCAL_MACHINE_ID.to_string(),
@@ -7450,6 +7595,8 @@ mod tests {
                 snippet: String::new(),
                 source_path: "claude.jsonl".into(),
                 source_dir: String::new(),
+                label: None,
+                conversation_kind: None,
             },
             SessionSummary {
                 machine: "mini".into(),
@@ -7463,6 +7610,8 @@ mod tests {
                 snippet: String::new(),
                 source_path: "remote-codex.jsonl".into(),
                 source_dir: String::new(),
+                label: None,
+                conversation_kind: None,
             },
         ];
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5618,13 +5618,21 @@ fn run_search_request(
     } else {
         None
     };
+    // The kind filter runs after retrieval caps the candidate list, so a
+    // filtered subset could starve the result list. Over-fetch while a subset
+    // is selected, then retain and truncate back to the display cap.
+    let query_limit = if matches!(request.kind, crate::analytics::SessionKindFilter::All) {
+        RESULT_LIMIT
+    } else {
+        RESULT_LIMIT.saturating_mul(5)
+    };
     let mut sessions = sessions_from_query(
         index,
         &request.query,
         request.source.as_filter(),
         tantivy_project,
         request.since,
-        RESULT_LIMIT,
+        query_limit,
     )?;
     enrich_session_projects(paths, &mut sessions, request.grouping);
     if let Some(project) = project {
@@ -5632,6 +5640,7 @@ fn run_search_request(
     }
     sessions
         .retain(|session| session_matches_kind(request.kind, session.conversation_kind.as_deref()));
+    sessions.truncate(RESULT_LIMIT);
     Ok((sessions, Vec::new()))
 }
 


### PR DESCRIPTION
## Summary
Adds sanitized auto-generated session labels, on top of the Jcode/Muse/OpenCode support in #116. This branch also carries the first cut of the origin classification that #118 later evolves - see stacking note.

Stacked on #116. Its GitHub base is `main`, so its diff currently includes #116 as well.

## Changes (unique to this PR)
- Schema: `label` column on `sessions` with additive migration and backfill recompute for labels generated before tag-stripping was complete.
- Extraction: first user text per session, with source titles preferred where they exist (OpenCode session titles, Grok summary titles); Jcode rereads its session file and skips preamble-only system-reminder openers.
- Sanitization (`sanitize_label`, char-safe): strips ANSI sequences and system/command wrapper tags (case-insensitive), collapses whitespace; over-long labels truncate head-with-ellipsis while preserving a readable tail suffix. Empty results fall back to the session id.
- CLI: `sessions` JSON output carries the label.
- TUI: home/recent rows render the label instead of the raw session id.
- Perf: first-user text is captured during record so extraction adds no extra scan; OpenCode/Grok titles resolve lazily in flush.

## Stacking note
The labels commit on this branch also introduces `conversation_kind` / `SessionKindFilter` and TUI kind state. #118 is the evolved version of that classification work (renames, UX, detection fixes). After #116 merges this PR should be rebased so its diff is labels (plus the shared early classification) only.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`