### PR TITLE
Limit history reads and provide offsets to continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,42 @@ Notes:
   finish. Explicit `index`, `reindex`, `embed`, and analytics backfill commands wait up to 30
   seconds for another index mutation to finish and report its holder on timeout.
 
-Full transcript:
+Bounded transcript page:
 ```
 memex session <session_id>
 ```
 
-Single record:
+Single bounded record:
 ```
 memex show <doc_id>
+memex show --record-id <record_id> --machine <machine_id>
 ```
+
+Read commands return at most 16,000 Unicode content characters by default. The budget
+counts `text`, `tool_input`, and `tool_output` together; JSON metadata and wire bytes do
+not count. Each record includes content metadata shaped like:
+
+```json
+{"returned_chars":16000,"total_chars":24000,"truncated":true,"continuations":[{"field":"tool_output","offset_chars":12000,"total_chars":20000}]}
+```
+
+Continue a truncated field from its reported Unicode character offset:
+
+```sh
+memex show --record-id <record_id> --machine <machine_id> \
+  --field tool-output --offset-chars 12000
+```
+
+`--field` accepts `text`, `tool-input`, or `tool-output`. Use `--max-chars N` to
+choose another shared budget. `--full` disables the content budget and conflicts with
+`--max-chars`.
+
+`memex session` returns 50 records by default and shares the 16,000-character budget
+across them. Its JSONL stream ends with a `{"type":"page",...}` object containing
+`offset`, `total`, and `next_offset`. Use `next_offset` with `--offset` to read later
+records, and use `memex show` with a record's continuation metadata to finish a field
+that was truncated within a record. `memex session --full` preserves the unbounded
+transcript behavior; adding `--limit` bounds its record count.
 
 Human output:
 ```
@@ -237,21 +264,35 @@ session from another machine:
 
 ~~~sh
 memex show 123 --machine mini
+memex show --record-id rid1_example --machine mini
 memex session SESSION_ID --machine mini --source-path /path/on/mini/session.jsonl
-memex session SESSION_ID --machine mini --offset 500 --limit 500
+memex session SESSION_ID --machine mini --offset 50
+memex context --record-id rid1_example --machine mini --before 5 --after 5
 ~~~
 
 `memex context` selects a source/session/path neighborhood around a stable record ID,
-document ID, or native event ID. `--expand-interactions` adds only directly owned tool
-calls/results and stops with an actionable error above 100 additional records.
+document ID, or native event ID. It accepts `--offset` into that neighborhood and returns
+`offset`, `total`, and `next_offset`, while applying the same shared content budget and
+per-record continuation metadata as `session`. Bounded pages use `order: "anchor_first"`
+so the requested record cannot be crowded out by preceding content; remaining records
+stay chronological. `--full` uses `order: "chronological"`. Keep the same mode when
+following `next_offset`. `--expand-interactions` adds only directly
+owned tool calls/results; it does not follow conversation ancestry. Expansion is capped at
+100 additional records and reports an actionable error when the cap is exceeded.
 
 New indexes provide exact canonical record-ID lookup plus indexed document/event lookup.
+Bounded remote reads require a peer with the new read RPC operations. If a peer is older,
+update it. Legacy document-ID `show`, `session`, and `hydrate` can explicitly use
+`--full` for complete-content reads; remote context and stable-ID reads need an updated
+peer in either mode. Memex does not silently fetch unbounded bodies as a fallback. Character limits apply before the peer
+serializes content. They are not limits on JSON metadata or total network bytes.
+
 Existing indexes remain readable: canonical record IDs fall back to a stored-record scan
 until the index is rebuilt. Neighborhood reads use indexed session, source, and source-path
-scope. Session pages sort by turn, timestamp, and document ID before applying the offset.
+scope.
 
-Session pages are limited to 500 records. To fetch several sessions in one bounded
-request, provide JSONL on stdin or as a file:
+Session and hydrate pages are limited to 500 records. To fetch several sessions in one
+bounded request, provide JSONL on stdin or as a file:
 
 ~~~json
 {"machine":"mini","session_id":"SESSION_ID","source_path":"/path/on/mini/session.jsonl","offset":0,"limit":500}
@@ -262,9 +303,12 @@ memex hydrate requests.jsonl
 cat requests.jsonl | memex hydrate
 ~~~
 
-The batch input accepts at most 32 requests and returns one JSONL response per request,
-including machine provenance, pagination metadata, and stable record_id values where
-available.
+The batch input accepts at most 32 requests and returns one JSONL response per request in
+input order, including machine provenance, `offset`, `total`, `next_offset`, stable
+`record_id` values, and per-record content metadata. One 16,000-character budget is shared
+across all requests in input order. Use `--max-chars N` to change it or `--full` for full
+record content; `--full` conflicts with `--max-chars`. The request envelope's
+`next_offset` resumes later records.
 
 ## Token usage
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -36,7 +36,7 @@ Choose the cheapest strategy that can answer the request.
 
 | User intent | First move |
 | --- | --- |
-| Has a session ID | `memex session <id>` |
+| Has a session ID | Read the first bounded page with `memex session <id>` |
 | "recent sessions", "resume", "the session from this repo" | `memex sessions` |
 | Exact path/symbol/error/command/PR | lexical `memex search` |
 | Fuzzy concept or remembered topic | hybrid search if vectors exist |
@@ -223,9 +223,22 @@ Do not let ten near-duplicate hits from one session crowd out the rest of the co
 
 ```bash
 memex show <doc_id>
+memex show --record-id <record_id> --machine <machine_id>
 ```
 
-Use its full text and linkage metadata to decide whether more context is necessary.
+The default read budget is 16,000 Unicode content characters across `text`,
+`tool_input`, and `tool_output` together. Metadata and JSON wire bytes do not consume it.
+Inspect the returned `content` object: `returned_chars`, `total_chars`, `truncated`, and
+`continuations`. Continue only the needed field with the reported offset:
+
+```bash
+memex show --record-id <record_id> --machine <machine_id> \
+  --field tool-output --offset-chars <offset_chars>
+```
+
+Field values are `text`, `tool-input`, and `tool-output`; continuation JSON names them
+`text`, `tool_input`, and `tool_output`. `--offset-chars` is a Unicode character offset,
+not a byte offset. Use `--max-chars N` when a different bound is justified.
 
 ### Drill inside a candidate session
 
@@ -241,13 +254,19 @@ memex search "<exact filename/error/decision term>" \
 
 This is often cheaper than immediately loading a giant transcript.
 
-### Fetch the full trajectory when the question requires sequence
+### Read a trajectory progressively when the question requires sequence
 
 ```bash
 memex session <session_id>
 ```
 
-Fetch the full session when you need:
+The default page contains at most 50 records and shares one 16,000-character content
+budget across them. JSONL ends with a `type: "page"` object carrying `offset`, `total`,
+and `next_offset`. Resume later records with `--offset <next_offset>`; if a returned
+record itself is truncated, use its `record_id` and `content.continuations` with
+`memex show` before advancing when that field matters.
+
+Continue far enough to recover:
 
 - decision evolution
 - failure -> changed action -> result
@@ -255,7 +274,9 @@ Fetch the full session when you need:
 - tool-call/result ownership
 - a complete handoff/resume summary
 
-For huge sessions, focus only on the relevant interval after fetching; do not summarize unrelated history.
+Use `memex session <id> --full` only when the complete unbounded transcript is required.
+Adding `--limit` keeps full-content mode record-bounded. All read-command `--full` modes
+conflict with `--max-chars`.
 
 ### Fetch bounded context around a result
 
@@ -269,13 +290,23 @@ memex context --event-id <event_id> --session <session_id> --before 5 --after 5 
 memex context --doc-id <doc_id> --before 5 --after 5
 ```
 
+Pass `--machine <machine_id>` for a remote anchor. Context uses the same shared read budget
+and per-record content continuations as session reads. Its envelope includes `offset`,
+`total`, and `next_offset`; use `--offset <next_offset>` to continue through the selected
+neighborhood. Bounded output uses `order: "anchor_first"`: the anchor comes first, followed
+by the remaining records in chronological order. `--full` uses `order: "chronological"`;
+keep the same mode when continuing by offset.
+
 Use `--expand-interactions` when directly owned tool calls/results matter. It does not
 follow general parent or conversation ancestry. Expansion has a hard cap of 100 additional
 records; if the command reports that cap, narrow `--before`/`--after` or disable expansion.
 Canonical record IDs use an exact field in new indexes and a stored-record fallback scan
-in old indexes until rebuilt. Document/event anchors are indexed, and neighborhoods are
-scoped by session, source, and source path. For a result on another machine, use
-machine-aware `show` or paginated `session`.
+in old indexes until rebuilt. Bounded remote reads require updated peers; on an older
+peer, upgrade it. Legacy document-ID `show`, `session`, and `hydrate` may explicitly use
+`--full` if unbounded content is appropriate; remote context/stable-ID reads need an
+updated peer in either mode.
+Document/event anchors are indexed, and neighborhoods are
+scoped by session, source, and source path.
 
 ## Step 7: Reformulate From Evidence
 
@@ -445,14 +476,21 @@ memex sessions --project <name> --since <date> --json-array
 
 ```bash
 memex show <doc_id>
-memex show <doc_id> --machine <machine_id>
-memex context --record-id <record_id> --before 5 --after 5 --expand-interactions
+memex show --record-id <record_id> --machine <machine_id>
+memex show --record-id <record_id> --machine <machine_id> --field text --offset-chars <n>
+memex context --record-id <record_id> --machine <machine_id> --before 5 --after 5 --expand-interactions
+memex context --record-id <record_id> --machine <machine_id> --offset <next_offset>
 memex session <session_id>
-memex session <session_id> --machine <machine_id> --offset 0 --limit 500
+memex session <session_id> --machine <machine_id> --offset <next_offset>
 memex hydrate requests.jsonl
 ```
 
-`memex hydrate` accepts JSONL requests and fetches bounded session pages in batches. Use it when several federated search results need context; do not use it for a single local hit.
+`memex hydrate` accepts JSONL requests and fetches bounded session pages in batches. Its
+response envelope keeps `offset`, `total`, and `next_offset`, and each record carries
+content metadata. A single 16,000-character budget is shared across requests in input
+order. Use `--max-chars N` to resize it or `--full` for complete content; those flags
+conflict. Use hydrate when several federated search results need context; do not use it
+for a single local hit.
 
 ### Retrieval evaluation
 
@@ -494,8 +532,8 @@ Memex provides native support for:
 1. bounded context around a record, document, or event, with optional interaction expansion
 2. multiple query views fused with reciprocal-rank fusion and session-level diversification
 3. direct working-directory/repository scoping with `memex search --cwd`
