### PR TITLE
Filter sessions by origin: interactive vs subagent

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -889,6 +889,10 @@ impl AnalyticsWriter {
                     conversation_kind = COALESCE(excluded.conversation_kind, sessions.conversation_kind)
                 "#,
             )?;
+            // OpenCode title/agent lookups hit the source SQLite database. Sessions
+            // from one database share the same file, so memoize per flush to
+            // avoid reopening it once per session during large index scans.
+            let mut opencode_cache = OpencodeLookupCache::default();
             for (session, metadata) in sessions {
                 let label = extract_session_label(
                     session.key.source,
@@ -896,6 +900,7 @@ impl AnalyticsWriter {
                     &session.key.session_id,
                     session.first_user_text.as_deref(),
                     metadata.cwd.as_deref(),
+                    &mut opencode_cache,
                 );
                 let conversation_kind = infer_session_kind(
                     session.key.source,
@@ -904,6 +909,7 @@ impl AnalyticsWriter {
                     session.conversation_kind.as_deref(),
                     metadata.cwd.as_deref(),
                     session.first_user_text.as_deref(),
+                    &mut opencode_cache,
                 );
                 stmt.execute(params![
                     session.key.source.storage_label(),
@@ -1640,16 +1646,42 @@ fn opencode_agent_is_subagent(db_path: &str, session_id: &str) -> bool {
     check().unwrap_or(false)
 }
 
+/// Memoized OpenCode source-database lookups for one flush. Titles and agent
+/// names are immutable per session, so caching across the sessions of a flush
+/// only collapses repeated reads of the same row.
+#[derive(Default)]
+struct OpencodeLookupCache {
+    titles: HashMap<(String, String), Option<String>>,
+    subagent: HashMap<(String, String), bool>,
+}
+
+impl OpencodeLookupCache {
+    fn title(&mut self, db_path: &str, session_id: &str) -> Option<String> {
+        self.titles
+            .entry((db_path.to_string(), session_id.to_string()))
+            .or_insert_with(|| opencode_title_for_session(db_path, session_id))
+            .clone()
+    }
+
+    fn is_subagent(&mut self, db_path: &str, session_id: &str) -> bool {
+        *self
+            .subagent
+            .entry((db_path.to_string(), session_id.to_string()))
+            .or_insert_with(|| opencode_agent_is_subagent(db_path, session_id))
+    }
+}
+
 fn extract_session_label(
     source: SourceKind,
     source_path: &str,
     session_id: &str,
     first_user_text: Option<&str>,
     _cwd: Option<&str>,
+    opencode: &mut OpencodeLookupCache,
 ) -> Option<String> {
     let raw = match source {
         SourceKind::Opencode => {
-            if let Some(title) = opencode_title_for_session(source_path, session_id)
+            if let Some(title) = opencode.title(source_path, session_id)
                 && !title.trim().is_empty()
             {
                 title
@@ -1686,6 +1718,7 @@ fn infer_session_kind(
     initial_kind: Option<&str>,
     cwd: Option<&str>,
     first_user_text: Option<&str>,
+    opencode: &mut OpencodeLookupCache,
 ) -> Option<String> {
     if let Some(kind) = initial_kind
         && kind != "main"
@@ -1715,13 +1748,13 @@ fn infer_session_kind(
             }
         }
         SourceKind::Opencode => {
-            if opencode_agent_is_subagent(source_path, session_id) {
+            if opencode.is_subagent(source_path, session_id) {
                 return Some("subagent".to_string());
             }
         }
         SourceKind::Muse => {
             let normalized = source_path.replace('\\', "/");
-            if normalized.contains("/subagent/") {
+            if normalized.contains("/subagent/") || normalized.contains("/subagents/") {
                 return Some("subagent".to_string());
             }
         }
@@ -1732,8 +1765,14 @@ fn infer_session_kind(
             }
         }
         SourceKind::Cursor => {
+            // Match whole path components (like the Cursor parser's
+            // `is_subagent_transcript`): a bare substring would false-positive
+            // on projects such as `my-subagents-tool`.
             let normalized = source_path.replace('\\', "/");
-            if normalized.contains("/subagents/") || normalized.contains("subagents") {
+            if normalized
+                .split('/')
+                .any(|c| c == "subagents" || c == "subagent")
+            {
                 return Some("subagent".to_string());
             }
         }
@@ -2413,6 +2452,7 @@ mod tests {
             Some("main"),
             Some("/tmp/work"),
             Some("hello"),
+            &mut OpencodeLookupCache::default(),
         );
         assert_eq!(kind.as_deref(), Some("subagent"));
         let kind2 = infer_session_kind(
@@ -2422,7 +2462,97 @@ mod tests {
             Some("main"),
             Some("/Users/joe/Code/memex"),
             Some("hello"),
+            &mut OpencodeLookupCache::default(),
         );
         assert_eq!(kind2.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn strip_ansi_preserves_multibyte_unicode() {
+        let label = sanitize_label("Fix the 🚀 deploy \x1b[31mred\x1b[0m pipeline ✅ now");
+        assert_eq!(label, "Fix the 🚀 deploy red pipeline ✅ now");
+        assert!(label.contains('🚀'));
+    }
+
+    #[test]
+    fn sanitize_label_truncates_unicode_by_chars_not_bytes() {
+        let raw = "🚀".repeat(200);
+        let label = sanitize_label(&raw);
+        assert!(label.chars().count() <= MAX_LABEL_CHARS);
+        assert!(label.contains('…'));
+        assert!(label.starts_with("🚀"));
+    }
+
+    #[test]
+    fn sanitize_label_with_unicode_case_fold_before_tag_does_not_panic() {
+        // U+0130 folds to 2 chars on lowercase; byte offsets computed on the
+        // folded copy would be wrong for the original. Must strip safely.
+        let raw = "İstanbul \u{130} <SYSTEM-REMINDER>hidden</SYSTEM-REMINDER> visible task";
+        let label = sanitize_label(raw);
+        assert!(!label.contains("hidden"));
+        assert!(!label.contains("SYSTEM-REMINDER"));
+        assert!(label.contains("visible task"));
+    }
+
+    #[test]
+    fn sanitize_label_preserves_lone_comparison_brackets() {
+        let raw = "a < b and c > d comparison";
+        let label = sanitize_label(raw);
+        assert_eq!(label, "a < b and c > d comparison");
+    }
+
+    #[test]
+    fn infer_session_kind_matches_cursor_path_components_only() {
+        let mut cache = OpencodeLookupCache::default();
+        // Bare substring must not classify: project merely mentions subagents.
+        let not_sub = infer_session_kind(
+            SourceKind::Cursor,
+            "/data/my-subagents-tool/session.json",
+            "session",
+            Some("main"),
+            None,
+            None,
+            &mut cache,
+        );
+        assert_eq!(not_sub.as_deref(), Some("main"));
+        let is_sub = infer_session_kind(
+            SourceKind::Cursor,
+            "/data/Cursor/projects/subagents/agent-1/transcript.json",
+            "agent-1",
+            Some("main"),
+            None,
+            None,
+            &mut cache,
+        );
+        assert_eq!(is_sub.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn infer_session_kind_matches_muse_plural_subagents_dir() {
+        let mut cache = OpencodeLookupCache::default();
+        let kind = infer_session_kind(
+            SourceKind::Muse,
+            "/data/muse/projects/p/subagents/abc123/stream.jsonl",
+            "abc123",
+            Some("main"),
+            None,
+            None,
+            &mut cache,
+        );
+        assert_eq!(kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn extract_session_label_falls_back_without_opencode_db() {
+        let mut cache = OpencodeLookupCache::default();
+        let label = extract_session_label(
+            SourceKind::Opencode,
+            "/nonexistent/opencode.db",
+            "missing",
+            Some("  hello world  "),
+            None,
+            &mut cache,
+        );
+        assert_eq!(label.as_deref(), Some("hello world"));
     }
 }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,5 +1,8 @@
-use crate::state::SessionScope;
-use crate::types::{Record, SourceFilter, SourceKind};
+<use crate::state::SessionScope;
+use crate::types::{
+    Record, SourceFilter, SourceKind, jcode_text_is_subagent_directive,
+    jcode_tmp_cwd_is_worker_sandbox,
+};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params, params_from_iter};
 use serde::{Deserialize, Serialize};
@@ -41,6 +44,29 @@ pub enum SessionKindFilter {
     Subagent,
     #[default]
     All,
+}
+
+impl SessionKindFilter {
+    /// Row-level predicate shared by SQL filters, the TUI, and CLI search:
+    /// interactive is (missing or 'main'); every other stored kind buckets
+    /// as subagent.
+    ///
+    /// The bucketing is intentionally lossy: the store keeps six session
+    /// kinds (`main`, `subagent`, `fork`, `sidechain`, `compaction`,
+    /// `branch`) but the query surface only switches on interactive or
+    /// not — forked, compacted, branched, and sidechain sessions are all
+    /// "not the user's own turn". Per-kind fidelity is not destroyed: it
+    /// stays on the `conversation_kind` column and on per-record links
+    /// for graph/search grouping. If this predicate ever gains a third
+    /// bucket, the `every_stored_kind_has_a_defined_filter_bucket` test
+    /// names every kind that must be reconsidered.
+    pub fn matches_kind(self, kind: Option<&str>) -> bool {
+        match self {
+            SessionKindFilter::All => true,
+            SessionKindFilter::Primary => kind.is_none() || kind == Some("main"),
+            SessionKindFilter::Subagent => kind.is_some() && kind != Some("main"),
+        }
+    }
 }
 
 /// A session row with every stored column, for `memex sessions`.
@@ -844,9 +870,13 @@ impl AnalyticsWriter {
         {
             entry.first_user_text = Some(record.text.clone());
         }
-        if entry.conversation_kind.is_none()
-            && let Some(kind) = record.links.conversation_kind.clone()
+        // Prefer an explicit "main" over per-record non-main kinds: Pi and
+        // OpenClaw stamp compaction/branch on entries inside otherwise-main
+        // sessions, and Claude stamps sidechain lines the same way. A session
+        // is non-interactive only when no record claims it as main.
+        if let Some(kind) = record.links.conversation_kind.clone()
             && !kind.is_empty()
+            && (entry.conversation_kind.is_none() || kind == "main")
         {
             entry.conversation_kind = Some(kind);
         }
@@ -885,8 +915,12 @@ impl AnalyticsWriter {
                     last_at = MAX(sessions.last_at, excluded.last_at),
                     message_count = sessions.message_count + excluded.message_count,
                     resolution_status = excluded.resolution_status,
+<                    -- The stored label/kind describe the session's opening and
+                    -- survive incremental deltas, which only see mid-session
+                    -- records. Corrections flow through parser-version bumps,
+                    -- which delete the row first (delete_first) and recompute.
                     label = COALESCE(sessions.label, excluded.label),
-                    conversation_kind = COALESCE(excluded.conversation_kind, sessions.conversation_kind)
+                    conversation_kind = COALESCE(sessions.conversation_kind, excluded.conversation_kind)
                 "#,
             )?;
             // OpenCode title/agent lookups hit the source SQLite database. Sessions
@@ -1302,10 +1336,11 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 pub fn sanitize_label(raw: &str) -> String {
     // Comprehensive stripping of system wrappers (case-insensitive).
     // Fast path: neither the tag stripper nor the generic unwrap can match
-    // without a '<', so skip both scans for ordinary prose. This keeps the
+    // without a '<', so ordinary prose skips the owned buffer entirely and
+    // goes straight to the single-allocation finish pass. This keeps the
     // per-record emptiness check in `record` cheap during index scans.
-    let mut current = raw.to_string();
-    if current.contains('<') {
+    if raw.contains('<') {
+        let mut current = raw.to_string();
         const DROP_TAGS: &[&str] = &[
             "system-reminder",
             "command-message",
@@ -1381,32 +1416,52 @@ pub fn sanitize_label(raw: &str) -> String {
                 break;
             }
         }
+        return finish_label(&current);
     }
-    let ansi_stripped = strip_ansi(&current);
-    let collapsed = ansi_stripped
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-    let trimmed = collapsed.trim();
-    if trimmed.is_empty() {
+    finish_label(raw)
+}
+
+/// Single-allocation finish pass for `sanitize_label`: ANSI strip (borrowed
+/// when there is no ESC), whitespace collapse, control-char removal, and
+/// the boilerplate suppressions. Equivalent to the old
+/// split-whitespace-join plus control-filter pipeline: after collapsing,
+/// the only surviving whitespace is ' ', and the suppression patterns are
+/// pure ASCII so `eq_ignore_ascii_case` matches `to_lowercase` + compare
+/// on them without a whole-message lowercase copy.
+fn finish_label(text: &str) -> String {
+    let stripped;
+    let no_ansi: &str = if text.contains('\x1b') {
+        stripped = strip_ansi(text);
+        &stripped
+    } else {
+        text
+    };
+    let mut collapsed = String::with_capacity(no_ansi.len().min(1024));
+    let mut pending_space = false;
+    for c in no_ansi.chars() {
+        if c.is_control() && c != ' ' {
+            continue;
+        }
+        if c.is_whitespace() {
+            pending_space = true;
+            continue;
+        }
+        if pending_space && !collapsed.is_empty() {
+            collapsed.push(' ');
+        }
+        pending_space = false;
+        collapsed.push(c);
+    }
+    if collapsed.is_empty() {
         return String::new();
     }
-    let lower = trimmed.to_lowercase();
-    if lower.starts_with("# agents.md")
-        || lower.contains("global agent preferences")
-        || lower.starts_with("you are a reminder observer")
+    if starts_ascii_ci(&collapsed, "# agents.md")
+        || find_ascii_ci(&collapsed, "global agent preferences").is_some()
+        || starts_ascii_ci(&collapsed, "you are a reminder observer")
     {
         return String::new();
     }
-    // Remove non-printable control chars
-    let printable: String = trimmed
-        .chars()
-        .filter(|c| !c.is_control() || *c == ' ')
-        .collect();
-    let printable = printable.trim();
-    if printable.is_empty() {
-        return String::new();
-    }
+    let printable = collapsed.as_str();
     if printable.chars().count() <= MAX_LABEL_CHARS {
         return printable.to_string();
     }
@@ -1461,6 +1516,14 @@ fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
         return None;
     }
     (0..=hay.len() - ndl.len()).find(|&i| hay[i..i + ndl.len()].eq_ignore_ascii_case(ndl))
+}
+
+/// ASCII case-insensitive prefix test. Uses `get` so a needle length that
+/// lands mid-char safely returns false instead of panicking.
+fn starts_ascii_ci(haystack: &str, needle: &str) -> bool {
+    haystack
+        .get(..needle.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(needle))
 }
 
 fn strip_ansi(input: &str) -> String {
@@ -1617,7 +1680,10 @@ fn jcode_label_from_file(path: &str) -> Option<String> {
     None
 }
 
-fn opencode_agent_is_subagent(db_path: &str, session_id: &str) -> bool {
+/// Parent linkage is the only subagent signal: the `agent` column records
+/// the selected agent (build/plan/custom), so a plan-mode session without
+/// a parent is still interactive.
+fn opencode_session_has_parent(db_path: &str, session_id: &str) -> bool {
     let path = Path::new(db_path);
     if !path.is_file() {
         return false;
@@ -1632,27 +1698,25 @@ fn opencode_agent_is_subagent(db_path: &str, session_id: &str) -> bool {
     let _ = conn.busy_timeout(Duration::from_secs(1));
     let check = || -> Option<bool> {
         let mut stmt = conn
-            .prepare("SELECT agent FROM session WHERE id = ?1")
+            .prepare("SELECT parent_id FROM session WHERE id = ?1")
             .ok()?;
-        let agent: Option<String> = stmt
+        let parent: Option<String> = stmt
             .query_row(params![session_id], |row| row.get(0))
             .optional()
             .ok()
             .flatten();
-        Some(!crate::sources::opencode::opencode_agent_is_primary(
-            agent.as_deref(),
-        ))
+<        Some(parent.is_some_and(|p| !p.trim().is_empty()))
     };
     check().unwrap_or(false)
 }
 
-/// Memoized OpenCode source-database lookups for one flush. Titles and agent
-/// names are immutable per session, so caching across the sessions of a flush
-/// only collapses repeated reads of the same row.
+/// Memoized OpenCode source-database lookups for one flush. Titles and
+/// parent links are immutable per session, so caching across the sessions
+/// of a flush only collapses repeated reads of the same row.
 #[derive(Default)]
 struct OpencodeLookupCache {
     titles: HashMap<(String, String), Option<String>>,
-    subagent: HashMap<(String, String), bool>,
+    parented: HashMap<(String, String), bool>,
 }
 
 impl OpencodeLookupCache {
@@ -1663,11 +1727,11 @@ impl OpencodeLookupCache {
             .clone()
     }
 
-    fn is_subagent(&mut self, db_path: &str, session_id: &str) -> bool {
+    fn has_parent(&mut self, db_path: &str, session_id: &str) -> bool {
         *self
-            .subagent
+            .parented
             .entry((db_path.to_string(), session_id.to_string()))
-            .or_insert_with(|| opencode_agent_is_subagent(db_path, session_id))
+            .or_insert_with(|| opencode_session_has_parent(db_path, session_id))
     }
 }
 
@@ -1728,57 +1792,45 @@ fn infer_session_kind(
     }
     match source {
         SourceKind::Jcode => {
+            // Same worker-sandbox rule as the parser: a bare /tmp cwd is
+            // not evidence, only a sandbox leaf name is.
             if let Some(cwd) = cwd
-                && (cwd.starts_with("/tmp/")
-                    || cwd.starts_with("/private/tmp/")
-                    || cwd == "/tmp"
-                    || cwd == "/private/tmp")
+                && jcode_tmp_cwd_is_worker_sandbox(cwd)
             {
                 return Some("subagent".to_string());
             }
             if let Some(text) = first_user_text {
-                // Keep in sync with the jcode parser directive scan.
-                let lower = text.to_lowercase();
-                if lower.contains("you are a low-effort fact-checker")
-                    || lower.contains("role: manager")
-                    || lower.contains("you are a subagent")
-                    || lower.contains("you are a low effort")
-                    || lower.contains("you are downstream")
-                    || lower.contains("you are the downstream")
-                    || lower.contains("implementation worker")
-                    || lower.contains("investigation subagent")
-                    || lower.contains("0 repo writes")
-                    || lower.contains("deep validation:")
-                {
+                // Shared with the jcode parser directive scan; see
+                // `crate::types::jcode_text_is_subagent_directive`.
+                if jcode_text_is_subagent_directive(&text.to_lowercase()) {
                     return Some("subagent".to_string());
                 }
             }
         }
         SourceKind::Opencode => {
-            if opencode.is_subagent(source_path, session_id) {
-                return Some("subagent".to_string());
+            // Same value the parser stores, so parse-time and backfill
+            // classification can never disagree.
+            if opencode.has_parent(source_path, session_id) {
+                return Some("fork".to_string());
             }
         }
-        SourceKind::Muse => {
-            let normalized = source_path.replace('\\', "/");
-            if normalized.contains("/subagent/") || normalized.contains("/subagents/") {
-                return Some("subagent".to_string());
-            }
-        }
-        SourceKind::Claude => {
-            let normalized = source_path.replace('\\', "/");
-            if normalized.contains("/subagents/") || normalized.contains("/subagent/") {
-                return Some("subagent".to_string());
-            }
-        }
-        SourceKind::Cursor => {
-            // Match whole path components (like the Cursor parser's
-            // `is_subagent_transcript`): a bare substring would false-positive
-            // on projects such as `my-subagents-tool`.
+        // Match whole path components (like the Cursor parser's
+        // `is_subagent_transcript`): a bare substring would false-positive
+        // on projects such as `my-subagents-tool`.
+        SourceKind::Muse | SourceKind::Claude | SourceKind::Cursor => {
             let normalized = source_path.replace('\\', "/");
             if normalized
                 .split('/')
                 .any(|c| c == "subagents" || c == "subagent")
+            {
+                return Some("subagent".to_string());
+            }
+            // Same agent-file convention as the Claude parser's
+            // `is_agent_transcript`: applies to any of these sources.
+            if source == SourceKind::Claude
+                && let Some(name) = normalized.rsplit('/').next()
+                && name.starts_with("agent-")
+                && name.ends_with(".jsonl")
             {
                 return Some("subagent".to_string());
             }
@@ -2318,35 +2370,28 @@ mod tests {
     }
 
     #[test]
-    fn analytics_preserves_label_on_incremental_append() {
+    fn incremental_delta_keeps_original_label_and_kind() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let transcript = tmp.path().join("session.jsonl");
-        fs::write(
-            &transcript,
-            format!(
-                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
-                tmp.path().display()
-            ),
-        )
-        .expect("write");
+        fs::write(&transcript, "").expect("write");
         let db = tmp.path().join("analytics.sqlite");
-        let mut writer = AnalyticsWriter::open(&db).expect("open");
-        let mut first = record("proj", "s-append", &transcript, 10);
+        let mut first = record("proj", "s-delta", &transcript, 10);
         first.role = "user".to_string();
-        first.text = "Fix the login bug on the dashboard".to_string();
+        first.text = "REAL FIRST PROMPT about the login bug".to_string();
         first.links.conversation_kind = Some("main".to_string());
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
         writer.record(&first).expect("record");
         writer.flush().expect("flush");
-
-        // An append-only batch resumes past the original prompt, so its
-        // derived label reflects a later turn and must not replace the stored one.
-        let mut later = record("proj", "s-append", &transcript, 20);
-        later.role = "user".to_string();
-        later.text = "Also check the settings page".to_string();
-        later.links.conversation_kind = Some("main".to_string());
-        writer.record(&later).expect("record");
+        drop(writer);
+        // A later incremental run sees only a mid-session message, possibly
+        // with a different per-record kind. Neither may clobber the stored row.
+        let mut delta = record("proj", "s-delta", &transcript, 20);
+        delta.role = "user".to_string();
+        delta.text = "now also update the changelog".to_string();
+        delta.links.conversation_kind = Some("subagent".to_string());
+        let mut writer = AnalyticsWriter::open(&db).expect("reopen");
+        writer.record(&delta).expect("record");
         writer.flush().expect("flush");
-
         let store = AnalyticsStore::open_read_only(&db).expect("open ro");
         let rows = store
             .query_sessions_detailed(None, None, None, None, None)
@@ -2354,8 +2399,101 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(
             rows[0].label.as_deref(),
-            Some("Fix the login bug on the dashboard")
+            Some("REAL FIRST PROMPT about the login bug")
         );
+        assert_eq!(rows[0].conversation_kind.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn main_record_wins_over_compaction_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(&transcript, "").expect("write");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        // Compaction summary arrives before any main message, as in a
+        // resumed Pi transcript: the session is still interactive.
+        let mut summary = record("proj", "s-compact", &transcript, 5);
+        summary.role = "user".to_string();
+        summary.text = "summary of prior work".to_string();
+        summary.links.conversation_kind = Some("compaction".to_string());
+        writer.record(&summary).expect("record");
+        let mut prompt = record("proj", "s-compact", &transcript, 10);
+        prompt.role = "user".to_string();
+        prompt.text = "please fix the parser".to_string();
+        prompt.links.conversation_kind = Some("main".to_string());
+        writer.record(&prompt).expect("record");
+        writer.flush().expect("flush");
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        let rows = store
+            .query_sessions_detailed(None, None, None, None, None)
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].conversation_kind.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn every_stored_kind_has_a_defined_filter_bucket() {
+        // Contract: Primary is (NULL or 'main'); every other stored kind
+        // filters as subagent. If the predicate ever changes, this test
+        // names every kind that must be reconsidered.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        for (id, kind, ts) in [
+            ("s-main", "main", 10),
+            ("s-sub", "subagent", 20),
+            ("s-fork", "fork", 30),
+            ("s-side", "sidechain", 40),
+            ("s-compact", "compaction", 50),
+            ("s-branch", "branch", 60),
+        ] {
+            let path = tmp.path().join(format!("{id}.jsonl"));
+            fs::write(&path, "").expect("write");
+            let mut rec = record("proj", id, &path, ts);
+            rec.role = "user".to_string();
+            rec.text = format!("task {id}");
+            rec.links.conversation_kind = Some(kind.to_string());
+            writer.record(&rec).expect("record");
+        }
+        writer.flush().expect("flush");
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        let filtered = |kind| {
+            store
+                .query_sessions_detailed_filtered(None, None, None, None, Some(kind), None)
+                .expect("query")
+                .into_iter()
+                .map(|row| row.session_id)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(filtered(SessionKindFilter::Primary), vec!["s-main"]);
+        let mut sub = filtered(SessionKindFilter::Subagent);
+        sub.sort();
+        assert_eq!(
+            sub,
+            vec!["s-branch", "s-compact", "s-fork", "s-side", "s-sub"]
+        );
+        assert_eq!(
+            store
+                .query_sessions_detailed(None, None, None, None, None)
+                .expect("all")
+                .len(),
+            6
+        );
+    }
+
+    #[test]
+    fn session_cwd_resolves_from_jcode_working_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("session_cwd.json");
+        fs::write(
+            &path,
+            r#"{"id":"s-cwd","working_dir":"/repo/example","messages":[]}"#,
+        )
+        .expect("write");
+        let cwd =
+            resolve_session_cwd_from_parts(SourceKind::Jcode, &path.to_string_lossy(), "s-cwd");
+        assert_eq!(cwd.as_deref(), Some("/repo/example"));
     }
 
     #[test]
@@ -2447,27 +2585,36 @@ mod tests {
     }
 
     #[test]
-    fn jcode_tmp_cwd_is_classified_as_subagent() {
+    fn jcode_tmp_cwd_needs_worker_sandbox_leaf_for_subagent() {
         let _tmp = tempfile::tempdir().expect("tempdir");
         let _transcript = _tmp.path().join("session_session_tmp.json");
         // Need a file that contains cwd; but we also need to test inference via cwd.
         // We'll directly test infer_session_kind helper.
-        let kind = infer_session_kind(
-            SourceKind::Jcode,
-            "/tmp/.jcode/sessions/session_tmp.json",
-            "session_tmp",
-            Some("main"),
-            Some("/tmp/work"),
-            Some("hello"),
-            &mut OpencodeLookupCache::default(),
+        let infer = |cwd: &str| {
+            infer_session_kind(
+                SourceKind::Jcode,
+                "/tmp/.jcode/sessions/session_tmp.json",
+                "session_tmp",
+                None,
+                Some(cwd),
+                Some("hello"),
+                &mut OpencodeLookupCache::default(),
+            )
+        };
+        // A bare /tmp cwd is not evidence: users legitimately work in /tmp.
+        assert_eq!(infer("/tmp/work").as_deref(), Some("main"));
+        assert_eq!(infer("/tmp").as_deref(), Some("main"));
+        // A worker-sandbox leaf under /tmp corroborates a spawned worker.
+        assert_eq!(
+            infer("/private/tmp/bossmode-hygiene-v2-worker-docs").as_deref(),
+            Some("subagent")
         );
-        assert_eq!(kind.as_deref(), Some("subagent"));
         let kind2 = infer_session_kind(
             SourceKind::Jcode,
             "/tmp/.jcode/sessions/session_main.json",
             "session_main",
             Some("main"),
-            Some("/Users/joe/Code/memex"),
+            Some("/repo/example"),
             Some("hello"),
             &mut OpencodeLookupCache::default(),
         );

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -545,7 +545,14 @@ impl AnalyticsStore {
     }
 
     pub fn query_source_timestamps(&self, since_ms: Option<u64>) -> Result<Vec<(SourceKind, u64)>> {
-        self.query_source_timestamps_filtered(None, since_ms, None, None, ProjectGrouping::Flat)
+        self.query_source_timestamps_filtered(
+            None,
+            since_ms,
+            None,
+            None,
+            ProjectGrouping::Flat,
+            None,
+        )
     }
 
     pub fn query_source_timestamps_filtered(
@@ -555,6 +562,7 @@ impl AnalyticsStore {
         until_ms: Option<u64>,
         project: Option<&str>,
         grouping: ProjectGrouping,
+        kind: Option<SessionKindFilter>,
     ) -> Result<Vec<(SourceKind, u64)>> {
         let mut sql = String::from("SELECT source, last_at FROM sessions");
         let mut clauses = Vec::new();
@@ -586,6 +594,21 @@ impl AnalyticsStore {
             };
             clauses.push(format!("{project_expr} = ?"));
             values.push(rusqlite::types::Value::Text(project.to_string()));
+        }
+        if let Some(kind) = kind {
+            match kind {
+                SessionKindFilter::Primary => {
+                    clauses.push(
+                        "(conversation_kind IS NULL OR conversation_kind = 'main')".to_string(),
+                    );
+                }
+                SessionKindFilter::Subagent => {
+                    clauses.push(
+                        "conversation_kind IS NOT NULL AND conversation_kind != 'main'".to_string(),
+                    );
+                }
+                SessionKindFilter::All => {}
+            }
         }
         if !clauses.is_empty() {
             sql.push_str(" WHERE ");
@@ -2029,6 +2052,7 @@ mod tests {
                     Some(25),
                     Some("alpha"),
                     ProjectGrouping::Flat,
+                    None,
                 )
                 .expect("filtered activity"),
             vec![(SourceKind::Codex, 20)]
@@ -2338,6 +2362,42 @@ mod tests {
             .query_sessions_detailed(None, None, None, None, None)
             .expect("all");
         assert_eq!(all_rows.len(), 2);
+
+        let primary_ts = store
+            .query_source_timestamps_filtered(
+                None,
+                None,
+                None,
+                None,
+                ProjectGrouping::Flat,
+                Some(SessionKindFilter::Primary),
+            )
+            .expect("primary ts");
+        assert_eq!(primary_ts, vec![(SourceKind::Codex, 10)]);
+
+        let sub_ts = store
+            .query_source_timestamps_filtered(
+                None,
+                None,
+                None,
+                None,
+                ProjectGrouping::Flat,
+                Some(SessionKindFilter::Subagent),
+            )
+            .expect("sub ts");
+        assert_eq!(sub_ts, vec![(SourceKind::Codex, 20)]);
+
+        let all_ts = store
+            .query_source_timestamps_filtered(
+                None,
+                None,
+                None,
+                None,
+                ProjectGrouping::Flat,
+                Some(SessionKindFilter::All),
+            )
+            .expect("all ts");
+        assert_eq!(all_ts.len(), 2);
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1737,11 +1737,16 @@ fn infer_session_kind(
                 return Some("subagent".to_string());
             }
             if let Some(text) = first_user_text {
+                // Keep in sync with the jcode parser directive scan.
                 let lower = text.to_lowercase();
                 if lower.contains("you are a low-effort fact-checker")
                     || lower.contains("role: manager")
                     || lower.contains("you are a subagent")
                     || lower.contains("you are a low effort")
+                    || lower.contains("you are downstream")
+                    || lower.contains("you are the downstream")
+                    || lower.contains("implementation worker")
+                    || lower.contains("investigation subagent")
                 {
                     return Some("subagent".to_string());
                 }

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -533,6 +533,31 @@ impl AnalyticsStore {
         Ok(out)
     }
 
+    /// Stored conversation kind for one exact session identity, if the
+    /// analytics cache has a row for it. Search-result grouping uses this
+    /// complete-session truth so a session is never classified from only
+    /// the matched records; missing rows yield `None` and callers fall
+    /// back to hit-derived kinds.
+    pub fn session_conversation_kind(
+        &self,
+        source: &str,
+        session_id: &str,
+        source_path: &str,
+    ) -> Option<String> {
+        self.conn
+            .query_row(
+                "SELECT conversation_kind FROM sessions
+                 WHERE source = ?1 AND session_id = ?2 AND source_path = ?3",
+                params![source, session_id, source_path],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .ok()
+            .flatten()
+            .flatten()
+            .filter(|kind| !kind.is_empty())
+    }
+
     pub fn query_projects(
         &self,
         source: Option<SourceFilter>,
@@ -1439,11 +1464,14 @@ fn finish_label(text: &str) -> String {
     let mut collapsed = String::with_capacity(no_ansi.len().min(1024));
     let mut pending_space = false;
     for c in no_ansi.chars() {
-        if c.is_control() && c != ' ' {
-            continue;
-        }
+        // Whitespace first: newlines/tabs are also control characters, and
+        // dropping them here would glue words together ("hello\nworld" must
+        // collapse to "hello world", not "helloworld").
         if c.is_whitespace() {
             pending_space = true;
+            continue;
+        }
+        if c.is_control() {
             continue;
         }
         if pending_space && !collapsed.is_empty() {
@@ -2619,6 +2647,45 @@ mod tests {
         let raw = "a < b and c > d comparison";
         let label = sanitize_label(raw);
         assert_eq!(label, "a < b and c > d comparison");
+    }
+
+    #[test]
+    fn session_conversation_kind_resolves_stored_row() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let transcript = tmp.path().join("session.jsonl");
+        fs::write(&transcript, "").expect("write");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut writer = AnalyticsWriter::open(&db).expect("open");
+        let mut rec = record("proj", "s-kind", &transcript, 10);
+        rec.role = "user".to_string();
+        rec.text = "do the thing".to_string();
+        rec.links.conversation_kind = Some("fork".to_string());
+        writer.record(&rec).expect("record");
+        writer.flush().expect("flush");
+        let store = AnalyticsStore::open_read_only(&db).expect("open ro");
+        assert_eq!(
+            store.session_conversation_kind(
+                SourceKind::Codex.storage_label(),
+                "s-kind",
+                &transcript.to_string_lossy()
+            ),
+            Some("fork".to_string())
+        );
+        assert_eq!(
+            store.session_conversation_kind(
+                SourceKind::Codex.storage_label(),
+                "s-missing",
+                &transcript.to_string_lossy()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn sanitize_label_keeps_word_boundary_on_control_whitespace() {
+        assert_eq!(sanitize_label("hello\nworld"), "hello world");
+        assert_eq!(sanitize_label("hello\tworld"), "hello world");
+        assert_eq!(sanitize_label("hello\r\nworld"), "hello world");
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,4 +1,4 @@
-<use crate::state::SessionScope;
+use crate::state::SessionScope;
 use crate::types::{
     Record, SourceFilter, SourceKind, jcode_text_is_subagent_directive,
     jcode_tmp_cwd_is_worker_sandbox,
@@ -915,7 +915,7 @@ impl AnalyticsWriter {
                     last_at = MAX(sessions.last_at, excluded.last_at),
                     message_count = sessions.message_count + excluded.message_count,
                     resolution_status = excluded.resolution_status,
-<                    -- The stored label/kind describe the session's opening and
+                    -- The stored label/kind describe the session's opening and
                     -- survive incremental deltas, which only see mid-session
                     -- records. Corrections flow through parser-version bumps,
                     -- which delete the row first (delete_first) and recompute.
@@ -1705,7 +1705,7 @@ fn opencode_session_has_parent(db_path: &str, session_id: &str) -> bool {
             .optional()
             .ok()
             .flatten();
-<        Some(parent.is_some_and(|p| !p.trim().is_empty()))
+        Some(parent.is_some_and(|p| !p.trim().is_empty()))
     };
     check().unwrap_or(false)
 }
@@ -2301,40 +2301,6 @@ mod tests {
         assert!(label.chars().count() <= MAX_LABEL_CHARS);
         assert!(label.ends_with('…') || label.chars().count() < MAX_LABEL_CHARS);
         assert!(label.starts_with("Hello world red"));
-    }
-
-    #[test]
-    fn strip_ansi_preserves_multibyte_unicode() {
-        let label = sanitize_label("Fix the 🚀 deploy \x1b[31mred\x1b[0m pipeline ✅ now");
-        assert_eq!(label, "Fix the 🚀 deploy red pipeline ✅ now");
-        assert!(label.contains('🚀'));
-    }
-
-    #[test]
-    fn sanitize_label_truncates_unicode_by_chars_not_bytes() {
-        let raw = "🚀".repeat(200);
-        let label = sanitize_label(&raw);
-        assert!(label.chars().count() <= MAX_LABEL_CHARS);
-        assert!(label.contains('…'));
-        assert!(label.starts_with("🚀"));
-    }
-
-    #[test]
-    fn sanitize_label_with_unicode_case_fold_before_tag_does_not_panic() {
-        // U+0130 folds to 2 chars on lowercase; byte offsets computed on the
-        // folded copy would be wrong for the original. Must strip safely.
-        let raw = "İstanbul \u{130} <SYSTEM-REMINDER>hidden</SYSTEM-REMINDER> visible task";
-        let label = sanitize_label(raw);
-        assert!(!label.contains("hidden"));
-        assert!(!label.contains("SYSTEM-REMINDER"));
-        assert!(label.contains("visible task"));
-    }
-
-    #[test]
-    fn sanitize_label_preserves_lone_comparison_brackets() {
-        let raw = "a < b and c > d comparison";
-        let label = sanitize_label(raw);
-        assert_eq!(label, "a < b and c > d comparison");
     }
 
     #[test]

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1747,6 +1747,8 @@ fn infer_session_kind(
                     || lower.contains("you are the downstream")
                     || lower.contains("implementation worker")
                     || lower.contains("investigation subagent")
+                    || lower.contains("0 repo writes")
+                    || lower.contains("deep validation:")
                 {
                     return Some("subagent".to_string());
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -453,10 +453,10 @@ EXAMPLES:
         /// Maximum number of sessions
         #[arg(long, default_value_t = 20)]
         limit: usize,
-        /// Filter by session kind: primary (interactive), subagent, or all
+        /// Filter by session origin: interactive, subagent, or all
         #[arg(long, value_enum, default_value_t = SessionKind::All)]
         kind: SessionKind,
-        /// Only show primary (interactive) sessions (alias for --kind primary)
+        /// Only show interactive sessions (alias for --kind interactive)
         #[arg(long, conflicts_with = "kind")]
         primary_only: bool,
         /// Emit one JSON array instead of JSON Lines
@@ -712,7 +712,7 @@ impl From<TransferMode> for CoreTransferMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 enum SessionKind {
-    Primary,
+    Interactive,
     Subagent,
     All,
 }
@@ -720,7 +720,7 @@ enum SessionKind {
 impl From<SessionKind> for crate::analytics::SessionKindFilter {
     fn from(value: SessionKind) -> Self {
         match value {
-            SessionKind::Primary => crate::analytics::SessionKindFilter::Primary,
+            SessionKind::Interactive => crate::analytics::SessionKindFilter::Primary,
             SessionKind::Subagent => crate::analytics::SessionKindFilter::Subagent,
             SessionKind::All => crate::analytics::SessionKindFilter::All,
         }
@@ -1099,7 +1099,7 @@ pub fn run() -> Result<()> {
             root,
         } => {
             let kind = if primary_only {
-                SessionKind::Primary
+                SessionKind::Interactive
             } else {
                 kind
             };
@@ -4899,6 +4899,7 @@ mod tests {
         );
         assert!(Cli::try_parse_from(["memex", "sessions", "--primary-only"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "subagent"]).is_ok());
+        assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "interactive"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions"]).is_ok());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2342,6 +2342,7 @@ fn run_usage(options: UsageCommandOptions) -> Result<()> {
                 cost_mode,
                 include_events,
                 memo_ttl_ms: 0,
+                kind: None,
             },
         )?;
         if json {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -457,7 +457,7 @@ EXAMPLES:
         #[arg(long, value_enum, default_value_t = SessionKind::All)]
         kind: SessionKind,
         /// Only show primary (interactive) sessions (alias for --kind primary)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "kind")]
         primary_only: bool,
         /// Emit one JSON array instead of JSON Lines
         #[arg(long)]
@@ -4889,6 +4889,18 @@ mod tests {
     use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use tempfile::TempDir;
+
+    #[test]
+    #[test]
+    fn sessions_primary_only_conflicts_with_explicit_kind() {
+        assert!(
+            Cli::try_parse_from(["memex", "sessions", "--kind", "subagent", "--primary-only"])
+                .is_err()
+        );
+        assert!(Cli::try_parse_from(["memex", "sessions", "--primary-only"]).is_ok());
+        assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "subagent"]).is_ok());
+        assert!(Cli::try_parse_from(["memex", "sessions"]).is_ok());
+    }
 
     #[test]
     fn build_index_command_args_preserves_disabled_sources() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -246,6 +246,9 @@ OUTPUT FIELDS (--fields):
         /// Filter by source: claude, codex, cursor, opencode, pi, omp (Oh My Pi), openclaw, copilot, grok, hermes, jcode, or muse
         #[arg(long)]
         source: Option<SourceFilter>,
+        /// Filter by session origin: interactive, subagent, or all
+        #[arg(long, value_enum, default_value_t = SessionOrigin::All)]
+        origin: SessionOrigin,
         /// Use semantic (embedding-based) search instead of keyword search
         #[arg(long)]
         semantic: bool,
@@ -896,6 +899,7 @@ pub fn run() -> Result<()> {
             tool,
             session,
             source,
+            origin,
             semantic,
             hybrid,
             min_score,
@@ -923,6 +927,7 @@ pub fn run() -> Result<()> {
                 tool,
                 session,
                 source,
+                origin,
                 semantic,
                 hybrid,
                 min_score,
@@ -1487,6 +1492,7 @@ fn run_search(
     tool: Option<String>,
     session: Option<String>,
     source: Option<SourceFilter>,
+    origin: SessionOrigin,
     semantic: bool,
     hybrid: bool,
     min_score: Option<f32>,
@@ -1540,6 +1546,7 @@ fn run_search(
     } else {
         top_n_per_session
     };
+    let kind_filter: crate::analytics::SessionKindFilter = origin.into();
     let render = RenderOptions {
         verbose,
         matchers,
@@ -1549,12 +1556,14 @@ fn run_search(
         min_score,
         top_n_per_session,
         limit,
+        kind_filter,
     };
 
     let candidate_limit = if queries.len() > 1
         || top_n_per_session.is_some()
         || options.source.is_some()
         || cwd.is_some()
+        || kind_filter != crate::analytics::SessionKindFilter::All
     {
         (limit * 5).max(limit + 10)
     } else {
@@ -1646,6 +1655,7 @@ struct RenderOptions {
     min_score: Option<f32>,
     top_n_per_session: Option<usize>,
     limit: usize,
+    kind_filter: crate::analytics::SessionKindFilter,
 }
 
 #[derive(Serialize)]
@@ -2814,15 +2824,30 @@ fn run_herdr_resume(
 
     let mut rows =
         store.query_sessions_detailed(source, None, cwd_filter.as_deref(), None, None)?;
+    // Resume-last targets the user's own work, never a background worker
+    // transcript. An explicit session id still resumes anything.
+    let interactive = |row: &crate::analytics::SessionDetailRow| {
+        row.conversation_kind
+            .as_deref()
+            .is_none_or(|kind| kind == "main")
+    };
     if let Some(session_id) = &session_id {
         rows.retain(|row| &row.session_id == session_id);
         if rows.is_empty() {
             return Err(anyhow!("session '{session_id}' not found"));
         }
-    } else if rows.is_empty() && cwd_filter.is_some() && !strict_cwd {
-        // The public CLI keeps its historical global fallback unless the Herdr plugin
-        // explicitly requires the focused directory to match.
-        rows = store.query_sessions_detailed(source, None, None, None, Some(50))?;
+    } else {
+        if rows.iter().any(&interactive) {
+            rows.retain(&interactive);
+        }
+        if rows.is_empty() && cwd_filter.is_some() && !strict_cwd {
+            // The public CLI keeps its historical global fallback unless the Herdr plugin
+            // explicitly requires the focused directory to match.
+            rows = store.query_sessions_detailed(source, None, None, None, Some(50))?;
+            if rows.iter().any(&interactive) {
+                rows.retain(&interactive);
+            }
+        }
     }
 
     let Some((row, command, cwd)) = rows
@@ -4539,6 +4564,39 @@ fn apply_post_processing_located(
 ) -> Vec<LocatedRecord> {
     if let Some(min_score) = render.min_score {
         results.retain(|result| result.score >= min_score);
+    }
+
+    // Session-grouped origin filter with prefer-main: a sidechain hit inside
+    // a primary session must not hide the session (mirrors the TUI and the
+    // analytics accumulator).
+    if render.kind_filter != crate::analytics::SessionKindFilter::All {
+        let mut group_kind: HashMap<(String, String, String), Option<String>> = HashMap::new();
+        for result in &results {
+            let key = (
+                result.machine.clone(),
+                result.record.source.storage_label().to_string(),
+                result.record.session_id.clone(),
+            );
+            let dominated = result.record.links.conversation_kind.as_deref() == Some("main");
+            group_kind
+                .entry(key)
+                .and_modify(|kind| {
+                    if dominated {
+                        *kind = Some("main".to_string());
+                    }
+                })
+                .or_insert_with(|| result.record.links.conversation_kind.clone());
+        }
+        results.retain(|result| {
+            let key = (
+                result.machine.clone(),
+                result.record.source.storage_label().to_string(),
+                result.record.session_id.clone(),
+            );
+            render
+                .kind_filter
+                .matches_kind(group_kind.get(&key).and_then(|kind| kind.as_deref()))
+        });
     }
 
     match render.sort {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4899,7 +4899,6 @@ mod tests {
         );
         assert!(Cli::try_parse_from(["memex", "sessions", "--primary-only"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "subagent"]).is_ok());
-        assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "interactive"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions"]).is_ok());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -454,10 +454,10 @@ EXAMPLES:
         #[arg(long, default_value_t = 20)]
         limit: usize,
         /// Filter by session origin: interactive, subagent, or all
-        #[arg(long, value_enum, default_value_t = SessionKind::All)]
-        kind: SessionKind,
-        /// Only show interactive sessions (alias for --kind interactive)
-        #[arg(long, conflicts_with = "kind")]
+        #[arg(long, value_enum, default_value_t = SessionOrigin::All)]
+        origin: SessionOrigin,
+        /// Only show interactive sessions (alias for --origin interactive)
+        #[arg(long, conflicts_with = "origin")]
         primary_only: bool,
         /// Emit one JSON array instead of JSON Lines
         #[arg(long)]
@@ -711,18 +711,18 @@ impl From<TransferMode> for CoreTransferMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
-enum SessionKind {
+enum SessionOrigin {
     Interactive,
     Subagent,
     All,
 }
 
-impl From<SessionKind> for crate::analytics::SessionKindFilter {
-    fn from(value: SessionKind) -> Self {
+impl From<SessionOrigin> for crate::analytics::SessionKindFilter {
+    fn from(value: SessionOrigin) -> Self {
         match value {
-            SessionKind::Interactive => crate::analytics::SessionKindFilter::Primary,
-            SessionKind::Subagent => crate::analytics::SessionKindFilter::Subagent,
-            SessionKind::All => crate::analytics::SessionKindFilter::All,
+            SessionOrigin::Interactive => crate::analytics::SessionKindFilter::Primary,
+            SessionOrigin::Subagent => crate::analytics::SessionKindFilter::Subagent,
+            SessionOrigin::All => crate::analytics::SessionKindFilter::All,
         }
     }
 }
@@ -1093,17 +1093,17 @@ pub fn run() -> Result<()> {
             source,
             since,
             limit,
-            kind,
+            origin,
             primary_only,
             json_array,
             root,
         } => {
-            let kind = if primary_only {
-                SessionKind::Interactive
+            let origin = if primary_only {
+                SessionOrigin::Interactive
             } else {
-                kind
+                origin
             };
-            run_sessions(cwd, project, source, since, limit, kind, json_array, root)?;
+            run_sessions(cwd, project, source, since, limit, origin, json_array, root)?;
         }
         Commands::Herdr { action } => match action {
             HerdrCommand::ResumeLast {
@@ -2749,7 +2749,7 @@ fn run_sessions(
     source: Option<SourceFilter>,
     since: Option<String>,
     limit: usize,
-    kind: SessionKind,
+    origin: SessionOrigin,
     json_array: bool,
     root: Option<PathBuf>,
 ) -> Result<()> {
@@ -2758,8 +2758,8 @@ fn run_sessions(
     let store = open_analytics_read_only(&paths)?;
     let since_ms = parse_ts_millis(since)?;
     let cwd_filter = canonical_cwd_filter(cwd);
-    let kind_filter = match kind {
-        SessionKind::All => None,
+    let kind_filter = match origin {
+        SessionOrigin::All => None,
         other => Some(other.into()),
     };
     let rows = store.query_sessions_detailed_filtered(
@@ -4892,13 +4892,19 @@ mod tests {
 
     #[test]
     #[test]
-    fn sessions_primary_only_conflicts_with_explicit_kind() {
+    fn sessions_primary_only_conflicts_with_explicit_origin() {
         assert!(
-            Cli::try_parse_from(["memex", "sessions", "--kind", "subagent", "--primary-only"])
-                .is_err()
+            Cli::try_parse_from([
+                "memex",
+                "sessions",
+                "--origin",
+                "subagent",
+                "--primary-only"
+            ])
+            .is_err()
         );
         assert!(Cli::try_parse_from(["memex", "sessions", "--primary-only"]).is_ok());
-        assert!(Cli::try_parse_from(["memex", "sessions", "--kind", "subagent"]).is_ok());
+        assert!(Cli::try_parse_from(["memex", "sessions", "--origin", "subagent"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions"]).is_ok());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1559,11 +1559,16 @@ fn run_search(
         kind_filter,
     };
 
-    let candidate_limit = if queries.len() > 1
+    // Origin filtering applies after retrieval, so a fixed overfetch can
+    // still starve when wanted-kind matches rank below the cap. Re-run with
+    // a wider cap (bounded) until the filtered list is full or retrieval
+    // stops offering more candidates.
+    let origin_filtered = kind_filter != crate::analytics::SessionKindFilter::All;
+    let mut candidate_limit = if queries.len() > 1
         || top_n_per_session.is_some()
         || options.source.is_some()
         || cwd.is_some()
-        || kind_filter != crate::analytics::SessionKindFilter::All
+        || origin_filtered
     {
         (limit * 5).max(limit + 10)
     } else {
@@ -1577,49 +1582,63 @@ fn run_search(
         SearchMode::Lexical
     };
     let selected_machines = crate::machine::selected_machine_ids(&config, &machines)?;
-    let mut ranked_queries = Vec::with_capacity(queries.len());
-    let mut query_candidate_counts = Vec::with_capacity(queries.len());
     let mut failures = Vec::new();
     let mut seen_failures = HashSet::new();
-    for (query_index, query) in queries.iter().enumerate() {
-        let spec = SearchSpec {
-            query: query.clone(),
-            project: options.project.clone(),
-            role: options.role.clone(),
-            tool: options.tool.clone(),
-            session_id: options.session_id.clone(),
-            session_scope: None,
-            cwd: cwd.clone(),
-            source: options.source,
-            since: options.since,
-            until: options.until,
-            limit: candidate_limit,
-            mode,
-            recency_weight,
-            recency_half_life_days,
-            min_score,
-            project_grouping: None,
-        };
-        let federated =
-            federated_search(&paths, &config, &selected_machines, &spec, query_index == 0)?;
-        query_candidate_counts.push(federated.candidate_count);
-        for (machine, error) in federated.failures {
-            let message = format!("{machine}: {error}");
-            if seen_failures.insert(message.clone()) {
-                eprintln!("Warning: machine '{machine}' unavailable: {error}");
-                failures.push(message);
+    let mut ranked_queries;
+    let mut query_candidate_counts;
+    let mut results;
+    let mut round = 0;
+    loop {
+        ranked_queries = Vec::with_capacity(queries.len());
+        query_candidate_counts = Vec::with_capacity(queries.len());
+        let mut round_capped = false;
+        for (query_index, query) in queries.iter().enumerate() {
+            let spec = SearchSpec {
+                query: query.clone(),
+                project: options.project.clone(),
+                role: options.role.clone(),
+                tool: options.tool.clone(),
+                session_id: options.session_id.clone(),
+                session_scope: None,
+                cwd: cwd.clone(),
+                source: options.source,
+                since: options.since,
+                until: options.until,
+                limit: candidate_limit,
+                mode,
+                recency_weight,
+                recency_half_life_days,
+                min_score,
+                project_grouping: None,
+            };
+            let federated =
+                federated_search(&paths, &config, &selected_machines, &spec, query_index == 0)?;
+            round_capped = round_capped || federated.candidate_count > federated.items.len();
+            query_candidate_counts.push(federated.candidate_count);
+            for (machine, error) in federated.failures {
+                let message = format!("{machine}: {error}");
+                if seen_failures.insert(message.clone()) {
+                    eprintln!("Warning: machine '{machine}' unavailable: {error}");
+                    failures.push(message);
+                }
             }
+            ranked_queries.push(federated.items);
         }
-        ranked_queries.push(federated.items);
+        let fused = if ranked_queries.len() == 1 {
+            ranked_queries.pop().unwrap_or_default()
+        } else {
+            fuse_ranked_queries(ranked_queries, crate::retrieval_eval::DEFAULT_RRF_K)
+        };
+        let stored_kinds = stored_session_kinds(&paths, &fused, origin_filtered);
+        let mut merged_render = render.clone();
+        merged_render.min_score = None;
+        results = apply_post_processing_located(fused, &merged_render, &stored_kinds);
+        round += 1;
+        if !origin_filtered || results.len() >= render.limit || !round_capped || round >= 3 {
+            break;
+        }
+        candidate_limit = candidate_limit.saturating_mul(5);
     }
-    let mut results = if ranked_queries.len() == 1 {
-        ranked_queries.pop().unwrap_or_default()
-    } else {
-        fuse_ranked_queries(ranked_queries, crate::retrieval_eval::DEFAULT_RRF_K)
-    };
-    let mut merged_render = render.clone();
-    merged_render.min_score = None;
-    results = apply_post_processing_located(results, &merged_render);
     if trace {
         let mode_label = match (mode, queries.len() > 1) {
             (SearchMode::Lexical, false) => "lexical",
@@ -2838,16 +2857,15 @@ fn run_herdr_resume(
             return Err(anyhow!("session '{session_id}' not found"));
         }
     } else {
-        if rows.iter().any(&interactive) {
-            rows.retain(&interactive);
-        }
+        // Implicit resume never selects a background worker: discard
+        // non-interactive rows even when nothing interactive matches, so
+        // selection falls through to the global fallback or reports none.
+        rows.retain(&interactive);
         if rows.is_empty() && cwd_filter.is_some() && !strict_cwd {
             // The public CLI keeps its historical global fallback unless the Herdr plugin
             // explicitly requires the focused directory to match.
             rows = store.query_sessions_detailed(source, None, None, None, Some(50))?;
-            if rows.iter().any(&interactive) {
-                rows.retain(&interactive);
-            }
+            rows.retain(&interactive);
         }
     }
 
@@ -4559,9 +4577,50 @@ fn wants_field(fields: &Option<HashSet<String>>, name: &str) -> bool {
         .unwrap_or(true)
 }
 
+/// Stored session kinds for the candidate groups, keyed by
+/// (machine, source label, session id) with prefer-main dominance. Remote
+/// machines and sessions missing from the analytics cache simply have no
+/// entry, and grouping falls back to the matched records. Empty unless an
+/// origin filter is active.
+fn stored_session_kinds(
+    paths: &Paths,
+    results: &[LocatedRecord],
+    origin_filtered: bool,
+) -> HashMap<(String, String, String), Option<String>> {
+    let mut out = HashMap::new();
+    if !origin_filtered {
+        return out;
+    }
+    let Ok(store) = open_analytics_read_only(paths) else {
+        return out;
+    };
+    for result in results {
+        let key = (
+            result.machine.clone(),
+            result.record.source.storage_label().to_string(),
+            result.record.session_id.clone(),
+        );
+        let stored = store.session_conversation_kind(
+            result.record.source.storage_label(),
+            &result.record.session_id,
+            &result.record.source_path,
+        );
+        let dominated = stored.as_deref() == Some("main");
+        out.entry(key)
+            .and_modify(|kind: &mut Option<String>| {
+                if dominated {
+                    *kind = Some("main".to_string());
+                }
+            })
+            .or_insert(stored);
+    }
+    out
+}
+
 fn apply_post_processing_located(
     mut results: Vec<LocatedRecord>,
     render: &RenderOptions,
+    stored_kinds: &HashMap<(String, String, String), Option<String>>,
 ) -> Vec<LocatedRecord> {
     if let Some(min_score) = render.min_score {
         results.retain(|result| result.score >= min_score);
@@ -4569,7 +4628,10 @@ fn apply_post_processing_located(
 
     // Session-grouped origin filter with prefer-main: a sidechain hit inside
     // a primary session must not hide the session (mirrors the TUI and the
-    // analytics accumulator).
+    // analytics accumulator). Groups resolve against the stored session kind
+    // first — complete-session truth — and only fall back to the matched
+    // records when the analytics cache has no row (remote machines, stale
+    // caches).
     if render.kind_filter != crate::analytics::SessionKindFilter::All {
         let mut group_kind: HashMap<(String, String, String), Option<String>> = HashMap::new();
         for result in &results {
@@ -4594,9 +4656,11 @@ fn apply_post_processing_located(
                 result.record.source.storage_label().to_string(),
                 result.record.session_id.clone(),
             );
-            render
-                .kind_filter
-                .matches_kind(group_kind.get(&key).and_then(|kind| kind.as_deref()))
+            let kind = stored_kinds
+                .get(&key)
+                .and_then(|stored| stored.as_deref())
+                .or_else(|| group_kind.get(&key).and_then(|kind| kind.as_deref()));
+            render.kind_filter.matches_kind(kind)
         });
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -458,7 +458,7 @@ EXAMPLES:
         origin: SessionOrigin,
         /// Only show interactive sessions (alias for --origin interactive)
         #[arg(long, conflicts_with = "origin")]
-        primary_only: bool,
+        interactive_only: bool,
         /// Emit one JSON array instead of JSON Lines
         #[arg(long)]
         json_array: bool,
@@ -1094,11 +1094,11 @@ pub fn run() -> Result<()> {
             since,
             limit,
             origin,
-            primary_only,
+            interactive_only,
             json_array,
             root,
         } => {
-            let origin = if primary_only {
+            let origin = if interactive_only {
                 SessionOrigin::Interactive
             } else {
                 origin
@@ -4891,19 +4891,18 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    #[test]
-    fn sessions_primary_only_conflicts_with_explicit_origin() {
+    fn sessions_interactive_only_conflicts_with_explicit_origin() {
         assert!(
             Cli::try_parse_from([
                 "memex",
                 "sessions",
                 "--origin",
                 "subagent",
-                "--primary-only"
+                "--interactive-only"
             ])
             .is_err()
         );
-        assert!(Cli::try_parse_from(["memex", "sessions", "--primary-only"]).is_ok());
+        assert!(Cli::try_parse_from(["memex", "sessions", "--interactive-only"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions", "--origin", "subagent"]).is_ok());
         assert!(Cli::try_parse_from(["memex", "sessions"]).is_ok());
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -240,13 +240,11 @@ fn prepare_file_task(
             previous.pending_tool_calls.clone(),
             true,
         ),
-        // Jcode sessions are whole JSON documents, not appendable JSONL: any change
-        // must delete existing records and re-index from scratch, otherwise the
-        // parser (which replays the full messages array) would duplicate history.
-        Some(previous) if source == SourceKind::Jcode => {
-            let _ = previous;
-            (0, 0, true, HashMap::new(), false)
-        }
+<        // A jcode session is one JSON object, so a byte offset cannot resume
+        // mid-file and the parser always emits from message zero. Reparse
+        // atomically instead: delete_first purges the stale rows first, so
+        // growing files can neither duplicate records nor inflate counts.
+        Some(_) if source == SourceKind::Jcode => (0, 0, true, HashMap::new(), false),
         Some(previous) => (
             previous.offset,
             previous.turn_id,
@@ -4425,6 +4423,46 @@ mod tests {
         assert!(task.parser_version_invalidated);
         assert_eq!(task.offset, 0);
         assert!(task.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn grown_jcode_file_reparses_atomically_instead_of_resuming() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("session_jcode.json");
+        // Fabricate prior state for a smaller file with identical identity
+        // so only the jcode whole-object arm (not replacement detection)
+        // can explain atomic reparse.
+        fs::write(&path, "A".repeat(5100)).expect("transcript");
+        let metadata = path.metadata().expect("metadata");
+        let identity = file_identity(
+            &path,
+            &metadata,
+            metadata.len().min(FILE_IDENTITY_PREFIX_BYTES as u64) as usize,
+        );
+        let version = crate::sources::index_state_version(SourceKind::Jcode);
+        let mtime = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0);
+        let previous = FileState {
+            size: metadata.len() - 100,
+            mtime,
+            offset: metadata.len() - 100,
+            turn_id: 3,
+            parser_version: version,
+            pending_tool_calls: HashMap::new(),
+            identity,
+        };
+        let (task, skip) =
+            prepare_file_task(path, SourceKind::Jcode, false, &metadata, Some(&previous));
+        // Byte offsets cannot resume a single-JSON-object file: the parser
+        // re-emits from message zero, so the stale rows must go first.
+        assert!(!skip);
+        assert!(task.delete_first);
+        assert_eq!(task.offset, 0);
+        assert_eq!(task.turn_id, 0);
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -240,7 +240,7 @@ fn prepare_file_task(
             previous.pending_tool_calls.clone(),
             true,
         ),
-<        // A jcode session is one JSON object, so a byte offset cannot resume
+        // A jcode session is one JSON object, so a byte offset cannot resume
         // mid-file and the parser always emits from message zero. Reparse
         // atomically instead: delete_first purges the stale rows first, so
         // growing files can neither duplicate records nor inflate counts.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -11,7 +11,7 @@ use crate::usage::{
 use crate::vector::VectorIndex;
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -166,6 +166,11 @@ pub struct UsageSpec {
     pub cost_mode: CostMode,
     pub include_events: bool,
     pub memo_ttl_ms: u64,
+    /// Origin filter (`interactive` / `subagent` / `all`). `None` and `All`
+    /// both mean no restriction; kept `Option` for RPC compatibility with
+    /// peers that predate the field.
+    #[serde(default)]
+    pub kind: Option<SessionKindFilter>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1105,7 +1110,7 @@ fn usage_local(paths: &Paths, config: &UserConfig, spec: &UsageSpec) -> Result<U
     if !config.token_usage_enabled() {
         bail!("token usage tracking is disabled on this machine");
     }
-    let report = scan_usage(&usage_query(paths, spec))?;
+    let report = scan_usage(&usage_query(paths, spec)?)?;
     let details = report
         .details
         .iter()
@@ -1138,7 +1143,7 @@ fn usage_activity_local(
     if !config.token_usage_enabled() {
         bail!("token usage tracking is disabled on this machine");
     }
-    let (points, partial) = scan_usage_activity(&usage_query(paths, spec))?;
+    let (points, partial) = scan_usage_activity(&usage_query(paths, spec)?)?;
     Ok((
         points
             .into_iter()
@@ -1177,22 +1182,65 @@ fn session_activity_local(
         .collect())
 }
 
-fn usage_query(paths: &Paths, spec: &UsageSpec) -> UsageQuery {
-    UsageQuery {
+/// Session keys allowed by an origin filter, resolved against the local
+/// analytics store. Keys collapse to usage-event coordinates
+/// `(source label, session id)`; codex storage variants collapse via
+/// `label()`, matching `scan_usage_activity`'s
+/// `(event.source, session_id)` check. Returns an error when the analytics
+/// store cannot be opened so callers surface it instead of silently
+/// showing unfiltered totals.
+pub(crate) fn usage_session_keys_for_kind(
+    paths: &Paths,
+    kind: SessionKindFilter,
+) -> Result<HashSet<(String, String)>> {
+    let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
+    let rows =
+        store.query_sessions_filtered(None, None, None, ProjectGrouping::Flat, Some(kind), None)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.source.label().to_string(), row.session_id))
+        .collect())
+}
+
+/// Intersects an explicit session-key filter (e.g. from a text search) with
+/// the origin filter. Either side being unrestricted leaves the other side.
+fn apply_kind_to_session_keys(
+    session_keys: Option<HashSet<(String, String)>>,
+    kind: Option<SessionKindFilter>,
+    allowed: Option<HashSet<(String, String)>>,
+) -> Option<HashSet<(String, String)>> {
+    let kind = kind.unwrap_or(SessionKindFilter::All);
+    if kind == SessionKindFilter::All {
+        return session_keys;
+    }
+    let allowed = allowed?;
+    Some(match session_keys {
+        Some(keys) => keys.intersection(&allowed).cloned().collect(),
+        None => allowed,
+    })
+}
+
+fn usage_query(paths: &Paths, spec: &UsageSpec) -> Result<UsageQuery> {
+    let session_keys: Option<HashSet<(String, String)>> = spec
+        .session_keys
+        .as_ref()
+        .map(|keys| keys.iter().cloned().collect());
+    let allowed = match spec.kind.unwrap_or(SessionKindFilter::All) {
+        SessionKindFilter::All => None,
+        kind => Some(usage_session_keys_for_kind(paths, kind)?),
+    };
+    Ok(UsageQuery {
         source: spec.source,
         project: spec.project.clone(),
         project_grouping: spec.project_grouping,
-        session_keys: spec
-            .session_keys
-            .as_ref()
-            .map(|keys| keys.iter().cloned().collect()),
+        session_keys: apply_kind_to_session_keys(session_keys, spec.kind, allowed),
         since_ms: spec.since_ms,
         until_ms: spec.until_ms,
         cost_mode: spec.cost_mode,
         include_events: spec.include_events,
         cache_path: Some(paths.state.join("usage-cache.sqlite3")),
         memo_ttl_ms: spec.memo_ttl_ms,
-    }
+    })
 }
 
 fn merge_usage_reports(
@@ -2234,6 +2282,7 @@ mod tests {
             cost_mode: CostMode::Source,
             include_events: false,
             memo_ttl_ms: 0,
+            kind: None,
         };
 
         let local = usage_spec_for_machine(&spec, "local");
@@ -2251,6 +2300,97 @@ mod tests {
         assert_eq!(other.session_keys, Some(Vec::new()));
         assert!(local.machine_session_keys.is_none());
         assert!(mini.machine_session_keys.is_none());
+    }
+
+    #[test]
+    fn usage_query_resolves_origin_filter_against_analytics() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut analytics =
+            AnalyticsWriter::open(analytics_path(&paths.state)).expect("analytics writer");
+        for (session_id, kind) in [("main-ses", None), ("sub-ses", Some("subagent"))] {
+            analytics
+                .record(&Record {
+                    source: SourceKind::Codex,
+                    doc_id: 1,
+                    ts: 10,
+                    project: "memex".to_string(),
+                    session_id: session_id.to_string(),
+                    turn_id: 1,
+                    role: "user".to_string(),
+                    text: "hello".to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks {
+                        conversation_kind: kind.map(str::to_string),
+                        ..RecordLinks::default()
+                    },
+                    source_path: format!("{session_id}.jsonl"),
+                })
+                .expect("record session");
+        }
+        analytics.flush().expect("flush analytics");
+
+        let spec = |kind: Option<SessionKindFilter>,
+                    session_keys: Option<Vec<(String, String)>>| {
+            UsageSpec {
+                source: None,
+                project: None,
+                project_grouping: ProjectGrouping::Flat,
+                session_keys,
+                machine_session_keys: None,
+                since_ms: None,
+                until_ms: None,
+                cost_mode: CostMode::Source,
+                include_events: false,
+                memo_ttl_ms: 0,
+                kind,
+            }
+        };
+
+        let sub = usage_query(&paths, &spec(Some(SessionKindFilter::Subagent), None))
+            .expect("subagent query");
+        assert_eq!(
+            sub.session_keys,
+            Some(HashSet::from([(
+                "codex".to_string(),
+                "sub-ses".to_string()
+            )]))
+        );
+
+        let primary = usage_query(&paths, &spec(Some(SessionKindFilter::Primary), None))
+            .expect("primary query");
+        assert_eq!(
+            primary.session_keys,
+            Some(HashSet::from([(
+                "codex".to_string(),
+                "main-ses".to_string()
+            )]))
+        );
+
+        let all =
+            usage_query(&paths, &spec(Some(SessionKindFilter::All), None)).expect("all query");
+        assert!(all.session_keys.is_none());
+
+        let none = usage_query(&paths, &spec(None, None)).expect("unfiltered query");
+        assert!(none.session_keys.is_none());
+
+        // An explicit text-search filter intersects with the origin filter.
+        let both = vec![
+            ("codex".to_string(), "main-ses".to_string()),
+            ("codex".to_string(), "sub-ses".to_string()),
+        ];
+        let intersected = usage_query(&paths, &spec(Some(SessionKindFilter::Subagent), Some(both)))
+            .expect("intersected query");
+        assert_eq!(
+            intersected.session_keys,
+            Some(HashSet::from([(
+                "codex".to_string(),
+                "sub-ses".to_string()
+            )]))
+        );
     }
 
     #[test]

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,4 +1,4 @@
-use crate::analytics::{AnalyticsStore, ProjectGrouping, analytics_path};
+use crate::analytics::{AnalyticsStore, ProjectGrouping, SessionKindFilter, analytics_path};
 use crate::config::{MachineConfig, Paths, UserConfig, default_claude_sources};
 use crate::embed::{EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex, SessionScopeKey};
@@ -202,6 +202,8 @@ pub struct SessionActivitySpec {
     pub project_grouping: ProjectGrouping,
     pub since_ms: Option<u64>,
     pub until_ms: Option<u64>,
+    #[serde(default)]
+    pub kind: Option<SessionKindFilter>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1162,6 +1164,7 @@ fn session_activity_local(
         spec.until_ms,
         spec.project.as_deref(),
         spec.project_grouping,
+        spec.kind,
     )?;
     Ok(rows
         .into_iter()
@@ -2286,6 +2289,7 @@ mod tests {
                 project_grouping: ProjectGrouping::Flat,
                 since_ms: None,
                 until_ms: None,
+                kind: None,
             },
         )
         .expect("session activity");

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 pub struct SourceAudit {
     pub source: String,
     pub files: u64,
+    pub unreadable_files: u64,
     pub valid_json_lines: u64,
     pub malformed_json_lines: u64,
     pub non_object_json_lines: u64,
@@ -129,7 +130,14 @@ fn audit_files(source: SourceKind, files: &[PathBuf]) -> SourceAudit {
         ..SourceAudit::default()
     };
     for file in files {
+        if source == SourceKind::Hermes {
+            // Hermes usage truth is SQLite aggregate data. Audit must not
+            // reinterpret the database as JSON, and in particular must not
+            // read transcript/message columns: count the file, skip content.
+            continue;
+        }
         let Ok(file) = std::fs::File::open(file) else {
+            audit.unreadable_files += 1;
             continue;
         };
         if source == SourceKind::Hermes {
@@ -392,5 +400,33 @@ mod tests {
 
         let audit = audit_files(SourceKind::Pi, &[path]);
         assert_eq!(audit.producer_versions.get("3"), Some(&1));
+    }
+
+    #[test]
+    fn audit_skips_hermes_database_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        // SQLite header plus binary pages: must never be line-read.
+        let mut bytes = b"SQLite format 3\0".to_vec();
+        bytes.extend([0x7Fu8; 4096]);
+        bytes.extend(b"{\"type\":\"should_not_parse\"}\n");
+        fs::write(&path, &bytes).unwrap();
+
+        let audit = audit_files(SourceKind::Hermes, &[path]);
+        assert_eq!(audit.files, 1);
+        assert_eq!(audit.valid_json_lines, 0);
+        assert_eq!(audit.malformed_json_lines, 0);
+        assert_eq!(audit.unreadable_files, 0);
+    }
+
+    #[test]
+    fn audit_counts_unreadable_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("gone.jsonl");
+
+        let audit = audit_files(SourceKind::Codex, &[missing]);
+        assert_eq!(audit.files, 1);
+        assert_eq!(audit.unreadable_files, 1);
+        assert_eq!(audit.valid_json_lines, 0);
     }
 }

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -18,7 +18,9 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 3,
+    // Bumped for the agent-file backfill mirror: forces a full re-parse
+    // so unlabeled agent-*.jsonl transcripts reclassify on next index.
+    index: 4,
     usage: 4,
 };
 

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -93,6 +93,10 @@ pub fn discover(root: &Path, include_agents: bool) -> Result<Vec<SourceFile>> {
         if under_subagents && (!include_agents || !is_agent) {
             continue;
         }
+        // Standard sessions live at most two levels below root
+        // (`<project>/<session>.jsonl`); only agent transcripts nest
+        // deeper, under a `subagents/` directory (see `is_subagent_path`).
+        // Anything deeper outside `subagents/` is not a session file.
         let relative_depth = entry
             .path()
             .strip_prefix(root)

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -20,7 +20,9 @@ use std::sync::{Arc, Mutex};
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 4,
+    // Bumped for role-string subagent source detection: forces a full
+    // re-parse so stored kinds are recomputed on next index.
+    index: 5,
     usage: 4,
 };
 
@@ -218,10 +220,17 @@ fn apply_meta(payload: &simd_json::borrowed::Object<'_>, metadata: &mut SessionM
         .get("forked_from_id")
         .and_then(|value| value.as_str())
         .map(str::to_string);
-    let parent_thread_id = payload
+    // Older CLIs record spawned agents as `"source": {"subagent": "<role>"}`
+    // with no `thread_spawn` wrapper or explicit `thread_source`; any
+    // object- or role-string-shaped marker means this thread is a subagent.
+    let subagent_marker = payload
         .get("source")
         .and_then(|value| value.as_object())
-        .and_then(|source| source.get("subagent"))
+        .and_then(|source| source.get("subagent"));
+    let subagent_present = subagent_marker.is_some_and(|marker| {
+        marker.as_object().is_some() || marker.as_str().is_some_and(|role| !role.is_empty())
+    });
+    let parent_thread_id = subagent_marker
         .and_then(|value| value.as_object())
         .and_then(|subagent| subagent.get("thread_spawn"))
         .and_then(|value| value.as_object())
@@ -233,6 +242,7 @@ fn apply_meta(payload: &simd_json::borrowed::Object<'_>, metadata: &mut SessionM
         .and_then(|value| value.as_str())
         .map(str::to_string)
         .or_else(|| parent_thread_id.as_ref().map(|_| "subagent".to_string()))
+        .or_else(|| subagent_present.then(|| "subagent".to_string()))
         .or_else(|| forked_from_id.as_ref().map(|_| "fork".to_string()));
     metadata.links.parent_session_id = forked_from_id.clone().or(parent_thread_id);
     metadata.links.thread_source = thread_source.clone();
@@ -1533,6 +1543,27 @@ mod tests {
             ConversationKind::Subagent
         );
         assert_eq!(metadata.project.as_deref(), Some("memex"));
+    }
+
+    #[test]
+    fn probe_marks_role_string_subagent_source() {
+        // Older CLIs write `"source": {"subagent": "review"}` with neither
+        // `thread_spawn` nor an explicit `thread_source`.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp
+            .path()
+            .join("rollout-2026-01-26T13-38-17-019bfb99-7735-77a0-8792-176cdc56fda7.jsonl");
+        fs::write(
+            &path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"019bfb99-7735-77a0-8792-176cdc56fda7\",\"cwd\":\"/repo/memex\",\"source\":{\"subagent\":\"review\"}}}\n",
+        )
+        .unwrap();
+        let metadata = probe(&path).unwrap();
+        assert_eq!(
+            metadata.session.conversation_kind,
+            ConversationKind::Subagent
+        );
+        assert_eq!(metadata.session.parent_session_id, None);
     }
 
     #[test]

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -17,7 +17,10 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    index: 2,
+    // Bumped for per-event subagent origin flags: already-indexed
+    // transcripts must reparse so historical inline subagent events
+    // classify by event flags instead of path-only logic.
+    index: 3,
     usage: 3,
 };
 

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -145,6 +145,7 @@ pub(crate) fn parse_index_records(
         let Some(message) = object.get("message").and_then(|value| value.as_object()) else {
             continue;
         };
+        let subagent_flag = is_subagent_event(object, Some(message));
         let mut text_parts = Vec::new();
         if let Some(content) = message.get("content") {
             if let Some(text) = content.as_str() {
@@ -175,7 +176,12 @@ pub(crate) fn parse_index_records(
                                     block_object.get(*key).and_then(|value| value.as_str())
                                 })
                                 .map(str::to_string);
-                            let mut links = record_links(path, &session_id, turn_id);
+                            let mut links = record_links_with_subagent(
+                                path,
+                                &session_id,
+                                turn_id,
+                                subagent_flag,
+                            );
                             links.event_id = tool_id.clone();
                             let doc_id = next_doc_id.fetch_add(1, Ordering::SeqCst);
                             if let Some(tool_id) = tool_id {
@@ -230,7 +236,12 @@ pub(crate) fn parse_index_records(
                                 .and_then(|id| pending_tool_calls.remove(id));
                             let tool_name = super::common::borrowed_string(block_object, "name")
                                 .or_else(|| pending.and_then(|call| call.tool_name));
-                            let mut links = record_links(path, &session_id, turn_id);
+                            let mut links = record_links_with_subagent(
+                                path,
+                                &session_id,
+                                turn_id,
+                                subagent_flag,
+                            );
                             if let Some(tool_use_id) = tool_use_id {
                                 links.parent_event_id = Some(tool_use_id.clone());
                                 links.parent_tool_use_id = Some(tool_use_id);
@@ -271,7 +282,7 @@ pub(crate) fn parse_index_records(
                 tool_name: None,
                 tool_input: None,
                 tool_output: None,
-                links: record_links(path, &session_id, turn_id),
+                links: record_links_with_subagent(path, &session_id, turn_id, subagent_flag),
                 source_path: source_path.clone(),
             })?;
             turn_id += 1;
@@ -309,8 +320,54 @@ fn is_subagent_transcript(path: &Path) -> bool {
         .any(|component| component.as_os_str().to_str() == Some("subagents"))
 }
 
-pub(crate) fn record_links(path: &Path, session_id: &str, turn_id: u32) -> RecordLinks {
-    let is_subagent = is_subagent_transcript(path);
+fn is_subagent_event(
+    object: &simd_json::borrowed::Object<'_>,
+    message: Option<&simd_json::borrowed::Object<'_>>,
+) -> bool {
+    let check_val = |v: &BorrowedValue<'_>| -> bool {
+        if let Some(b) = v.as_bool() {
+            return b;
+        }
+        if let Some(s) = v.as_str() {
+            return s.eq_ignore_ascii_case("subagent") || s.eq_ignore_ascii_case("true");
+        }
+        if v.as_object().is_some() {
+            return true;
+        }
+        false
+    };
+
+    for key in [
+        "is_subagent",
+        "isSubagent",
+        "subagent",
+        "is_subagent_turn",
+        "isSubagentTurn",
+        "subagentId",
+        "subagent_id",
+    ] {
+        if let Some(v) = object.get(key)
+            && check_val(v)
+        {
+            return true;
+        }
+        if let Some(msg) = message
+            && let Some(v) = msg.get(key)
+            && check_val(v)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn record_links_with_subagent(
+    path: &Path,
+    session_id: &str,
+    turn_id: u32,
+    is_subagent_event: bool,
+) -> RecordLinks {
+    let is_subagent = is_subagent_transcript(path) || is_subagent_event;
     RecordLinks {
         event_id: Some(format!("{}:{turn_id}", transcript_id(path))),
         parent_session_id: is_subagent.then(|| session_id.to_string()),
@@ -318,6 +375,11 @@ pub(crate) fn record_links(path: &Path, session_id: &str, turn_id: u32) -> Recor
         conversation_kind: Some(if is_subagent { "subagent" } else { "main" }.to_string()),
         ..RecordLinks::default()
     }
+}
+
+#[allow(dead_code)]
+pub(crate) fn record_links(path: &Path, session_id: &str, turn_id: u32) -> RecordLinks {
+    record_links_with_subagent(path, session_id, turn_id, false)
 }
 
 fn stable_turn_bucket(value: &str) -> u32 {
@@ -609,5 +671,36 @@ mod tests {
             53
         );
         assert_eq!(events[0].project.as_deref(), Some("memex"));
+    }
+
+    #[test]
+    fn parses_subagent_flag_from_event_json() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"role":"user","is_subagent":true,"message":{"content":"subagent instruction"}}"#
+                .as_bytes(),
+        )
+        .unwrap();
+
+        let mut records = Vec::new();
+        let _ = parse_index_records(
+            &path,
+            0,
+            IndexParseState::default(),
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].links.conversation_kind.as_deref(),
+            Some("subagent")
+        );
     }
 }

--- a/src/sources/grok.rs
+++ b/src/sources/grok.rs
@@ -73,6 +73,11 @@ struct GrokSummary {
     session_id: Option<String>,
     cwd: Option<String>,
     project: Option<String>,
+    title: Option<String>,
+}
+
+pub fn session_title(updates_path: &Path) -> Option<String> {
+    read_summary(updates_path).title
 }
 
 fn read_summary(updates_path: &Path) -> GrokSummary {
@@ -95,6 +100,22 @@ fn read_summary(updates_path: &Path) -> GrokSummary {
         .filter(|value| !value.is_empty())
         .or(cwd.as_deref())
         .map(super::common::project_from_path);
+    let title = value
+        .get("generated_title")
+        .or_else(|| value.get("generatedTitle"))
+        .or_else(|| value.get("title"))
+        .or_else(|| value.get("session_summary"))
+        .or_else(|| value.get("sessionSummary"))
+        .or_else(|| value.get("summary"))
+        .or_else(|| value.pointer("/info/generated_title"))
+        .or_else(|| value.pointer("/info/generatedTitle"))
+        .or_else(|| value.pointer("/info/title"))
+        .or_else(|| value.pointer("/info/session_summary"))
+        .or_else(|| value.pointer("/info/sessionSummary"))
+        .or_else(|| value.pointer("/info/summary"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
     GrokSummary {
         session_id: value
             .pointer("/info/id")
@@ -102,6 +123,7 @@ fn read_summary(updates_path: &Path) -> GrokSummary {
             .map(str::to_string),
         cwd,
         project,
+        title,
     }
 }
 
@@ -690,5 +712,22 @@ mod tests {
         assert_eq!(events[0].tokens.output, 20);
         assert_eq!(events[0].tokens.reasoning, 7);
         assert_eq!(events[0].source_cost_usd, Some(0.0125));
+    }
+
+    #[test]
+    fn parses_grok_title_from_summary() {
+        let temp = TempDir::new().unwrap();
+        let session = temp.path().join("encoded-cwd").join("session-id");
+        fs::create_dir_all(&session).unwrap();
+        fs::write(
+            session.join("summary.json"),
+            r#"{"generated_title":"My Grok Project","info":{"id":"session-id","cwd":"/work/repo"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            session_title(&session.join("updates.jsonl")).as_deref(),
+            Some("My Grok Project")
+        );
     }
 }

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -729,7 +729,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "session_probe",
             "parent_id": null,
-            "working_dir": "/Users/joe/Developer/BenchBox",
+            "working_dir": "/repo/example",
             "messages": messages,
         });
         std::fs::write(&path, serde_json::to_string(&doc).unwrap()).unwrap();
@@ -765,7 +765,7 @@ mod tests {
         ]);
         assert_eq!(kind.as_deref(), Some("subagent"));
         let kind = kind_for_user_texts(&[
-            "You are an investigation subagent. In /Users/joe/Developer/BenchBox, triage the failure.",
+            "You are an investigation subagent. In /repo/example, triage the failure.",
         ]);
         assert_eq!(kind.as_deref(), Some("subagent"));
     }
@@ -790,7 +790,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "session_empty",
             "parent_id": null,
-            "working_dir": "/Users/joe/Developer/BenchBox",
+            "working_dir": "/repo/example",
             "messages": [
                 {"id": "m001", "role": "user", "timestamp": 1,
                  "content": "<system-reminder>\n# Session Context\nDate: 2026-09-02\n</system-reminder>"},

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -12,7 +12,9 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    index: 1,
+    // Bumped for preamble-skipping subagent directive detection: forces a
+    // full re-parse so stored kinds/labels are recomputed on next index.
+    index: 2,
     usage: 1,
 };
 

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -1,6 +1,9 @@
 use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
 use crate::analytics::sanitize_label;
-use crate::types::{Record, RecordLinks, SourceKind};
+use crate::types::{
+    Record, RecordLinks, SourceKind, jcode_text_is_subagent_directive,
+    jcode_tmp_cwd_is_worker_sandbox,
+};
 use crate::usage::{TokenBuckets, UsageEvent};
 use anyhow::Result;
 use simd_json::BorrowedValue;
@@ -131,6 +134,14 @@ fn timestamp_millis(value: &BorrowedValue<'_>) -> u64 {
         .unwrap_or(0)
 }
 
+/// Resume origin for jcode parses. A session file is rewritten in place as
+/// a single JSON object, so no byte offset can resume mid-file: the parser
+/// always replays from this origin and ingest always pairs jcode with
+/// atomic delete-first reparse (see `prepare_file_task`). The reported
+/// output offset is the file length — a stored change marker, never a seek
+/// position — so `state.offset` is deliberately unread.
+pub(crate) const JCODE_PARSE_ORIGIN: u64 = 0;
+
 pub(crate) fn parse_index_records(
     path: &Path,
     state: IndexParseState,
@@ -147,7 +158,7 @@ pub(crate) fn parse_index_records(
     let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
         diagnostics.malformed_json_lines += 1;
         return Ok(IndexParseOutput {
-            offset: 0,
+            offset: JCODE_PARSE_ORIGIN,
             turn_id: state.turn_id,
             pending_tool_calls: state.pending_tool_calls,
             session_id: Some(session_id_from_path(path)),
@@ -172,21 +183,21 @@ pub(crate) fn parse_index_records(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    let mut conversation_kind = if parent_session_id.is_some()
-        || working_dir.starts_with("/tmp/")
-        || working_dir.starts_with("/private/tmp/")
-        || working_dir == "/tmp"
-        || working_dir == "/private/tmp"
-    {
-        "subagent"
-    } else {
-        "main"
-    };
+    // A bare /tmp working directory is not evidence on its own — users
+    // legitimately work in /tmp — so the tmp cue needs a worker-sandbox
+    // leaf name (see `crate::types::jcode_tmp_cwd_is_worker_sandbox`).
+    let mut conversation_kind =
+        if parent_session_id.is_some() || jcode_tmp_cwd_is_worker_sandbox(working_dir) {
+            "subagent"
+        } else {
+            "main"
+        };
     // Check directives in the first real user message for subagent hints.
     // Jcode sessions open with <system-reminder> preamble messages, so the
     // spawning directive usually sits in the second or third user message;
-    // preamble-only messages sanitize to empty and are skipped. Keep the
-    // patterns in sync with the analytics `infer_session_kind` backstop.
+    // preamble-only messages sanitize to empty and are skipped. Patterns
+    // live in `crate::types::jcode_text_is_subagent_directive`, shared with
+    // the analytics `infer_session_kind` backstop.
     if conversation_kind == "main"
         && let Some(messages) = value.get("messages").and_then(|v| v.as_array())
     {
@@ -217,17 +228,7 @@ pub(crate) fn parse_index_records(
             if sanitize_label(&first_text).is_empty() {
                 continue;
             }
-            let lower = first_text.to_lowercase();
-            if lower.contains("you are a low-effort fact-checker")
-                || lower.contains("role: manager")
-                || lower.contains("you are a subagent")
-                || lower.contains("you are downstream")
-                || lower.contains("you are the downstream")
-                || lower.contains("implementation worker")
-                || lower.contains("investigation subagent")
-                || lower.contains("0 repo writes")
-                || lower.contains("deep validation:")
-            {
+            if jcode_text_is_subagent_directive(&first_text.to_lowercase()) {
                 conversation_kind = "subagent";
             }
             break;
@@ -506,6 +507,7 @@ pub(crate) fn parse_index_records(
     }
 
     Ok(IndexParseOutput {
+        // Change marker only: resume always restarts at JCODE_PARSE_ORIGIN.
         offset: bytes_len,
         turn_id,
         pending_tool_calls,
@@ -631,7 +633,7 @@ mod tests {
                 "id": "session_test_123",
                 "parent_id": null,
                 "title": "Test Jcode Session",
-                "working_dir": "/Users/joe/Developer/memex",
+                "working_dir": "/repo/memex",
                 "provider_key": "meta-muse",
                 "model": "muse-spark-1.2-contributor",
                 "messages": [
@@ -811,6 +813,24 @@ mod tests {
         )
         .unwrap();
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn ordinary_prompts_with_worker_words_stay_main() {
+        // Adversarial negatives: each contains a bare worker-vocabulary
+        // word, but none in the role-assignment or constraint forms the
+        // classifier requires.
+        for text in [
+            "Add a `role: manager` column to the users table and backfill it.",
+            "Please review the implementation worker pool sizing in src/pool.rs",
+            "Our CI policy says 0 repo writes from forks - document that in CONTRIBUTING.md",
+        ] {
+            assert_eq!(
+                kind_for_user_texts(&[text]),
+                Some("main".to_string()),
+                "should stay main: {text}"
+            );
+        }
     }
 
     #[test]

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -1,4 +1,5 @@
 use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
+use crate::analytics::sanitize_label;
 use crate::types::{Record, RecordLinks, SourceKind};
 use crate::usage::{TokenBuckets, UsageEvent};
 use anyhow::Result;
@@ -178,11 +179,15 @@ pub(crate) fn parse_index_records(
     } else {
         "main"
     };
-    // Check directives in first user message for subagent hints
+    // Check directives in the first real user message for subagent hints.
+    // Jcode sessions open with <system-reminder> preamble messages, so the
+    // spawning directive usually sits in the second or third user message;
+    // preamble-only messages sanitize to empty and are skipped. Keep the
+    // patterns in sync with the analytics `infer_session_kind` backstop.
     if conversation_kind == "main"
         && let Some(messages) = value.get("messages").and_then(|v| v.as_array())
     {
-        for message in messages.iter().take(3) {
+        for message in messages {
             let Some(obj) = message.as_object() else {
                 continue;
             };
@@ -206,13 +211,19 @@ pub(crate) fn parse_index_records(
                     }
                 }
             }
+            if sanitize_label(&first_text).is_empty() {
+                continue;
+            }
             let lower = first_text.to_lowercase();
             if lower.contains("you are a low-effort fact-checker")
                 || lower.contains("role: manager")
                 || lower.contains("you are a subagent")
+                || lower.contains("you are downstream")
+                || lower.contains("you are the downstream")
+                || lower.contains("implementation worker")
+                || lower.contains("investigation subagent")
             {
                 conversation_kind = "subagent";
-                break;
             }
             break;
         }
@@ -689,5 +700,78 @@ mod tests {
             Some("muse-spark-1.2-contributor")
         );
         assert_eq!(events[0].provider.as_deref(), Some("meta-muse"));
+    }
+
+    fn kind_for_user_texts(texts: &[&str]) -> Option<String> {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session_probe.json");
+        let messages: Vec<serde_json::Value> = texts
+            .iter()
+            .enumerate()
+            .map(|(i, text)| {
+                serde_json::json!({
+                    "id": format!("m{i:03}"),
+                    "role": "user",
+                    "timestamp": i as u64,
+                    "content": text,
+                })
+            })
+            .collect();
+        let doc = serde_json::json!({
+            "id": "session_probe",
+            "parent_id": null,
+            "working_dir": "/Users/joe/Developer/BenchBox",
+            "messages": messages,
+        });
+        std::fs::write(&path, serde_json::to_string(&doc).unwrap()).unwrap();
+        let mut kinds = Vec::new();
+        let next_doc_id = AtomicU64::new(1);
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &next_doc_id,
+            |rec| {
+                kinds.push(rec.links.conversation_kind.clone());
+                Ok(())
+            },
+        )
+        .unwrap();
+        kinds.into_iter().next().flatten()
+    }
+
+    #[test]
+    fn directive_behind_preamble_is_classified_as_subagent() {
+        let kind = kind_for_user_texts(&[
+            "<system-reminder>\n# Session Context\nDate: 2026-09-01\n</system-reminder>",
+            "You are downstream A8-A11 complete workflow mapper for BenchBox (fresh 01:48Z run). Read-only, no repo writes outside /tmp.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn worker_role_directives_are_classified_as_subagent() {
+        let kind = kind_for_user_texts(&[
+            "You are the focused implementation worker for Bossmode task task_f852ab12.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("subagent"));
+        let kind = kind_for_user_texts(&[
+            "You are an investigation subagent. In /Users/joe/Developer/BenchBox, triage the failure.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn interactive_prompts_stay_main() {
+        // Handoff continuations and read-only reviews are routinely issued
+        // interactively; they must not match the worker-role patterns.
+        let kind = kind_for_user_texts(&[
+            "take over and fully complete all work from the interrupted session `muse resume abc123`",
+        ]);
+        assert_eq!(kind.as_deref(), Some("main"));
+        let kind = kind_for_user_texts(&[
+            "Perform a final independent read-only pre-publication review of release 0.4.0.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("main"));
     }
 }

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -15,10 +15,9 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    // Bumped for preamble-record exclusion: forces a full re-parse so
-    // stale preamble records are purged and preamble-only sessions drop
-    // out on next index.
-    index: 4,
+    // Bumped for the worker-sandbox cwd rule: forces a full re-parse so
+    // bare-/tmp-cwd sessions reclassify on next index.
+    index: 5,
     usage: 1,
 };
 

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -12,9 +12,10 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    // Bumped for preamble-skipping subagent directive detection: forces a
-    // full re-parse so stored kinds/labels are recomputed on next index.
-    index: 2,
+    // Bumped for swarm-dialect directive detection (0 repo writes, deep
+    // validation): forces a full re-parse so stored kinds are recomputed
+    // on next index.
+    index: 3,
     usage: 1,
 };
 
@@ -224,6 +225,8 @@ pub(crate) fn parse_index_records(
                 || lower.contains("you are the downstream")
                 || lower.contains("implementation worker")
                 || lower.contains("investigation subagent")
+                || lower.contains("0 repo writes")
+                || lower.contains("deep validation:")
             {
                 conversation_kind = "subagent";
             }
@@ -759,6 +762,19 @@ mod tests {
         assert_eq!(kind.as_deref(), Some("subagent"));
         let kind = kind_for_user_texts(&[
             "You are an investigation subagent. In /Users/joe/Developer/BenchBox, triage the failure.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn fresh_cycle_and_validation_directives_are_subagent() {
+        let kind = kind_for_user_texts(&[
+            "<system-reminder>\n# Session Context\nDate: 2026-09-02\n</system-reminder>",
+            "FRESH 12:38Z definitive \u{2014} supersede wolf 183 authoritative: At live poll 12:38:43Z origin/develop STILL d7d518e. 0 repo writes.",
+        ]);
+        assert_eq!(kind.as_deref(), Some("subagent"));
+        let kind = kind_for_user_texts(&[
+            "Deep validation: Orchestration ORIGIN d7d518e STEADY ~255m at 07:50:05Z live triad. Read-only, 0 repo writes outside /tmp.",
         ]);
         assert_eq!(kind.as_deref(), Some("subagent"));
     }

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -12,10 +12,10 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    // Bumped for swarm-dialect directive detection (0 repo writes, deep
-    // validation): forces a full re-parse so stored kinds are recomputed
-    // on next index.
-    index: 3,
+    // Bumped for preamble-record exclusion: forces a full re-parse so
+    // stale preamble records are purged and preamble-only sessions drop
+    // out on next index.
+    index: 4,
     usage: 1,
 };
 
@@ -349,7 +349,11 @@ pub(crate) fn parse_index_records(
                     }
 
                     let full_text = text_parts.join("\n").trim().to_string();
-                    if !full_text.is_empty() {
+                    // Preamble-only messages (system context wrappers with no
+                    // real content) are dropped: they add no searchable value,
+                    // and a session containing nothing else yields zero
+                    // records, excluding it from the index altogether.
+                    if !sanitize_label(&full_text).is_empty() {
                         emit(Record {
                             source: SourceKind::Jcode,
                             doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -777,6 +781,36 @@ mod tests {
             "Deep validation: Orchestration ORIGIN d7d518e STEADY ~255m at 07:50:05Z live triad. Read-only, 0 repo writes outside /tmp.",
         ]);
         assert_eq!(kind.as_deref(), Some("subagent"));
+    }
+
+    #[test]
+    fn preamble_only_session_yields_no_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session_empty.json");
+        let doc = serde_json::json!({
+            "id": "session_empty",
+            "parent_id": null,
+            "working_dir": "/Users/joe/Developer/BenchBox",
+            "messages": [
+                {"id": "m001", "role": "user", "timestamp": 1,
+                 "content": "<system-reminder>\n# Session Context\nDate: 2026-09-02\n</system-reminder>"},
+            ],
+        });
+        std::fs::write(&path, serde_json::to_string(&doc).unwrap()).unwrap();
+        let mut records = Vec::new();
+        let next_doc_id = AtomicU64::new(1);
+        parse_index_records(
+            &path,
+            IndexParseState::default(),
+            true,
+            &next_doc_id,
+            |rec| {
+                records.push(rec);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(records.is_empty());
     }
 
     #[test]

--- a/src/sources/muse.rs
+++ b/src/sources/muse.rs
@@ -184,7 +184,12 @@ pub(crate) fn parse_index_records(
 
     let source_path = path.to_string_lossy().to_string();
     let normalized_path = source_path.replace('\\', "/");
-    let is_subagent = normalized_path.contains("/subagent/");
+    // Muse writes worker transcripts under `<session>/subagent*/…` (plural is
+    // also seen); match on path components, not substrings, so a session id
+    // that merely contains the word never misfires.
+    let is_subagent = Path::new(&normalized_path)
+        .components()
+        .any(|c| c.as_os_str().to_string_lossy().starts_with("subagent"));
 
     let mut session_id = session_id_from_path(path);
     let mut parent_session_id = None;
@@ -638,11 +643,11 @@ mod tests {
         std::fs::write(
             &path,
             concat!(
-                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308372342264,"payload":{"kind":"metadata","record":{"workspace_root":"/Users/joe/Developer/memex","provider_id":"meta","model_id":"muse-spark-1.2"}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308372342264,"payload":{"kind":"metadata","record":{"workspace_root":"/repo/memex","provider_id":"meta","model_id":"muse-spark-1.2"}}}"#, "\n",
                 r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308372900000,"payload":{"kind":"run","event":{"kind":"started","prompt":"Hello Muse"}}}"#, "\n",
                 r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373000000,"payload":{"kind":"run","event":{"kind":"reasoning_committed","message_id":"m1","text":"Let me think"}}}"#, "\n",
                 r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373100000,"payload":{"kind":"run","event":{"kind":"assistant_tool_calls_committed","message_id":"m1","tool_calls":[{"call_id":"call1","name":"bash","args":"{\"command\":\"pwd\"}"}]}}}"#, "\n",
-                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373200000,"payload":{"kind":"run","event":{"kind":"tool_result_batch_committed","results":[{"tool_call_id":"call1","text":"/Users/joe/Developer/memex"}]}}}"#, "\n",
+                r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373200000,"payload":{"kind":"run","event":{"kind":"tool_result_batch_committed","results":[{"tool_call_id":"call1","text":"/repo/memex"}]}}}"#, "\n",
                 r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373300000,"payload":{"kind":"run","event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"input_tokens":100,"output_tokens":20,"cached_tokens":10,"reasoning_tokens":5}}}}"#, "\n",
                 r#"{"stream":{"kind":"session","id":"01a05f7c-3b49-77a1"},"recorded_at":1788308373400000,"payload":{"kind":"run","event":{"kind":"assistant_message_committed","message_id":"m2","text":"I checked the current directory."}}}"#, "\n"
             ),

--- a/src/sources/muse.rs
+++ b/src/sources/muse.rs
@@ -14,7 +14,9 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 1,
-    index: 1,
+    // Bumped for subagent* directory matching: forces a full re-parse so
+    // plural-dir worker transcripts reclassify on next index.
+    index: 2,
     usage: 1,
 };
 

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -225,7 +225,6 @@ pub struct OpencodeSession {
     pub directory: String,
     pub time_created: u64,
     pub time_updated: u64,
-    pub agent: Option<String>,
 }
 
 /// Enumerate the modern session inventory from one OpenCode database.
@@ -260,7 +259,6 @@ fn enumerate_sessions_from_connection(
         })
         .with_context(|| format!("query OpenCode sessions in {}", path.display()))?;
     let mut sessions = Vec::new();
-    let agents = session_agents(connection);
     for row in rows {
         let (id, parent_id, directory, time_created, time_updated) = row?;
         sessions.push(OpencodeSession {
@@ -271,43 +269,13 @@ fn enumerate_sessions_from_connection(
                 .with_context(|| format!("session `{id}` has invalid time_created"))?,
             time_updated: nonnegative_timestamp(time_updated)
                 .with_context(|| format!("session `{id}` has invalid time_updated"))?,
-            agent: agents.get(&id).cloned(),
         });
     }
     Ok(sessions)
 }
 
-/// Tolerantly load the `agent` column for subagent detection (`agent != 'build'`).
-/// Older databases may lack the column; in that case every session reports `None`
-/// and callers fall back to parent-id-only classification.
-fn session_agents(connection: &Connection) -> HashMap<String, String> {
-    let mut agents = HashMap::new();
-    let Ok(mut statement) = connection.prepare("SELECT id, agent FROM session") else {
-        return agents;
-    };
-    let Ok(rows) = statement.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
-    }) else {
-        return agents;
-    };
-    for row in rows.flatten() {
-        let (id, agent) = row;
-        if let Some(agent) = agent.filter(|a| !a.is_empty()) {
-            agents.insert(id, agent);
-        }
-    }
-    agents
-}
-
 fn nonnegative_timestamp(value: i64) -> Result<u64> {
     u64::try_from(value).map_err(|_| anyhow::anyhow!("negative timestamp"))
-}
-
-/// OpenCode's interactive primary agents. `plan` is a primary interactive mode,
-/// not a subagent, even though it is not `build`. Anything else recorded in
-/// the session `agent` column runs as a subagent.
-pub(crate) fn opencode_agent_is_primary(agent: Option<&str>) -> bool {
-    matches!(agent, None | Some("") | Some("build") | Some("plan"))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -754,13 +722,14 @@ pub(crate) fn parse_database_records(
             diagnostics: Default::default(),
         });
     };
+    // Parent linkage is the only subagent signal: the `agent` column records
+    // the selected agent (build/plan/custom), so a plan-mode session without
+    // a parent is still interactive.
     let links = SessionLinks {
         parent_session_id: session.parent_id.clone(),
         thread_source: session.parent_id.as_ref().map(|_| "fork".to_string()),
         conversation_kind: Some(if session.parent_id.is_some() {
             "fork".to_string()
-        } else if !opencode_agent_is_primary(session.agent.as_deref()) {
-            "subagent".to_string()
         } else {
             "main".to_string()
         }),
@@ -910,16 +879,6 @@ fn enumerate_session_from_connection(
         return Ok(None);
     };
     let (id, parent_id, directory, time_created, time_updated) = row;
-    let agent = connection
-        .query_row(
-            "SELECT agent FROM session WHERE id = ?1",
-            [session_id],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .optional()
-        .unwrap_or(None)
-        .flatten()
-        .filter(|a| !a.is_empty());
     Ok(Some(OpencodeSession {
         id,
         parent_id,
@@ -928,7 +887,6 @@ fn enumerate_session_from_connection(
             .with_context(|| format!("session `{session_id}` has invalid time_created"))?,
         time_updated: nonnegative_timestamp(time_updated)
             .with_context(|| format!("session `{session_id}` has invalid time_updated"))?,
-        agent,
     }))
 }
 
@@ -1245,13 +1203,40 @@ mod tests {
     }
 
     #[test]
-    fn plan_and_build_agents_are_primary() {
-        assert!(opencode_agent_is_primary(None));
-        assert!(opencode_agent_is_primary(Some("")));
-        assert!(opencode_agent_is_primary(Some("build")));
-        assert!(opencode_agent_is_primary(Some("plan")));
-        assert!(!opencode_agent_is_primary(Some("explore")));
-        assert!(!opencode_agent_is_primary(Some("custom-agent")));
+    fn plan_agent_without_parent_stays_main() {
+        // The `agent` column records the selected agent, not subagent-ness:
+        // only parent linkage classifies.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("opencode.db");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, agent TEXT);
+                 INSERT INTO session VALUES ('ses_plan', NULL, '/repo/example', 1000, 1001, 'plan');
+                 INSERT INTO session VALUES ('ses_child', 'ses_plan', '/repo/example', 1002, 1003, 'general');
+                 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+                 INSERT INTO message VALUES ('msg_1', 'ses_plan', 1001, '{\"role\":\"user\"}');
+                 INSERT INTO message VALUES ('msg_2', 'ses_child', 1002, '{\"role\":\"user\"}');
+                 CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, data TEXT NOT NULL);
+                 INSERT INTO part VALUES ('part_1', 'msg_1', '{\"type\":\"text\",\"text\":\"Plan the work\"}');
+                 INSERT INTO part VALUES ('part_2', 'msg_2', '{\"type\":\"text\",\"text\":\"Do the work\"}');",
+            )
+            .unwrap();
+        drop(connection);
+
+        let plan = parse_database_session(&path, "ses_plan", 0, &AtomicU64::new(1)).unwrap();
+        assert_eq!(plan.len(), 1);
+        assert_eq!(
+            plan[0].links.conversation_kind.as_deref(),
+            Some("main")
+        );
+        let child =
+            parse_database_session(&path, "ses_child", 0, &AtomicU64::new(10)).unwrap();
+        assert_eq!(child.len(), 1);
+        assert_eq!(
+            child[0].links.conversation_kind.as_deref(),
+            Some("fork")
+        );
     }
 
     #[test]

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -22,7 +22,11 @@ pub const VERSIONS: ParserVersions = ParserVersions {
 /// Version for the SQLite event cursor and owned-session reconciliation rules.  This is
 /// intentionally independent of the shared source identity/index versions: legacy JSON parsing
 /// has not changed merely because database planning was added.
-pub const DATABASE_STATE_VERSION: u32 = 1;
+///
+/// Bumped for the parent-linkage-only reclassification: unparented sessions
+/// with non-primary agent values were stored as subagent and must reconcile
+/// once so their records and analytics rows reflect the new kinds.
+pub const DATABASE_STATE_VERSION: u32 = 2;
 
 pub fn matches_path(path: &str) -> bool {
     (path.contains("opencode/storage/message") || path.contains("opencode\\storage\\message"))

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -1226,17 +1226,10 @@ mod tests {
 
         let plan = parse_database_session(&path, "ses_plan", 0, &AtomicU64::new(1)).unwrap();
         assert_eq!(plan.len(), 1);
-        assert_eq!(
-            plan[0].links.conversation_kind.as_deref(),
-            Some("main")
-        );
-        let child =
-            parse_database_session(&path, "ses_child", 0, &AtomicU64::new(10)).unwrap();
+        assert_eq!(plan[0].links.conversation_kind.as_deref(), Some("main"));
+        let child = parse_database_session(&path, "ses_child", 0, &AtomicU64::new(10)).unwrap();
         assert_eq!(child.len(), 1);
-        assert_eq!(
-            child[0].links.conversation_kind.as_deref(),
-            Some("fork")
-        );
+        assert_eq!(child[0].links.conversation_kind.as_deref(), Some("fork"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1490,7 +1490,8 @@ impl App {
                 .map(|(_, source, session_id)| (source.clone(), session_id.clone()))
                 .collect()
         });
-        let query = home_token_usage_query(
+        let session_kind = self.session_kind;
+        let mut query = home_token_usage_query(
             self.source,
             &self.project,
             self.project_display.grouping(),
@@ -1516,6 +1517,7 @@ impl App {
                         cost_mode: query.cost_mode,
                         include_events: false,
                         memo_ttl_ms: query.memo_ttl_ms,
+                        kind: Some(session_kind),
                     },
                 )
                 .map(|(events, partial)| {
@@ -1546,6 +1548,23 @@ impl App {
                     }),
                 };
                 return;
+            }
+            // A text search already restricts `session_keys` to the
+            // origin-filtered results; with an empty query the usage scan
+            // is otherwise unfiltered, so resolve the origin here.
+            if query.session_keys.is_none()
+                && session_kind != crate::analytics::SessionKindFilter::All
+            {
+                match crate::machine::usage_session_keys_for_kind(&paths, session_kind) {
+                    Ok(keys) => query.session_keys = Some(keys),
+                    Err(error) => {
+                        let _ = tx.send(SearchUpdate::HomeTokenActivityError {
+                            request_id,
+                            message: error.to_string(),
+                        });
+                        return;
+                    }
+                }
             }
             let result = scan_usage_activity(&query).map(|(events, partial)| {
                 let points = events
@@ -1773,13 +1792,14 @@ impl App {
         let project_changed = project_selection && self.project != previous_project;
         let machine_changed = machine_selection && self.machine != previous_machine;
         let range_changed = range_selection && self.home_activity_range != previous_range;
-        let token_filter_changed = machine_changed || source_changed || project_changed;
+        let token_filter_changed =
+            machine_changed || source_changed || project_changed || kind_changed;
         if token_filter_changed {
             self.invalidate_home_token_activity();
         }
         if refresh_search {
             self.kickoff_search();
-            if token_filter_changed || kind_changed || range_changed {
+            if token_filter_changed || range_changed {
                 self.kickoff_home_activity();
             }
         } else if range_changed {
@@ -7839,6 +7859,24 @@ mod tests {
             crate::analytics::SessionKindFilter::Subagent
         );
         assert_eq!(app.home_dropdown, HomeDropdown::None);
+    }
+
+    #[test]
+    fn kind_dropdown_change_reloads_token_chart() {
+        let (_tmp, mut app) = test_app();
+        app.config.token_usage = Some(true);
+        app.home_chart_mode = HomeChartMode::Tokens;
+        app.home_token_activity_state = LoadState::Loaded;
+        // Default filter is primary at index 1 in all/interactive/subagent order.
+        app.open_home_dropdown(HomeDropdown::Kind);
+        app.move_home_dropdown_selection(1);
+        app.apply_home_dropdown();
+        assert_eq!(
+            app.session_kind,
+            crate::analytics::SessionKindFilter::Subagent
+        );
+        // The origin change must kick a token reload, not leave stale totals.
+        assert_eq!(app.home_token_activity_state, LoadState::Loading);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7057,7 +7057,9 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 mod tests {
     use super::*;
     use crate::types::{RecordLinks, SourceKind};
-    use ratatui::{backend::TestBackend, buffer::Buffer, widgets::Widget};
+    use ratatui::{
+        TerminalOptions, Viewport, backend::TestBackend, buffer::Buffer, widgets::Widget,
+    };
     use std::hint::black_box;
 
     fn create_stale_schema_index(dir: &std::path::Path) {
@@ -7897,7 +7899,15 @@ mod tests {
             .write(true)
             .open("/dev/null")
             .expect("devnull");
-        let mut terminal = Terminal::new(CrosstermBackend::new(devnull)).expect("terminal");
+        // Fixed viewport: `Terminal::new` queries the real terminal size,
+        // which fails without a TTY (sandbox, CI). Key handling never draws.
+        let mut terminal = Terminal::with_options(
+            CrosstermBackend::new(devnull),
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 80, 24)),
+            },
+        )
+        .expect("terminal");
         app.open_home_dropdown(HomeDropdown::Kind);
         // Default filter is primary at index 1 in all/primary/subagent order.
         assert_eq!(app.home_dropdown_state.selected(), Some(1));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1638,7 +1638,7 @@ impl App {
             }
             HomeDropdown::Kind => vec![
                 "all".to_string(),
-                "primary".to_string(),
+                "interactive".to_string(),
                 "subagent".to_string(),
             ],
             HomeDropdown::Project => {
@@ -1708,7 +1708,8 @@ impl App {
             self.close_home_dropdown();
             return;
         };
-        let refresh_activity = self.home_dropdown == HomeDropdown::Range;
+        let range_selection = self.home_dropdown == HomeDropdown::Range;
+        let previous_range = self.home_activity_range;
         let machine_selection = self.home_dropdown == HomeDropdown::Machine;
         let previous_machine = self.machine.clone();
         let source_selection = self.home_dropdown == HomeDropdown::Source;
@@ -1723,7 +1724,10 @@ impl App {
                     .get(idx)
                     .copied()
                     .unwrap_or(TimelineRange::Month);
-                false
+                // The timeframe filters the chart and the recent list alike:
+                // sync the list's `since` bound (All clears it back to None).
+                self.sessions_since = self.home_activity_range.since_ms(now_ms());
+                true
             }
             HomeDropdown::Machine => {
                 self.machine = if idx == 0 {
@@ -1768,16 +1772,17 @@ impl App {
         let kind_changed = kind_selection && self.session_kind != previous_kind;
         let project_changed = project_selection && self.project != previous_project;
         let machine_changed = machine_selection && self.machine != previous_machine;
+        let range_changed = range_selection && self.home_activity_range != previous_range;
         let token_filter_changed = machine_changed || source_changed || project_changed;
         if token_filter_changed {
             self.invalidate_home_token_activity();
         }
         if refresh_search {
             self.kickoff_search();
-            if token_filter_changed || kind_changed {
+            if token_filter_changed || kind_changed || range_changed {
                 self.kickoff_home_activity();
             }
-        } else if refresh_activity {
+        } else if range_changed {
             self.kickoff_home_activity();
         }
     }
@@ -2317,7 +2322,7 @@ impl App {
             }
         };
         let label = match self.session_kind {
-            crate::analytics::SessionKindFilter::Primary => "primary",
+            crate::analytics::SessionKindFilter::Primary => "interactive",
             crate::analytics::SessionKindFilter::All => "all",
             crate::analytics::SessionKindFilter::Subagent => "subagent",
         };
@@ -2964,7 +2969,7 @@ fn handle_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> Resul
                 app.kickoff_home_activity();
             }
         }
-        KeyCode::Char('K') => {
+        KeyCode::Char('c') => {
             app.cycle_session_kind();
         }
         KeyCode::Char('[') => {
@@ -3034,9 +3039,9 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
             KeyCode::Esc => {
                 app.close_home_dropdown();
             }
-            // `c`/`K` toggle the kind dropdown closed; `k` must keep moving
+            // `c` toggles the kind dropdown closed; `k` must keep moving
             // the selection up like in every other dropdown.
-            KeyCode::Char('c') | KeyCode::Char('K') if app.home_dropdown == HomeDropdown::Kind => {
+            KeyCode::Char('c') if app.home_dropdown == HomeDropdown::Kind => {
                 app.close_home_dropdown();
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -3140,7 +3145,7 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
         KeyCode::Char('s') => {
             app.open_home_dropdown(HomeDropdown::Source);
         }
-        KeyCode::Char('c') | KeyCode::Char('K') => {
+        KeyCode::Char('c') => {
             app.open_home_dropdown(HomeDropdown::Kind);
         }
         KeyCode::Char('p') => {
@@ -3444,12 +3449,12 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         String::new()
     };
     let source_word = format!("{} ▾", app.source.label());
-    let kind_word = format!(
+    let origin_word = format!(
         "{} ▾",
         match app.session_kind {
-            crate::analytics::SessionKindFilter::Primary => "primary",
-            crate::analytics::SessionKindFilter::All => "all kinds",
-            crate::analytics::SessionKindFilter::Subagent => "subagents",
+            crate::analytics::SessionKindFilter::Primary => "interactive",
+            crate::analytics::SessionKindFilter::All => "all",
+            crate::analytics::SessionKindFilter::Subagent => "subagent",
         }
     );
     let project_word = format!(
@@ -3462,7 +3467,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     );
     let machine_width = machine_word.chars().count() as u16;
     let source_width = source_word.chars().count() as u16;
-    let kind_width = kind_word.chars().count() as u16;
+    let origin_width = origin_word.chars().count() as u16;
     let project_width_hdr = project_word.chars().count() as u16;
     let header_cols = Layout::default()
         .direction(Direction::Horizontal)
@@ -3472,7 +3477,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
             Constraint::Length(if machine_width > 0 { 3 } else { 0 }),
             Constraint::Length(source_width),
             Constraint::Length(3),
-            Constraint::Length(kind_width),
+            Constraint::Length(origin_width),
             Constraint::Length(3),
             Constraint::Length(project_width_hdr),
         ])
@@ -3513,7 +3518,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         header_cols[3],
     );
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(kind_word, kind_style))),
+        Paragraph::new(Line::from(Span::styled(origin_word, kind_style))),
         header_cols[5],
     );
     frame.render_widget(
@@ -3599,11 +3604,7 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
     if anchor.width == 0 {
         return;
     }
-    let max_len = if app.home_dropdown == HomeDropdown::Kind {
-        38
-    } else {
-        options.iter().map(|o| o.chars().count()).max().unwrap_or(8)
-    };
+    let max_len = options.iter().map(|o| o.chars().count()).max().unwrap_or(8);
     let width = ((max_len as u16).clamp(8, 42) + 2).min(area.width);
     let x = anchor
         .right()
@@ -3627,27 +3628,10 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
     app.home_dropdown_area = popup;
     frame.render_widget(Clear, popup);
     frame.render_widget(Block::default().style(theme.panel_alt), popup);
-    let items: Vec<ListItem> = if app.home_dropdown == HomeDropdown::Kind {
-        let kind_items = [
-            ("all", "all sessions"),
-            ("primary", "primary interactive sessions"),
-            ("subagent", "subagent sessions only"),
-        ];
-        kind_items
-            .into_iter()
-            .map(|(label, desc)| {
-                ListItem::new(Line::from(vec![
-                    Span::styled(format!(" {label}"), theme.text_bold),
-                    Span::styled(format!("  {desc}"), theme.muted),
-                ]))
-            })
-            .collect()
-    } else {
-        options
-            .into_iter()
-            .map(|option| ListItem::new(Line::from(Span::styled(format!(" {option}"), theme.text))))
-            .collect()
-    };
+    let items: Vec<ListItem> = options
+        .into_iter()
+        .map(|option| ListItem::new(Line::from(Span::styled(format!(" {option}"), theme.text))))
+        .collect();
     let list = List::new(items)
         .style(theme.text)
         .highlight_style(theme.selection)
@@ -4911,12 +4895,12 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
         || app.layout_mode == LayoutMode::Split
     {
         let kind_label = match app.session_kind {
-            crate::analytics::SessionKindFilter::Primary => "primary",
+            crate::analytics::SessionKindFilter::Primary => "interactive",
             crate::analytics::SessionKindFilter::Subagent => "subagent",
             crate::analytics::SessionKindFilter::All => "all",
         };
-        right_spans.push(Span::styled("kind ", theme.muted));
-        right_spans.push(Span::styled("(c/K) ", theme.accent));
+        right_spans.push(Span::styled("origin ", theme.muted));
+        right_spans.push(Span::styled("(c) ", theme.accent));
         right_spans.push(Span::styled(kind_label, theme.text));
         right_spans.push(Span::raw("   "));
     }
@@ -5016,7 +5000,7 @@ fn footer_shortcuts<'a>(app: &App, theme: &Theme, width: u16) -> Line<'a> {
             Span::styled("s", theme.accent),
             Span::styled(" source  ", theme.muted),
             Span::styled("c", theme.accent),
-            Span::styled(" kind  ", theme.muted),
+            Span::styled(" origin  ", theme.muted),
             Span::styled("p", theme.accent),
             Span::styled(" projects  ", theme.muted),
             Span::styled("/", theme.accent),
@@ -6465,7 +6449,7 @@ fn render_preview_line<'a>(line: &'a PreviewLine, theme: &Theme) -> Line<'a> {
             ];
             if let Some(kind_str) = kind.as_deref().filter(|s| !s.is_empty()) {
                 spans.push(Span::raw("  "));
-                spans.push(Span::styled("kind ", theme.muted));
+                spans.push(Span::styled("origin ", theme.muted));
                 spans.push(Span::styled(kind_str, theme.accent));
             }
             Line::from(spans)
@@ -7840,7 +7824,7 @@ mod tests {
         app.open_home_dropdown(HomeDropdown::Kind);
         assert_eq!(
             app.home_dropdown_options(),
-            vec!["all", "primary", "subagent"]
+            vec!["all", "interactive", "subagent"]
         );
     }
 
@@ -7899,7 +7883,7 @@ mod tests {
     }
 
     #[test]
-    fn range_dropdown_changes_chart_without_restarting_search() {
+    fn range_dropdown_filters_list_and_chart() {
         let (_tmp, mut app) = test_app();
         app.active_search_request = 7;
         app.open_home_dropdown(HomeDropdown::Range);
@@ -7908,9 +7892,20 @@ mod tests {
         app.move_home_dropdown_selection(1);
         app.apply_home_dropdown();
 
+        // "All" clears the list's `since` bound and restarts the search.
         assert_eq!(app.home_activity_range, TimelineRange::All);
-        assert_eq!(app.active_search_request, 7);
+        assert_eq!(app.sessions_since, None);
+        assert_ne!(app.active_search_request, 7);
         assert_eq!(app.home_activity_state, LoadState::Loading);
+
+        // A bounded range syncs the list's `since` bound to the same cutoff.
+        app.open_home_dropdown(HomeDropdown::Range);
+        app.move_home_dropdown_selection(-2);
+        app.apply_home_dropdown();
+        assert_eq!(app.home_activity_range, TimelineRange::Week);
+        let since = app.sessions_since.expect("bounded range sets since");
+        let now = now_ms();
+        assert!(since <= now && since > now.saturating_sub(8 * 86_400_000));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5275,11 +5275,7 @@ fn sessions_from_analytics_filtered(
 }
 
 fn session_matches_kind(filter: crate::analytics::SessionKindFilter, kind: Option<&str>) -> bool {
-    match filter {
-        crate::analytics::SessionKindFilter::All => true,
-        crate::analytics::SessionKindFilter::Primary => kind.is_none() || kind == Some("main"),
-        crate::analytics::SessionKindFilter::Subagent => kind.is_some() && kind != Some("main"),
-    }
+    filter.matches_kind(kind)
 }
 
 fn session_summary_from_row(row: SessionRow) -> SessionSummary {
@@ -5470,7 +5466,12 @@ fn add_record_to_session(
             conversation_kind: label.clone(),
         });
     entry.hit_count += 1;
-    if entry.conversation_kind.is_none() && record.links.conversation_kind.is_some() {
+    // Prefer an explicit "main": sidechain/compaction lines inside a primary
+    // session must not determine the grouped kind (mirrors the analytics
+    // accumulator).
+    let main_claim = record.links.conversation_kind.as_deref() == Some("main");
+    if (entry.conversation_kind.is_none() || main_claim) && record.links.conversation_kind.is_some()
+    {
         entry.conversation_kind = record.links.conversation_kind.clone();
     }
     if record.ts > entry.last_ts {
@@ -5517,7 +5518,12 @@ fn add_located_record_to_session(
         conversation_kind: record.links.conversation_kind.clone(),
     });
     entry.hit_count += 1;
-    if entry.conversation_kind.is_none() && record.links.conversation_kind.is_some() {
+    // Prefer an explicit "main": sidechain/compaction lines inside a primary
+    // session must not determine the grouped kind (mirrors the analytics
+    // accumulator).
+    let main_claim = record.links.conversation_kind.as_deref() == Some("main");
+    if (entry.conversation_kind.is_none() || main_claim) && record.links.conversation_kind.is_some()
+    {
         entry.conversation_kind = record.links.conversation_kind.clone();
     }
     entry.last_ts = entry.last_ts.max(record.ts);
@@ -5681,13 +5687,13 @@ fn run_search_request(
     } else {
         None
     };
-    // The kind filter runs after retrieval caps the candidate list, so a
-    // filtered subset could starve the result list. Over-fetch while a subset
-    // is selected, then retain and truncate back to the display cap.
-    let query_limit = if matches!(request.kind, crate::analytics::SessionKindFilter::All) {
+<    // Over-fetch when an origin filter is active: the kind filter applies
+    // after grouping, so capping the record query at RESULT_LIMIT first
+    // could starve interactive matches in subagent-heavy corpora.
+    let record_limit = if request.kind == crate::analytics::SessionKindFilter::All {
         RESULT_LIMIT
     } else {
-        RESULT_LIMIT.saturating_mul(5)
+        RESULT_LIMIT * 5
     };
     let mut sessions = sessions_from_query(
         index,
@@ -5695,7 +5701,7 @@ fn run_search_request(
         request.source.as_filter(),
         tantivy_project,
         request.since,
-        query_limit,
+        record_limit,
     )?;
     enrich_session_projects(paths, &mut sessions, request.grouping);
     if let Some(project) = project {
@@ -7112,6 +7118,23 @@ mod tests {
             links: RecordLinks::default(),
             source_path: "source.jsonl".to_string(),
         }
+    }
+
+    #[test]
+    fn grouped_session_prefers_main_over_side_records() {
+        let mut sessions = std::collections::HashMap::new();
+        let mut side = record("assistant", "sidechain output");
+        side.links.conversation_kind = Some("sidechain".to_string());
+        add_record_to_session(&mut sessions, 1.0, side);
+        let mut main = record("user", "please fix the parser");
+        main.links.conversation_kind = Some("main".to_string());
+        add_record_to_session(&mut sessions, 0.5, main);
+        let summary = sessions.get("session").expect("grouped");
+        assert_eq!(summary.conversation_kind.as_deref(), Some("main"));
+        assert!(session_matches_kind(
+            crate::analytics::SessionKindFilter::Primary,
+            summary.conversation_kind.as_deref()
+        ));
     }
 
     fn markdown_perf_records() -> Vec<Record> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5707,7 +5707,7 @@ fn run_search_request(
     } else {
         None
     };
-<    // Over-fetch when an origin filter is active: the kind filter applies
+    // Over-fetch when an origin filter is active: the kind filter applies
     // after grouping, so capping the record query at RESULT_LIMIT first
     // could starve interactive matches in subagent-heavy corpora.
     let record_limit = if request.kind == crate::analytics::SessionKindFilter::All {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3034,9 +3034,9 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
             KeyCode::Esc => {
                 app.close_home_dropdown();
             }
-            KeyCode::Char('k') | KeyCode::Char('c') | KeyCode::Char('K')
-                if app.home_dropdown == HomeDropdown::Kind =>
-            {
+            // `c`/`K` toggle the kind dropdown closed; `k` must keep moving
+            // the selection up like in every other dropdown.
+            KeyCode::Char('c') | KeyCode::Char('K') if app.home_dropdown == HomeDropdown::Kind => {
                 app.close_home_dropdown();
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -7830,6 +7830,33 @@ mod tests {
             app.session_kind,
             crate::analytics::SessionKindFilter::Subagent
         );
+        assert_eq!(app.home_dropdown, HomeDropdown::None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kind_dropdown_k_navigates_instead_of_closing() {
+        let (_tmp, mut app) = test_app();
+        let devnull = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .expect("devnull");
+        let mut terminal = Terminal::new(CrosstermBackend::new(devnull)).expect("terminal");
+        app.open_home_dropdown(HomeDropdown::Kind);
+        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        // `j` moves down like in every other dropdown.
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty());
+        handle_home_key(key, &mut terminal, &mut app).expect("key");
+        assert_eq!(app.home_dropdown, HomeDropdown::Kind);
+        assert_eq!(app.home_dropdown_state.selected(), Some(1));
+        // `k` moves back up and leaves the dropdown open.
+        let key = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty());
+        handle_home_key(key, &mut terminal, &mut app).expect("key");
+        assert_eq!(app.home_dropdown, HomeDropdown::Kind);
+        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        // `c` toggles the kind dropdown closed.
+        let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty());
+        handle_home_key(key, &mut terminal, &mut app).expect("key");
         assert_eq!(app.home_dropdown, HomeDropdown::None);
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1637,8 +1637,8 @@ impl App {
                 options
             }
             HomeDropdown::Kind => vec![
-                "primary".to_string(),
                 "all".to_string(),
+                "primary".to_string(),
                 "subagent".to_string(),
             ],
             HomeDropdown::Project => {
@@ -1672,8 +1672,8 @@ impl App {
                 .map(|idx| idx + 1)
                 .unwrap_or(0),
             HomeDropdown::Kind => match self.session_kind {
-                crate::analytics::SessionKindFilter::Primary => 0,
-                crate::analytics::SessionKindFilter::All => 1,
+                crate::analytics::SessionKindFilter::All => 0,
+                crate::analytics::SessionKindFilter::Primary => 1,
                 crate::analytics::SessionKindFilter::Subagent => 2,
             },
             HomeDropdown::Project => self
@@ -1746,8 +1746,8 @@ impl App {
             }
             HomeDropdown::Kind => {
                 self.session_kind = match idx {
-                    0 => crate::analytics::SessionKindFilter::Primary,
-                    1 => crate::analytics::SessionKindFilter::All,
+                    0 => crate::analytics::SessionKindFilter::All,
+                    1 => crate::analytics::SessionKindFilter::Primary,
                     2 => crate::analytics::SessionKindFilter::Subagent,
                     _ => crate::analytics::SessionKindFilter::Primary,
                 };
@@ -3629,8 +3629,8 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
     frame.render_widget(Block::default().style(theme.panel_alt), popup);
     let items: Vec<ListItem> = if app.home_dropdown == HomeDropdown::Kind {
         let kind_items = [
-            ("primary", "primary interactive sessions"),
             ("all", "all sessions"),
+            ("primary", "primary interactive sessions"),
             ("subagent", "subagent sessions only"),
         ];
         kind_items
@@ -7822,15 +7822,26 @@ mod tests {
     #[test]
     fn kind_dropdown_applies_selection() {
         let (_tmp, mut app) = test_app();
+        // Default filter is primary, which sits at index 1 in all/primary/subagent order.
         app.open_home_dropdown(HomeDropdown::Kind);
-        assert_eq!(app.home_dropdown_state.selected(), Some(0));
-        app.move_home_dropdown_selection(2);
+        assert_eq!(app.home_dropdown_state.selected(), Some(1));
+        app.move_home_dropdown_selection(1);
         app.apply_home_dropdown();
         assert_eq!(
             app.session_kind,
             crate::analytics::SessionKindFilter::Subagent
         );
         assert_eq!(app.home_dropdown, HomeDropdown::None);
+    }
+
+    #[test]
+    fn kind_dropdown_lists_all_first() {
+        let (_tmp, mut app) = test_app();
+        app.open_home_dropdown(HomeDropdown::Kind);
+        assert_eq!(
+            app.home_dropdown_options(),
+            vec!["all", "primary", "subagent"]
+        );
     }
 
     #[cfg(unix)]
@@ -7843,17 +7854,18 @@ mod tests {
             .expect("devnull");
         let mut terminal = Terminal::new(CrosstermBackend::new(devnull)).expect("terminal");
         app.open_home_dropdown(HomeDropdown::Kind);
-        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        // Default filter is primary at index 1 in all/primary/subagent order.
+        assert_eq!(app.home_dropdown_state.selected(), Some(1));
         // `j` moves down like in every other dropdown.
         let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty());
         handle_home_key(key, &mut terminal, &mut app).expect("key");
         assert_eq!(app.home_dropdown, HomeDropdown::Kind);
-        assert_eq!(app.home_dropdown_state.selected(), Some(1));
+        assert_eq!(app.home_dropdown_state.selected(), Some(2));
         // `k` moves back up and leaves the dropdown open.
         let key = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty());
         handle_home_key(key, &mut terminal, &mut app).expect("key");
         assert_eq!(app.home_dropdown, HomeDropdown::Kind);
-        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        assert_eq!(app.home_dropdown_state.selected(), Some(1));
         // `c` toggles the kind dropdown closed.
         let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty());
         handle_home_key(key, &mut terminal, &mut app).expect("key");

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -397,6 +397,7 @@ enum HomeDropdown {
     Range,
     Machine,
     Source,
+    Kind,
     Project,
 }
 
@@ -579,6 +580,7 @@ struct App {
     home_range_area: Rect,
     home_machine_area: Rect,
     home_source_area: Rect,
+    home_kind_area: Rect,
     home_project_area: Rect,
     home_sources: Vec<SourceChoice>,
     home_projects: Vec<String>,
@@ -633,6 +635,7 @@ enum PreviewLine {
         project: String,
         source: String,
         session_id: String,
+        kind: Option<String>,
     },
     Meta {
         role: String,
@@ -969,6 +972,7 @@ impl App {
             home_range_area: Rect::default(),
             home_machine_area: Rect::default(),
             home_source_area: Rect::default(),
+            home_kind_area: Rect::default(),
             home_project_area: Rect::default(),
             home_sources: Vec::new(),
             home_projects: Vec::new(),
@@ -1053,6 +1057,7 @@ impl App {
             || !self.machine.is_empty()
             || self.source != SourceChoice::All
             || !self.project.trim().is_empty()
+            || self.session_kind != crate::analytics::SessionKindFilter::All
     }
 
     fn home_chart_uses_search_results(&self) -> bool {
@@ -1384,6 +1389,7 @@ impl App {
         let config = self.config.clone();
         let machines = self.selected_machines();
         let source = self.source.as_filter();
+        let session_kind = self.session_kind;
         let project = (!self.project.trim().is_empty()).then(|| self.project.trim().to_string());
         let project_grouping = self.project_display.grouping();
         let tx = self.search_tx.clone();
@@ -1399,6 +1405,7 @@ impl App {
                         None,
                         project.as_deref(),
                         project_grouping,
+                        Some(session_kind),
                     )?;
                     Ok((
                         rows.into_iter()
@@ -1423,6 +1430,7 @@ impl App {
                         project_grouping,
                         since_ms,
                         until_ms: None,
+                        kind: Some(session_kind),
                     },
                 )
                 .map(|(points, partial)| {
@@ -1628,6 +1636,11 @@ impl App {
                 options.extend(self.home_sources.iter().map(|s| s.label().to_string()));
                 options
             }
+            HomeDropdown::Kind => vec![
+                "primary".to_string(),
+                "all".to_string(),
+                "subagent".to_string(),
+            ],
             HomeDropdown::Project => {
                 let mut options = vec!["all projects".to_string()];
                 options.extend(self.home_projects.iter().cloned());
@@ -1658,6 +1671,11 @@ impl App {
                 .position(|s| *s == self.source)
                 .map(|idx| idx + 1)
                 .unwrap_or(0),
+            HomeDropdown::Kind => match self.session_kind {
+                crate::analytics::SessionKindFilter::Primary => 0,
+                crate::analytics::SessionKindFilter::All => 1,
+                crate::analytics::SessionKindFilter::Subagent => 2,
+            },
             HomeDropdown::Project => self
                 .home_projects
                 .iter()
@@ -1695,6 +1713,8 @@ impl App {
         let previous_machine = self.machine.clone();
         let source_selection = self.home_dropdown == HomeDropdown::Source;
         let previous_source = self.source;
+        let kind_selection = self.home_dropdown == HomeDropdown::Kind;
+        let previous_kind = self.session_kind;
         let project_selection = self.home_dropdown == HomeDropdown::Project;
         let previous_project = self.project.clone();
         let refresh_search = match self.home_dropdown {
@@ -1724,6 +1744,15 @@ impl App {
                 };
                 true
             }
+            HomeDropdown::Kind => {
+                self.session_kind = match idx {
+                    0 => crate::analytics::SessionKindFilter::Primary,
+                    1 => crate::analytics::SessionKindFilter::All,
+                    2 => crate::analytics::SessionKindFilter::Subagent,
+                    _ => crate::analytics::SessionKindFilter::Primary,
+                };
+                true
+            }
             HomeDropdown::Project => {
                 self.project = if idx == 0 {
                     String::new()
@@ -1736,6 +1765,7 @@ impl App {
         };
         self.close_home_dropdown();
         let source_changed = source_selection && self.source != previous_source;
+        let kind_changed = kind_selection && self.session_kind != previous_kind;
         let project_changed = project_selection && self.project != previous_project;
         let machine_changed = machine_selection && self.machine != previous_machine;
         let token_filter_changed = machine_changed || source_changed || project_changed;
@@ -1744,7 +1774,7 @@ impl App {
         }
         if refresh_search {
             self.kickoff_search();
-            if token_filter_changed {
+            if token_filter_changed || kind_changed {
                 self.kickoff_home_activity();
             }
         } else if refresh_activity {
@@ -3004,6 +3034,11 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
             KeyCode::Esc => {
                 app.close_home_dropdown();
             }
+            KeyCode::Char('k') | KeyCode::Char('c') | KeyCode::Char('K')
+                if app.home_dropdown == HomeDropdown::Kind =>
+            {
+                app.close_home_dropdown();
+            }
             KeyCode::Up | KeyCode::Char('k') => {
                 app.move_home_dropdown_selection(-1);
             }
@@ -3105,11 +3140,11 @@ fn handle_home_key(key: KeyEvent, terminal: &mut TuiTerminal, app: &mut App) -> 
         KeyCode::Char('s') => {
             app.open_home_dropdown(HomeDropdown::Source);
         }
+        KeyCode::Char('c') | KeyCode::Char('K') => {
+            app.open_home_dropdown(HomeDropdown::Kind);
+        }
         KeyCode::Char('p') => {
             app.open_home_dropdown(HomeDropdown::Project);
-        }
-        KeyCode::Char('K') => {
-            app.cycle_session_kind();
         }
         KeyCode::Char('S') => {
             let _ = app.share_selected();
@@ -3200,6 +3235,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     app.home_range_area = Rect::default();
     app.home_machine_area = Rect::default();
     app.home_source_area = Rect::default();
+    app.home_kind_area = Rect::default();
     app.home_project_area = Rect::default();
     app.home_dropdown_area = Rect::default();
     if area.width < 8 || area.height < 4 {
@@ -3382,7 +3418,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     );
     y += 4;
 
-    // Header row: label on the left, machine/source/project dropdown anchors on the right.
+    // Header row: label on the left, machine/source/kind/project dropdown anchors on the right.
     let searching = !app.query.trim().is_empty();
     let header_area = col(y, 1);
     let mut header_spans = vec![Span::styled(
@@ -3408,6 +3444,14 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         String::new()
     };
     let source_word = format!("{} ▾", app.source.label());
+    let kind_word = format!(
+        "{} ▾",
+        match app.session_kind {
+            crate::analytics::SessionKindFilter::Primary => "primary",
+            crate::analytics::SessionKindFilter::All => "all kinds",
+            crate::analytics::SessionKindFilter::Subagent => "subagents",
+        }
+    );
     let project_word = format!(
         "{} ▾",
         if app.project.trim().is_empty() {
@@ -3418,6 +3462,7 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
     );
     let machine_width = machine_word.chars().count() as u16;
     let source_width = source_word.chars().count() as u16;
+    let kind_width = kind_word.chars().count() as u16;
     let project_width_hdr = project_word.chars().count() as u16;
     let header_cols = Layout::default()
         .direction(Direction::Horizontal)
@@ -3427,12 +3472,15 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
             Constraint::Length(if machine_width > 0 { 3 } else { 0 }),
             Constraint::Length(source_width),
             Constraint::Length(3),
+            Constraint::Length(kind_width),
+            Constraint::Length(3),
             Constraint::Length(project_width_hdr),
         ])
         .split(header_area);
     app.home_machine_area = header_cols[1];
     app.home_source_area = header_cols[3];
-    app.home_project_area = header_cols[5];
+    app.home_kind_area = header_cols[5];
+    app.home_project_area = header_cols[7];
     frame.render_widget(Paragraph::new(Line::from(header_spans)), header_cols[0]);
     let machine_style = if app.machine.is_empty() {
         theme.muted
@@ -3440,6 +3488,11 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         theme.accent
     };
     let source_style = if app.source == SourceChoice::All {
+        theme.muted
+    } else {
+        theme.accent
+    };
+    let kind_style = if app.session_kind == crate::analytics::SessionKindFilter::All {
         theme.muted
     } else {
         theme.accent
@@ -3460,8 +3513,12 @@ fn draw_home(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, area: Rec
         header_cols[3],
     );
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(project_word, project_style))),
+        Paragraph::new(Line::from(Span::styled(kind_word, kind_style))),
         header_cols[5],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(project_word, project_style))),
+        header_cols[7],
     );
     y += 1;
 
@@ -3535,20 +3592,19 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
         HomeDropdown::Range => app.home_range_area,
         HomeDropdown::Machine => app.home_machine_area,
         HomeDropdown::Source => app.home_source_area,
+        HomeDropdown::Kind => app.home_kind_area,
         HomeDropdown::Project => app.home_project_area,
         HomeDropdown::None => Rect::default(),
     };
     if anchor.width == 0 {
         return;
     }
-    let width = options
-        .iter()
-        .map(|o| o.chars().count())
-        .max()
-        .unwrap_or(8)
-        .clamp(8, 32) as u16
-        + 2;
-    let width = width.min(area.width);
+    let max_len = if app.home_dropdown == HomeDropdown::Kind {
+        38
+    } else {
+        options.iter().map(|o| o.chars().count()).max().unwrap_or(8)
+    };
+    let width = ((max_len as u16).clamp(8, 42) + 2).min(area.width);
     let x = anchor
         .right()
         .saturating_sub(width)
@@ -3571,10 +3627,27 @@ fn draw_home_dropdown(frame: &mut ratatui::Frame, app: &mut App, theme: &Theme, 
     app.home_dropdown_area = popup;
     frame.render_widget(Clear, popup);
     frame.render_widget(Block::default().style(theme.panel_alt), popup);
-    let items: Vec<ListItem> = options
-        .into_iter()
-        .map(|option| ListItem::new(Line::from(Span::styled(format!(" {option}"), theme.text))))
-        .collect();
+    let items: Vec<ListItem> = if app.home_dropdown == HomeDropdown::Kind {
+        let kind_items = [
+            ("primary", "primary interactive sessions"),
+            ("all", "all sessions"),
+            ("subagent", "subagent sessions only"),
+        ];
+        kind_items
+            .into_iter()
+            .map(|(label, desc)| {
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!(" {label}"), theme.text_bold),
+                    Span::styled(format!("  {desc}"), theme.muted),
+                ]))
+            })
+            .collect()
+    } else {
+        options
+            .into_iter()
+            .map(|option| ListItem::new(Line::from(Span::styled(format!(" {option}"), theme.text))))
+            .collect()
+    };
     let list = List::new(items)
         .style(theme.text)
         .highlight_style(theme.selection)
@@ -4843,7 +4916,7 @@ fn draw_footer(frame: &mut ratatui::Frame, app: &App, theme: &Theme, area: Rect)
             crate::analytics::SessionKindFilter::All => "all",
         };
         right_spans.push(Span::styled("kind ", theme.muted));
-        right_spans.push(Span::styled("(K) ", theme.accent));
+        right_spans.push(Span::styled("(c/K) ", theme.accent));
         right_spans.push(Span::styled(kind_label, theme.text));
         right_spans.push(Span::raw("   "));
     }
@@ -4942,10 +5015,10 @@ fn footer_shortcuts<'a>(app: &App, theme: &Theme, width: u16) -> Line<'a> {
             Span::styled(" timeframe  ", theme.muted),
             Span::styled("s", theme.accent),
             Span::styled(" source  ", theme.muted),
+            Span::styled("c", theme.accent),
+            Span::styled(" kind  ", theme.muted),
             Span::styled("p", theme.accent),
             Span::styled(" projects  ", theme.muted),
-            Span::styled("K", theme.accent),
-            Span::styled(" kind  ", theme.muted),
             Span::styled("/", theme.accent),
             Span::styled(" search  ", theme.muted),
             Span::styled("tab", theme.accent),
@@ -5413,6 +5486,9 @@ fn add_record_to_session(
             conversation_kind: label.clone(),
         });
     entry.hit_count += 1;
+    if entry.conversation_kind.is_none() && record.links.conversation_kind.is_some() {
+        entry.conversation_kind = record.links.conversation_kind.clone();
+    }
     if record.ts > entry.last_ts {
         entry.last_ts = record.ts;
     }
@@ -5457,6 +5533,9 @@ fn add_located_record_to_session(
         conversation_kind: record.links.conversation_kind.clone(),
     });
     entry.hit_count += 1;
+    if entry.conversation_kind.is_none() && record.links.conversation_kind.is_some() {
+        entry.conversation_kind = record.links.conversation_kind.clone();
+    }
     entry.last_ts = entry.last_ts.max(record.ts);
     if score >= entry.top_score {
         entry.top_score = score;
@@ -5720,6 +5799,7 @@ fn build_detail_lines_from_records(
             format!("{}:{}", session.machine, session.source.label())
         },
         session_id: session.session_id.clone(),
+        kind: session.conversation_kind.clone(),
     }];
     if records.is_empty() {
         lines.push(PreviewLine::Text("no records in session".to_string()));
@@ -6371,16 +6451,25 @@ fn render_preview_line<'a>(line: &'a PreviewLine, theme: &Theme) -> Line<'a> {
             project,
             source,
             session_id,
-        } => Line::from(vec![
-            Span::styled("project ", theme.muted),
-            Span::styled(project.as_str(), theme.accent),
-            Span::raw("  "),
-            Span::styled("source ", theme.muted),
-            Span::styled(source.as_str(), theme.muted),
-            Span::raw("  "),
-            Span::styled("session ", theme.muted),
-            Span::styled(session_id.as_str(), theme.text),
-        ]),
+            kind,
+        } => {
+            let mut spans = vec![
+                Span::styled("project ", theme.muted),
+                Span::styled(project.as_str(), theme.accent),
+                Span::raw("  "),
+                Span::styled("source ", theme.muted),
+                Span::styled(source.as_str(), theme.muted),
+                Span::raw("  "),
+                Span::styled("session ", theme.muted),
+                Span::styled(session_id.as_str(), theme.text),
+            ];
+            if let Some(kind_str) = kind.as_deref().filter(|s| !s.is_empty()) {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("kind ", theme.muted));
+                spans.push(Span::styled(kind_str, theme.accent));
+            }
+            Line::from(spans)
+        }
         PreviewLine::Meta {
             role,
             ts,
@@ -6700,6 +6789,8 @@ fn handle_home_mouse(mouse: MouseEvent, terminal: &mut TuiTerminal, app: &mut Ap
                 app.open_home_dropdown(HomeDropdown::Machine);
             } else if app.home_source_area.contains(pos) {
                 app.open_home_dropdown(HomeDropdown::Source);
+            } else if app.home_kind_area.contains(pos) {
+                app.open_home_dropdown(HomeDropdown::Kind);
             } else if app.home_project_area.contains(pos) {
                 app.open_home_dropdown(HomeDropdown::Project);
             } else if app.home_list_area.contains(pos) && app.home_list_area.height > 0 {
@@ -7373,6 +7464,7 @@ mod tests {
         assert_eq!(app.home_chart_activity(), app.home_activity.as_slice());
 
         app.source = SourceChoice::All;
+        app.session_kind = crate::analytics::SessionKindFilter::All;
         app.config.machines.push(crate::config::MachineConfig {
             id: "mini".to_string(),
             label: None,
@@ -7384,6 +7476,9 @@ mod tests {
         });
         assert!(!app.home_chart_is_filtered());
         assert_eq!(app.home_chart_activity(), app.home_activity.as_slice());
+
+        app.session_kind = crate::analytics::SessionKindFilter::Primary;
+        assert!(app.home_chart_is_filtered());
     }
 
     #[test]
@@ -7721,6 +7816,20 @@ mod tests {
         app.move_home_dropdown_selection(2);
         app.apply_home_dropdown();
         assert_eq!(app.source, SourceChoice::Codex);
+        assert_eq!(app.home_dropdown, HomeDropdown::None);
+    }
+
+    #[test]
+    fn kind_dropdown_applies_selection() {
+        let (_tmp, mut app) = test_app();
+        app.open_home_dropdown(HomeDropdown::Kind);
+        assert_eq!(app.home_dropdown_state.selected(), Some(0));
+        app.move_home_dropdown_selection(2);
+        app.apply_home_dropdown();
+        assert_eq!(
+            app.session_kind,
+            crate::analytics::SessionKindFilter::Subagent
+        );
         assert_eq!(app.home_dropdown, HomeDropdown::None);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,11 +244,134 @@ pub struct Record {
     pub source_path: String,
 }
 
+/// Lowercase substrings marking a first user message as a spawned-worker
+/// directive rather than an interactive prompt. Shared by the jcode parser
+/// and the analytics backstop so the two can never disagree.
+pub const JCODE_SUBAGENT_MARKERS: &[&str] = &[
+    "you are a low-effort fact-checker",
+    "you are a low effort",
+    "you are a subagent",
+    "you are downstream",
+    "you are the downstream",
+    "investigation subagent",
+    "deep validation:",
+    "bossmode task",
+    // The trailing colon is load-bearing: without it, ordinary prose such
+    // as "add a `role: manager` column" would match. Only the colon
+    // form ("Role: Manager: ...") marks a spawned worker.
+    "role: manager:",
+];
+
+/// Leaf-name tokens marking a /tmp working directory as a spawned-worker
+/// sandbox (e.g. `/private/tmp/bossmode-hygiene-v2-worker-docs`). A bare
+/// /tmp cwd alone is not evidence — users legitimately work in /tmp — so
+/// the sandbox cue needs one of these tokens in the leaf directory name.
+pub const JCODE_WORKER_SANDBOX_TOKENS: &[&str] =
+    &["worker", "agent", "swarm", "sandbox", "spawn", "subagent"];
+
+/// Returns true when `cwd` is a spawned-worker sandbox under the system
+/// temp dir. Shared by the jcode parser and the analytics backstop so the
+/// two can never disagree.
+pub fn jcode_tmp_cwd_is_worker_sandbox(cwd: &str) -> bool {
+    let under_tmp = cwd == "/tmp"
+        || cwd == "/private/tmp"
+        || cwd.starts_with("/tmp/")
+        || cwd.starts_with("/private/tmp/");
+    if !under_tmp {
+        return false;
+    }
+    let leaf = cwd.rsplit('/').next().unwrap_or("").to_lowercase();
+    JCODE_WORKER_SANDBOX_TOKENS
+        .iter()
+        .any(|token| leaf.contains(token))
+}
+
+/// Returns true when lowercase first-directive text identifies a spawned
+/// worker. Compound rules keep precision against ordinary prompts:
+/// - "implementation worker" needs a role assignment ("for <task>" or
+///   "you are") so "review the implementation worker pool sizing" stays out.
+/// - "0 repo writes" needs the read-only constraint form ("outside …" or
+///   sentence-final) so "0 repo writes from forks" stays out.
+pub fn jcode_text_is_subagent_directive(lower: &str) -> bool {
+    if JCODE_SUBAGENT_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+    {
+        return true;
+    }
+    if lower.contains("implementation worker")
+        && (lower.contains("implementation worker for") || lower.contains("you are"))
+    {
+        return true;
+    }
+    if let Some(pos) = lower.find("0 repo writes") {
+        let rest = lower[pos + "0 repo writes".len()..].trim_start();
+        if rest.starts_with("outside") || rest.starts_with('.') {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{SourceFilter, SourceKind};
+    use super::{
+        SourceFilter, SourceKind, jcode_text_is_subagent_directive, jcode_tmp_cwd_is_worker_sandbox,
+    };
     use clap::ValueEnum;
     use std::collections::HashSet;
+
+    #[test]
+    fn subagent_directive_markers_match_worker_roles() {
+        for text in [
+            "You are downstream A8 mapper. Read-only.",
+            "You are the focused implementation worker for Bossmode task task_abc.",
+            "You are an investigation subagent. Triage the failure.",
+            "Deep validation: Orchestration ORIGIN steady. Read-only.",
+            "Act as an independent reviewer for Bossmode task task_abc.",
+            "Role: Manager: Repo Hygiene. You are the coordinator.",
+            "FRESH run. 0 repo writes outside /tmp.",
+            "FRESH run. 0 repo writes.",
+        ] {
+            assert!(
+                jcode_text_is_subagent_directive(&text.to_lowercase()),
+                "should match: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn subagent_directive_markers_reject_ordinary_prose() {
+        for text in [
+            "Add a `role: manager` column to the users table.",
+            "Please review the implementation worker pool sizing.",
+            "Our CI policy says 0 repo writes from forks.",
+            "take over and fully complete the interrupted session",
+            "Perform a final independent read-only review of the release.",
+        ] {
+            assert!(
+                !jcode_text_is_subagent_directive(&text.to_lowercase()),
+                "should not match: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn worker_sandbox_cwd_needs_token_leaf_under_tmp() {
+        for cwd in [
+            "/private/tmp/bossmode-hygiene-v2-worker-docs",
+            "/tmp/swarm-run-12",
+            "/tmp/agent-scratch",
+        ] {
+            assert!(jcode_tmp_cwd_is_worker_sandbox(cwd), "should match: {cwd}");
+        }
+        for cwd in ["/tmp", "/private/tmp", "/tmp/work", "/repo/example", ""] {
+            assert!(
+                !jcode_tmp_cwd_is_worker_sandbox(cwd),
+                "should not match: {cwd}"
+            );
+        }
+    }
 
     #[test]
     fn source_indices_and_storage_labels_are_unique() {


### PR DESCRIPTION
## Summary
Classifies sessions by origin (interactive vs subagent) and filters by it in search, sessions, charts, TUI, and resume.

Evolves the early classification first introduced on #117: renames it to origin/interactive language, fixes detection per adversarial review, and excludes content-free sessions.

## Detection (stored in `conversation_kind`, interactive stored as main)
- Jcode: parent id set, worker-sandbox working directory (sandbox leaf-name match - a bare temp cwd alone is not evidence), or a worker directive in the first real user message behind the system-reminder preamble. Sessions containing only the preamble are excluded from the index.
- OpenCode: parent session linkage only. A parentless plan-mode session is still interactive.
- Muse: worker transcript path segments with the subagent prefix.
- Claude: subagents path component, or sidechain flag (stored as its own sidechain bucket, shown under subagent in origin views).
- Codex: spawned-thread linkage (parent thread / fork), including the legacy role-string subagent source shape.
- Cursor: subagents path component or subagent event flags.
- Grok: summary sidecar session_kind in the subagent family (subagent, subagent_resume, subagent_fork stored raw); unmarked, headless, and worktree sessions stay interactive. Compaction records keep the compaction bucket, shown under subagent.
- Analytics backfill mirrors the parser rules so reindex and query-time classification agree. Parser reparse versions are bumped, so users reindex once.

## UX
- CLI: `search --origin interactive|subagent|all` and `sessions --origin ...` plus `sessions --interactive-only` (conflicts with `--origin`). Resume-last prefers interactive sessions.
- TUI: origin dropdown ordered all, interactive, subagent with a single binding to open/cycle it; badge on subagent rows; origin shown in the preview header; home activity chart follows the origin filter; token activity chart now follows the origin filter too, resolved against the analytics store on local and remote machines.
- Storage detail: interactive matches null or main, subagent matches any other stored kind (subagent, fork, sidechain, compaction, subagent_resume).

## Stacking note
GitHub base is `main`, and this branch is not a descendant of #117, so its diff currently includes #116 plus its own copy of the label work. After #116/#117 merge it should be rebased to the classification-only remainder.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
