### PR TITLE
Avoid repeated macOS verification in update tests

### DIFF
--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -32,7 +32,10 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
-        let temp = tempfile::tempdir().unwrap();
+        let executable = Path::new(env!("CARGO_BIN_EXE_memex"));
+        // Keep fixtures on the executable's filesystem so they can share its inode.
+        // Copying a fresh Mach-O for every case triggers repeated macOS verification.
+        let temp = tempfile::tempdir_in(executable.parent().unwrap()).unwrap();
         let home = temp.path().join("home");
         let root = temp.path().join("root");
         let bin = temp.path().join("bin");
@@ -55,8 +58,9 @@ impl Fixture {
             "auto_index_on_search = false\n",
         )
         .unwrap();
-        std::fs::copy(env!("CARGO_BIN_EXE_memex"), &cellar_memex).unwrap();
-        make_executable(&cellar_memex);
+        // A hard link preserves the simulated Cellar path (unlike a symlink)
+        // without creating another executable or changing the build's permissions.
+        std::fs::hard_link(executable, &cellar_memex).unwrap();
 
         write_script(
             &bin.join("brew"),
@@ -438,7 +442,8 @@ fn no_update_check_keeps_stale_skill_warning_off_search_stdout() {
         .args(search_args)
         .args(["--format", "toon"]));
     assert!(toon.status.success());
-    toon_format::decode_default(std::str::from_utf8(&toon.stdout).unwrap()).unwrap();
+    toon_format::decode_default::<serde_json::Value>(std::str::from_utf8(&toon.stdout).unwrap())
+        .unwrap();
     let stderr = String::from_utf8_lossy(&toon.stderr);
     assert!(stderr.contains("memex-search skill is outdated or locally modified (shared)"));
     assert!(!stderr.contains("update: memex v99.0.0 is available"));


### PR DESCRIPTION
Update tests copied and launched a fresh Memex executable for every fixture, repeatedly opening macOS verification dialogs. Create fixtures beside the built executable and hard-link it into the simulated Homebrew Cellar so cases reuse the same executable identity while retaining Homebrew path detection. Also specify the decoded JSON type required to compile the existing TOON assertion.

Formatting and clippy pass. Five of six update integration tests pass; the existing interactive decline test fails because its pseudo-terminal does not answer the cursor-position query. macOS logs showed one verification event per suite run after this change instead of repeated events for individual fixtures.
