### PR TITLE
Offer startup updates and refresh installed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,34 @@ The shared `memex-search` skill is installed once at
 For Claude Code, use `memex skill install --target claude`; its copy lives at
 `~/.claude/skills/memex-search/SKILL.md`.
 
-Use `memex skill status` to compare installed copies with the current Memex binary,
-`memex skill update` after upgrading Memex, and `memex skill cleanup` to explicitly
-remove obsolete paths left by older releases. Install never overwrites a differing file;
-update only replaces copies that are already installed.
+Launching `memex` in a human terminal offers an update when a newer release is
+available. Press Enter to update Memex and refresh its installed skill copies, or
+choose no to continue into the TUI. Homebrew installs run `brew update` followed by
+`brew upgrade nicosuave/tap/memex`; skills are refreshed by the newly installed binary.
+After updating, run `memex` again to start that version.
 
-Restart Claude, Codex, OpenCode, Pi, or Oh My Pi after installing or updating the skill.
+Agents and scripts still receive update notices but never a startup prompt. Memex
+recognizes CI, Codex, and Claude Code environment markers; use `--non-interactive`
+explicitly for other agents, including those using a PTY. Bare noninteractive
+`memex` prints help, while `search` and other data commands run normally. To update:
+
+```bash
+memex update --yes
+```
+
+Without `--yes`, explicit `memex update` requires a human terminal and confirmation.
+Both update paths replace existing shared/Claude skill copies, including local edits;
+they do not install missing copies. Restart your agent after its skill is updated.
+
+Searches warn on stderr when an installed skill differs from the running binary
+(outdated or locally modified). `memex skill status` shows which copies differ;
+`memex skill update` refreshes skills without upgrading Memex. Searches never update
+anything or prompt, and JSONL/TOON output on stdout stays clean. Use
+`memex skill cleanup` to explicitly remove obsolete paths from older releases.
+
+Release checks have a two-second network timeout and are cached for six hours
+(failed checks retry after five minutes). `--no-update-check` skips release checks
+without hiding stale-skill warnings. Install never overwrites a differing skill file.
 
 ## Quickstart
 

--- a/skills/memex-search/SKILL.md
+++ b/skills/memex-search/SKILL.md
@@ -151,6 +151,15 @@ results. Cite session IDs or timestamps where useful, preserve exact resumption
 identifiers, and flag outcomes supported only by narration. Do not invent missing
 turns or expose irrelevant private transcript content.
 
+## Updates
+
+Use `--non-interactive` when invoking Memex from an agent, especially in a PTY.
+Update notices and stale-skill warnings still appear on stderr; searches never prompt
+or update anything. When updating is authorized, run `memex update --yes` to upgrade
+Memex and refresh existing skills. `memex skill status` inspects differing copies;
+`memex skill update` refreshes just the skills. Updates replace local skill edits,
+leave missing copies uninstalled, and require restarting the agent to load changes.
+
 ## Specialized tasks
 
 - For retrieval debugging or relevance evaluation, use `memex search --help` for

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,14 +27,14 @@ use crate::usage::{CostMode, UsageQuery, scan_usage};
 use crate::vector::VectorIndex;
 use anyhow::{Context, Result, anyhow};
 use chrono::SecondsFormat;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::io::{Read, Write};
+use std::io::{IsTerminal, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
@@ -58,6 +58,12 @@ LEARN MORE:
     memex <command> --help          # Detailed help for each command"
 )]
 pub struct Cli {
+    /// Never prompt or open the TUI (agents may use this even with a PTY)
+    #[arg(long, global = true)]
+    non_interactive: bool,
+    /// Skip release availability checks; does not disable stale-skill warnings
+    #[arg(long, global = true)]
+    no_update_check: bool,
     /// Defaults to the interactive TUI when no command is given
     #[command(subcommand)]
     command: Option<Commands>,
@@ -571,9 +577,12 @@ EXAMPLES:
         #[arg(short, long)]
         force: bool,
     },
-    /// Update memex to the latest version
+    /// Update memex and refresh existing memex-search skill copies
+    #[command(
+        after_help = "Use --yes for agents and scripts, including shells with a PTY.\nWithout --yes, update requires a terminal and asks for confirmation.\nExisting skill copies are replaced; missing copies are not installed."
+    )]
     Update {
-        /// Skip confirmation prompt
+        /// Update without prompting (for agents and scripts)
         #[arg(short = 'y', long)]
         yes: bool,
     },
