### PR TITLE
Show compact search hits with excerpts around matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Search (JSONL default):
 memex search "your query" --limit 20
 ```
 
+Search output is compact by default. Each hit contains `machine`, `score`, `ts`,
+`doc_id`, `record_id`, `project`, `role`, `session_id`, `source`, `source_path`,
+`snippet`, and `matches`. Lexical snippets center the earliest literal match;
+semantic-only hits use a compact prefix. Use `--fields` for an explicit projection or
+`--full` to restore every legacy search field, including full record text and linkage
+metadata.
+
 TUI:
 ```
 memex tui
@@ -323,10 +330,12 @@ Omit `--target` for an interactive menu of detected Claude/Codex/OpenCode/Pi/Oh 
 - `--sort score|ts`
 - `--top-n-per-session <n>`
 - `--unique-session`
-- `--fields score,ts,doc_id,session_id,snippet`
+- `--fields score,ts,doc_id,record_id,session_id,snippet`
+- `--full` (all legacy search fields; conflicts with `--fields`)
 - `--json-array`
 
-JSON output also includes `source` and, when available, tree/linkage metadata:
+Default JSON search output uses the compact fields documented above. Full or explicit
+projections can also include tree/linkage metadata:
 `event_id`, `parent_event_id`, `logical_parent_event_id`,
 `parent_session_id`, `thread_source`, `conversation_kind`,
 `parent_tool_use_id`, `source_tool_use_id`, and

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memex-search
-description: Search prior agent-session history with memex when a request depends on earlier work, decisions, investigations, fixes, commands, errors, or project context, including details lost or summarized across context-compaction boundaries. Invoke proactively to recover exact evidence, resume prior work, avoid repeating work, or find an analogous solution.
+description: Discover prior agent work across sessions, projects, providers, and machines. Use for historical investigations and analogous solutions, or as a fallback when native conversation and history tools cannot recover the needed evidence.
 allowed-tools: Bash(memex:*)
 ---
 
@@ -11,6 +11,11 @@ Use memex as an episodic retrieval system, not as a one-shot search box.
 The goal is to recover the smallest set of source-grounded records or trajectories that actually answer the user's question. Search iteratively when needed, but stop once the evidence is sufficient.
 
 ## Core Rules
+
+For recovery within the current active task, use native notes/history and the task worklog
+first. Read known Codex or ChatGPT conversations with native conversation tools when
+available. Use Memex when those sources are unavailable or insufficient, and for discovery
+across prior sessions, projects, providers, or machines.
 
 1. **Retrieve adaptively.** A known session ID needs no search. An exact filename or error may need one lexical query. An ambiguous historical question may need several query views and one or two reformulation rounds.
 2. **Search for evidence, not an answer-shaped snippet.** Search rank is only a candidate generator. Inspect the record or trajectory before making claims.
@@ -190,9 +195,14 @@ During discovery, default to one hit per session:
 ```bash
 memex search "query" \
   --unique-session \
-  --limit 20 \
-  --fields machine,score,ts,doc_id,session_id,project,role,source,snippet,event_id,parent_event_id,parent_tool_use_id
+  --limit 20
 ```
+
+Search already returns a compact projection by default: `machine`, `score`, `ts`,
+`doc_id`, `record_id`, `project`, `role`, `session_id`, `source`, `source_path`,
+`snippet`, and `matches`. Lexical snippets center a literal match; semantic-only results
+fall back to a compact prefix. Use `--fields` only when a different explicit projection
+helps, and `--full` only when discovery itself requires all stored fields.
 
 Use `--top-n-per-session 2` when two nuclei per session are helpful.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -286,6 +286,9 @@ OUTPUT FIELDS (--fields):
         /// Comma-separated list of fields to include in output
         #[arg(long, value_name = "FIELDS")]
         fields: Option<String>,
+        /// Include full record text and all metadata (legacy search output)
+        #[arg(long, conflicts_with = "fields")]
+        full: bool,
         /// Sort results by score or timestamp
         #[arg(long, value_enum, default_value = "score")]
         sort: SortBy,
