### PR TITLE
Show native Claude and Codex titles for recent sessions

### DIFF
--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -22,6 +22,58 @@ pub const VERSIONS: ParserVersions = ParserVersions {
     usage: 4,
 };
 
+/// Return the human-facing title Claude stores alongside a conversation.
+///
+/// Title records are metadata rather than transcript messages, so the search
+/// index intentionally does not contain them. The TUI uses this lightweight
+/// reader when it builds the recent-session list.
+pub fn session_title(path: &Path, session_id: &str) -> Option<String> {
+    let reader = BufReader::new(File::open(path).ok()?);
+    let mut custom_title = None;
+    let mut ai_title = None;
+    let mut agent_name = None;
+
+    for line in reader.lines().map_while(Result::ok) {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if value
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id != session_id)
+        {
+            continue;
+        }
+        let Some(entry_type) = value.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let title = match entry_type {
+            "custom-title" => value
+                .get("customTitle")
+                .or_else(|| value.get("title"))
+                .and_then(Value::as_str),
+            "ai-title" => value.get("aiTitle").and_then(Value::as_str),
+            "agent-name" => value
+                .get("agentName")
+                .or_else(|| value.get("name"))
+                .and_then(Value::as_str),
+            _ => None,
+        }
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_string);
+
+        match entry_type {
+            "custom-title" if title.is_some() => custom_title = title,
+            "ai-title" if title.is_some() => ai_title = title,
+            "agent-name" if title.is_some() => agent_name = title,
+            _ => {}
+        }
+    }
+
+    custom_title.or(ai_title).or(agent_name)
+}
+
 pub fn discover(root: &Path, include_agents: bool) -> Result<Vec<SourceFile>> {
     let mut files = Vec::new();
     for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
@@ -759,6 +811,26 @@ mod tests {
             ConversationKind::Sidechain
         );
         assert_eq!(metadata.project.as_deref(), Some("memex"));
+    }
+
+    #[test]
+    fn session_title_prefers_custom_title_over_ai_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"ai-title\",\"sessionId\":\"session-1\",\"aiTitle\":\"Generated title\"}\n",
+                "{\"type\":\"custom-title\",\"sessionId\":\"session-1\",\"customTitle\":\"My title\"}\n"
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            session_title(&path, "session-1").as_deref(),
+            Some("My title")
+        );
+        assert_eq!(session_title(&path, "another-session"), None);
     }
 
     #[test]

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -9,10 +9,11 @@ use memchr::{memchr, memmem};
 use memmap2::Mmap;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use simd_json::BorrowedValue;
 use simd_json::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -84,6 +85,76 @@ pub fn history_paths() -> Vec<PathBuf> {
         .map(|home| home.join("history.jsonl"))
         .filter(|path| path.exists())
         .collect()
+}
+
+/// Load the human-facing titles maintained by Codex's local thread database.
+/// The rollout JSONL files do not carry this value themselves.
+pub fn session_titles(session_ids: &[String]) -> HashMap<String, String> {
+    let mut titles = HashMap::new();
+    for home in homes() {
+        for path in state_database_paths(&home) {
+            let Ok(connection) = Connection::open_with_flags(
+                path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+            ) else {
+                continue;
+            };
+            for session_id in session_ids {
+                if titles.contains_key(session_id) {
+                    continue;
+                }
+                if let Some(title) = codex_thread_title(&connection, session_id) {
+                    titles.insert(session_id.clone(), title);
+                }
+            }
+        }
+    }
+    titles
+}
+
+fn state_database_paths(home: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(home) else {
+        return Vec::new();
+    };
+    let mut versioned_paths = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            let version = name
+                .strip_prefix("state_")?
+                .strip_suffix(".sqlite")?
+                .parse::<u64>()
+                .ok()?;
+            Some((version, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    versioned_paths.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    versioned_paths.into_iter().map(|(_, path)| path).collect()
+}
+
+fn codex_thread_title(connection: &Connection, session_id: &str) -> Option<String> {
+    // Current Codex builds have all three columns. The second query keeps the
+    // reader useful with older databases that only stored `title`.
+    for sql in [
+        "SELECT COALESCE(NULLIF(name, ''), NULLIF(title, ''), NULLIF(first_user_message, '')) FROM threads WHERE id = ?1",
+        "SELECT NULLIF(title, '') FROM threads WHERE id = ?1",
+    ] {
+        let title = connection
+            .query_row(sql, params![session_id], |row| {
+                row.get::<_, Option<String>>(0)
+            })
+            .optional()
+            .ok()
+            .flatten()
+            .flatten()
+            .map(|title| title.trim().to_string())
+            .filter(|title| !title.is_empty());
+        if title.is_some() {
+            return title;
+        }
+    }
+    None
 }
 
 pub fn session_id_from_path(path: &Path) -> Option<String> {
@@ -1377,6 +1448,40 @@ mod tests {
         fs::write(archived.join("archived.jsonl"), "{}\n").unwrap();
         let files = super::super::common::jsonl_files([active, archived]);
         assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn codex_thread_title_prefers_an_explicit_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state_5.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE threads (id TEXT PRIMARY KEY, name TEXT, title TEXT, first_user_message TEXT);
+                 INSERT INTO threads VALUES ('session-1', 'Pinned name', 'Generated title', 'First prompt');",
+            )
+            .unwrap();
+
+        assert_eq!(
+            codex_thread_title(&connection, "session-1").as_deref(),
+            Some("Pinned name")
+        );
+        assert_eq!(codex_thread_title(&connection, "missing"), None);
+    }
+
+    #[test]
+    fn state_database_paths_prefer_the_newest_schema_version() {
+        let temp = tempfile::tempdir().unwrap();
+        for name in ["state_2.sqlite", "state_12.sqlite", "state.sqlite"] {
+            fs::write(temp.path().join(name), "").unwrap();
+        }
+
+        let names = state_database_paths(temp.path())
+            .into_iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["state_12.sqlite", "state_2.sqlite"]);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -488,6 +488,7 @@ struct SessionSummary {
     last_ts: u64,
     hit_count: usize,
     top_score: f32,
+    title: String,
     snippet: String,
     source_path: String,
     source_dir: String,
@@ -4035,11 +4036,14 @@ fn session_result_line(
         ),
         Span::raw("  "),
     ];
-    if session.snippet.is_empty() {
+    if session.snippet.is_empty() && session.title.is_empty() {
         spans.push(Span::styled(
             truncate_middle(&session.session_id, detail_width),
             theme.muted,
         ));
+    } else if session.snippet.is_empty() {
+        let title = strip_ansi_and_controls(&session.title);
+        spans.push(Span::styled(truncate_end(&title, detail_width), theme.text));
     } else {
         let snippet = strip_ansi_and_controls(&session.snippet);
         spans.extend(match_context_spans(&snippet, terms, detail_width, theme));
@@ -5100,10 +5104,51 @@ fn session_summary_from_row(row: SessionRow) -> SessionSummary {
         last_ts: row.last_at,
         hit_count: row.message_count.max(1) as usize,
         top_score: 0.0,
+        title: String::new(),
         snippet: String::new(),
         source_dir: row.cwd.unwrap_or_else(|| parent_dir(&row.source_path)),
         source_path: row.source_path,
     }
+}
+
+fn enrich_session_titles(index: &SearchIndex, sessions: &mut [SessionSummary]) {
+    let codex_ids = sessions
+        .iter()
+        .filter(|session| session.source == SourceKind::Codex)
+        .map(|session| session.session_id.clone())
+        .collect::<Vec<_>>();
+    let codex_titles = crate::sources::codex::session_titles(&codex_ids);
+
+    for session in sessions {
+        let source_title = match session.source {
+            SourceKind::Codex => codex_titles.get(&session.session_id).cloned(),
+            SourceKind::Claude => crate::sources::claude::session_title(
+                std::path::Path::new(&session.source_path),
+                &session.session_id,
+            ),
+            _ => None,
+        };
+        session.title = source_title
+            .or_else(|| first_user_prompt(index, session))
+            .map(|title| summarize(&title, 120))
+            .unwrap_or_default();
+    }
+}
+
+fn first_user_prompt(index: &SearchIndex, session: &SessionSummary) -> Option<String> {
+    let mut records = index.records_by_session_id(&session.session_id).ok()?;
+    records.retain(|record| {
+        record.source_path == session.source_path
+            && record.role == "user"
+            && !record.text.trim().is_empty()
+    });
+    records.sort_by(|left, right| {
+        left.turn_id
+            .cmp(&right.turn_id)
+            .then_with(|| left.ts.cmp(&right.ts))
+            .then_with(|| left.doc_id.cmp(&right.doc_id))
+    });
+    records.into_iter().next().map(|record| record.text)
 }
 
 fn enrich_session_projects(
@@ -5224,6 +5269,7 @@ fn add_record_to_session(
             last_ts: record.ts,
             hit_count: 0,
             top_score: score,
+            title: String::new(),
             snippet: summarize(&record.text, 160),
             source_path: record.source_path.clone(),
             source_dir: parent_dir(&record.source_path),
@@ -5265,6 +5311,7 @@ fn add_located_record_to_session(
         last_ts: record.ts,
         hit_count: 0,
         top_score: score,
+        title: String::new(),
         snippet: summarize(&record.text, 160),
         source_path: record.source_path.clone(),
         source_dir: parent_dir(&record.source_path),
@@ -5397,7 +5444,7 @@ fn run_search_request(
         return Ok((sessions, failures));
     }
     if request.query.is_empty() {
-        return sessions_from_analytics(
+        let mut sessions = sessions_from_analytics(
             paths,
             request.source.as_filter(),
             request.since,
@@ -5406,8 +5453,9 @@ fn run_search_request(
         )
         .or_else(|_| {
             sessions_from_recent(index, request.source.as_filter(), request.since, project)
-        })
-        .map(|sessions| (sessions, Vec::new()));
+        })?;
+        enrich_session_titles(index, &mut sessions);
+        return Ok((sessions, Vec::new()));
     }
 
     let tantivy_project = if request.grouping == ProjectGrouping::Flat {
@@ -6998,6 +7046,33 @@ mod tests {
     }
 
     #[test]
+    fn recent_session_row_shows_title_instead_of_uuid() {
+        let session = SessionSummary {
+            machine: LOCAL_MACHINE_ID.to_string(),
+            session_id: "01a00000-0000-0000-0000-000000000000".to_string(),
+            project: "memex".to_string(),
+            source: SourceKind::Codex,
+            last_ts: 1,
+            hit_count: 1,
+            top_score: 0.0,
+            title: "Readable session title".to_string(),
+            snippet: String::new(),
+            source_path: "source.jsonl".to_string(),
+            source_dir: String::new(),
+        };
+
+        let line = session_result_line(&session, &[], 8, 40, &Theme::new());
+        let rendered = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(rendered.contains("Readable session title"));
+        assert!(!rendered.contains("01a00000"));
+    }
+
+    #[test]
     fn enter_browse_switches_to_split_and_selects_first() {
         let (_tmp, mut app) = test_app();
         app.results.push(SessionSummary {
@@ -7008,6 +7083,7 @@ mod tests {
             last_ts: 1,
             hit_count: 1,
             top_score: 0.0,
+            title: String::new(),
             snippet: String::new(),
             source_path: "source.jsonl".to_string(),
             source_dir: String::new(),
@@ -7154,6 +7230,7 @@ mod tests {
                 last_ts: 42,
                 hit_count: 1,
                 top_score: 1.0,
+                title: String::new(),
                 snippet: String::new(),
                 source_path: "source.jsonl".to_string(),
                 source_dir: String::new(),
@@ -7338,6 +7415,7 @@ mod tests {
                 last_ts: 1,
                 hit_count: 1,
                 top_score: 1.0,
+                title: String::new(),
                 snippet: String::new(),
                 source_path: "codex.jsonl".into(),
                 source_dir: String::new(),
@@ -7350,6 +7428,7 @@ mod tests {
                 last_ts: 1,
                 hit_count: 1,
                 top_score: 1.0,
+                title: String::new(),
                 snippet: String::new(),
                 source_path: "claude.jsonl".into(),
                 source_dir: String::new(),
@@ -7362,6 +7441,7 @@ mod tests {
                 last_ts: 1,
                 hit_count: 1,
                 top_score: 1.0,
+                title: String::new(),
                 snippet: String::new(),
                 source_path: "remote-codex.jsonl".into(),
                 source_dir: String::new(),


### PR DESCRIPTION
## Summary

- show human-readable titles instead of raw UUIDs in the TUI's recent-session view
- read Claude titles from `custom-title`, `ai-title`, and `agent-name` metadata
- read Codex titles from its versioned local thread database, preferring `name`, `title`, then `first_user_message`
- fall back to the earliest indexed user prompt when a native title is unavailable
- preserve match snippets for active searches

## Motivation

The empty-query/recent-session view currently has no snippet, so its detail column falls back to the session UUID. That makes scanning a mixed Claude/Codex history difficult even though both clients maintain useful local titles.

This is related to #117, which introduces persisted generated session labels. It provides the native Claude/Codex title extraction mentioned in the maintainer's comment there, as a focused change against current `main`. If #117 lands first, these readers can instead feed its label extraction path.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1` (465 library tests passed, 2 CI-only performance tests ignored; all 3 integration tests passed)
- release build tested end-to-end through a locally linked Herdr plugin with real Claude and Codex histories