-4. machine-aware `show` and paginated `session` access for federated search results
-5. bounded JSONL batch fetching for several trajectory/session pages
+4. machine-aware, character-bounded `show`, `session`, and `context` reads with explicit continuations
+5. bounded JSONL batch fetching with one shared content budget across requested pages
 6. stable canonical record IDs and interaction neighborhoods
 7. metadata-only retrieval tracing and JSONL relevance evaluation
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,13 +5,14 @@ use crate::index::{QueryOptions, SearchIndex, SessionScopeKey};
 use crate::ingest::{IngestOptions, ingest_all};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease};
 use crate::machine::{
-    LocatedRecord, MAX_HYDRATE_INPUT_BYTES, MAX_HYDRATE_LINE_BYTES, MAX_SESSION_BATCH_SIZE,
-    MAX_SESSION_PAGE_SIZE, SearchMode, SearchSpec, SessionPageRequest, UsageSpec,
-    batch_session_contexts, federated_search, federated_usage, record_by_doc_id,
+    BoundedRecord, LocatedRecord, MAX_HYDRATE_INPUT_BYTES, MAX_HYDRATE_LINE_BYTES,
+    MAX_SESSION_BATCH_SIZE, MAX_SESSION_PAGE_SIZE, SearchMode, SearchSpec, SessionPageRequest,
+    UsageSpec, federated_search, federated_usage, read_context, read_record, read_session_pages,
     session_page_context,
 };
+use crate::read_budget::{ContentPage, DEFAULT_MAX_CHARS, ReadBudget, ReadField};
 use crate::retrieval::canonical_record_id;
-use crate::retrieval::{ContextOptions, ContextSelector, context_records};
+use crate::retrieval::{ContextOptions, ContextSelector};
 use crate::retrieval_eval::{
     EvaluationDataset, RetrievalTrace, RetrievalTraceMetadata, TraceQuery, append_trace,
     fuse_ranked_queries, mean_reciprocal_rank, ndcg_at_k, recall_at_k, unique_sessions_at_k,
@@ -335,7 +336,7 @@ EXAMPLES:
         #[command(subcommand)]
         action: IndexServiceCommand,
     },
-    /// Display all messages from a specific session
+    /// Display a bounded page from a specific session
     Session {
         /// Session ID (from search results or TUI)
         session_id: String,
@@ -348,26 +349,40 @@ EXAMPLES:
         /// Number of records to skip before the page
         #[arg(long, default_value_t = 0)]
         offset: usize,
-        /// Return at most this many records (maximum 500)
+        /// Return at most this many records (default 50, maximum 500; --full defaults to all)
         #[arg(long)]
         limit: Option<usize>,
         /// Show human-readable output with timestamps and role labels
         #[arg(short, long)]
         verbose: bool,
+        #[command(flatten)]
+        read: ReadArgs,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
     },
