### PR TITLE
Report judged answer accuracy against context token cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,3 +659,19 @@ description = "memex session palette"
 
 The plugin is listed in the herdr marketplace through the `herdr-plugin` GitHub topic on this
 repo.
+
+### Retrieval workflow evaluation
+
+`memex eval-retrieval dataset.jsonl --outcomes outcomes.jsonl` adds an optional workflow
+outcome summary to the existing search-ranking metrics. Supply externally judged outcomes
+and measured context-token counts, keyed by the dataset case's `id`:
+
+```json
+{"case_id":"investigation-a","correct_conclusion":true,"context_tokens":2000}
+{"case_id":"investigation-b","correct_conclusion":false,"context_tokens":3000}
+```
+
+The `outcomes` object reports evaluated-case coverage, accuracy, total context tokens,
+and correct conclusions per 1,000 context tokens. Missing judgments are not counted as
+failures or successes. Unknown/duplicate case IDs and zero token counts are rejected.
+Memex does not generate correctness judgments or estimate tokens from character counts.

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -499,6 +499,12 @@ memex search "query" --trace
 memex eval-retrieval <dataset.jsonl> --k 20
 ```
 
+For workflow evaluation with externally judged answers, use
+`memex eval-retrieval dataset.jsonl --outcomes outcomes.jsonl`. Each outcome names a dataset
+case ID and records `correct_conclusion` plus measured `context_tokens`. The optional
+summary reports judged-case coverage, accuracy, and correct conclusions per 1,000 context
+tokens; it does not infer judgments or treat unjudged cases as failures.
+
 Tracing records retrieval metadata without transcript contents. Evaluation reports recall, MRR, nDCG, and session diversity against JSONL relevance cases.
 
 ### Index freshness / embeddings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,8 @@ use crate::retrieval::canonical_record_id;
 use crate::retrieval::{ContextOptions, ContextSelector};
 use crate::retrieval_eval::{
     EvaluationDataset, RetrievalTrace, RetrievalTraceMetadata, TraceQuery, append_trace,
-    fuse_ranked_queries, mean_reciprocal_rank, ndcg_at_k, recall_at_k, unique_sessions_at_k,
+    evaluate_outcomes, fuse_ranked_queries, mean_reciprocal_rank, ndcg_at_k, recall_at_k,
+    unique_sessions_at_k,
 };
 use crate::transfer::{
     TransferMode as CoreTransferMode, TransferOptions, TransferTarget as CoreTransferTarget,
@@ -458,6 +459,9 @@ The input contains at most 32 requests; each page is limited to 500 records."
         /// Cutoff used for recall and nDCG metrics
         #[arg(long, default_value_t = 20)]
         k: usize,
+        /// Optional JSONL of externally judged conclusions and measured context tokens
+        #[arg(long)]
+        outcomes: Option<PathBuf>,
         /// Path to memex data directory [default: ~/.memex]
         #[arg(long)]
         root: Option<PathBuf>,
@@ -1145,8 +1149,13 @@ pub fn run() -> Result<()> {
                 root,
             })?;
         }
-        Commands::EvalRetrieval { dataset, k, root } => {
-            run_eval_retrieval(dataset, k, root)?;
+        Commands::EvalRetrieval {
+            dataset,
+            k,
+            outcomes,
+            root,
+        } => {
+            run_eval_retrieval(dataset, k, outcomes, root)?;
         }
         Commands::Sessions {
             cwd,
@@ -2264,8 +2273,17 @@ fn hydrate_error_value(machine: &str, request: &SessionPageRequest, error: &str)
     })?)
 }
 
-fn run_eval_retrieval(dataset_path: PathBuf, k: usize, root: Option<PathBuf>) -> Result<()> {
+fn run_eval_retrieval(
+    dataset_path: PathBuf,
+    k: usize,
+    outcomes: Option<PathBuf>,
+    root: Option<PathBuf>,
+) -> Result<()> {
     let dataset = EvaluationDataset::read_jsonl(&dataset_path)?;
+    let outcomes = outcomes
+        .as_deref()
+        .map(|path| evaluate_outcomes(path, &dataset.cases))
+        .transpose()?;
     let paths = Paths::new(root)?;
     let index = SearchIndex::open_or_create(&paths.index)?;
     let mut result_lists = Vec::with_capacity(dataset.cases.len());
@@ -2327,18 +2345,15 @@ fn run_eval_retrieval(dataset_path: PathBuf, k: usize, root: Option<PathBuf>) ->
         .map(|results| unique_sessions_at_k(results, k))
         .sum::<usize>() as f64
         / dataset.cases.len() as f64;
-    println!(
-        "{}",
-        serde_json::json!({
-            "cases": dataset.cases.len(),
-            "k": k,
-            "mrr": mrr,
-            "recall_at_k": recall,
-            "ndcg_at_k": ndcg,
-            "mean_unique_sessions_at_k": unique_sessions,
-        })
-    );
-    Ok(())
+    let mut report = serde_json::json!({
+        "cases": dataset.cases.len(), "k": k, "mrr": mrr,
+        "recall_at_k": recall, "ndcg_at_k": ndcg,
+        "mean_unique_sessions_at_k": unique_sessions,
+    });
+    if let Some(outcomes) = outcomes {
+        report["outcomes"] = serde_json::to_value(outcomes)?;
+    }
+    print_json(&report, false)
 }
 
 struct SessionRunArgs {

--- a/src/retrieval_eval.rs
+++ b/src/retrieval_eval.rs
@@ -329,6 +329,70 @@ pub struct EvaluationCase {
     pub relevant: Vec<EvaluationRelevance>,
 }
 
+/// Measured workflow outcomes are supplied by an external evaluator, never inferred
+/// from relevance scores or estimated from character counts.
+#[derive(Debug, Serialize)]
+pub struct OutcomeSummary {
+    pub evaluated_cases: usize,
+    pub correct_conclusions: usize,
+    pub total_context_tokens: u64,
+    pub accuracy: f64,
+    pub correct_conclusions_per_1000_context_tokens: f64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JudgedOutcome {
+    case_id: String,
+    correct_conclusion: bool,
+    context_tokens: u64,
+}
+
+pub fn evaluate_outcomes(path: &Path, cases: &[EvaluationCase]) -> Result<OutcomeSummary> {
+    use std::io::BufRead;
+    let mut known = HashSet::new();
+    for id in cases.iter().filter_map(|case| case.id.as_deref()) {
+        if id.trim().is_empty() || !known.insert(id) {
+            bail!("outcome evaluation requires unique non-empty dataset case IDs");
+        }
+    }
+    let reader = std::io::BufReader::new(fs::File::open(path)?);
+    let mut seen = HashSet::new();
+    let mut correct = 0;
+    let mut tokens = 0u64;
+    for (line, raw) in reader.lines().enumerate() {
+        let raw = raw?;
+        if raw.trim().is_empty() {
+            continue;
+        }
+        let outcome: JudgedOutcome = serde_json::from_str(&raw)
+            .with_context(|| format!("parse outcome line {}", line + 1))?;
+        if !known.contains(outcome.case_id.as_str()) {
+            bail!("unknown outcome case ID: {}", outcome.case_id);
+        }
+        if !seen.insert(outcome.case_id.clone()) {
+            bail!("duplicate outcome case ID: {}", outcome.case_id);
+        }
+        if outcome.context_tokens == 0 {
+            bail!("context_tokens must be positive for {}", outcome.case_id);
+        }
+        tokens = tokens
+            .checked_add(outcome.context_tokens)
+            .ok_or_else(|| anyhow!("outcome context token total overflows u64"))?;
+        correct += usize::from(outcome.correct_conclusion);
+    }
+    if seen.is_empty() {
+        bail!("outcome file contains no judgments");
+    }
+    Ok(OutcomeSummary {
+        evaluated_cases: seen.len(),
+        correct_conclusions: correct,
+        total_context_tokens: tokens,
+        accuracy: correct as f64 / seen.len() as f64,
+        correct_conclusions_per_1000_context_tokens: correct as f64 * 1000.0 / tokens as f64,
+    })
+}
+
 impl EvaluationCase {
     pub fn query_views(&self) -> Result<Vec<String>> {
         if self.query.is_some() && !self.queries.is_empty() {
@@ -691,6 +755,41 @@ mod tests {
             doc_id: result.record.doc_id,
             record_id: None,
             relevance: value,
+        }
+    }
+
+    #[test]
+    fn outcomes_use_only_judged_cases_and_measured_tokens() {
+        let cases: Vec<EvaluationCase> = ["a", "b", "unjudged"]
+            .into_iter()
+            .map(|id| EvaluationCase {
+                id: Some(id.into()),
+                query: Some("needle".into()),
+                queries: vec![],
+                cwd: None,
+                relevant: vec![],
+            })
+            .collect();
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), "{\"case_id\":\"a\",\"correct_conclusion\":true,\"context_tokens\":2000}\n{\"case_id\":\"b\",\"correct_conclusion\":false,\"context_tokens\":3000}\n").unwrap();
+        let summary = evaluate_outcomes(file.path(), &cases).unwrap();
+        assert_eq!(summary.evaluated_cases, 2);
+        assert_eq!(summary.correct_conclusions, 1);
+        assert_eq!(summary.total_context_tokens, 5000);
+        assert_eq!(summary.accuracy, 0.5);
+        assert_eq!(summary.correct_conclusions_per_1000_context_tokens, 0.2);
+        for invalid in [
+            "",
+            "{}",
+            "{\"case_id\":\"missing\",\"correct_conclusion\":true,\"context_tokens\":1}",
+            "{\"case_id\":\"a\",\"correct_conclusion\":true,\"context_tokens\":0}",
+            "{\"case_id\":\"a\",\"correct_conclusion\":true,\"context_tokens\":1}\n{\"case_id\":\"a\",\"correct_conclusion\":false,\"context_tokens\":1}",
+        ] {
+            fs::write(file.path(), invalid).unwrap();
+            assert!(
+                evaluate_outcomes(file.path(), &cases).is_err(),
+                "accepted {invalid}"
+            );
         }
     }
 

--- a/tests/retrieval_cli.rs
+++ b/tests/retrieval_cli.rs
@@ -354,6 +354,44 @@ fn tool_payload_continuations_can_be_used_directly_as_field_selectors() {
 }
 
 #[test]
+fn retrieval_evaluation_reports_supplied_outcomes_separately_from_search_metrics() {
+    let (root, _) = fixture();
+    let dataset = root.path().join("evaluation.jsonl");
+    let outcomes = root.path().join("outcomes.jsonl");
+    let qrel = serde_json::json!({ "machine":"local", "source":"codex", "session_id":"session", "source_path":"/tmp/fixture.jsonl", "doc_id":2 });
+    std::fs::write(
+        &dataset,
+        format!(
+            "{}\n{}\n",
+            serde_json::json!({"id":"case-a","query":"late_needle","relevant":[qrel]}),
+            serde_json::json!({"id":"case-b","query":"late_needle","relevant":[qrel]})
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        &outcomes,
+        "{\"case_id\":\"case-a\",\"correct_conclusion\":true,\"context_tokens\":2000}\n",
+    )
+    .unwrap();
+    let report = values(
+        root.path(),
+        &[
+            "eval-retrieval",
+            dataset.to_str().unwrap(),
+            "--outcomes",
+            outcomes.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(report[0]["cases"], 2);
+    assert_eq!(report[0]["outcomes"]["evaluated_cases"], 1);
+    assert_eq!(report[0]["outcomes"]["accuracy"], 1.0);
+    assert_eq!(
+        report[0]["outcomes"]["correct_conclusions_per_1000_context_tokens"],
+        0.5
+    );
+}
+
+#[test]
 fn rpc_serializes_bounded_bodies_before_transport() {
     use std::io::Write;
     use std::process::Stdio;


### PR DESCRIPTION
Search ranking scores do not show whether retrieved history helped an agent reach the right answer. `eval-retrieval --outcomes outcomes.jsonl` optionally adds answer accuracy and correct answers per 1,000 context tokens alongside the existing ranking metrics.

The input supplies an externally judged result and measured token count for each case. Memex does not judge answers or estimate tokens, and it leaves unjudged cases out of the outcome metrics.