@@ -877,21 +886,55 @@ enum IndexServiceCommand {
 
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
+    let interactive = interaction_allowed(
+        cli.non_interactive,
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+        std::io::stderr().is_terminal(),
+        agent_or_ci_environment(),
+    );
+    let check_updates = !cli.no_update_check;
+    if cli.command.is_none() && !interactive {
+        if check_updates {
+            print_update_notice(available_update().as_deref());
+        }
+        warn_if_skill_outdated();
+        Cli::command().print_help()?;
+        println!();
+        return Ok(());
+    }
     // Bare `memex` opens the TUI home screen.
     let command = cli.command.unwrap_or(Commands::Tui {
         query: None,
         project: None,
         root: None,
     });
+    if !interactive
+        && matches!(
+            command,
+            Commands::Setup { .. }
+                | Commands::Skill {
+                    command: SkillCommand::Install { target: None }
+                }
+        )
+    {
+        return Err(anyhow!(
+            "skill installation requires a destination without interactive selection; use `memex skill install --target shared`, `--target claude`, or `--target all`"
+        ));
+    }
     let should_check = !matches!(
         command,
         Commands::Tui { .. }
             | Commands::Update { .. }
+            | Commands::Skill { .. }
             | Commands::Rpc { .. }
             | Commands::Herdr { .. }
     );
-    if should_check {
-        check_for_update_async(None);
+    if should_check && check_updates {
+        print_update_notice(available_update().as_deref());
+    }
+    if matches!(command, Commands::Search { .. }) {
+        warn_if_skill_outdated();
     }
     match command {
         Commands::Index {
@@ -988,9 +1031,26 @@ pub fn run() -> Result<()> {
             project,
             root,
         } => {
-            let (update_tx, update_rx) = std::sync::mpsc::channel();
-            check_for_update_async(Some(update_tx));
-            tui::run(root, Some(update_rx), query, project)?;
+            if !interactive {
+                return Err(anyhow!(
+                    "TUI requires an interactive human terminal; use `memex search` or `memex sessions` for agent/script output"
+                ));
+            }
+            let latest = check_updates.then(available_update).flatten();
+            if let Some(latest) = latest.as_deref() {
+                print_update_notice(Some(latest));
+                if confirm_update()? {
+                    perform_update(Some(latest))?;
+                    println!("Update finished. Run `memex` again to start the installed version.");
+                    return Ok(());
+                }
+            }
+            let update_rx = latest.map(|latest| {
+                let (tx, rx) = std::sync::mpsc::channel();
+                let _ = tx.send(format!("update: v{latest} (memex update)"));
+                rx
+            });
+            tui::run(root, update_rx, query, project)?;
         }
         Commands::Web { listen, root } => {
             crate::web::serve(root, &listen)?;
@@ -1227,7 +1287,18 @@ pub fn run() -> Result<()> {
             run_skill_install(None, force.then_some(SkillWriteMode::Replace))?;
         }
         Commands::Update { yes } => {
-            run_update(yes)?;
+            if !yes {
+                if !interactive {
+                    return Err(anyhow!(
+                        "update requires confirmation; use `memex update --yes` for a noninteractive update of memex and installed skills"
+                    ));
+                }
+                if !confirm_update()? {
+                    println!("Update cancelled.");
+                    return Ok(());
+                }
+            }
+            perform_update(None)?;
         }
         Commands::Share {
             session_id,
@@ -3222,6 +3293,37 @@ fn run_skill_status(target: SkillTarget) -> Result<()> {
     Ok(())
 }
 
+fn skill_warnings(home: &Path) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let mut differing = Vec::new();
+    for (label, path) in skill_destinations(home, SkillTarget::All) {
+        match std::fs::read(&path) {
+            Ok(contents) if contents != MEMEX_SEARCH_SKILL.as_bytes() => differing.push(label),
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => warnings.push(format!(
+                "cannot check {label} memex-search skill ({}): {err}",
+                path.display()
+            )),
+        }
+    }
+    if !differing.is_empty() {
+        warnings.push(format!(
+            "memex-search skill is outdated or locally modified ({}). Run `memex skill status` to inspect, or `memex skill update` to replace installed copies with this version. Use `memex update --yes` to update both memex and its skills.",
+            differing.join(", ")
+        ));
+    }
+    warnings
+}
+
+fn warn_if_skill_outdated() {
+    if let Ok(home) = home_dir() {
+        for warning in skill_warnings(&home) {
+            eprintln!("warning: {warning}");
+        }
+    }
+}
+
 fn run_skill_install(
     target: Option<SkillTarget>,
     mode_override: Option<SkillWriteMode>,
@@ -5096,106 +5198,220 @@ fn resolve_flag(default: bool, enable: bool, disable: bool, name: &str) -> Resul
 
 const REPO: &str = "nicosuave/memex";
 
+const HOMEBREW_FORMULA: &str = "nicosuave/tap/memex";
+
+fn interaction_allowed(
+    explicitly_disabled: bool,
+    stdin_tty: bool,
+    stdout_tty: bool,
+    stderr_tty: bool,
+    agent_or_ci: bool,
+) -> bool {
+    !explicitly_disabled && stdin_tty && stdout_tty && stderr_tty && !agent_or_ci
+}
+
+fn agent_or_ci_environment() -> bool {
+    [
+        "CI",
+        "CODEX_CI",
+        "CODEX_THREAD_ID",
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+    ]
+    .iter()
+    .any(|name| {
+        std::env::var_os(name).is_some_and(|value| {
+            let value = value.to_string_lossy();
+            !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+        })
+    })
+}
+
+fn homebrew_executable(path: &Path) -> bool {
+    let components: Vec<_> = path.components().collect();
+    components
+        .windows(2)
+        .any(|pair| pair[0].as_os_str() == "Cellar" && pair[1].as_os_str() == "memex")
+}
+
 fn is_homebrew_install() -> bool {
     std::env::current_exe()
         .ok()
-        .and_then(|p| {
-            p.to_str()
-                .map(|s| s.contains("/Cellar/") || s.contains("/homebrew/"))
-        })
-        .unwrap_or(false)
+        .and_then(|path| path.canonicalize().ok())
+        .is_some_and(|path| homebrew_executable(&path))
 }
 
-fn run_update(skip_confirm: bool) -> Result<()> {
+fn confirm_update() -> Result<bool> {
+    use dialoguer::{Confirm, theme::ColorfulTheme};
     if is_homebrew_install() {
-        println!("memex was installed via Homebrew.");
-        println!("Run 'brew upgrade memex' to update.");
-        return Ok(());
+        eprintln!("brew update && brew upgrade {HOMEBREW_FORMULA}");
     }
+    eprintln!(
+        "Existing memex-search skill copies will also be replaced with the installed version; missing copies stay uninstalled."
+    );
+    Ok(Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Update memex and its installed skills now?")
+        .default(true)
+        .interact()?)
+}
 
-    let current = env!("CARGO_PKG_VERSION");
-    let latest = fetch_latest_version()?;
-
-    if !is_newer_version(current, &latest) {
-        println!("memex is already up to date (v{current})");
-        return Ok(());
+fn refresh_installed_skills(binary: &Path) -> Result<()> {
+    let status = std::process::Command::new(binary)
+        .args(["skill", "update", "--target", "all"])
+        .stdin(std::process::Stdio::null())
+        .status()
+        .with_context(|| format!("run installed skill updater {}", binary.display()))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "memex is installed, but refreshing its skills failed ({status}); run `memex skill update` to retry"
+        ));
     }
+    Ok(())
+}
 
-    println!("Current version: v{current}");
-    println!("Latest version:  v{latest}");
-    println!();
-
-    if !skip_confirm {
-        use dialoguer::{Confirm, theme::ColorfulTheme};
-        let confirm = Confirm::with_theme(&ColorfulTheme::default())
-            .with_prompt(format!("Update to v{latest}?"))
-            .default(true)
-            .interact()?;
-        if !confirm {
-            println!("Update cancelled.");
-            return Ok(());
+fn update_homebrew(brew: &Path, expected_version: Option<&str>) -> Result<PathBuf> {
+    for args in [vec!["update"], vec!["upgrade", HOMEBREW_FORMULA]] {
+        let status = std::process::Command::new(brew)
+            .args(&args)
+            .env("HOMEBREW_NO_AUTO_UPDATE", "1")
+            .stdin(std::process::Stdio::null())
+            .status()
+            .with_context(|| format!("run brew {}", args.join(" ")))?;
+        if !status.success() {
+            return Err(anyhow!(
+                "brew {} failed ({status}); update stopped",
+                args.join(" ")
+            ));
         }
     }
+    // The running executable can live in an old Cellar version that brew just removed.
+    let output = std::process::Command::new(brew)
+        .args(["--prefix", HOMEBREW_FORMULA])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .context("locate the installed Homebrew memex")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Homebrew upgrade finished, but `brew --prefix {HOMEBREW_FORMULA}` failed; run `memex skill update` after resolving the installation"
+        ));
+    }
+    let prefix = std::str::from_utf8(&output.stdout)
+        .context("Homebrew returned a non-UTF-8 memex prefix")?
+        .trim();
+    if prefix.is_empty() || prefix.lines().count() != 1 || !Path::new(prefix).is_absolute() {
+        return Err(anyhow!(
+            "Homebrew returned an invalid memex installation prefix"
+        ));
+    }
+    let binary = Path::new(prefix).join("bin/memex");
+    let version = std::process::Command::new(&binary)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .with_context(|| format!("check installed memex {}", binary.display()))?;
+    if !version.status.success() {
+        return Err(anyhow!(
+            "Homebrew upgrade finished, but the installed memex version check failed"
+        ));
+    }
+    let version = std::str::from_utf8(&version.stdout)?.trim();
+    let installed_version = version
+        .strip_prefix("memex ")
+        .filter(|value| parse_version_parts(value).is_some())
+        .ok_or_else(|| anyhow!("unexpected installed memex version: {version}"))?;
+    println!("Installed {version}");
+    refresh_installed_skills(&binary)?;
+    if expected_version.is_some_and(|latest| is_newer_version(installed_version, latest)) {
+        return Err(anyhow!(
+            "Homebrew still provides memex v{installed_version}; release v{} is newer. The tap may not have caught up or the formula may be pinned. Installed skills were refreshed; retry `memex update` later",
+            expected_version.unwrap()
+        ));
+    }
+    Ok(binary)
+}
 
+fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
+    let parent = current_exe
+        .parent()
+        .ok_or_else(|| anyhow!("binary has no parent directory"))?;
+    // Stage in the destination filesystem so a failed copy leaves the running binary intact.
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    let mut source = std::fs::File::open(new_binary)?;
+    std::io::copy(&mut source, &mut staged)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        staged
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o755))?;
+    }
+    staged.as_file().sync_all()?;
+    staged.persist(current_exe).map_err(|error| error.error)?;
+    Ok(())
+}
+
+fn update_release(current_exe: &Path, latest: &str) -> Result<()> {
+    let current = env!("CARGO_PKG_VERSION");
+    if !is_newer_version(current, latest) {
+        println!("memex is already up to date (v{current}); refreshing installed skills");
+        return refresh_installed_skills(current_exe);
+    }
     let (os, arch) = detect_platform()?;
     let url = format!(
         "https://github.com/{REPO}/releases/download/v{latest}/memex-{latest}-{os}-{arch}.tar.gz"
     );
-
-    println!("Downloading {url}...");
-
+    println!("Downloading memex v{latest}...");
     let tmp_dir = tempfile::tempdir()?;
     let archive_path = tmp_dir.path().join("memex.tar.gz");
-
-    // Download using curl
     let status = std::process::Command::new("curl")
-        .args(["-fsSL", "-o"])
+        .args([
+            "-fsSL",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "300",
+            "-o",
+        ])
         .arg(&archive_path)
         .arg(&url)
+        .stdin(std::process::Stdio::null())
         .status()?;
     if !status.success() {
         return Err(anyhow!("Failed to download release"));
     }
-
-    // Extract
     let status = std::process::Command::new("tar")
         .args(["-xzf"])
         .arg(&archive_path)
         .arg("-C")
         .arg(tmp_dir.path())
+        .stdin(std::process::Stdio::null())
         .status()?;
     if !status.success() {
         return Err(anyhow!("Failed to extract release"));
     }
-
-    let new_binary = tmp_dir.path().join("memex");
-    if !new_binary.exists() {
-        return Err(anyhow!("Binary not found in release archive"));
-    }
-
-    // Replace current binary
-    let current_exe = std::env::current_exe()?;
-    let backup = current_exe.with_extension("old");
-
-    // Move current to backup, move new to current
-    if backup.exists() {
-        std::fs::remove_file(&backup)?;
-    }
-    std::fs::rename(&current_exe, &backup)?;
-    std::fs::copy(&new_binary, &current_exe)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&current_exe, std::fs::Permissions::from_mode(0o755))?;
-    }
-
-    // Remove backup
-    let _ = std::fs::remove_file(&backup);
-
+    replace_binary(&tmp_dir.path().join("memex"), current_exe)?;
     println!("Updated memex to v{latest}");