-    /// Display a single document by its internal ID
+    /// Display a bounded record by document or stable canonical ID
     Show {
         /// Document ID (from search results)
-        doc_id: u64,
+        #[arg(required_unless_present = "record_id", conflicts_with = "record_id")]
+        doc_id: Option<u64>,
+        /// Stable canonical record ID from search output
+        #[arg(long)]
+        record_id: Option<String>,
+        /// Select a content field to continue reading
+        #[arg(long, value_enum)]
+        field: Option<ReadField>,
+        /// Unicode character offset within --field
+        #[arg(long, default_value_t = 0, requires = "field")]
+        offset_chars: usize,
         /// Originating machine for federated search results
         #[arg(long, default_value = crate::machine::LOCAL_MACHINE_ID)]
         machine: String,
         /// Pretty-print JSON output
         #[arg(short, long)]
         verbose: bool,
+        #[command(flatten)]
+        read: ReadArgs,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -389,12 +404,20 @@ The input contains at most 32 requests; each page is limited to 500 records."
     Hydrate {
         /// JSONL request file; omit or use '-' to read stdin
         input: Option<PathBuf>,
+        #[command(flatten)]
+        read: ReadArgs,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
     },
     /// Return a bounded context neighborhood around a record, document, or native event ID
     Context {
+        /// Originating machine for the anchor
+        #[arg(long, default_value = crate::machine::LOCAL_MACHINE_ID)]
+        machine: String,
+        /// Skip this many records in the selected neighborhood
+        #[arg(long, default_value_t = 0)]
+        offset: usize,
         /// Stable canonical record ID
         #[arg(long, conflicts_with_all = ["doc_id", "event_id"])]
         record_id: Option<String>,
@@ -422,6 +445,8 @@ The input contains at most 32 requests; each page is limited to 500 records."
         /// Pretty-print the JSON result
         #[arg(short, long)]
         verbose: bool,
+        #[command(flatten)]
+        read: ReadArgs,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -1047,30 +1072,51 @@ pub fn run() -> Result<()> {
             offset,
             limit,
             verbose,
+            read,
             root,
         } => {
-            run_session(
+            run_session(SessionRunArgs {
                 session_id,
                 machine,
                 source_path,
                 offset,
                 limit,
                 verbose,
+                read,
                 root,
-            )?;
+            })?;
         }
         Commands::Show {
             doc_id,
+            record_id,
+            field,
+            offset_chars,
             machine,
             verbose,
+            read,
             root,
         } => {
-            run_show(doc_id, machine, verbose, root)?;
+            let selector = match (doc_id, record_id) {
+                (Some(id), None) => ContextSelector::doc_id(id),
+                (None, Some(id)) => ContextSelector::record_id(id),
+                _ => return Err(anyhow!("provide a document ID or --record-id")),
+            };
+            run_show(ShowRunArgs {
+                selector,
+                field,
+                offset_chars,
+                machine,
+                verbose,
+                read,
+                root,
+            })?;
         }
-        Commands::Hydrate { input, root } => {
-            run_hydrate(input, root)?;
+        Commands::Hydrate { input, read, root } => {
+            run_hydrate(input, read, root)?;
         }
         Commands::Context {
+            machine,
+            offset,
             record_id,
             doc_id,
             event_id,
@@ -1080,9 +1126,12 @@ pub fn run() -> Result<()> {
             after,
             expand_interactions,
             verbose,
+            read,
             root,
         } => {
             run_context(ContextRunArgs {
+                machine,
+                offset,
                 record_id,
                 doc_id,
                 event_id,
@@ -1092,6 +1141,7 @@ pub fn run() -> Result<()> {
                 after,
                 expand_interactions,
                 verbose,
+                read,
                 root,
             })?;
         }
@@ -1900,7 +1950,29 @@ fn insert_optional_field(
     }
 }
 
+#[derive(Debug, Clone, Args)]
+struct ReadArgs {
+    /// Maximum Unicode characters across text/tool input/tool output (default 16000; metadata excluded)
+    #[arg(long, conflicts_with = "full")]
+    max_chars: Option<usize>,
+    /// Return complete content without a character budget
+    #[arg(long)]
+    full: bool,
+}
+
+impl ReadArgs {
+    fn budget(&self) -> Result<ReadBudget> {
+        ReadBudget::new(if self.full {
+            None
+        } else {
+            Some(self.max_chars.unwrap_or(DEFAULT_MAX_CHARS))
+        })
+    }
+}
+
 struct ContextRunArgs {
+    machine: String,
+    offset: usize,
     record_id: Option<String>,
     doc_id: Option<u64>,
     event_id: Option<String>,
@@ -1910,11 +1982,14 @@ struct ContextRunArgs {
     after: usize,
     expand_interactions: bool,
     verbose: bool,
+    read: ReadArgs,
     root: Option<PathBuf>,
 }
 
 fn run_context(args: ContextRunArgs) -> Result<()> {
     let ContextRunArgs {
+        machine,
+        offset,
         record_id,
         doc_id,
         event_id,
@@ -1924,8 +1999,10 @@ fn run_context(args: ContextRunArgs) -> Result<()> {
         after,
         expand_interactions,
         verbose,
+        read,
         root,
     } = args;
+    let budget = read.budget()?;
     let selector = match (record_id, doc_id, event_id) {
         (Some(id), None, None) => ContextSelector::record_id(id),
         (None, Some(id), None) => ContextSelector::doc_id(id),
@@ -1938,21 +2015,34 @@ fn run_context(args: ContextRunArgs) -> Result<()> {
     };
     let source = source.and_then(|value| crate::types::SourceKind::from_label(value.as_str()));
     let paths = Paths::new(root)?;
-    let index = SearchIndex::open_or_create(&paths.index)?;
-    let result = context_records(
-        &index,
+    let config = UserConfig::load(&paths)?;
+    let result = read_context(
+        &paths,
+        &config,
+        &machine,
         &selector.with_scope(session, source),
         ContextOptions {
             before,
             after,
             expand_interactions,
         },
+        offset,
+        budget.remaining(),
     )?;
-    if verbose {
-        println!("{}", serde_json::to_string_pretty(&result)?);
-    } else {
-        println!("{}", serde_json::to_string(&result)?);
-    }
+    let mut value = serde_json::to_value(result)?;
+    value["machine"] = Value::from(machine);
+    print_json(&value, verbose)
+}
+
+fn print_json(value: &Value, pretty: bool) -> Result<()> {
+    println!(
+        "{}",
+        if pretty {
+            serde_json::to_string_pretty(value)?
+        } else {
+            serde_json::to_string(value)?
+        }
+    );
     Ok(())
 }
 
@@ -1972,6 +2062,7 @@ struct HydrateRecordOutput {
     #[serde(flatten)]
     record: crate::types::Record,
     record_id: String,
+    content: ContentPage,
 }
 
 #[derive(Debug, Serialize)]
@@ -1995,7 +2086,8 @@ struct HydrateErrorOutput {
     error: String,
 }
 
-fn run_hydrate(input: Option<PathBuf>, root: Option<PathBuf>) -> Result<()> {
+fn run_hydrate(input: Option<PathBuf>, read: ReadArgs, root: Option<PathBuf>) -> Result<()> {
+    let budget = read.budget()?;
     let mut contents = String::new();
     let mut reader: Box<dyn Read> = match input {
         Some(path) if path.to_string_lossy() != "-" => Box::new(std::fs::File::open(path)?),
@@ -2049,77 +2141,117 @@ fn run_hydrate(input: Option<PathBuf>, root: Option<PathBuf>) -> Result<()> {
     }
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let mut grouped: HashMap<String, Vec<(usize, SessionPageRequest)>> = HashMap::new();
-    for (index, request) in requests.into_iter().enumerate() {
-        let machine = request
-            .machine
-            .unwrap_or_else(|| crate::machine::LOCAL_MACHINE_ID.to_string());
-        grouped.entry(machine).or_default().push((
-            index,
-            SessionPageRequest {
-                session_id: request.session_id,
-                source_path: request.source_path,
-                offset: request.offset,
-                limit: request.limit,
-            },
-        ));
-    }
-    let total_requests = grouped.values().map(Vec::len).sum();
-    let mut output: Vec<Option<Value>> = vec![None; total_requests];
-    for (machine, batch) in grouped {
-        let page_requests: Vec<_> = batch.iter().map(|(_, request)| request.clone()).collect();
-        match batch_session_contexts(&paths, &config, &machine, &page_requests) {
-            Ok(contexts) => {
-                for ((original_index, _), context) in batch.into_iter().zip(contexts) {
-                    output[original_index] = Some(hydrate_success_value(&machine, context)?);
+    // Contiguous batches preserve input order while allowing the peer to enforce
+    // the remaining command budget before sending record bodies over SSH.
+    let requests: Vec<_> = requests
+        .into_iter()
+        .map(|request| {
+            (
+                request
+                    .machine
+                    .unwrap_or_else(|| crate::machine::LOCAL_MACHINE_ID.to_string()),
+                SessionPageRequest {
+                    session_id: request.session_id,
+                    source_path: request.source_path,
+                    offset: request.offset,
+                    limit: request.limit,
+                },
+            )
+        })
+        .collect();
+    let mut remaining = budget.remaining();
+    let mut position = 0;
+    while position < requests.len() {
+        let machine = &requests[position].0;
+        let end = position
+            + requests[position..]
+                .iter()
+                .take_while(|(id, _)| id == machine)
+                .count();
+        let batch: Vec<_> = requests[position..end]
+            .iter()
+            .map(|(_, request)| request.clone())
+            .collect();
+        match read_session_pages(&paths, &config, machine, &batch, remaining) {
+            Ok(pages) => {
+                for page in pages {
+                    emit_hydrate_page(machine, page, &mut remaining)?;
                 }
             }
-            Err(batch_error) => {
-                eprintln!("Warning: hydrate machine '{machine}' failed: {batch_error}");
-                for (original_index, request) in batch {
-                    let value = if machine == crate::machine::LOCAL_MACHINE_ID {
-                        match session_page_context(&paths, &config, &machine, &request) {
-                            Ok(context) => hydrate_success_value(&machine, context)?,
+            Err(error) => {
+                eprintln!("Warning: hydrate machine '{machine}' failed: {error}");
+                for request in &batch {
+                    if machine == crate::machine::LOCAL_MACHINE_ID {
+                        match read_session_pages(
+                            &paths,
+                            &config,
+                            machine,
+                            std::slice::from_ref(request),
+                            remaining,
+                        ) {
+                            Ok(pages) => {
+                                for page in pages {
+                                    emit_hydrate_page(machine, page, &mut remaining)?;
+                                }
+                                continue;
+                            }
                             Err(error) => {
-                                hydrate_error_value(&machine, &request, &error.to_string())?
+                                print_json(
+                                    &hydrate_error_value(machine, request, &error.to_string())?,
+                                    false,
+                                )?;
+                                continue;
                             }
                         }
-                    } else {
-                        hydrate_error_value(&machine, &request, &batch_error.to_string())?
-                    };
-                    output[original_index] = Some(value);
+                    }
+                    print_json(
+                        &hydrate_error_value(machine, request, &error.to_string())?,
+                        false,
+                    )?;
                 }
             }
         }
-    }
-    for value in output {
-        let value = value.ok_or_else(|| anyhow!("hydrate response missing for request"))?;
-        println!("{}", value);
+        position = end;
     }
     Ok(())
 }
 
-fn hydrate_success_value(
+fn emit_hydrate_page(
     machine: &str,
-    context: crate::machine::SessionPageContext,
-) -> Result<Value> {
-    Ok(serde_json::to_value(HydrateOutput {
-        machine: machine.to_string(),
-        session_id: context.session_id,
-        source_path: context.source_path,
-        cwd: context.cwd,
-        offset: context.offset,
-        total: context.total,
-        next_offset: context.next_offset,
-        records: context
-            .records
-            .into_iter()
-            .map(|record| HydrateRecordOutput {
-                record_id: canonical_record_id(&record),
-                record,
-            })
-            .collect(),
-    })?)
+    page: crate::machine::BoundedSessionPage,
+    remaining: &mut Option<usize>,
+) -> Result<()> {
+    let returned: usize = page
+        .records
+        .iter()
+        .map(|record| record.content.returned_chars)
+        .sum();
+    if let Some(remaining) = remaining {
+        *remaining = remaining
+            .checked_sub(returned)
+            .ok_or_else(|| anyhow!("hydrate response exceeds remaining character budget"))?;
+    }
+    print_json(
+        &serde_json::to_value(HydrateOutput {
+            machine: machine.to_string(),
+            session_id: page.session_id,
+            source_path: page.source_path,
+            cwd: page.cwd,
+            offset: page.offset,
+            total: page.total,
+            next_offset: page.next_offset,
+            records: page
+                .records
+                .into_iter()
+                .map(|item| HydrateRecordOutput {
+                    record: item.record,
+                    record_id: item.record_id,
+                    content: item.content,
+                })
+                .collect(),
+        })?,
+        false,
+    )
 }
 
 fn hydrate_error_value(machine: &str, request: &SessionPageRequest, error: &str) -> Result<Value> {
@@ -2209,80 +2341,145 @@ fn run_eval_retrieval(dataset_path: PathBuf, k: usize, root: Option<PathBuf>) ->
     Ok(())
 }
 
-fn run_session(
+struct SessionRunArgs {
     session_id: String,
     machine: String,
     source_path: Option<String>,
     offset: usize,
     limit: Option<usize>,
     verbose: bool,
+    read: ReadArgs,
     root: Option<PathBuf>,
-) -> Result<()> {
+}
+
+fn run_session(args: SessionRunArgs) -> Result<()> {
+    let SessionRunArgs {
+        session_id,
+        machine,
+        source_path,
+        offset,
+        limit,
+        verbose,
+        read,
+        root,
+    } = args;
+    let mut budget = read.budget()?;
     if session_id.is_empty() {
         return Err(anyhow!("session_id must not be empty"));
     }
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let records = hydrate_session_records(
-        &paths,
-        &config,
-        &machine,
-        &session_id,
-        source_path.as_deref().unwrap_or_default(),
-        offset,
-        limit,
-    )?;
-    if verbose {
-        for record in records {
-            let ts = format_ts(record.ts);
-            println!("{ts} {}", record.role);
-            if record.text.is_empty() {
-                println!("  <empty>");
-                continue;
-            }
-            for line in record.text.lines() {
+    let source_path = source_path.unwrap_or_default();
+    let (records, page) = if read.full {
+        let records = hydrate_session_records(
+            &paths,
+            &config,
+            &machine,
+            &session_id,
+            &source_path,
+            offset,
+            limit,
+        )?
+        .into_iter()
+        .map(|mut record| {
+            let record_id = canonical_record_id(&record);
+            let content = budget.apply(&mut record, None, 0)?;
+            Ok(BoundedRecord {
+                record_id,
+                record,
+                content,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+        (records, None)
+    } else {
+        let request = SessionPageRequest {
+            session_id: session_id.clone(),
+            source_path: source_path.clone(),
+            offset,
+            limit: limit.unwrap_or(50),
+        };
+        let mut pages =
+            read_session_pages(&paths, &config, &machine, &[request], budget.remaining())?;
+        let page = pages
+            .pop()
+            .ok_or_else(|| anyhow!("session response missing page"))?;
+        (page.records, Some((page.total, page.next_offset)))
+    };
+    for item in records {
+        if verbose {
+            println!("{} {}", format_ts(item.record.ts), item.record.role);
+            for line in item.record.text.lines() {
                 println!("  {line}");
             }
+            for (name, value) in [
+                ("tool_input", &item.record.tool_input),
+                ("tool_output", &item.record.tool_output),
+            ] {
+                if let Some(value) = value {
+                    println!("  {name}: {value}");
+                }
+            }
+            if item.content.truncated {
+                println!(
+                    "  continuation: {}",
+                    serde_json::to_string(
+                        &serde_json::json!({"machine": machine, "record_id": item.record_id, "content": item.content})
+                    )?
+                );
+            }
+        } else {
+            let mut value = serde_json::to_value(item)?;
+            value["machine"] = Value::from(machine.clone());
+            print_json(&value, false)?;
         }
-        return Ok(());
     }
-    for record in records {
-        println!(
-            "{}",
-            serde_json::to_string(&serde_json::json!({
-                "machine": &machine,
-                "record_id": canonical_record_id(&record),
-                "record": record,
-            }))?
-        );
+    if let Some((total, next_offset)) = page {
+        let value = serde_json::json!({ "type": "page", "machine": machine, "session_id": session_id, "source_path": source_path, "offset": offset, "total": total, "next_offset": next_offset });
+        if verbose {
+            println!("page: {value}");
+        } else {
+            print_json(&value, false)?;
+        }
     }
     Ok(())
 }
 
-fn run_show(doc_id: u64, machine: String, verbose: bool, root: Option<PathBuf>) -> Result<()> {
+struct ShowRunArgs {
+    selector: ContextSelector,
+    field: Option<ReadField>,
+    offset_chars: usize,
+    machine: String,
+    verbose: bool,
+    read: ReadArgs,
+    root: Option<PathBuf>,
+}
+
+fn run_show(args: ShowRunArgs) -> Result<()> {
+    let ShowRunArgs {
+        selector,
+        field,
+        offset_chars,
+        machine,
+        verbose,
+        read,
+        root,
+    } = args;
+    let budget = read.budget()?;
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
-    let record = record_by_doc_id(&paths, &config, &machine, doc_id)?;
-    if verbose {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "machine": &machine,
-                "record_id": canonical_record_id(&record),
-                "record": record,
-            }))?
-        );
-        return Ok(());
-    }
-    println!(
-        "{}",
-        serde_json::to_string(&serde_json::json!({
-            "machine": &machine,
-            "record_id": canonical_record_id(&record),
-            "record": record,
-        }))?
-    );
-    Ok(())
+    let record = read_record(
+        &paths,
+        &config,
+        &machine,
+        &selector,
+        field,
+        offset_chars,
+        budget.remaining(),
+    )?;
+    let mut value = serde_json::to_value(record)?;
+    value["machine"] = Value::from(machine);
+    print_json(&value, verbose)
 }
 
 fn hydrate_session_records(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ingest;
 pub mod lease;
 pub mod machine;
 pub mod progress;
+pub mod read_budget;
 pub mod resume;
 pub mod retrieval;
 pub mod retrieval_eval;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -4,6 +4,11 @@ use crate::embed::{EmbedderHandle, ModelChoice};
 use crate::index::{QueryOptions, SearchIndex, SessionScopeKey};
 use crate::ingest::{IngestOptions, IngestReport, ingest_all, ingest_if_stale};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease};
+use crate::read_budget::{ContentPage, ReadBudget, ReadField};
+use crate::retrieval::{
+    ContextOptions, ContextRelation, ContextResult, ContextSelector, canonical_record_id,
+    context_records, resolve_record,
+};
 use crate::types::{Record, SourceFilter};
 use crate::usage::{
     CacheWaste, CostMode, UsageQuery, UsageSummary, scan_usage, scan_usage_activity,
@@ -154,6 +159,43 @@ pub struct SessionPageContext {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundedRecord {
+    pub record_id: String,
+    pub record: Record,
+    pub content: ContentPage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundedContextRecord {
+    pub record_id: String,
+    pub relation: ContextRelation,
+    pub distance: i64,
+    pub record: Record,
+    pub content: ContentPage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundedContext {
+    pub anchor_record_id: String,
+    pub order: String,
+    pub offset: usize,
+    pub total: usize,
+    pub next_offset: Option<usize>,
+    pub records: Vec<BoundedContextRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoundedSessionPage {
+    pub session_id: String,
+    pub source_path: String,
+    pub cwd: Option<String>,
+    pub offset: usize,
+    pub total: usize,
+    pub next_offset: Option<usize>,
+    pub records: Vec<BoundedRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageSpec {
     pub source: Option<SourceFilter>,
     pub project: Option<String>,
@@ -244,6 +286,29 @@ enum RpcOperation {
     Show {
         doc_id: u64,
     },
+    ResolveRecord {
+        selector: ContextSelector,
+    },
+    Context {
+        selector: ContextSelector,
+        options: ContextOptions,
+    },
+    ReadRecord {
+        selector: ContextSelector,
+        field: Option<ReadField>,
+        offset_chars: usize,
+        max_chars: usize,
+    },
+    ReadContext {
+        selector: ContextSelector,
+        options: ContextOptions,
+        offset: usize,
+        max_chars: usize,
+    },
+    ReadSessionPages {
+        requests: Vec<SessionPageRequest>,
+        max_chars: usize,
+    },
     SessionPage {
         request: SessionPageRequest,
     },
@@ -282,6 +347,18 @@ enum RpcPayload {
     },
     Record {
         record: Box<Record>,
+    },
+    Context {
+        context: ContextResult,
+    },
+    BoundedRecord {
+        record: Box<BoundedRecord>,
+    },
+    BoundedContext {
+        context: BoundedContext,
+    },
+    BoundedSessionPages {
+        pages: Vec<BoundedSessionPage>,
     },
     SessionPage {
         context: SessionPageContext,
@@ -601,6 +678,217 @@ pub fn record_by_doc_id(
     }
 }
 
+/// Resolve a record on exactly the machine that supplied its retrieval reference.
+/// Legacy document-ID reads retain the existing RPC operation for older peers.
+pub fn record_by_selector(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    selector: &ContextSelector,
+) -> Result<Record> {
+    if let ContextSelector::DocId {
+        id,
+        session_id: None,
+        source: None,
+    } = selector
+    {
+        return record_by_doc_id(paths, config, machine_id, *id);
+    }
+    if machine_id == LOCAL_MACHINE_ID {
+        return resolve_record(&SearchIndex::open_or_create(&paths.index)?, selector);
+    }
+    let machine = machine_by_id(config, machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    match rpc(
+        machine,
+        RpcOperation::ResolveRecord {
+            selector: selector.clone(),
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )? {
+        RpcPayload::Record { record } => Ok(*record),
+        RpcPayload::Error { message } => Err(anyhow!("record resolution failed: {message}")),
+        other => Err(anyhow!(
+            "record resolution returned unexpected response: {other:?}"
+        )),
+    }
+}
+
+pub fn context_on_machine(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    selector: &ContextSelector,
+    options: ContextOptions,
+) -> Result<ContextResult> {
+    options.validate()?;
+    if machine_id == LOCAL_MACHINE_ID {
+        return context_records(
+            &SearchIndex::open_or_create(&paths.index)?,
+            selector,
+            options,
+        );
+    }
+    let machine = machine_by_id(config, machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    match rpc(
+        machine,
+        RpcOperation::Context {
+            selector: selector.clone(),
+            options,
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )? {
+        RpcPayload::Context { context } => Ok(context),
+        RpcPayload::Error { message } => Err(anyhow!("context failed: {message}")),
+        other => Err(anyhow!("context returned unexpected response: {other:?}")),
+    }
+}
+
+pub fn read_record(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    selector: &ContextSelector,
+    field: Option<ReadField>,
+    offset_chars: usize,
+    max_chars: Option<usize>,
+) -> Result<BoundedRecord> {
+    validate_context_selector(selector)?;
+    if max_chars == Some(0) {
+        bail!("max_chars must be greater than zero for a record read");
+    }
+    if max_chars.is_none() {
+        let record = record_by_selector(paths, config, machine_id, selector)?;
+        let mut budget = ReadBudget::from_remaining(None);
+        let bounded = apply_record_budget(record, &mut budget, field, offset_chars)?;
+        validate_bounded_record(&bounded, selector, None)?;
+        return Ok(bounded);
+    }
+    if machine_id == LOCAL_MACHINE_ID {
+        let record = resolve_record(&SearchIndex::open_or_create(&paths.index)?, selector)?;
+        let mut budget = ReadBudget::from_remaining(max_chars);
+        return apply_record_budget(record, &mut budget, field, offset_chars);
+    }
+    let machine = machine_by_id(config, machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    let response = rpc(
+        machine,
+        RpcOperation::ReadRecord {
+            selector: selector.clone(),
+            field,
+            offset_chars,
+            max_chars: max_chars.expect("bounded branch"),
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )
+    .with_context(|| bounded_rpc_help(machine_id, "record read"))?;
+    match response {
+        RpcPayload::BoundedRecord { record } => {
+            validate_bounded_record(&record, selector, max_chars)?;
+            Ok(*record)
+        }
+        RpcPayload::Error { message } => Err(anyhow!("record read failed: {message}")),
+        other => Err(anyhow!(
+            "record read returned an unexpected response; upgrade peer for bounded reads: {other:?}"
+        )),
+    }
+}
+
+pub fn read_context(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    selector: &ContextSelector,
+    options: ContextOptions,
+    offset: usize,
+    max_chars: Option<usize>,
+) -> Result<BoundedContext> {
+    validate_context_selector(selector)?;
+    options.validate()?;
+    if max_chars.is_none() {
+        let context = context_on_machine(paths, config, machine_id, selector, options)?;
+        let bounded = apply_context_budget(context, offset, None)?;
+        validate_bounded_context(&bounded, selector, offset, None)?;
+        return Ok(bounded);
+    }
+    if machine_id == LOCAL_MACHINE_ID {
+        let context = context_records(
+            &SearchIndex::open_or_create(&paths.index)?,
+            selector,
+            options,
+        )?;
+        return apply_context_budget(context, offset, max_chars);
+    }
+    let machine = machine_by_id(config, machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    let response = rpc(
+        machine,
+        RpcOperation::ReadContext {
+            selector: selector.clone(),
+            options,
+            offset,
+            max_chars: max_chars.expect("bounded branch"),
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )
+    .with_context(|| bounded_rpc_help(machine_id, "context read"))?;
+    match response {
+        RpcPayload::BoundedContext { context } => {
+            validate_bounded_context(&context, selector, offset, max_chars)?;
+            Ok(context)
+        }
+        RpcPayload::Error { message } => Err(anyhow!("context read failed: {message}")),
+        other => Err(anyhow!(
+            "context read returned an unexpected response; upgrade peer for bounded reads: {other:?}"
+        )),
+    }
+}
+
+pub fn read_session_pages(
+    paths: &Paths,
+    config: &UserConfig,
+    machine_id: &str,
+    requests: &[SessionPageRequest],
+    max_chars: Option<usize>,
+) -> Result<Vec<BoundedSessionPage>> {
+    validate_session_batch(requests)?;
+    if max_chars.is_none() {
+        let contexts = batch_session_contexts(paths, config, machine_id, requests)?;
+        let pages = apply_session_pages_budget(contexts, None)?;
+        validate_bounded_session_pages(&pages, requests, None)?;
+        return Ok(pages);
+    }
+    if machine_id == LOCAL_MACHINE_ID {
+        let contexts = requests
+            .iter()
+            .map(|request| session_page_context_local(paths, request))
+            .collect::<Result<Vec<_>>>()?;
+        return apply_session_pages_budget(contexts, max_chars);
+    }
+    let machine = machine_by_id(config, machine_id)
+        .ok_or_else(|| anyhow!("unknown machine '{machine_id}'"))?;
+    let response = rpc(
+        machine,
+        RpcOperation::ReadSessionPages {
+            requests: requests.to_vec(),
+            max_chars: max_chars.expect("bounded branch"),
+        },
+        Duration::from_secs(config.multi_machine.timeout_seconds()),
+    )
+    .with_context(|| bounded_rpc_help(machine_id, "session-page read"))?;
+    match response {
+        RpcPayload::BoundedSessionPages { pages } => {
+            validate_bounded_session_pages(&pages, requests, max_chars)?;
+            Ok(pages)
+        }
+        RpcPayload::Error { message } => Err(anyhow!("session-page read failed: {message}")),
+        other => Err(anyhow!(
+            "session-page read returned an unexpected response; upgrade peer for bounded reads: {other:?}"
+        )),
+    }
+}
+
 pub fn session_page_context(
     paths: &Paths,
     config: &UserConfig,
@@ -766,6 +1054,335 @@ fn validate_session_page_context(
         bail!("session page response has invalid pagination metadata");
     }
     Ok(())
+}
+
+fn apply_record_budget(
+    mut record: Record,
+    budget: &mut ReadBudget,
+    field: Option<ReadField>,
+    offset_chars: usize,
+) -> Result<BoundedRecord> {
+    let record_id = canonical_record_id(&record);
+    let content = budget.apply(&mut record, field, offset_chars)?;
+    Ok(BoundedRecord {
+        record_id,
+        record,
+        content,
+    })
+}
+
+fn apply_context_budget(
+    mut context: ContextResult,
+    offset: usize,
+    max_chars: Option<usize>,
+) -> Result<BoundedContext> {
+    let order = if max_chars.is_some() {
+        context
+            .records
+            .sort_by_key(|item| item.relation != ContextRelation::Anchor);
+        "anchor_first"
+    } else {
+        "chronological"
+    };
+    let total = context.records.len();
+    let mut budget = ReadBudget::from_remaining(max_chars);
+    let mut records = Vec::new();
+    if max_chars != Some(0) {
+        for item in context.records.into_iter().skip(offset) {
+            if budget.remaining() == Some(0) {
+                break;
+            }
+            let bounded = apply_record_budget(item.record, &mut budget, None, 0)?;
+            records.push(BoundedContextRecord {
+                record_id: bounded.record_id,
+                relation: item.relation,
+                distance: item.distance,
+                record: bounded.record,
+                content: bounded.content,
+            });
+        }
+    }
+    let next_offset = bounded_next_offset(offset, records.len(), total);
+    Ok(BoundedContext {
+        anchor_record_id: context.anchor_record_id,
+        order: order.to_string(),
+        offset,
+        total,
+        next_offset,
+        records,
+    })
+}
+
+fn apply_session_pages_budget(
+    contexts: Vec<SessionPageContext>,
+    max_chars: Option<usize>,
+) -> Result<Vec<BoundedSessionPage>> {
+    let mut budget = ReadBudget::from_remaining(max_chars);
+    contexts
+        .into_iter()
+        .map(|context| {
+            let mut records = Vec::new();
+            if budget.remaining() != Some(0) {
+                for record in context.records {
+                    if budget.remaining() == Some(0) {
+                        break;
+                    }
+                    records.push(apply_record_budget(record, &mut budget, None, 0)?);
+                }
+            }
+            Ok(BoundedSessionPage {
+                session_id: context.session_id,
+                source_path: context.source_path,
+                cwd: context.cwd,
+                offset: context.offset,
+                total: context.total,
+                next_offset: bounded_next_offset(context.offset, records.len(), context.total),
+                records,
+            })
+        })
+        .collect()
+}
+
+fn bounded_next_offset(offset: usize, returned: usize, total: usize) -> Option<usize> {
+    let end = offset.saturating_add(returned);
+    (end < total).then_some(end)
+}
+
+fn validate_context_selector(selector: &ContextSelector) -> Result<()> {
+    let (id, session_id) = match selector {
+        ContextSelector::RecordId { id, session_id, .. }
+        | ContextSelector::EventId { id, session_id, .. } => (Some(id.as_str()), session_id),
+        ContextSelector::DocId { session_id, .. } => (None, session_id),
+    };
+    if id.is_some_and(str::is_empty) {
+        bail!("record selector id must not be empty");
+    }
+    if session_id.as_deref().is_some_and(str::is_empty) {
+        bail!("record selector session_id must not be empty");
+    }
+    Ok(())
+}
+
+fn record_matches_selector(record: &Record, selector: &ContextSelector) -> bool {
+    let (session_id, source, identity_matches) = match selector {
+        ContextSelector::RecordId {
+            id,
+            session_id,
+            source,
+        } => (session_id, source, canonical_record_id(record) == *id),
+        ContextSelector::DocId {
+            id,
+            session_id,
+            source,
+        } => (session_id, source, record.doc_id == *id),
+        ContextSelector::EventId {
+            id,
+            session_id,
+            source,
+        } => (
+            session_id,
+            source,
+            record.links.event_id.as_deref() == Some(id.as_str()),
+        ),
+    };
+    identity_matches
+        && session_id
+            .as_deref()
+            .is_none_or(|session_id| record.session_id == session_id)
+        && source.is_none_or(|source| record.source == source)
+}
+
+fn validate_content_page(record: &Record, content: &ContentPage) -> Result<usize> {
+    let actual = record.text.chars().count()
+        + record
+            .tool_input
+            .as_deref()
+            .map_or(0, |value| value.chars().count())
+        + record
+            .tool_output
+            .as_deref()
+            .map_or(0, |value| value.chars().count());
+    if actual != content.returned_chars {
+        bail!("bounded response content length does not match returned_chars");
+    }
+    if content.returned_chars > content.total_chars {
+        bail!("bounded response returned_chars exceeds total_chars");
+    }
+    if content.truncated != !content.continuations.is_empty() {
+        bail!("bounded response has inconsistent truncation metadata");
+    }
+    let mut fields = Vec::new();
+    for continuation in &content.continuations {
+        if continuation.offset_chars > continuation.total_chars {
+            bail!("bounded response has invalid continuation metadata");
+        }
+        if fields.contains(&continuation.field) {
+            bail!("bounded response repeats a continuation field");
+        }
+        fields.push(continuation.field);
+    }
+    Ok(actual)
+}
+
+fn validate_bounded_record(
+    bounded: &BoundedRecord,
+    selector: &ContextSelector,
+    max_chars: Option<usize>,
+) -> Result<()> {
+    if bounded.record_id != canonical_record_id(&bounded.record) {
+        bail!("record read returned a non-canonical record identity");
+    }
+    if !record_matches_selector(&bounded.record, selector) {
+        bail!("record read response does not match its selector");
+    }
+    let returned = validate_content_page(&bounded.record, &bounded.content)?;
+    if max_chars.is_some_and(|max_chars| returned > max_chars) {
+        bail!("record read response exceeds its requested character budget");
+    }
+    Ok(())
+}
+
+fn validate_bounded_context(
+    context: &BoundedContext,
+    selector: &ContextSelector,
+    offset: usize,
+    max_chars: Option<usize>,
+) -> Result<()> {
+    if context.offset != offset {
+        bail!("context read response has an unexpected offset");
+    }
+    let expected_order = if max_chars.is_some() {
+        "anchor_first"
+    } else {
+        "chronological"
+    };
+    if context.order != expected_order {
+        bail!("context read response has an unexpected order");
+    }
+    validate_bounded_pagination(
+        context.offset,
+        context.total,
+        context.next_offset,
+        context.records.len(),
+        "context read",
+    )?;
+    let mut returned = 0usize;
+    let mut anchor_count = 0usize;
+    for item in &context.records {
+        if item.record_id != canonical_record_id(&item.record) {
+            bail!("context read returned a non-canonical record identity");
+        }
+        if item.relation == ContextRelation::Anchor {
+            anchor_count += 1;
+            if item.record_id != context.anchor_record_id
+                || !record_matches_selector(&item.record, selector)
+            {
+                bail!("context read returned the wrong anchor record");
+            }
+        }
+        returned = returned
+            .checked_add(validate_content_page(&item.record, &item.content)?)
+            .ok_or_else(|| anyhow!("context read character count overflowed"))?;
+    }
+    if max_chars.is_some_and(|max_chars| returned > max_chars) {
+        bail!("context read response exceeds its requested character budget");
+    }
+    if max_chars.is_some_and(|max_chars| max_chars > 0) && offset == 0 {
+        if context.records.first().is_none_or(|item| {
+            item.relation != ContextRelation::Anchor
+                || item.record_id != context.anchor_record_id
+                || !record_matches_selector(&item.record, selector)
+        }) || anchor_count != 1
+        {
+            bail!("bounded context response does not begin with exactly the selected anchor");
+        }
+    } else if anchor_count > 1 {
+        bail!("context read response contains duplicate anchors");
+    }
+    Ok(())
+}
+
+fn validate_bounded_session_pages(
+    pages: &[BoundedSessionPage],
+    requests: &[SessionPageRequest],
+    max_chars: Option<usize>,
+) -> Result<()> {
+    if pages.len() != requests.len() {
+        bail!(
+            "session-page read returned {} pages for {} requests",
+            pages.len(),
+            requests.len()
+        );
+    }
+    let mut returned = 0usize;
+    for (page, request) in pages.iter().zip(requests) {
+        if page.session_id != request.session_id
+            || page.source_path != request.source_path
+            || page.offset != request.offset
+        {
+            bail!("session-page read response does not match its request");
+        }
+        if page.records.len() > request.limit {
+            bail!("session-page read response exceeds its requested record limit");
+        }
+        validate_bounded_pagination(
+            page.offset,
+            page.total,
+            page.next_offset,
+            page.records.len(),
+            "session-page read",
+        )?;
+        for bounded in &page.records {
+            if bounded.record_id != canonical_record_id(&bounded.record) {
+                bail!("session-page read returned a non-canonical record identity");
+            }
+            if bounded.record.session_id != request.session_id
+                || (!request.source_path.is_empty()
+                    && bounded.record.source_path != request.source_path)
+            {
+                bail!("session-page read returned a record outside its requested session");
+            }
+            returned = returned
+                .checked_add(validate_content_page(&bounded.record, &bounded.content)?)
+                .ok_or_else(|| anyhow!("session-page read character count overflowed"))?;
+        }
+    }
+    if max_chars.is_some_and(|max_chars| returned > max_chars) {
+        bail!("session-page read response exceeds its requested character budget");
+    }
+    Ok(())
+}
+
+fn validate_bounded_pagination(
+    offset: usize,
+    total: usize,
+    next_offset: Option<usize>,
+    returned: usize,
+    context: &str,
+) -> Result<()> {
+    if offset > total {
+        if returned != 0 || next_offset.is_some() {
+            bail!("{context} response has invalid out-of-range pagination");
+        }
+        return Ok(());
+    }
+    let expected_end = offset
+        .checked_add(returned)
+        .ok_or_else(|| anyhow!("{context} response has overflowing pagination metadata"))?;
+    if expected_end > total {
+        bail!("{context} response has an invalid pagination total");
+    }
+    let expected_next = (expected_end < total).then_some(expected_end);
+    if next_offset != expected_next {
+        bail!("{context} response has inconsistent continuation metadata");
+    }
+    Ok(())
+}
+
+fn bounded_rpc_help(machine_id: &str, operation: &str) -> String {
+    format!(
+        "{operation} requires bounded-read RPC support on machine '{machine_id}'; upgrade peer for bounded reads"
+    )
 }
 
 pub fn machine_by_id<'a>(config: &'a UserConfig, id: &str) -> Option<&'a MachineConfig> {
@@ -1068,6 +1685,66 @@ fn handle_rpc(paths: &Paths, config: &UserConfig, request: RpcOperation) -> Resu
                 .ok_or_else(|| anyhow!("doc_id not found"))?;
             Ok(RpcPayload::Record {
                 record: Box::new(record),
+            })
+        }
+        RpcOperation::ResolveRecord { selector } => {
+            let index = SearchIndex::open_or_create(&paths.index)?;
+            Ok(RpcPayload::Record {
+                record: Box::new(resolve_record(&index, &selector)?),
+            })
+        }
+        RpcOperation::Context { selector, options } => {
+            let index = SearchIndex::open_or_create(&paths.index)?;
+            Ok(RpcPayload::Context {
+                context: context_records(&index, &selector, options)?,
+            })
+        }
+        RpcOperation::ReadRecord {
+            selector,
+            field,
+            offset_chars,
+            max_chars,
+        } => {
+            validate_context_selector(&selector)?;
+            if max_chars == 0 {
+                bail!("max_chars must be greater than zero for a record read");
+            }
+            let index = SearchIndex::open_or_create(&paths.index)?;
+            let record = resolve_record(&index, &selector)?;
+            let mut budget = ReadBudget::from_remaining(Some(max_chars));
+            Ok(RpcPayload::BoundedRecord {
+                record: Box::new(apply_record_budget(
+                    record,
+                    &mut budget,
+                    field,
+                    offset_chars,
+                )?),
+            })
+        }
+        RpcOperation::ReadContext {
+            selector,
+            options,
+            offset,
+            max_chars,
+        } => {
+            validate_context_selector(&selector)?;
+            let index = SearchIndex::open_or_create(&paths.index)?;
+            let context = context_records(&index, &selector, options)?;
+            Ok(RpcPayload::BoundedContext {
+                context: apply_context_budget(context, offset, Some(max_chars))?,
+            })
+        }
+        RpcOperation::ReadSessionPages {
+            requests,
+            max_chars,
+        } => {
+            validate_session_batch(&requests)?;
+            let contexts = requests
+                .iter()
+                .map(|request| session_page_context_local(paths, request))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(RpcPayload::BoundedSessionPages {
+                pages: apply_session_pages_budget(contexts, Some(max_chars))?,
             })
         }
         RpcOperation::SessionPage { request } => {
@@ -1615,45 +2292,12 @@ fn records_for_session_page(
     index: &SearchIndex,
     request: &SessionPageRequest,
 ) -> Result<(Vec<Record>, usize)> {
-    if request.source_path.is_empty() {
-        return index.records_by_session_id_page(
-            &request.session_id,
-            request.offset,
-            request.limit,
-        );
-    }
-
-    // The index page collector can page by session but not by source path.
-    // Scan bounded index pages while retaining only the requested output page,
-    // so a source-qualified request cannot materialize the whole trajectory.
-    let mut scan_offset = 0usize;
-    let mut matched = 0usize;
-    let mut records = Vec::with_capacity(request.limit);
-    loop {
-        let (page, total) = index.records_by_session_id_page(
-            &request.session_id,
-            scan_offset,
-            MAX_SESSION_PAGE_SIZE,
-        )?;
-        if page.is_empty() {
-            break;
-        }
-        for record in page {
-            if record.source_path != request.source_path {
-                continue;
-            }
-            if matched >= request.offset && records.len() < request.limit {
-                records.push(record);
-            }
-            matched = matched.saturating_add(1);
-        }
-        scan_offset = scan_offset
-            .saturating_add(MAX_SESSION_PAGE_SIZE.min(total.saturating_sub(scan_offset)));
-        if scan_offset >= total {
-            break;
-        }
-    }
-    Ok((records, matched))
+    index.records_by_session_path_page(
+        &request.session_id,
+        (!request.source_path.is_empty()).then_some(request.source_path.as_str()),
+        request.offset,
+        request.limit,
+    )
 }
 
 fn discover_cwd(path: &std::path::Path, session_id: &str) -> Option<String> {
@@ -1956,6 +2600,28 @@ mod tests {
         index.publish_generation().unwrap();
     }
 
+    fn rpc_handler_round_trip(
+        paths: &Paths,
+        config: &UserConfig,
+        operation: RpcOperation,
+    ) -> RpcPayload {
+        let request = serde_json::to_vec(&RpcRequest {
+            protocol: RPC_PROTOCOL,
+            request: operation,
+        })
+        .unwrap();
+        let request: RpcRequest = serde_json::from_slice(&request).unwrap();
+        let response = handle_rpc(paths, config, request.request).unwrap();
+        let response = serde_json::to_vec(&RpcResponse {
+            protocol: RPC_PROTOCOL,
+            response,
+        })
+        .unwrap();
+        serde_json::from_slice::<RpcResponse>(&response)
+            .unwrap()
+            .response
+    }
+
     #[test]
     fn vector_query_model_prefers_metadata_and_uses_configured_fallback() {
         let tmp = TempDir::new().unwrap();
@@ -2100,6 +2766,137 @@ mod tests {
         assert_eq!(contexts.len(), 2);
         assert_eq!(contexts[0].records[0].doc_id, 1);
         assert_eq!(contexts[1].records[0].doc_id, 3);
+    }
+
+    #[test]
+    fn bounded_rpc_handlers_apply_budgets_before_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        let records = vec![
+            test_record(1, "session", "a.jsonl", 1),
+            test_record(2, "session", "a.jsonl", 2),
+            test_record(3, "session", "b.jsonl", 3),
+        ];
+        write_test_index(&paths, &records);
+        let config = UserConfig::default();
+
+        let selector = ContextSelector::doc_id(2);
+        let RpcPayload::BoundedRecord { record } = rpc_handler_round_trip(
+            &paths,
+            &config,
+            RpcOperation::ReadRecord {
+                selector: selector.clone(),
+                field: Some(ReadField::Text),
+                offset_chars: 1,
+                max_chars: 2,
+            },
+        ) else {
+            panic!("unexpected bounded-record response");
+        };
+        assert_eq!(record.record.text, "ec");
+        assert_eq!(record.content.returned_chars, 2);
+        assert_eq!(record.content.total_chars, 8);
+        assert_eq!(record.content.continuations[0].offset_chars, 3);
+        validate_bounded_record(&record, &selector, Some(2)).unwrap();
+
+        let RpcPayload::BoundedContext { context } = rpc_handler_round_trip(
+            &paths,
+            &config,
+            RpcOperation::ReadContext {
+                selector: selector.clone(),
+                options: ContextOptions {
+                    before: 1,
+                    after: 0,
+                    expand_interactions: false,
+                },
+                offset: 0,
+                max_chars: 3,
+            },
+        ) else {
+            panic!("unexpected bounded-context response");
+        };
+        assert_eq!(context.order, "anchor_first");
+        assert_eq!(context.records.len(), 1);
+        assert_eq!(context.records[0].relation, ContextRelation::Anchor);
+        assert_eq!(context.records[0].record.text, "rec");
+        validate_bounded_context(&context, &selector, 0, Some(3)).unwrap();
+
+        let requests = vec![
+            SessionPageRequest {
+                session_id: "session".to_string(),
+                source_path: "a.jsonl".to_string(),
+                offset: 0,
+                limit: 1,
+            },
+            SessionPageRequest {
+                session_id: "session".to_string(),
+                source_path: "b.jsonl".to_string(),
+                offset: 0,
+                limit: 1,
+            },
+        ];
+        let RpcPayload::BoundedSessionPages { pages } = rpc_handler_round_trip(
+            &paths,
+            &config,
+            RpcOperation::ReadSessionPages {
+                requests: requests.clone(),
+                max_chars: 10,
+            },
+        ) else {
+            panic!("unexpected bounded-session response");
+        };
+        assert_eq!(pages[0].records[0].content.returned_chars, 8);
+        assert_eq!(pages[1].records[0].content.returned_chars, 2);
+        validate_bounded_session_pages(&pages, &requests, Some(10)).unwrap();
+
+        let RpcPayload::BoundedSessionPages { pages } = rpc_handler_round_trip(
+            &paths,
+            &config,
+            RpcOperation::ReadSessionPages {
+                requests: requests.clone(),
+                max_chars: 0,
+            },
+        ) else {
+            panic!("unexpected exhausted-session response");
+        };
+        assert!(pages.iter().all(|page| page.records.is_empty()));
+        assert!(pages.iter().all(|page| page.next_offset == Some(0)));
+        validate_bounded_session_pages(&pages, &requests, Some(0)).unwrap();
+    }
+
+    #[test]
+    fn bounded_response_validation_rejects_identity_and_scope_mismatches() {
+        let selector = ContextSelector::doc_id(1);
+        let record = test_record(1, "session", "source.jsonl", 1);
+        let mut budget = ReadBudget::from_remaining(Some(4));
+        let mut bounded = apply_record_budget(record, &mut budget, None, 0).unwrap();
+
+        bounded.record_id = "rid1_wrong".to_string();
+        assert!(validate_bounded_record(&bounded, &selector, Some(4)).is_err());
+
+        bounded.record_id = canonical_record_id(&bounded.record);
+        bounded.record.doc_id = 2;
+        assert!(validate_bounded_record(&bounded, &selector, Some(4)).is_err());
+
+        let request = SessionPageRequest {
+            session_id: "session".to_string(),
+            source_path: "source.jsonl".to_string(),
+            offset: 0,
+            limit: 1,
+        };
+        bounded.record.doc_id = 1;
+        bounded.record_id = canonical_record_id(&bounded.record);
+        bounded.record.session_id = "other".to_string();
+        let page = BoundedSessionPage {
+            session_id: request.session_id.clone(),
+            source_path: request.source_path.clone(),
+            cwd: None,
+            offset: 0,
+            total: 1,
+            next_offset: None,
+            records: vec![bounded],
+        };
+        assert!(validate_bounded_session_pages(&[page], &[request], Some(4)).is_err());
     }
 
     #[test]

--- a/src/read_budget.rs
+++ b/src/read_budget.rs
@@ -1,0 +1,427 @@
+use anyhow::{Result, anyhow};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::types::Record;
+
+pub const DEFAULT_MAX_CHARS: usize = 16_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+#[value(rename_all = "kebab-case")]
+pub enum ReadField {
+    Text,
+    #[value(alias = "tool_input")]
+    ToolInput,
+    #[value(alias = "tool_output")]
+    ToolOutput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentContinuation {
+    pub field: ReadField,
+    pub offset_chars: usize,
+    pub total_chars: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentPage {
+    pub returned_chars: usize,
+    pub total_chars: usize,
+    pub truncated: bool,
+    pub continuations: Vec<ContentContinuation>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadBudget {
+    remaining: Option<usize>,
+}
+
+impl ReadBudget {
+    pub fn new(max_chars: Option<usize>) -> Result<Self> {
+        if max_chars == Some(0) {
+            return Err(anyhow!("max_chars must be greater than zero"));
+        }
+        Ok(Self {
+            remaining: max_chars,
+        })
+    }
+
+    /// Internal continuation budgets may already be exhausted. User-facing limits
+    /// must go through `new` so an explicit zero remains an error.
+    pub(crate) fn from_remaining(remaining: Option<usize>) -> Self {
+        Self { remaining }
+    }
+
+    pub fn remaining(&self) -> Option<usize> {
+        self.remaining
+    }
+
+    pub fn apply(
+        &mut self,
+        record: &mut Record,
+        field: Option<ReadField>,
+        offset_chars: usize,
+    ) -> Result<ContentPage> {
+        if field.is_none() && offset_chars != 0 {
+            return Err(anyhow!(
+                "offset_chars requires an explicitly selected field"
+            ));
+        }
+
+        match field {
+            Some(field) => self.apply_field(record, field, offset_chars),
+            None => Ok(self.apply_all(record)),
+        }
+    }
+
+    fn apply_field(
+        &mut self,
+        record: &mut Record,
+        field: ReadField,
+        offset_chars: usize,
+    ) -> Result<ContentPage> {
+        let original = match field {
+            ReadField::Text => Some(record.text.as_str()),
+            ReadField::ToolInput => record.tool_input.as_deref(),
+            ReadField::ToolOutput => record.tool_output.as_deref(),
+        };
+        let total_chars = original.map_or(0, char_count);
+        if offset_chars > total_chars {
+            return Err(anyhow!(
+                "offset_chars {offset_chars} is past the end of {field:?} ({total_chars} chars)"
+            ));
+        }
+
+        let available = self.remaining.unwrap_or(usize::MAX);
+        let returned_chars = available.min(total_chars - offset_chars);
+        let selected = original.map(|value| char_range(value, offset_chars, returned_chars));
+
+        record.text.clear();
+        record.tool_input = None;
+        record.tool_output = None;
+        match field {
+            ReadField::Text => record.text = selected.unwrap_or_default(),
+            ReadField::ToolInput => record.tool_input = selected,
+            ReadField::ToolOutput => record.tool_output = selected,
+        }
+        self.consume(returned_chars);
+
+        let next_offset = offset_chars + returned_chars;
+        let continuations = if next_offset < total_chars {
+            vec![ContentContinuation {
+                field,
+                offset_chars: next_offset,
+                total_chars,
+            }]
+        } else {
+            Vec::new()
+        };
+        Ok(ContentPage {
+            returned_chars,
+            total_chars,
+            truncated: !continuations.is_empty(),
+            continuations,
+        })
+    }
+
+    fn apply_all(&mut self, record: &mut Record) -> ContentPage {
+        let text = std::mem::take(&mut record.text);
+        let tool_input = record.tool_input.take();
+        let tool_output = record.tool_output.take();
+
+        let fields = [
+            (ReadField::Text, Some(text)),
+            (ReadField::ToolInput, tool_input),
+            (ReadField::ToolOutput, tool_output),
+        ];
+        let total_chars = fields
+            .iter()
+            .filter_map(|(_, value)| value.as_deref())
+            .map(char_count)
+            .sum();
+        let mut available = self.remaining.unwrap_or(usize::MAX);
+        let mut returned_chars = 0;
+        let mut continuations = Vec::new();
+
+        for (field, original) in fields {
+            let page = original.map(|value| {
+                let field_total = char_count(&value);
+                let take = available.min(field_total);
+                available -= take;
+                returned_chars += take;
+                if take < field_total {
+                    continuations.push(ContentContinuation {
+                        field,
+                        offset_chars: take,
+                        total_chars: field_total,
+                    });
+                }
+                char_range(&value, 0, take)
+            });
+
+            match field {
+                ReadField::Text => record.text = page.unwrap_or_default(),
+                ReadField::ToolInput => record.tool_input = page,
+                ReadField::ToolOutput => record.tool_output = page,
+            }
+        }
+        self.consume(returned_chars);
+
+        ContentPage {
+            returned_chars,
+            total_chars,
+            truncated: !continuations.is_empty(),
+            continuations,
+        }
+    }
+
+    fn consume(&mut self, chars: usize) {
+        if let Some(remaining) = &mut self.remaining {
+            *remaining -= chars;
+        }
+    }
+}
+
+fn char_count(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn char_range(value: &str, offset_chars: usize, length_chars: usize) -> String {
+    value
+        .chars()
+        .skip(offset_chars)
+        .take(length_chars)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{RecordLinks, SourceKind};
+
+    fn record(text: &str, tool_input: Option<&str>, tool_output: Option<&str>) -> Record {
+        Record {
+            source: SourceKind::Codex,
+            doc_id: 1,
+            ts: 2,
+            project: "project".into(),
+            session_id: "session".into(),
+            turn_id: 3,
+            role: "assistant".into(),
+            text: text.into(),
+            tool_name: None,
+            tool_input: tool_input.map(str::to_owned),
+            tool_output: tool_output.map(str::to_owned),
+            links: RecordLinks::default(),
+            source_path: "source".into(),
+        }
+    }
+
+    #[test]
+    fn defaults_to_a_sixteen_thousand_character_limit() {
+        let mut value = record(&"x".repeat(DEFAULT_MAX_CHARS + 1), None, None);
+        let mut budget = ReadBudget::new(Some(DEFAULT_MAX_CHARS)).unwrap();
+
+        let page = budget.apply(&mut value, None, 0).unwrap();
+
+        assert_eq!(value.text.chars().count(), DEFAULT_MAX_CHARS);
+        assert_eq!(page.returned_chars, DEFAULT_MAX_CHARS);
+        assert_eq!(page.total_chars, DEFAULT_MAX_CHARS + 1);
+        assert!(page.truncated);
+        assert_eq!(
+            page.continuations,
+            [ContentContinuation {
+                field: ReadField::Text,
+                offset_chars: DEFAULT_MAX_CHARS,
+                total_chars: DEFAULT_MAX_CHARS + 1,
+            }]
+        );
+        assert_eq!(budget.remaining(), Some(0));
+    }
+
+    #[test]
+    fn unicode_offsets_are_scalar_character_offsets() {
+        let mut value = record("aé🦀z", Some("ignored"), Some("ignored"));
+        let mut budget = ReadBudget::new(Some(2)).unwrap();
+
+        let page = budget.apply(&mut value, Some(ReadField::Text), 1).unwrap();
+
+        assert_eq!(value.text, "é🦀");
+        assert_eq!(value.tool_input, None);
+        assert_eq!(value.tool_output, None);
+        assert_eq!(page.returned_chars, 2);
+        assert_eq!(page.total_chars, 4);
+        assert_eq!(page.continuations[0].offset_chars, 3);
+    }
+
+    #[test]
+    fn one_budget_crosses_fields_and_marks_unreached_fields() {
+        let mut value = record("abc", Some("de"), Some("fghi"));
+        let mut budget = ReadBudget::new(Some(6)).unwrap();
+
+        let page = budget.apply(&mut value, None, 0).unwrap();
+
+        assert_eq!(value.text, "abc");
+        assert_eq!(value.tool_input.as_deref(), Some("de"));
+        assert_eq!(value.tool_output.as_deref(), Some("f"));
+        assert_eq!(page.returned_chars, 6);
+        assert_eq!(page.total_chars, 9);
+        assert_eq!(
+            page.continuations,
+            [ContentContinuation {
+                field: ReadField::ToolOutput,
+                offset_chars: 1,
+                total_chars: 4,
+            }]
+        );
+    }
+
+    #[test]
+    fn zero_remaining_emits_empty_values_and_continuations_from_zero() {
+        let mut first = record("a", None, None);
+        let mut second = record("bc", Some("de"), Some(""));
+        let mut budget = ReadBudget::new(Some(1)).unwrap();
+        budget.apply(&mut first, None, 0).unwrap();
+
+        let page = budget.apply(&mut second, None, 0).unwrap();
+
+        assert_eq!(second.text, "");
+        assert_eq!(second.tool_input.as_deref(), Some(""));
+        assert_eq!(second.tool_output.as_deref(), Some(""));
+        assert_eq!(page.returned_chars, 0);
+        assert_eq!(page.total_chars, 4);
+        assert_eq!(
+            page.continuations,
+            [
+                ContentContinuation {
+                    field: ReadField::Text,
+                    offset_chars: 0,
+                    total_chars: 2,
+                },
+                ContentContinuation {
+                    field: ReadField::ToolInput,
+                    offset_chars: 0,
+                    total_chars: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn absent_and_empty_optional_fields_remain_distinct() {
+        let mut absent = record("", None, None);
+        let mut empty = record("", Some(""), Some(""));
+        let mut budget = ReadBudget::new(Some(1)).unwrap();
+
+        budget.apply(&mut absent, None, 0).unwrap();
+        budget.apply(&mut empty, None, 0).unwrap();
+
+        assert_eq!(absent.tool_input, None);
+        assert_eq!(absent.tool_output, None);
+        assert_eq!(empty.tool_input.as_deref(), Some(""));
+        assert_eq!(empty.tool_output.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn budget_is_shared_across_records() {
+        let mut first = record("abc", None, None);
+        let mut second = record("def", None, None);
+        let mut budget = ReadBudget::new(Some(5)).unwrap();
+
+        let first_page = budget.apply(&mut first, None, 0).unwrap();
+        let second_page = budget.apply(&mut second, None, 0).unwrap();
+
+        assert_eq!(first.text, "abc");
+        assert!(!first_page.truncated);
+        assert_eq!(second.text, "de");
+        assert!(second_page.truncated);
+        assert_eq!(budget.remaining(), Some(0));
+    }
+
+    #[test]
+    fn exact_limit_empty_and_full_modes_are_complete() {
+        let mut exact = record("abc", Some("de"), None);
+        let mut exact_budget = ReadBudget::new(Some(5)).unwrap();
+        let exact_page = exact_budget.apply(&mut exact, None, 0).unwrap();
+        assert!(!exact_page.truncated);
+        assert_eq!(exact_budget.remaining(), Some(0));
+
+        let mut empty = record("", Some(""), None);
+        let empty_page = exact_budget.apply(&mut empty, None, 0).unwrap();
+        assert_eq!(empty_page.returned_chars, 0);
+        assert!(!empty_page.truncated);
+
+        let mut full = record("αβ", Some("γ"), Some("δ"));
+        let original = full.clone();
+        let mut full_budget = ReadBudget::new(None).unwrap();
+        let full_page = full_budget.apply(&mut full, None, 0).unwrap();
+        assert_eq!(full.text, original.text);
+        assert_eq!(full.tool_input, original.tool_input);
+        assert_eq!(full.tool_output, original.tool_output);
+        assert_eq!(full_page.returned_chars, 4);
+        assert!(!full_page.truncated);
+        assert_eq!(full_budget.remaining(), None);
+    }
+
+    #[test]
+    fn continuations_reconstruct_each_field_without_loss_or_duplication() {
+        let original = record("ab🦀", Some("déf"), Some("ghij"));
+        for field in [ReadField::Text, ReadField::ToolInput, ReadField::ToolOutput] {
+            let expected = match field {
+                ReadField::Text => original.text.as_str(),
+                ReadField::ToolInput => original.tool_input.as_deref().unwrap(),
+                ReadField::ToolOutput => original.tool_output.as_deref().unwrap(),
+            };
+            let mut offset = 0;
+            let mut reconstructed = String::new();
+
+            loop {
+                let mut value = original.clone();
+                let mut budget = ReadBudget::new(Some(2)).unwrap();
+                let page = budget.apply(&mut value, Some(field), offset).unwrap();
+                reconstructed.push_str(match field {
+                    ReadField::Text => &value.text,
+                    ReadField::ToolInput => value.tool_input.as_deref().unwrap(),
+                    ReadField::ToolOutput => value.tool_output.as_deref().unwrap(),
+                });
+                let Some(continuation) = page.continuations.first() else {
+                    break;
+                };
+                offset = continuation.offset_chars;
+            }
+
+            assert_eq!(reconstructed, expected);
+        }
+    }
+
+    #[test]
+    fn rejects_zero_limit_and_invalid_offsets() {
+        assert!(ReadBudget::new(Some(0)).is_err());
+
+        let mut value = record("abc", None, None);
+        let mut budget = ReadBudget::new(Some(1)).unwrap();
+        assert!(budget.apply(&mut value, None, 1).is_err());
+        assert!(budget.apply(&mut value, Some(ReadField::Text), 4).is_err());
+
+        let page = budget.apply(&mut value, Some(ReadField::Text), 3).unwrap();
+        assert_eq!(value.text, "");
+        assert_eq!(page.returned_chars, 0);
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn field_names_serialize_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ReadField::ToolInput).unwrap(),
+            "\"tool_input\""
+        );
+        assert_eq!(
+            ReadField::ToolOutput
+                .to_possible_value()
+                .unwrap()
+                .get_name(),
+            "tool-output"
+        );
+    }
+}

--- a/tests/retrieval_cli.rs
+++ b/tests/retrieval_cli.rs
@@ -111,3 +111,297 @@ fn search_defaults_to_compact_match_centered_references_and_full_is_explicit() {
     assert_eq!(projected[0].as_object().unwrap().len(), 2);
     assert_eq!(projected[0]["text"], records[1].text);
 }
+
+#[test]
+fn stable_record_reads_continue_without_losing_unicode() {
+    let (root, records) = fixture();
+    let id = canonical_record_id(&records[0]);
+    let first = values(
+        root.path(),
+        &["show", "--record-id", &id, "--max-chars", "2"],
+    );
+    assert_eq!(first[0]["record"]["text"], "αβ");
+    assert_eq!(first[0]["content"]["returned_chars"], 2);
+    assert_eq!(first[0]["content"]["continuations"][0]["offset_chars"], 2);
+    let second = values(
+        root.path(),
+        &[
+            "show",
+            "--record-id",
+            &id,
+            "--field",
+            "text",
+            "--offset-chars",
+            "2",
+            "--max-chars",
+            "3",
+        ],
+    );
+    assert_eq!(second[0]["record"]["text"], "γδε");
+    assert_eq!(second[0]["content"]["truncated"], false);
+    let full = values(root.path(), &["show", "2", "--full"]);
+    assert_eq!(full[0]["record"]["text"], records[1].text);
+    let default = values(root.path(), &["show", "2"]);
+    assert_eq!(
+        default[0]["record"]["text"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count(),
+        16_000
+    );
+    assert_eq!(default[0]["content"]["truncated"], true);
+    assert!(
+        !run(root.path(), &["show", "1", "--max-chars", "0"])
+            .status
+            .success()
+    );
+    assert!(
+        !run(
+            root.path(),
+            &["show", "1", "--field", "text", "--offset-chars", "6"]
+        )
+        .status
+        .success()
+    );
+}
+
+#[test]
+fn session_and_context_page_metadata_preserve_unread_records() {
+    let (root, _) = fixture();
+    let session = values(root.path(), &["session", "session", "--max-chars", "5"]);
+    assert_eq!(session.len(), 2);
+    assert_eq!(session[0]["record"]["doc_id"], 1);
+    assert_eq!(session[1]["type"], "page");
+    assert_eq!(session[1]["next_offset"], 1);
+    let next = values(
+        root.path(),
+        &["session", "session", "--offset", "1", "--max-chars", "4"],
+    );
+    assert_eq!(next[0]["record"]["doc_id"], 2);
+    assert_eq!(next[0]["content"]["continuations"][0]["offset_chars"], 4);
+    assert_eq!(next[1]["next_offset"], 2);
+    let context = values(
+        root.path(),
+        &[
+            "context",
+            "--doc-id",
+            "2",
+            "--machine",
+            "local",
+            "--max-chars",
+            "5",
+        ],
+    );
+    assert_eq!(context[0]["records"].as_array().unwrap().len(), 1);
+    assert_eq!(context[0]["records"][0]["record"]["doc_id"], 2);
+    assert_eq!(context[0]["order"], "anchor_first");
+    assert_eq!(context[0]["next_offset"], 1);
+    assert_eq!(context[0]["total"], 3);
+    let next = values(root.path(), &["context", "--doc-id", "2", "--offset", "2"]);
+    assert_eq!(next[0]["records"][0]["record"]["doc_id"], 3);
+    assert!(next[0]["next_offset"].is_null());
+    let full = values(root.path(), &["session", "session", "--full"]);
+    assert_eq!(full.len(), 3);
+    assert!(full.iter().all(|item| item.get("type").is_none()));
+}
+
+#[test]
+fn hydrate_applies_one_budget_in_input_order_and_preserves_continuation() {
+    let (root, _) = fixture();
+    let request = root.path().join("requests.jsonl");
+    std::fs::write(&request, "{\"session_id\":\"session\",\"offset\":0,\"limit\":3}\n{\"session_id\":\"session\",\"offset\":2,\"limit\":1}\n").unwrap();
+    let out = values(
+        root.path(),
+        &["hydrate", request.to_str().unwrap(), "--max-chars", "7"],
+    );
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0]["records"].as_array().unwrap().len(), 2);
+    assert_eq!(out[0]["records"][1]["text"], "pa");
+    assert_eq!(out[0]["next_offset"], 2);
+    assert_eq!(out[1]["records"], serde_json::json!([]));
+    assert_eq!(out[1]["next_offset"], 2);
+}
+
+#[test]
+fn cli_rejects_conflicting_or_ambiguous_read_options() {
+    let (root, _) = fixture();
+    for args in [
+        vec!["show", "1", "--record-id", "rid1_other"],
+        vec!["show", "1", "--full", "--max-chars", "2"],
+        vec!["search", "needle", "--full", "--fields", "text"],
+    ] {
+        assert!(
+            !run(root.path(), &args).status.success(),
+            "accepted {args:?}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn remote_context_and_stable_reads_use_the_originating_machine() {
+    use std::os::unix::fs::PermissionsExt;
+    let (remote, records) = fixture();
+    let local = tempfile::tempdir().unwrap();
+    let fake_bin = tempfile::tempdir().unwrap();
+    let binary = env!("CARGO_BIN_EXE_memex");
+    let command = binary.replace('\\', "\\\\").replace('"', "\\\"");
+    std::fs::write(
+        local.path().join("config.toml"),
+        format!(
+            r#"auto_index_on_search = false
+[multi_machine]
+timeout_seconds = 10
+[[machines]]
+id = "remote"
+command = "{command}"
+[machines.control]
+type = "ssh"
+host = "fixture-host"
+[machines.index]
+type = "remote"
+"#
+        ),
+    )
+    .unwrap();
+    let ssh = fake_bin.path().join("ssh");
+    std::fs::write(
+        &ssh,
+        r#"#!/bin/sh
+for argument in "$@"; do
+  remote_command="$argument"
+done
+exec sh -c "$remote_command --root \"$MEMEX_TEST_REMOTE_ROOT\""
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin.path().to_path_buf()];
+    paths.extend(std::env::split_paths(&inherited));
+    let path = std::env::join_paths(paths).unwrap();
+    let id = canonical_record_id(&records[1]);
+    for args in [
+        vec![
+            "context",
+            "--record-id",
+            &id,
+            "--before",
+            "0",
+            "--after",
+            "0",
+        ],
+        vec!["show", "--record-id", &id],
+        vec!["show", "2"],
+    ] {
+        let output = Command::new(binary)
+            .args(&args)
+            .args(["--machine", "remote", "--max-chars", "4", "--root"])
+            .arg(local.path())
+            .env("PATH", &path)
+            .env("MEMEX_TEST_REMOTE_ROOT", remote.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(value["machine"], "remote");
+        let item = if args[0] == "context" {
+            &value["records"][0]
+        } else {
+            &value
+        };
+        assert_eq!(item["record_id"], id);
+        assert_eq!(item["record"]["text"], "padd");
+        assert_eq!(item["content"]["truncated"], true);
+    }
+}
+
+#[test]
+fn tool_payload_continuations_can_be_used_directly_as_field_selectors() {
+    let (root, _) = fixture();
+    let paths = Paths::new(Some(root.path().to_path_buf())).unwrap();
+    let index = SearchIndex::open_or_create(&paths.index).unwrap();
+    let mut tool = record(4, "abc".into());
+    tool.tool_input = Some("λμν".into());
+    tool.tool_output = Some("result".into());
+    let mut writer = index.writer().unwrap();
+    index.add_record(&mut writer, &tool).unwrap();
+    writer.commit().unwrap();
+    drop(writer);
+    let page = values(root.path(), &["show", "4", "--max-chars", "4"]);
+    assert_eq!(page[0]["record"]["text"], "abc");
+    assert_eq!(page[0]["record"]["tool_input"], "λ");
+    let next = &page[0]["content"]["continuations"][0];
+    let offset = next["offset_chars"].to_string();
+    let second = values(
+        root.path(),
+        &[
+            "show",
+            "4",
+            "--field",
+            next["field"].as_str().unwrap(),
+            "--offset-chars",
+            &offset,
+        ],
+    );
+    assert_eq!(second[0]["record"]["tool_input"], "μν");
+    assert_eq!(second[0]["content"]["truncated"], false);
+}
+
+#[test]
+fn rpc_serializes_bounded_bodies_before_transport() {
+    use std::io::Write;
+    use std::process::Stdio;
+    let (root, records) = fixture();
+    let selector = serde_json::to_value(memex::retrieval::ContextSelector::doc_id(2)).unwrap();
+    for request in [
+        serde_json::json!({"op":"read_record","selector":selector,"field":"text","offset_chars":0,"max_chars":4}),
+        serde_json::json!({"op":"read_context","selector":selector,"options":{"before":1,"after":1,"expand_interactions":false},"offset":0,"max_chars":4}),
+        serde_json::json!({"op":"read_session_pages","requests":[{"session_id":"session","source_path":"","offset":1,"limit":2}],"max_chars":4}),
+    ] {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_memex"))
+            .args(["rpc", "--root"])
+            .arg(root.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(
+                serde_json::to_string(&serde_json::json!({"protocol":1,"request":request}))
+                    .unwrap()
+                    .as_bytes(),
+            )
+            .unwrap();
+        let out = child.wait_with_output().unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.stdout.len() < 3000,
+            "bounded response included a large body"
+        );
+        let value: Value = serde_json::from_slice(&out.stdout).unwrap();
+        let payload = &value["response"];
+        let item = match payload["kind"].as_str().unwrap() {
+            "bounded_record" => &payload["record"],
+            "bounded_context" => &payload["context"]["records"][0],
+            "bounded_session_pages" => &payload["pages"][0]["records"][0],
+            other => panic!("unexpected {other}: {payload}"),
+        };
+        assert_eq!(item["record_id"], canonical_record_id(&records[1]));
+        assert_eq!(item["record"]["text"], "padd");
+        assert_eq!(item["content"]["continuations"][0]["offset_chars"], 4);
+    }
+}


### PR DESCRIPTION
Opening one large record or session can consume an agent's context window. `show`, `session`, `context`, and `hydrate` now share a default limit of 16,000 content characters per command. Session reads return at most 50 records by default.

Responses say what was truncated and provide offsets to continue a field or fetch the next page. Use `--max-chars` to choose the limit or `--full` for complete content. Context returns the requested record first so earlier messages cannot consume its budget.

Stable record IDs and `--machine` work for show/context, and remote peers apply read limits before sending content. Bounded remote reads require an updated peer. The character limit covers text and tool payloads; JSON metadata is excluded.