@@ -913,6 +916,7 @@ pub fn run() -> Result<()> {
             unique_session,
             json_array,
             fields,
+            full,
             sort,
             verbose,
             root,
@@ -941,6 +945,7 @@ pub fn run() -> Result<()> {
                 unique_session,
                 json_array,
                 fields,
+                full,
                 sort,
                 verbose,
                 root,
@@ -1506,6 +1511,7 @@ fn run_search(
     unique_session: bool,
     json_array: bool,
     fields: Option<String>,
+    full: bool,
     sort: SortBy,
     verbose: bool,
     root: Option<PathBuf>,
@@ -1540,8 +1546,14 @@ fn run_search(
         until: parse_ts_millis(until)?,
         limit,
     };
-    let matchers = build_matchers(&options.query)?;
-    let fields = parse_fields(fields)?;
+    let matchers = queries
+        .iter()
+        .map(|query| build_matchers(query))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    let fields = search_fields(fields, full)?;
     let top_n_per_session = if unique_session && top_n_per_session.is_none() {
         Some(1)
     } else {
@@ -1715,7 +1727,7 @@ fn render_located_results(results: Vec<LocatedRecord>, render: &RenderOptions) -
         } in results
         {
             let ts = format_ts(record.ts);
-            let text = summarize(&record.text, 200);
+            let text = match_preview(&record.text, &render.matchers, 200);
             println!(
                 "[{score:.3}] {} {} {} {} {} {} {}",
                 machine, ts, record.doc_id, record.project, record.role, record.session_id, text
@@ -1738,7 +1750,7 @@ fn render_located_results(results: Vec<LocatedRecord>, render: &RenderOptions) -
         let wants_matches = wants_field(&render.fields, "matches");
         let wants_text = wants_field(&render.fields, "text");
         let snippet = if wants_snippet {
-            summarize(text_ref, 400)
+            match_preview(text_ref, &render.matchers, 400)
         } else {
             String::new()
         };
@@ -4553,6 +4565,23 @@ enum SortBy {
     Ts,
 }
 
+const DEFAULT_SEARCH_FIELDS: &str =
+    "machine,score,ts,doc_id,record_id,project,role,session_id,source,source_path,snippet,matches";
+
+fn search_fields(fields: Option<String>, full: bool) -> Result<Option<HashSet<String>>> {
+    if full {
+        return Ok(None);
+    }
+    Ok(parse_fields(fields)?.or_else(|| {
+        Some(
+            DEFAULT_SEARCH_FIELDS
+                .split(',')
+                .map(str::to_string)
+                .collect(),
+        )
+    }))
+}
+
 fn parse_fields(value: Option<String>) -> Result<Option<HashSet<String>>> {
     let Some(value) = value else {
         return Ok(None);
@@ -4712,26 +4741,70 @@ fn format_ts(ts: u64) -> String {
 }
 
 fn build_matchers(query: &str) -> Result<Vec<regex::Regex>> {
-    let mut terms = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for part in query.split_whitespace() {
-        let cleaned = part.trim_matches(|c: char| !c.is_alphanumeric());
-        if cleaned.len() < 2 {
-            continue;
-        }
-        let key = cleaned.to_lowercase();
-        if seen.insert(key.clone()) {
-            terms.push(key);
+    use tantivy::query_grammar::{Occur, UserInputAst, UserInputLeaf};
+    fn literals(ast: &UserInputAst, terms: &mut Vec<String>) {
+        match ast {
+            UserInputAst::Clause(children) => {
+                for (occur, child) in children {
+                    if *occur != Some(Occur::MustNot) {
+                        literals(child, terms);
+                    }
+                }
+            }
+            UserInputAst::Boost(child, _) => literals(child, terms),
+            UserInputAst::Leaf(leaf) => {
+                if let UserInputLeaf::Literal(literal) = leaf.as_ref()
+                    && literal
+                        .field_name
+                        .as_deref()
+                        .is_none_or(|field| field == "text")
+                {
+                    terms.extend(literal.phrase.split_whitespace().map(str::to_string));
+                }
+            }
         }
     }
+    let mut terms = Vec::new();
+    match tantivy::query_grammar::parse_query(query) {
+        Ok(ast) => literals(&ast, &mut terms),
+        // Semantic requests need not be valid lexical syntax.
+        Err(_) => terms.extend(query.split_whitespace().map(str::to_string)),
+    }
+    let mut seen = HashSet::new();
     let mut out = Vec::new();
     for term in terms {
-        let re = RegexBuilder::new(&regex::escape(&term))
-            .case_insensitive(true)
-            .build()?;
-        out.push(re);
+        let term = term
+            .trim_matches(|c: char| !c.is_alphanumeric())
+            .to_lowercase();
+        if term.is_empty() || !seen.insert(term.clone()) {
+            continue;
+        }
+        out.push(
+            RegexBuilder::new(&regex::escape(&term))
+                .case_insensitive(true)
+                .build()?,
+        );
     }
     Ok(out)
+}
+
+// Preview the earliest literal hit; semantic-only hits fall back to a compact prefix.
+fn match_preview(text: &str, matchers: &[regex::Regex], max_chars: usize) -> String {
+    let first = matchers
+        .iter()
+        .filter_map(|matcher| matcher.find(text))
+        .min_by_key(|m| m.start());
+    let Some(hit) = first else {
+        return summarize(text, max_chars);
+    };
+    let prefix = take_last_chars(&text[..hit.start()], 80);
+    let start = hit.start() - prefix.len();
+    let preview = summarize(&text[start..], max_chars.saturating_sub(1));
+    if start > 0 {
+        format!("…{preview}")
+    } else {
+        preview
+    }
 }
 
 fn collect_matches(text: &str, matchers: &[regex::Regex], max: usize) -> Vec<MatchSpan> {
@@ -5013,6 +5086,31 @@ mod tests {
     use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use tempfile::TempDir;
+
+    #[test]
+    fn previews_use_positive_text_literals_and_bound_unicode() {
+        let text = format!("padding {} needlé evidence", "界".repeat(1000));
+        let matchers = build_matchers("text:needlé AND NOT text:padding").unwrap();
+        let preview = match_preview(&text, &matchers, 400);
+        assert!(preview.contains("needlé"));
+        assert!(!preview.contains("padding"));
+        assert!(preview.chars().count() <= 400);
+        assert_eq!(
+            match_preview("semantic fallback", &[], 400),
+            "semantic fallback"
+        );
+        assert!(build_matchers("project:memex").unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_search_projection_keeps_the_compact_default() {
+        for fields in [None, Some("".to_string()), Some(" , ".to_string())] {
+            let fields = search_fields(fields, false).unwrap().unwrap();
+            assert!(fields.contains("record_id"));
+            assert!(!fields.contains("text"));
+        }
+        assert!(search_fields(None, true).unwrap().is_none());
+    }
 
     #[test]
     fn sessions_interactive_only_conflicts_with_explicit_origin() {

--- a/tests/retrieval_cli.rs
+++ b/tests/retrieval_cli.rs
@@ -1,0 +1,113 @@
+use memex::config::Paths;
+use memex::index::SearchIndex;
+use memex::retrieval::canonical_record_id;
+use memex::types::{Record, RecordLinks, SourceKind};
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn fixture() -> (tempfile::TempDir, Vec<Record>) {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = Paths::new(Some(temp.path().to_path_buf())).unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        "auto_index_on_search = false\n",
+    )
+    .unwrap();
+    let records = vec![
+        record(1, "αβγδε".into()),
+        record(
+            2,
+            format!("{} late_needle evidence", "padding ".repeat(5000)),
+        ),
+        record(3, "final outcome".into()),
+    ];
+    let index = SearchIndex::open_or_create(&paths.index).unwrap();
+    let mut writer = index.writer().unwrap();
+    for record in &records {
+        index.add_record(&mut writer, record).unwrap();
+    }
+    writer.commit().unwrap();
+    (temp, records)
+}
+
+fn record(id: u64, text: String) -> Record {
+    Record {
+        source: SourceKind::Codex,
+        doc_id: id,
+        ts: id * 1000,
+        project: "test".into(),
+        session_id: "session".into(),
+        turn_id: id as u32,
+        role: "assistant".into(),
+        text,
+        tool_name: None,
+        tool_input: None,
+        tool_output: None,
+        links: RecordLinks {
+            event_id: Some(format!("event-{id}")),
+            ..Default::default()
+        },
+        source_path: "/tmp/fixture.jsonl".into(),
+    }
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_memex"))
+        .args(args)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .unwrap()
+}
+
+fn values(root: &Path, args: &[&str]) -> Vec<Value> {
+    let out = run(root, args);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn search_defaults_to_compact_match_centered_references_and_full_is_explicit() {
+    let (root, records) = fixture();
+    let hits = values(
+        root.path(),
+        &["search", "late_needle", "--machine", "local"],
+    );
+    assert_eq!(hits.len(), 1);
+    let hit = &hits[0];
+    assert!(hit.get("text").is_none());
+    assert!(hit["snippet"].as_str().unwrap().contains("late_needle"));
+    assert!(hit["snippet"].as_str().unwrap().chars().count() <= 400);
+    assert_eq!(hit["machine"], "local");
+    assert_eq!(hit["record_id"], canonical_record_id(&records[1]));
+    assert_eq!(hit["session_id"], "session");
+    assert_eq!(hit["source_path"], "/tmp/fixture.jsonl");
+    assert!(serde_json::to_string(hit).unwrap().len() < 2000);
+    let full = values(
+        root.path(),
+        &["search", "late_needle", "--machine", "local", "--full"],
+    );
+    assert_eq!(full[0]["text"], records[1].text);
+    let projected = values(
+        root.path(),
+        &[
+            "search",
+            "late_needle",
+            "--machine",
+            "local",
+            "--fields",
+            "text,doc_id",
+        ],
+    );
+    assert_eq!(projected[0].as_object().unwrap().len(), 2);
+    assert_eq!(projected[0]["text"], records[1].text);
+}


### PR DESCRIPTION
Searching a long transcript currently prints each matching record in full, and its preview can miss a match buried later in the text. Search now returns record references and short excerpts around the matched words by default.

Use `--full` for the previous complete output or `--fields` for a custom selection. Semantic results without a literal match keep a short opening excerpt.