-    println!();
-    println!("Run 'memex skill update' to update installed skill copies.");
+    refresh_installed_skills(current_exe)
+}
+
+fn perform_update(known_latest: Option<&str>) -> Result<()> {
+    let current_exe = std::env::current_exe()?.canonicalize()?;
+    if homebrew_executable(&current_exe) {
+        let brew = find_in_path("brew").ok_or_else(|| {
+            anyhow!("Homebrew manages this installation, but brew is not on PATH")
+        })?;
+        update_homebrew(&brew, known_latest)?;
+    } else {
+        let fetched;
+        let latest = match known_latest {
+            Some(latest) => latest,
+            None => {
+                fetched = fetch_latest_version()?;
+                &fetched
+            }
+        };
+        update_release(&current_exe, latest)?;
+    }
     Ok(())
 }
 
@@ -5203,8 +5419,13 @@ fn fetch_latest_version() -> Result<String> {
     let output = std::process::Command::new("curl")
         .args([
             "-fsSL",
+            "--connect-timeout",
+            "1",
+            "--max-time",
+            "2",
             &format!("https://api.github.com/repos/{REPO}/releases/latest"),
         ])
+        .stdin(std::process::Stdio::null())
         .output()?;
 
     if !output.status.success() {
@@ -5239,31 +5460,70 @@ fn detect_platform() -> Result<(&'static str, &'static str)> {
     Ok((os, arch))
 }
 
-/// Check for updates in the background and print a warning if outdated.
-/// This is non-blocking and fails silently.
-pub fn check_for_update_async(sender: Option<std::sync::mpsc::Sender<String>>) {
-    let is_brew = is_homebrew_install();
-    std::thread::spawn(move || {
-        if let Ok(latest) = fetch_latest_version() {
-            let current = env!("CARGO_PKG_VERSION");
-            if is_newer_version(current, &latest) {
-                let upgrade_cmd = if is_brew {
-                    "brew upgrade memex"
-                } else {
-                    "memex update"
-                };
-                if let Some(sender) = sender {
-                    let message = format!("update: v{latest} ({upgrade_cmd})");
-                    let _ = sender.send(message);
-                } else {
-                    eprintln!(
-                        "\x1b[33mA new version of memex is available: v{latest} (current: v{current})\x1b[0m"
-                    );
-                    eprintln!("\x1b[33mRun '{upgrade_cmd}' to upgrade.\x1b[0m");
-                }
-            }
+#[derive(Serialize, Deserialize)]
+struct UpdateCheck {
+    checked_at: u64,
+    latest: Option<String>,
+}
+
+fn latest_version_cached(
+    cache_path: &Path,
+    now: u64,
+    fetch: impl FnOnce() -> Result<String>,
+) -> Option<String> {
+    if let Ok(contents) = std::fs::read(cache_path)
+        && let Ok(cached) = serde_json::from_slice::<UpdateCheck>(&contents)
+    {
+        // Retry a failed check sooner, without delaying every command while offline.
+        let ttl = if cached.latest.is_some() {
+            6 * 60 * 60
+        } else {
+            5 * 60
+        };
+        if cached.checked_at <= now && now - cached.checked_at < ttl {
+            return cached.latest;
         }
-    });
+    }
+    let latest = fetch().ok();
+    let check = UpdateCheck {
+        checked_at: now,
+        latest: latest.clone(),
+    };
+    // Cache writes are best effort and atomic; concurrent launches never read a partial file.
+    let _ = (|| -> Result<()> {
+        let parent = cache_path
+            .parent()
+            .ok_or_else(|| anyhow!("cache has no parent"))?;
+        std::fs::create_dir_all(parent)?;
+        let mut file = tempfile::NamedTempFile::new_in(parent)?;
+        serde_json::to_writer(file.as_file_mut(), &check)?;
+        file.persist(cache_path).map_err(|error| error.error)?;
+        Ok(())
+    })();
+    latest
+}
+
+fn available_update() -> Option<String> {
+    let home = home_dir().ok()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    latest_version_cached(
+        &home.join(".memex/update-check.json"),
+        now,
+        fetch_latest_version,
+    )
+    .filter(|latest| is_newer_version(env!("CARGO_PKG_VERSION"), latest))
+}
+
+fn print_update_notice(latest: Option<&str>) {
+    if let Some(latest) = latest {
+        eprintln!(
+            "update: memex v{latest} is available (current v{}). Run `memex update` or `memex update --yes` for a noninteractive update of memex and installed skills.",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
 }
 
 fn is_newer_version(current: &str, latest: &str) -> bool {
@@ -5305,6 +5565,139 @@ mod tests {
     use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use tempfile::TempDir;
+
+    #[test]
+    fn update_interaction_requires_a_human_terminal_and_explicit_opt_out_wins() {
+        assert!(interaction_allowed(false, true, true, true, false));
+        for (disabled, stdin, stdout, stderr, agent) in [
+            (true, true, true, true, false),
+            (false, false, true, true, false),
+            (false, true, false, true, false),
+            (false, true, true, false, false),
+            (false, true, true, true, true),
+        ] {
+            assert!(!interaction_allowed(disabled, stdin, stdout, stderr, agent));
+        }
+        for args in [
+            vec!["memex", "--non-interactive", "update", "--yes"],
+            vec!["memex", "update", "--yes", "--non-interactive"],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert!(cli.non_interactive);
+            assert!(matches!(cli.command, Some(Commands::Update { yes: true })));
+        }
+        let cli = Cli::try_parse_from(["memex", "update", "--non-interactive"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Update { yes: false })));
+    }
+
+    #[test]
+    fn update_install_detection_requires_the_memex_cellar_entry() {
+        for path in [
+            "/opt/homebrew/Cellar/memex/0.14.0/bin/memex",
+            "/usr/local/Cellar/memex/0.14.0/bin/memex",
+            "/home/linuxbrew/.linuxbrew/Cellar/memex/0.14.0/bin/memex",
+        ] {
+            assert!(homebrew_executable(Path::new(path)));
+        }
+        for path in [
+            "/home/me/homebrew/project/target/debug/memex",
+            "/opt/homebrew/Cellar/other/0.14.0/bin/memex",
+            "/home/me/.local/bin/memex",
+        ] {
+            assert!(!homebrew_executable(Path::new(path)));
+        }
+    }
+
+    #[test]
+    fn update_cache_reuses_notices_and_retries_expired_or_failed_checks() {
+        let temp = TempDir::new().unwrap();
+        let cache = temp.path().join("cache.json");
+        assert_eq!(
+            latest_version_cached(&cache, 100, || Ok("99.0.0".into())),
+            Some("99.0.0".into())
+        );
+        assert_eq!(
+            latest_version_cached(&cache, 200, || panic!("fresh cache must avoid network")),
+            Some("99.0.0".into())
+        );
+        assert_eq!(
+            latest_version_cached(&cache, 100 + 6 * 60 * 60, || Ok("100.0.0".into())),
+            Some("100.0.0".into())
+        );
+        std::fs::write(&cache, "partial invalid cache").unwrap();
+        assert_eq!(
+            latest_version_cached(&cache, 30_000, || Err(anyhow!("offline"))),
+            None
+        );
+        assert_eq!(
+            latest_version_cached(&cache, 30_001, || panic!(
+                "failure backoff must avoid network"
+            )),
+            None
+        );
+        assert_eq!(
+            latest_version_cached(&cache, 30_300, || Ok("101.0.0".into())),
+            Some("101.0.0".into())
+        );
+        // A clock correction must not make a future-dated cache permanent.
+        assert_eq!(
+            latest_version_cached(&cache, 20_000, || Ok("102.0.0".into())),
+            Some("102.0.0".into())
+        );
+        assert_eq!(
+            latest_version_cached(&temp.path().join("missing/other.json"), 1, || Ok(
+                "99.0.0".into()
+            )),
+            Some("99.0.0".into())
+        );
+    }
+
+    #[test]
+    fn skill_warnings_are_quiet_for_missing_or_matching_copies_and_clear_after_update() {
+        let home = TempDir::new().unwrap();
+        assert!(skill_warnings(home.path()).is_empty());
+        write_skill_targets(home.path(), &[SkillTarget::Shared], SkillWriteMode::Install).unwrap();
+        assert!(skill_warnings(home.path()).is_empty());
+        let shared = home.path().join(".agents/skills/memex-search/SKILL.md");
+        std::fs::write(&shared, "older or edited skill").unwrap();
+        let warning = skill_warnings(home.path());
+        assert_eq!(warning.len(), 1);
+        assert!(warning[0].contains("outdated or locally modified (shared)"));
+        assert_eq!(
+            std::fs::read_to_string(&shared).unwrap(),
+            "older or edited skill"
+        );
+        write_skill_targets(home.path(), &[SkillTarget::Claude], SkillWriteMode::Install).unwrap();
+        let claude = home.path().join(".claude/skills/memex-search/SKILL.md");
+        std::fs::write(&claude, "edited Claude copy").unwrap();
+        assert!(skill_warnings(home.path())[0].contains("shared, claude"));
+        write_skill_targets(home.path(), &[SkillTarget::All], SkillWriteMode::Update).unwrap();
+        assert!(skill_warnings(home.path()).is_empty());
+    }
+
+    #[test]
+    fn skill_warnings_do_not_fail_on_unreadable_paths() {
+        let home = TempDir::new().unwrap();
+        std::fs::create_dir_all(home.path().join(".agents/skills/memex-search/SKILL.md")).unwrap();
+        let warnings = skill_warnings(home.path());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("cannot check shared"));
+        assert!(!warnings[0].contains("outdated"));
+    }
+
+    #[test]
+    fn update_binary_replacement_leaves_old_binary_intact_on_copy_failure() {
+        let temp = TempDir::new().unwrap();
+        let installed = temp.path().join("memex");
+        let release = temp.path().join("release-memex");
+        std::fs::write(&installed, "old binary").unwrap();
+        assert!(replace_binary(&release, &installed).is_err());
+        assert_eq!(std::fs::read_to_string(&installed).unwrap(), "old binary");
+        std::fs::write(&release, "new binary").unwrap();
+        replace_binary(&release, &installed).unwrap();
+        assert_eq!(std::fs::read_to_string(&installed).unwrap(), "new binary");
+        assert!(!temp.path().join("memex.old").exists());
+    }
 
     #[test]
     fn previews_use_positive_text_literals_and_bound_unicode() {

--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -1,0 +1,445 @@
+#![cfg(unix)]
+
+use memex::config::Paths;
+use memex::index::SearchIndex;
+use memex::types::{Record, RecordLinks, SourceKind};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::fd::FromRawFd;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const AGENT_ENV: &[&str] = &[
+    "CI",
+    "CODEX_CI",
+    "CODEX_THREAD_ID",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+];
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    home: PathBuf,
+    root: PathBuf,
+    bin: PathBuf,
+    cellar_memex: PathBuf,
+    prefix: PathBuf,
+    log: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let root = temp.path().join("root");
+        let bin = temp.path().join("bin");
+        let cellar_memex = temp.path().join("Cellar/memex/0.14.0/bin/memex");
+        let prefix = temp.path().join("Cellar/memex/99.0.0");
+        let log = temp.path().join("commands.log");
+        for path in [
+            &home,
+            &root,
+            &bin,
+            cellar_memex.parent().unwrap(),
+            &prefix.join("bin"),
+        ] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::write(root.join("config.toml"), "auto_index_on_search = false\n").unwrap();
+        std::fs::create_dir_all(home.join(".memex")).unwrap();
+        std::fs::write(
+            home.join(".memex/config.toml"),
+            "auto_index_on_search = false\n",
+        )
+        .unwrap();
+        std::fs::copy(env!("CARGO_BIN_EXE_memex"), &cellar_memex).unwrap();
+        make_executable(&cellar_memex);
+
+        write_script(
+            &bin.join("brew"),
+            r#"#!/bin/sh
+printf 'brew %s\n' "$*" >> "$MEMEX_TEST_LOG"
+if [ "$MEMEX_TEST_FAIL" = "$1" ]; then exit 17; fi
+if [ "$1" = "--prefix" ]; then printf '%s\n' "$MEMEX_TEST_PREFIX"; fi
+"#,
+        );
+        write_script(
+            &bin.join("curl"),
+            r#"#!/bin/sh
+printf 'curl %s\n' "$*" >> "$MEMEX_TEST_LOG"
+exit 97
+"#,
+        );
+        write_script(
+            &prefix.join("bin/memex"),
+            r#"#!/bin/sh
+printf 'installed %s\n' "$*" >> "$MEMEX_TEST_LOG"
+if [ "$1" = "--version" ]; then
+  [ "$MEMEX_TEST_FAIL" = "version" ] && exit 18
+  printf 'memex 99.0.0\n'
+  exit 0
+fi
+if [ "$MEMEX_TEST_FAIL" = "skill" ]; then exit 19; fi
+mkdir -p "$HOME/.agents/skills/memex-search"
+printf 'updated by installed binary\n' > "$HOME/.agents/skills/memex-search/SKILL.md"
+"#,
+        );
+
+        Self {
+            _temp: temp,
+            home,
+            root,
+            bin,
+            cellar_memex,
+            prefix,
+            log,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(&self.cellar_memex);
+        let mut path = vec![self.bin.clone()];
+        path.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("HOME", &self.home)
+            .env("PATH", std::env::join_paths(path).unwrap())
+            .env("TERM", "xterm-256color")
+            .env("MEMEX_TEST_LOG", &self.log)
+            .env("MEMEX_TEST_PREFIX", &self.prefix)
+            .env("MEMEX_TEST_FAIL", "");
+        for name in AGENT_ENV {
+            command.env_remove(name);
+        }
+        command
+    }
+
+    fn cache_update(&self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        std::fs::write(
+            self.home.join(".memex/update-check.json"),
+            format!(r#"{{"checked_at":{now},"latest":"99.0.0"}}"#),
+        )
+        .unwrap();
+    }
+
+    fn log(&self) -> String {
+        std::fs::read_to_string(&self.log).unwrap_or_default()
+    }
+}
+
+fn write_script(path: &Path, contents: &str) {
+    std::fs::write(path, contents).unwrap();
+    make_executable(path);
+}
+
+fn make_executable(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn run(command: &mut Command) -> Output {
+    command.output().unwrap()
+}
+
+struct PtyOutput {
+    status: ExitStatus,
+    output: String,
+}
+
+fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
+    let mut master_fd = -1;
+    let mut slave_fd = -1;
+    let size = libc::winsize {
+        ws_row: 30,
+        ws_col: 120,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let result = unsafe {
+        libc::openpty(
+            &mut master_fd,
+            &mut slave_fd,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            &size,
+        )
+    };
+    assert_eq!(
+        result,
+        0,
+        "openpty failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let mut master = unsafe { File::from_raw_fd(master_fd) };
+    let slave = unsafe { File::from_raw_fd(slave_fd) };
+    command
+        .stdin(Stdio::from(slave.try_clone().unwrap()))
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave.try_clone().unwrap()));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(slave);
+    let mut reader = master.try_clone().unwrap();
+    let output = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = reader.read_to_end(&mut bytes);
+        String::from_utf8_lossy(&bytes).into_owned()
+    });
+    master.write_all(input).unwrap();
+    master.flush().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            let _ = child.wait();
+            panic!("PTY child did not exit within 10 seconds");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    drop(master);
+    PtyOutput {
+        status,
+        output: output.join().unwrap(),
+    }
+}
+
+#[test]
+fn bare_human_startup_accepts_cached_update_before_tui() {
+    let fixture = Fixture::new();
+    fixture.cache_update();
+    let output = run_pty(&mut fixture.command(), b"\r");
+    assert!(output.status.success(), "{}", output.output);
+    assert!(
+        output
+            .output
+            .contains("Update memex and its installed skills now?")
+    );
+    assert!(output.output.contains("Update finished. Run `memex` again"));
+    assert!(!output.output.contains("\u{1b}[?1049h"));
+    assert_eq!(
+        fixture.log(),
+        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(fixture.home.join(".agents/skills/memex-search/SKILL.md")).unwrap(),
+        "updated by installed binary\n"
+    );
+}
+
+#[test]
+fn declining_startup_update_enters_tui_without_mutation() {
+    let fixture = Fixture::new();
+    fixture.cache_update();
+    let output = run_pty(&mut fixture.command(), b"n\rq");
+    assert!(output.status.success(), "{}", output.output);
+    assert!(
+        output
+            .output
+            .contains("Update memex and its installed skills now?")
+    );
+    assert!(output.output.contains("\u{1b}[?1049h"));
+    assert!(fixture.log().is_empty());
+    assert!(
+        !fixture
+            .home
+            .join(".agents/skills/memex-search/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
+fn agent_and_non_interactive_ptys_show_help_without_prompting() {
+    for agent in [true, false] {
+        let fixture = Fixture::new();
+        fixture.cache_update();
+        let mut command = fixture.command();
+        if agent {
+            command.env("CODEX_THREAD_ID", "fixture-thread");
+        } else {
+            command.arg("--non-interactive");
+        }
+        let output = run_pty(&mut command, b"");
+        assert!(output.status.success(), "{}", output.output);
+        assert!(output.output.contains("Fast local history search"));
+        assert!(output.output.contains("update: memex v99.0.0 is available"));
+        assert!(
+            !output
+                .output
+                .contains("Update memex and its installed skills now?")
+        );
+        assert!(fixture.log().is_empty());
+    }
+
+    let fixture = Fixture::new();
+    fixture.cache_update();
+    let output = run_pty(fixture.command().args(["tui", "--non-interactive"]), b"");
+    assert!(!output.status.success());
+    assert!(
+        output
+            .output
+            .contains("TUI requires an interactive human terminal")
+    );
+    assert!(
+        !output
+            .output
+            .contains("Update memex and its installed skills now?")
+    );
+    assert!(fixture.log().is_empty());
+}
+
+#[test]
+fn update_requires_yes_without_a_tty_and_yes_runs_installed_binary_chain() {
+    let fixture = Fixture::new();
+    let refused = run(fixture.command().arg("update"));
+    assert!(!refused.status.success());
+    assert!(
+        String::from_utf8_lossy(&refused.stderr)
+            .contains("update requires confirmation; use `memex update --yes`")
+    );
+    assert!(fixture.log().is_empty());
+
+    let accepted = run(fixture.command().args(["update", "--yes"]));
+    assert!(
+        accepted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    assert_eq!(
+        fixture.log(),
+        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n"
+    );
+}
+
+#[test]
+fn homebrew_failures_stop_the_update_at_the_failing_step() {
+    let cases = [
+        ("update", "brew update\n", "brew update failed"),
+        (
+            "upgrade",
+            "brew update\nbrew upgrade nicosuave/tap/memex\n",
+            "brew upgrade nicosuave/tap/memex failed",
+        ),
+        (
+            "--prefix",
+            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\n",
+            "Homebrew upgrade finished, but `brew --prefix nicosuave/tap/memex` failed",
+        ),
+        (
+            "version",
+            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\n",
+            "installed memex version check failed",
+        ),
+        (
+            "skill",
+            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n",
+            "refreshing its skills failed",
+        ),
+    ];
+    for (failure, expected_log, expected_error) in cases {
+        let fixture = Fixture::new();
+        let output = run(fixture
+            .command()
+            .env("MEMEX_TEST_FAIL", failure)
+            .args(["update", "--yes"]));
+        assert!(!output.status.success(), "{failure} unexpectedly succeeded");
+        assert_eq!(fixture.log(), expected_log, "failure at {failure}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(expected_error),
+            "failure at {failure}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if failure == "skill" {
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                "Installed memex 99.0.0\n"
+            );
+        }
+    }
+}
+
+#[test]
+fn no_update_check_keeps_stale_skill_warning_off_search_stdout() {
+    let fixture = Fixture::new();
+    fixture.cache_update();
+    let skill = fixture.home.join(".agents/skills/memex-search/SKILL.md");
+    std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    std::fs::write(&skill, "stale skill\n").unwrap();
+    let paths = Paths::new(Some(fixture.root.clone())).unwrap();
+    let index = SearchIndex::open_or_create(&paths.index).unwrap();
+    let mut writer = index.writer().unwrap();
+    index
+        .add_record(
+            &mut writer,
+            &Record {
+                source: SourceKind::Codex,
+                doc_id: 1,
+                ts: 1,
+                project: "fixture".into(),
+                session_id: "session".into(),
+                turn_id: 1,
+                role: "assistant".into(),
+                text: "needle".into(),
+                tool_name: None,
+                tool_input: None,
+                tool_output: None,
+                links: RecordLinks::default(),
+                source_path: "/tmp/fixture.jsonl".into(),
+            },
+        )
+        .unwrap();
+    writer.commit().unwrap();
+    drop(writer);
+
+    let search_args = [
+        "--no-update-check",
+        "search",
+        "needle",
+        "--machine",
+        "local",
+        "--root",
+        fixture.root.to_str().unwrap(),
+    ];
+    let output = run(fixture.command().args(search_args));
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        serde_json::from_str::<serde_json::Value>(line).unwrap();
+    }
+    assert_eq!(String::from_utf8_lossy(&output.stdout).lines().count(), 1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("memex-search skill is outdated or locally modified (shared)"));
+    assert!(!stderr.contains("update: memex v99.0.0 is available"));
+
+    let toon = run(fixture
+        .command()
+        .args(search_args)
+        .args(["--format", "toon"]));
+    assert!(toon.status.success());
+    toon_format::decode_default(std::str::from_utf8(&toon.stdout).unwrap()).unwrap();
+    let stderr = String::from_utf8_lossy(&toon.stderr);
+    assert!(stderr.contains("memex-search skill is outdated or locally modified (shared)"));
+    assert!(!stderr.contains("update: memex v99.0.0 is available"));
+}

--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -156,7 +156,7 @@ struct PtyOutput {
 fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
     let mut master_fd = -1;
     let mut slave_fd = -1;
-    let size = libc::winsize {
+    let mut size = libc::winsize {
         ws_row: 30,
         ws_col: 120,
         ws_xpixel: 0,
@@ -167,8 +167,8 @@ fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
             &mut master_fd,
             &mut slave_fd,
             std::ptr::null_mut(),
-            std::ptr::null(),
-            &size,
+            std::ptr::null_mut(),
+            &mut size,
         )
     };
     assert_eq!(
@@ -188,7 +188,7 @@ fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
             if libc::setsid() == -1 {
                 return Err(std::io::Error::last_os_error());
             }
-            if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) == -1 {
+            if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
             Ok(())


### PR DESCRIPTION
Launching `memex` in a human terminal now offers an Enter-to-update prompt when a newer release is available. Homebrew updates only the Memex formula, then the newly installed binary refreshes existing skill copies. Declining continues into the TUI.

Agents and scripts still receive update notices without being prompted. Known agent/CI environments suppress startup interaction; `--non-interactive` makes that explicit even in a PTY, and `memex update --yes` updates both Memex and its skills without prompting.

Searches warn on stderr about outdated or locally modified skills, keeping JSONL/TOON stdout clean. Release checks have a short timeout and cache. Existing skill copies are replaced during updates; missing copies stay uninstalled.

Updater and skill unit tests passed locally. Final startup integration tests are left to CI.
