### PR TITLE
Look up context within its session and follow direct tool links

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,15 @@ memex session SESSION_ID --machine mini --source-path /path/on/mini/session.json
 memex session SESSION_ID --machine mini --offset 500 --limit 500
 ~~~
 
+`memex context` selects a source/session/path neighborhood around a stable record ID,
+document ID, or native event ID. `--expand-interactions` adds only directly owned tool
+calls/results and stops with an actionable error above 100 additional records.
+
+New indexes provide exact canonical record-ID lookup plus indexed document/event lookup.
+Existing indexes remain readable: canonical record IDs fall back to a stored-record scan
+until the index is rebuilt. Neighborhood reads use indexed session, source, and source-path
+scope. Session pages sort by turn, timestamp, and document ID before applying the offset.
+
 Session pages are limited to 500 records. To fetch several sessions in one bounded
 request, provide JSONL on stdin or as a file:
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -269,7 +269,13 @@ memex context --event-id <event_id> --session <session_id> --before 5 --after 5 
 memex context --doc-id <doc_id> --before 5 --after 5
 ```
 
-Use `--expand-interactions` when linked tool calls/results matter. It adds the connected interaction records without turning the request into an unbounded full-session fetch. For a result on another machine, use machine-aware `show` or paginated `session` instead.
+Use `--expand-interactions` when directly owned tool calls/results matter. It does not
+follow general parent or conversation ancestry. Expansion has a hard cap of 100 additional
+records; if the command reports that cap, narrow `--before`/`--after` or disable expansion.
+Canonical record IDs use an exact field in new indexes and a stored-record fallback scan
+in old indexes until rebuilt. Document/event anchors are indexed, and neighborhoods are
+scoped by session, source, and source path. For a result on another machine, use
+machine-aware `show` or paginated `session`.
 
 ## Step 7: Reformulate From Evidence
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -27,6 +27,9 @@ use tantivy::{Index, IndexReader, IndexWriter, Order, ReloadPolicy, TantivyDocum
 
 #[derive(Clone)]
 pub struct IndexFields {
+    /// Present in indexes created after canonical record lookup was introduced. Older indexes
+    /// remain readable and use a scoped stored-record fallback until they are rebuilt.
+    pub canonical_record_id: Option<Field>,
     pub doc_id: Field,
     pub ts: Field,
     pub project: Field,
@@ -543,6 +546,9 @@ impl SearchIndex {
 
     pub fn add_record(&self, writer: &mut IndexWriter, record: &Record) -> Result<()> {
         let mut doc = TantivyDocument::default();
+        if let Some(field) = self.fields.canonical_record_id {
+            doc.add_text(field, crate::retrieval::canonical_record_id(record));
+        }
         doc.add_u64(self.fields.doc_id, record.doc_id);
         doc.add_u64(self.fields.ts, record.ts);
         doc.add_text(self.fields.project, &record.project);
@@ -621,6 +627,106 @@ impl SearchIndex {
         Ok(Some(record_from_doc(&self.fields, &doc)))
     }
 
+    pub(crate) fn records_by_doc_id(&self, doc_id: u64) -> Result<Vec<Record>> {
+        self.records_matching_query(Box::new(TermQuery::new(
+            Term::from_field_u64(self.fields.doc_id, doc_id),
+            IndexRecordOption::Basic,
+        )))
+    }
+
+    pub(crate) fn records_by_event_id(&self, event_id: &str) -> Result<Vec<Record>> {
+        self.records_matching_query(Box::new(TermQuery::new(
+            Term::from_field_text(self.fields.event_id, event_id),
+            IndexRecordOption::Basic,
+        )))
+    }
+
+    /// Returns `None` when this index predates the canonical ID field. Callers can then use a
+    /// scoped fallback; rebuilding the index enables direct canonical-ID lookup.
+    pub(crate) fn records_by_canonical_id(&self, record_id: &str) -> Result<Option<Vec<Record>>> {
+        let Some(field) = self.fields.canonical_record_id else {
+            return Ok(None);
+        };
+        self.records_matching_query(Box::new(TermQuery::new(
+            Term::from_field_text(field, record_id),
+            IndexRecordOption::Basic,
+        )))
+        .map(Some)
+    }
+
+    pub(crate) fn records_by_context_scope(
+        &self,
+        session_id: Option<&str>,
+        source: Option<crate::types::SourceKind>,
+    ) -> Result<Vec<Record>> {
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+        if let Some(session_id) = session_id {
+            clauses.push((
+                Occur::Must,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.session_id, session_id),
+                    IndexRecordOption::Basic,
+                )),
+            ));
+        }
+        if let Some(source) = source
+            && let Some(query) = exact_source_query(&self.fields, source)
+        {
+            clauses.push((Occur::Must, query));
+        }
+        let query: Box<dyn Query> = if clauses.is_empty() {
+            Box::new(AllQuery)
+        } else {
+            Box::new(BooleanQuery::new(clauses))
+        };
+        self.records_matching_query(query)
+    }
+
+    pub(crate) fn records_by_session_path(
+        &self,
+        source: crate::types::SourceKind,
+        session_id: &str,
+        source_path: &str,
+    ) -> Result<Vec<Record>> {
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = vec![
+            (
+                Occur::Must,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.session_id, session_id),
+                    IndexRecordOption::Basic,
+                )),
+            ),
+            (
+                Occur::Must,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.source_path, source_path),
+                    IndexRecordOption::Basic,
+                )),
+            ),
+        ];
+        if let Some(query) = exact_source_query(&self.fields, source) {
+            clauses.push((Occur::Must, query));
+        }
+        self.records_matching_query(Box::new(BooleanQuery::new(clauses)))
+    }
+
+    fn records_matching_query(&self, query: Box<dyn Query>) -> Result<Vec<Record>> {
+        let reader = self.reader()?;
+        let searcher = reader.searcher();
+        let count = searcher.search(query.as_ref(), &Count)?;
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(count))?;
+        top_docs
+            .into_iter()
+            .map(|(_, address)| {
+                let doc = searcher.doc::<TantivyDocument>(address)?;
+                Ok(record_from_doc(&self.fields, &doc))
+            })
+            .collect()
+    }
+
     pub fn search(&self, options: &QueryOptions) -> Result<Vec<(f32, Record)>> {
         let reader = self.reader()?;
         let searcher = reader.searcher();
@@ -674,10 +780,37 @@ impl SearchIndex {
         offset: usize,
         limit: usize,
     ) -> Result<(Vec<Record>, usize)> {
+        self.records_by_session_path_page(session_id, None, offset, limit)
+    }
+
+    /// Read one globally ordered session page without materializing record content outside the
+    /// requested offset and limit. `source_path` is an exact indexed filter when supplied.
+    pub fn records_by_session_path_page(
+        &self,
+        session_id: &str,
+        source_path: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<Record>, usize)> {
         let reader = self.reader()?;
         let searcher = reader.searcher();
-        let term = Term::from_field_text(self.fields.session_id, session_id);
-        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = vec![(
+            Occur::Must,
+            Box::new(TermQuery::new(
+                Term::from_field_text(self.fields.session_id, session_id),
+                IndexRecordOption::Basic,
+            )),
+        )];
+        if let Some(source_path) = source_path {
+            clauses.push((
+                Occur::Must,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.source_path, source_path),
+                    IndexRecordOption::Basic,
+                )),
+            ));
+        }
+        let query = BooleanQuery::new(clauses);
         let total = searcher.search(&query, &Count)?;
         if offset >= total {
             return Ok((Vec::new(), total));
@@ -685,10 +818,10 @@ impl SearchIndex {
         let page_limit = limit.max(1).min(total - offset);
         let collector = TopDocs::with_limit(page_limit)
             .and_offset(offset)
-            .order_by_fast_field::<u64>("turn_id", Order::Asc);
-        let top_docs: Vec<(u64, tantivy::DocAddress)> = searcher.search(&query, &collector)?;
+            .custom_score(SessionOrderScorerFactory);
+        let top_docs = searcher.search(&query, &collector)?;
         let mut records = Vec::with_capacity(top_docs.len());
-        for (_turn_id, addr) in top_docs {
+        for (_order, addr) in top_docs {
             let doc = searcher.doc::<TantivyDocument>(addr)?;
             records.push(record_from_doc(&self.fields, &doc));
         }
@@ -806,6 +939,76 @@ fn source_scope_query(fields: &IndexFields, scope: &SessionScope) -> BooleanQuer
             )),
         ),
     ])
+}
+
+fn exact_source_query(
+    fields: &IndexFields,
+    source: crate::types::SourceKind,
+) -> Option<Box<dyn Query>> {
+    let field = fields.source?;
+    let labels: &[&str] = match source {
+        // Historical Codex projections used these labels. `record_from_doc` maps all three to
+        // one source identity, so exact context lookup must preserve the same compatibility.
+        crate::types::SourceKind::Codex => &["codex", "codex-session", "codex-history"],
+        _ => &[source.storage_label()],
+    };
+    let queries = labels
+        .iter()
+        .map(|label| {
+            (
+                Occur::Should,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(field, label),
+                    IndexRecordOption::Basic,
+                )) as Box<dyn Query>,
+            )
+        })
+        .collect();
+    Some(Box::new(BooleanQuery::new(queries)))
+}
+
+type SessionOrder = std::cmp::Reverse<(u64, u64, u64)>;
+
+struct SessionOrderScorerFactory;
+
+struct SessionOrderScorer {
+    turn_ids: Arc<dyn tantivy::columnar::ColumnValues<u64>>,
+    timestamps: Arc<dyn tantivy::columnar::ColumnValues<u64>>,
+    doc_ids: Arc<dyn tantivy::columnar::ColumnValues<u64>>,
+}
+
+impl tantivy::collector::CustomScorer<SessionOrder> for SessionOrderScorerFactory {
+    type Child = SessionOrderScorer;
+
+    fn segment_scorer(
+        &self,
+        segment_reader: &tantivy::SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        Ok(SessionOrderScorer {
+            turn_ids: segment_reader
+                .fast_fields()
+                .u64("turn_id")?
+                .first_or_default_col(0),
+            timestamps: segment_reader
+                .fast_fields()
+                .u64("ts")?
+                .first_or_default_col(0),
+            doc_ids: segment_reader
+                .fast_fields()
+                .u64("doc_id")?
+                .first_or_default_col(0),
+        })
+    }
+}
+
+impl tantivy::collector::CustomSegmentScorer<SessionOrder> for SessionOrderScorer {
+    fn score(&mut self, doc: tantivy::DocId) -> SessionOrder {
+        std::cmp::Reverse((
+            self.turn_ids.get_val(doc),
+            self.timestamps.get_val(doc),
+            self.doc_ids.get_val(doc),
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1136,8 +1339,15 @@ fn sync_directory(_dir: &Path) -> io::Result<()> {
 }
 
 fn build_schema() -> Result<Schema> {
+    build_schema_with_canonical_record_id(true)
+}
+
+fn build_schema_with_canonical_record_id(include_canonical_record_id: bool) -> Result<Schema> {
     let mut builder = SchemaBuilder::default();
 
+    if include_canonical_record_id {
+        builder.add_text_field("canonical_record_id", STRING | STORED);
+    }
     builder.add_u64_field("doc_id", INDEXED | STORED | FAST);
     builder.add_u64_field("ts", INDEXED | STORED | FAST);
     builder.add_text_field("project", STRING | STORED);
@@ -1206,6 +1416,7 @@ fn load_fields(schema: Schema) -> Result<IndexFields> {
             .map_err(|_| anyhow!(format!("missing field {name}")))
     };
     Ok(IndexFields {
+        canonical_record_id: schema.get_field("canonical_record_id").ok(),
         doc_id: get("doc_id")?,
         ts: get("ts")?,
         project: get("project")?,
@@ -1456,6 +1667,114 @@ mod tests {
         assert!(err.to_string().contains("index schema"));
         assert!(tmp.path().join("meta.json").exists());
         assert!(tmp.path().join("sentinel").exists());
+    }
+
+    #[test]
+    fn legacy_current_schema_remains_readable_without_canonical_record_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let schema = build_schema_with_canonical_record_id(false).expect("legacy schema");
+        let raw = Index::create_in_dir(tmp.path(), schema).expect("legacy index");
+        drop(raw);
+
+        let index = SearchIndex::open_or_create(tmp.path()).expect("open legacy index");
+        assert!(index.fields.canonical_record_id.is_none());
+        let mut writer = index.writer().expect("legacy writer");
+        let record = test_record(1, "legacy");
+        index
+            .add_record(&mut writer, &record)
+            .expect("add legacy record");
+        writer.commit().expect("commit legacy record");
+        assert_eq!(
+            index
+                .records_by_context_scope(Some("session"), Some(crate::types::SourceKind::Codex))
+                .expect("scoped legacy fallback")
+                .len(),
+            1
+        );
+        assert!(
+            index
+                .records_by_canonical_id("rid1_missing")
+                .expect("legacy canonical lookup")
+                .is_none()
+        );
+        let selector = crate::retrieval::ContextSelector::record_id(
+            crate::retrieval::canonical_record_id(&record),
+        )
+        .with_scope(Some(record.session_id.clone()), Some(record.source));
+        assert_eq!(
+            crate::retrieval::resolve_record(&index, &selector)
+                .expect("legacy scoped record-ID fallback")
+                .doc_id,
+            record.doc_id
+        );
+    }
+
+    #[test]
+    fn canonical_and_session_path_lookups_use_exact_index_fields() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let index = SearchIndex::open_or_create(tmp.path()).expect("index");
+        let first = test_record(1, "first");
+        let mut other_path = test_record(2, "other path");
+        other_path.source_path = "other.jsonl".to_string();
+        let mut writer = index.writer().expect("writer");
+        index.add_record(&mut writer, &first).expect("add first");
+        index
+            .add_record(&mut writer, &other_path)
+            .expect("add other path");
+        writer.commit().expect("commit");
+
+        let record_id = crate::retrieval::canonical_record_id(&first);
+        let exact = index
+            .records_by_canonical_id(&record_id)
+            .expect("canonical lookup")
+            .expect("canonical field");
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].doc_id, first.doc_id);
+
+        let scoped = index
+            .records_by_session_path(first.source, &first.session_id, &first.source_path)
+            .expect("session path lookup");
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].doc_id, first.doc_id);
+    }
+
+    #[test]
+    fn session_path_pages_preserve_global_tie_order_across_boundaries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let index = SearchIndex::open_or_create(tmp.path()).expect("index");
+        let mut writer = index.writer().expect("writer");
+        for doc_id in (1..=1_200).rev() {
+            let mut record = test_record(doc_id, "same turn");
+            record.turn_id = 7;
+            record.source_path = if doc_id % 2 == 0 {
+                "other.jsonl".to_string()
+            } else {
+                "selected.jsonl".to_string()
+            };
+            index
+                .add_record(&mut writer, &record)
+                .expect("add tied record");
+        }
+        writer.commit().expect("commit tied records");
+
+        let (first, total) = index
+            .records_by_session_path_page("session", Some("selected.jsonl"), 0, 500)
+            .expect("first page");
+        let (second, second_total) = index
+            .records_by_session_path_page("session", Some("selected.jsonl"), 500, 500)
+            .expect("second page");
+        let actual = first
+            .into_iter()
+            .chain(second)
+            .map(|record| record.doc_id)
+            .collect::<Vec<_>>();
+        let expected = (1..=1_200)
+            .filter(|doc_id| doc_id % 2 == 1)
+            .collect::<Vec<_>>();
+
+        assert_eq!(total, 600);
+        assert_eq!(second_total, total);
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -2,8 +2,8 @@
 //!
 //! This module deliberately sits above the current Tantivy projection.  It does not require a
 //! catalog migration: records are read through `SearchIndex`, while the canonical identity is
-//! reconstructed from source-native fields.  A future catalog can use the same identity and
-//! ordering contract without changing callers of this module.
+//! reconstructed from source-native fields. New indexes also project that identity into an exact
+//! lookup field; older indexes remain readable with a scoped fallback until they are rebuilt.
 
 use crate::index::SearchIndex;
 use crate::types::{Record, SourceKind};
@@ -20,10 +20,13 @@ const CANONICAL_RECORD_ID_VERSION: &str = "rid1";
 /// cannot turn a neighborhood request into an unbounded transcript dump.
 pub const MAX_CONTEXT_WINDOW: usize = 1_000;
 
+/// Maximum number of records that direct tool-interaction expansion may add.
+pub const MAX_INTERACTION_EXPANSION: usize = 100;
+
 /// A selector for a context anchor.  Session and source scopes are optional for all selector
 /// kinds; they are especially useful for event IDs, which are commonly only unique within one
 /// source/session.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ContextSelector {
     RecordId {
         id: String,
@@ -88,7 +91,7 @@ impl ContextSelector {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContextOptions {
     pub before: usize,
     pub after: usize,
@@ -96,7 +99,7 @@ pub struct ContextOptions {
 }
 
 impl ContextOptions {
-    fn validate(self) -> Result<()> {
+    pub(crate) fn validate(self) -> Result<()> {
         if self.before > MAX_CONTEXT_WINDOW {
             bail!(
                 "context before window {} exceeds maximum {}",
@@ -213,57 +216,18 @@ pub fn context_records(
     options: ContextOptions,
 ) -> Result<ContextResult> {
     options.validate()?;
-    let mut all_records = Vec::new();
-    index.for_each_record(|record| {
-        all_records.push(record);
-        Ok(())
-    })?;
-
-    // A current index can contain duplicate projections from older versions.  Collapse those by
-    // canonical identity before resolving an anchor, preferring the greatest local doc ID as the
-    // deterministic latest projection.
-    let mut unique = HashMap::<String, Record>::new();
-    for record in all_records {
-        let key = canonical_record_id(&record);
-        match unique.get(&key) {
-            Some(previous) if projection_order(previous, &record).is_ge() => {}
-            _ => {
-                unique.insert(key, record);
-            }
-        }
-    }
-    let mut records: Vec<Record> = unique.into_values().collect();
-    records.sort_by(record_order);
-
-    let candidates: Vec<Record> = records
-        .iter()
-        .filter(|record| selector_matches(record, selector))
-        .cloned()
-        .collect();
-    let anchor = match candidates.as_slice() {
-        [] => bail!("context anchor not found"),
-        [anchor] => anchor.clone(),
-        _ => {
-            let ids = candidates
-                .iter()
-                .map(canonical_record_id)
-                .collect::<Vec<_>>();
-            return Err(anyhow!(
-                "context selector is ambiguous; matching record IDs: {}",
-                ids.join(", ")
-            ));
-        }
-    };
-
+    let anchor = resolve_record(index, selector)?;
     let anchor_id = canonical_record_id(&anchor);
-    let session_records: Vec<Record> = records
-        .into_iter()
-        .filter(|record| {
-            record.session_id == anchor.session_id
-                && record.source_path == anchor.source_path
-                && record.source == anchor.source
-        })
-        .collect();
+    let session_records = deduplicate_records(
+        index
+            .records_by_session_path(anchor.source, &anchor.session_id, &anchor.source_path)?
+            .into_iter()
+            // Keep this check even though current indexes include `source` in the query. It
+            // preserves the old in-memory isolation contract for legacy projections where the
+            // source field is absent and `record_from_doc` infers it from the path.
+            .filter(|record| record.source == anchor.source)
+            .collect(),
+    );
     let anchor_position = session_records
         .iter()
         .position(|record| canonical_record_id(record) == anchor_id)
@@ -289,32 +253,32 @@ pub fn context_records(
     }
 
     if options.expand_interactions {
-        let mut interaction_ids = identifier_set(&anchor);
-        let mut changed = true;
-        while changed {
-            changed = false;
-            for record in &session_records {
-                if !identifier_set(record)
-                    .iter()
-                    .any(|identifier| interaction_ids.contains(identifier))
-                {
-                    continue;
-                }
-                for identifier in identifier_set(record) {
-                    changed |= interaction_ids.insert(identifier);
-                }
-            }
+        let interaction_ids = selected
+            .values()
+            .filter_map(|(record, _, _)| tool_interaction_id(record))
+            .map(str::to_string)
+            .collect::<HashSet<_>>();
+        let expanded = session_records
+            .iter()
+            .filter(|record| {
+                !selected.contains_key(&canonical_record_id(record))
+                    && tool_interaction_id(record)
+                        .is_some_and(|identifier| interaction_ids.contains(identifier))
+            })
+            .collect::<Vec<_>>();
+        if expanded.len() > MAX_INTERACTION_EXPANSION {
+            bail!(
+                "interaction expansion matched {} records, exceeding maximum {}; use a narrower \
+                 context window or disable --expand-interactions",
+                expanded.len(),
+                MAX_INTERACTION_EXPANSION
+            );
         }
-        for record in &session_records {
-            let key = canonical_record_id(record);
-            if selected.contains_key(&key)
-                || !identifier_set(record)
-                    .iter()
-                    .any(|identifier| interaction_ids.contains(identifier))
-            {
-                continue;
-            }
-            selected.insert(key, (record.clone(), ContextRelation::Interaction, 0));
+        for record in expanded {
+            selected.insert(
+                canonical_record_id(record),
+                (record.clone(), ContextRelation::Interaction, 0),
+            );
         }
     }
 
@@ -333,6 +297,62 @@ pub fn context_records(
         anchor_record_id: anchor_id,
         records,
     })
+}
+
+/// Resolve exactly one context selector without loading its surrounding conversation.
+///
+/// Canonical IDs use an indexed field on new indexes. On legacy indexes the fallback scans only
+/// the supplied session/source scope when present; an unscoped canonical ID necessarily scans the
+/// stored records until the index is rebuilt.
+pub fn resolve_record(index: &SearchIndex, selector: &ContextSelector) -> Result<Record> {
+    let raw_candidates = match selector {
+        ContextSelector::RecordId {
+            id,
+            session_id,
+            source,
+        } => match index.records_by_canonical_id(id)? {
+            Some(records) => records,
+            None => index.records_by_context_scope(session_id.as_deref(), *source)?,
+        },
+        ContextSelector::DocId { id, .. } => index.records_by_doc_id(*id)?,
+        ContextSelector::EventId { id, .. } => index.records_by_event_id(id)?,
+    };
+    let candidates = deduplicate_records(
+        raw_candidates
+            .into_iter()
+            .filter(|record| selector_matches(record, selector))
+            .collect(),
+    );
+    match candidates.as_slice() {
+        [] => bail!("context anchor not found"),
+        [anchor] => Ok(anchor.clone()),
+        _ => Err(anyhow!(
+            "context selector is ambiguous; matching record IDs: {}",
+            candidates
+                .iter()
+                .map(canonical_record_id)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn deduplicate_records(records: Vec<Record>) -> Vec<Record> {
+    // Older indexes can contain duplicate projections. Collapse them by canonical identity,
+    // preferring the deterministic latest projection before resolving selectors or neighborhoods.
+    let mut unique = HashMap::<String, Record>::new();
+    for record in records {
+        let key = canonical_record_id(&record);
+        match unique.get(&key) {
+            Some(previous) if projection_order(previous, &record).is_ge() => {}
+            _ => {
+                unique.insert(key, record);
+            }
+        }
+    }
+    let mut records = unique.into_values().collect::<Vec<_>>();
+    records.sort_by(record_order);
+    records
 }
 
 fn selector_matches(record: &Record, selector: &ContextSelector) -> bool {
@@ -379,35 +399,12 @@ fn projection_order(left: &Record, right: &Record) -> std::cmp::Ordering {
         .then_with(|| left.doc_id.cmp(&right.doc_id))
 }
 
-fn identifier_set(record: &Record) -> HashSet<String> {
-    let identifiers: Vec<String> = [
-        record.links.event_id.as_deref(),
-        record.links.parent_event_id.as_deref(),
-        record.links.logical_parent_event_id.as_deref(),
-        record.links.parent_tool_use_id.as_deref(),
-        record.links.source_tool_use_id.as_deref(),
-        record.links.source_tool_assistant_uuid.as_deref(),
-    ]
-    .into_iter()
-    .flatten()
-    .map(str::to_string)
-    .collect();
-    let mut result: HashSet<String> = identifiers.iter().cloned().collect();
-
-    // Conversation labels are not identifiers: using one by itself would join every record in
-    // a session. When both labels are present, pair them with a real event/tool identifier so
-    // they only strengthen an existing interaction edge.
-    if let (Some(thread_source), Some(conversation_kind)) = (
-        record.links.thread_source.as_deref(),
-        record.links.conversation_kind.as_deref(),
-    ) {
-        for identifier in identifiers {
-            result.insert(format!(
-                "__interaction_scope:{thread_source}:{conversation_kind}:{identifier}"
-            ));
-        }
+fn tool_interaction_id(record: &Record) -> Option<&str> {
+    match record.role.as_str() {
+        "tool_use" => record.links.event_id.as_deref(),
+        "tool_result" | "tool" => record.links.parent_tool_use_id.as_deref(),
+        _ => None,
     }
-    result
 }
 
 #[cfg(test)]
@@ -626,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn interaction_expansion_is_transitive_and_stays_in_session_path() {
+    fn interaction_expansion_pairs_tool_records_without_following_ancestry() {
         let mut anchor = record(1, 1, "assistant");
         anchor.links.event_id = Some("assistant".to_string());
         let mut call = record(2, 2, "call");
@@ -643,7 +640,7 @@ mod tests {
         other_path.links.parent_event_id = Some("assistant".to_string());
         let index = indexed(&[anchor, call, result, unrelated, other_path]);
 
-        let result = context_records(
+        let from_assistant = context_records(
             &index,
             &ContextSelector::event_id("assistant"),
             ContextOptions {
@@ -654,38 +651,55 @@ mod tests {
         )
         .expect("expanded context");
         assert_eq!(
-            result
+            from_assistant
                 .records
                 .iter()
                 .map(|item| item.record.text.as_str())
                 .collect::<Vec<_>>(),
-            vec!["assistant", "call", "result"]
+            vec!["assistant"]
         );
+
+        let from_call = context_records(
+            &index,
+            &ContextSelector::event_id("call"),
+            ContextOptions {
+                before: 0,
+                after: 0,
+                expand_interactions: true,
+            },
+        )
+        .expect("expanded tool pair");
         assert!(
-            result
+            from_call
                 .records
                 .iter()
                 .all(|item| item.record.text != "other path")
         );
-        assert!(
-            result
+        assert_eq!(
+            from_call
                 .records
                 .iter()
-                .filter(|item| item.record.text == "call" || item.record.text == "result")
-                .all(|item| item.relation == ContextRelation::Interaction)
+                .map(|item| (item.record.text.as_str(), item.relation))
+                .collect::<Vec<_>>(),
+            vec![
+                ("call", ContextRelation::Anchor),
+                ("result", ContextRelation::Interaction)
+            ]
         );
     }
 
     #[test]
     fn interaction_expansion_deduplicates_window_members() {
         let mut anchor = record(1, 1, "anchor");
-        anchor.links.event_id = Some("a".to_string());
+        anchor.role = "tool_use".to_string();
+        anchor.links.event_id = Some("call-a".to_string());
         let mut linked = record(2, 2, "linked");
-        linked.links.parent_event_id = Some("a".to_string());
+        linked.role = "tool_result".to_string();
+        linked.links.parent_tool_use_id = Some("call-a".to_string());
         let index = indexed(&[anchor, linked]);
         let result = context_records(
             &index,
-            &ContextSelector::event_id("a"),
+            &ContextSelector::event_id("call-a"),
             ContextOptions {
                 before: 0,
                 after: 1,
@@ -705,23 +719,99 @@ mod tests {
     }
 
     #[test]
-    fn interaction_expansion_does_not_join_on_parent_session_id() {
-        let mut anchor = record(1, 1, "anchor");
-        anchor.links.event_id = Some("anchor-event".to_string());
-        anchor.links.parent_session_id = Some("parent-session".to_string());
+    fn interaction_expansion_finds_invocation_from_result_anchor() {
+        let mut call = record(1, 1, "call");
+        call.role = "tool_use".to_string();
+        call.links.event_id = Some("call-a".to_string());
+        let mut result = record(2, 2, "result");
+        result.role = "tool_result".to_string();
+        result.links.parent_tool_use_id = Some("call-a".to_string());
+        let index = indexed(&[call, result]);
 
-        let mut linked = record(2, 2, "linked");
-        linked.links.parent_event_id = Some("anchor-event".to_string());
+        let context = context_records(
+            &index,
+            &ContextSelector::doc_id(2),
+            ContextOptions {
+                before: 0,
+                after: 0,
+                expand_interactions: true,
+            },
+        )
+        .expect("reverse tool pair");
+        assert_eq!(
+            context
+                .records
+                .iter()
+                .map(|item| (item.record.text.as_str(), item.relation))
+                .collect::<Vec<_>>(),
+            vec![
+                ("call", ContextRelation::Interaction),
+                ("result", ContextRelation::Anchor)
+            ]
+        );
+    }
+
+    #[test]
+    fn interaction_expansion_does_not_guess_from_containing_message_parent() {
+        // When a source omits a native call ID, a tool record can inherit its containing message
+        // ID while the result points back to that message through ordinary conversation ancestry.
+        // Only parent_tool_use_id is a sound direct interaction edge.
+        let mut call = record(1, 1, "call without native ID");
+        call.role = "tool_use".to_string();
+        call.links.event_id = Some("assistant-message".to_string());
+        let mut result = record(2, 2, "result without native ID");
+        result.role = "tool_result".to_string();
+        result.links.event_id = Some("result-message".to_string());
+        result.links.parent_event_id = Some("assistant-message".to_string());
+        let index = indexed(&[call, result]);
+
+        let context = context_records(
+            &index,
+            &ContextSelector::doc_id(1),
+            ContextOptions {
+                before: 0,
+                after: 0,
+                expand_interactions: true,
+            },
+        )
+        .expect("bounded context");
+        assert_eq!(context.records.len(), 1);
+        assert_eq!(context.records[0].record.text, "call without native ID");
+    }
+
+    #[test]
+    fn interaction_expansion_ignores_non_tool_link_fields() {
+        let mut anchor = record(1, 1, "anchor tool");
+        anchor.role = "tool_use".to_string();
+        anchor.links.event_id = Some("call-a".to_string());
+        anchor.links.parent_session_id = Some("parent-session".to_string());
+        anchor.links.logical_parent_event_id = Some("conversation-parent".to_string());
+        anchor.links.source_tool_use_id = Some("spawning-call".to_string());
+        anchor.links.source_tool_assistant_uuid = Some("spawning-assistant".to_string());
+
+        let mut linked = record(2, 2, "linked result");
+        linked.role = "tool_result".to_string();
+        linked.links.parent_tool_use_id = Some("call-a".to_string());
         linked.links.parent_session_id = Some("parent-session".to_string());
 
-        let mut unrelated = record(3, 3, "unrelated");
-        unrelated.links.event_id = Some("unrelated-event".to_string());
+        let mut unrelated = record(3, 3, "unrelated tool");
+        unrelated.role = "tool_use".to_string();
+        unrelated.links.event_id = Some("call-b".to_string());
         unrelated.links.parent_session_id = Some("parent-session".to_string());
+        unrelated.links.logical_parent_event_id = Some("conversation-parent".to_string());
+        unrelated.links.source_tool_use_id = Some("spawning-call".to_string());
+        unrelated.links.source_tool_assistant_uuid = Some("spawning-assistant".to_string());
 
-        let index = indexed(&[anchor, linked, unrelated]);
+        let mut unrelated_result = record(4, 4, "unrelated result");
+        unrelated_result.role = "tool_result".to_string();
+        unrelated_result.links.parent_tool_use_id = Some("call-b".to_string());
+        unrelated_result.links.source_tool_use_id = Some("spawning-call".to_string());
+        unrelated_result.links.source_tool_assistant_uuid = Some("spawning-assistant".to_string());
+
+        let index = indexed(&[anchor, linked, unrelated, unrelated_result]);
         let result = context_records(
             &index,
-            &ContextSelector::event_id("anchor-event"),
+            &ContextSelector::event_id("call-a"),
             ContextOptions {
                 before: 0,
                 after: 0,
@@ -736,7 +826,57 @@ mod tests {
                 .iter()
                 .map(|item| item.record.text.as_str())
                 .collect::<Vec<_>>(),
-            vec!["anchor", "linked"]
+            vec!["anchor tool", "linked result"]
+        );
+    }
+
+    #[test]
+    fn interaction_expansion_has_an_actionable_hard_cap() {
+        let mut call = record(1, 1, "call");
+        call.role = "tool_use".to_string();
+        call.links.event_id = Some("call-a".to_string());
+        let mut records = vec![call];
+        for offset in 0..=MAX_INTERACTION_EXPANSION {
+            let mut result = record((offset + 2) as u64, (offset + 2) as u32, "result");
+            result.role = "tool_result".to_string();
+            result.links.parent_tool_use_id = Some("call-a".to_string());
+            records.push(result);
+        }
+        let index = indexed(&records);
+        let error = context_records(
+            &index,
+            &ContextSelector::event_id("call-a"),
+            ContextOptions {
+                before: 0,
+                after: 0,
+                expand_interactions: true,
+            },
+        )
+        .expect_err("expansion cap");
+        let message = error.to_string();
+        assert!(message.contains("exceeding maximum 100"));
+        assert!(message.contains("disable --expand-interactions"));
+    }
+
+    #[test]
+    fn selector_and_options_round_trip_for_machine_requests() {
+        let selector = ContextSelector::event_id("event-a")
+            .with_scope(Some("session-a".to_string()), Some(SourceKind::Codex));
+        let selector_json = serde_json::to_string(&selector).expect("serialize selector");
+        assert_eq!(
+            serde_json::from_str::<ContextSelector>(&selector_json).expect("deserialize selector"),
+            selector
+        );
+
+        let options = ContextOptions {
+            before: 2,
+            after: 3,
+            expand_interactions: true,
+        };
+        let options_json = serde_json::to_string(&options).expect("serialize options");
+        assert_eq!(
+            serde_json::from_str::<ContextOptions>(&options_json).expect("deserialize options"),
+            options
         );
     }
 }


### PR DESCRIPTION
Reading context around a search hit currently scans the whole index. Context now finds the anchor through indexed IDs and loads its source/session/file neighborhood. Session pages also sort before pagination so records with the same turn number do not move between pages.

`--expand-interactions` follows direct tool-call/result links and stops with an error above 100 added records. It no longer pulls in conversation ancestors. Existing indexes remain readable; direct stable-ID lookup becomes available after rebuilding them.
