### PR TITLE
Fix browser origin on OAuth approval forms

### DIFF
--- a/src/mcp/oauth.rs
+++ b/src/mcp/oauth.rs
@@ -391,9 +391,12 @@ fn add_security_headers(mut response: Response) -> Response {
     let headers = response.headers_mut();
     headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
     headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+    // Native form POSTs use Origin: null under no-referrer, breaking the
+    // approval page's own origin check. Keep same-origin form submissions
+    // identifiable without sending referrers to external OAuth callbacks.
     headers.insert(
         header::REFERRER_POLICY,
-        HeaderValue::from_static("no-referrer"),
+        HeaderValue::from_static("same-origin"),
     );
     headers.insert(
         header::CONTENT_SECURITY_POLICY,

--- a/tests/mcp_oauth.rs
+++ b/tests/mcp_oauth.rs
@@ -191,6 +191,7 @@ impl OAuthMcpServer {
     fn approval(&self, request_id: &str, owner_key: &str, decision: &str) -> Response {
         self.client
             .post(self.endpoint("/oauth/authorize"))
+            .header("Origin", &self.public_url)
             .form(&[
                 ("request_id", request_id),
                 ("owner_key", owner_key),
@@ -609,6 +610,11 @@ fn authorization_pkce_refresh_rotation_and_replay_protection() {
         VERIFIER,
         "approval-state",
     );
+    assert_eq!(
+        approval.headers().get("referrer-policy").unwrap(),
+        "same-origin",
+        "native approval forms must retain their Origin without leaking external referrers"
+    );
     let html = text_response(approval, StatusCode::OK);
     assert!(!html.contains("<script>alert('approval')</script>"));
     assert!(html.contains("&lt;script&gt;"), "{html}");
@@ -632,6 +638,18 @@ fn authorization_pkce_refresh_rotation_and_replay_protection() {
         .send()
         .expect("foreign-origin approval");
     assert_eq!(foreign_approval.status(), StatusCode::FORBIDDEN);
+    let null_origin = server
+        .client
+        .post(server.endpoint("/oauth/authorize"))
+        .header("Origin", "null")
+        .form(&[
+            ("request_id", request_id.as_str()),
+            ("owner_key", owner_key.as_str()),
+            ("decision", "approve"),
+        ])
+        .send()
+        .expect("opaque-origin approval");
+    assert_eq!(null_origin.status(), StatusCode::FORBIDDEN);
     let wrong_owner = text_response(
         server.approval(&request_id, "wrong-owner-key", "approve"),
         StatusCode::UNAUTHORIZED,


### PR DESCRIPTION
Submitting the owner key in a browser failed with “origin is not allowed” because the approval page used Referrer-Policy: no-referrer, which turns native form POST origins into null. Use same-origin so approval retains its origin while external callbacks receive no referrer. Keep foreign and opaque origins rejected, and cover the response policy and approval behavior in the HTTP suite.