### PR TITLE
Hide inactive sources and narrate index tail in progress output

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -438,6 +438,7 @@ fn replay_opencode_spool(
     tx_record: &RecordSender,
     database_path: &Path,
     owned_session_ids: &HashSet<String>,
+    progress: &Progress,
 ) -> Result<()> {
     spool.as_file_mut().seek(SeekFrom::Start(0))?;
     let reader = BufReader::new(spool.as_file_mut());
@@ -455,6 +456,7 @@ fn replay_opencode_spool(
             )
         })?;
         if owned_session_ids.contains(&record.session_id) {
+            progress.add_produced(SourceKind::Opencode, 1);
             tx_record.send(record)?;
         }
     }
@@ -1605,6 +1607,7 @@ pub fn ingest_all(
                 &tx_record,
                 &database.path,
                 &owned_session_ids,
+                &progress,
             )?;
         }
         Ok(())
@@ -1613,6 +1616,10 @@ pub fn ingest_all(
     drop(tx_record);
     drop(tx_update);
 
+    // Parsers are done; what follows is commit/merge/publish plus analytics
+    // and state writes, none of which is per-source work. Keep one spinner
+    // visible so the tail doesn't read as hung.
+    let tail = progress.tail_spinner("committing index…");
     pending_ingest.next_doc_id = next_doc_id.load(Ordering::SeqCst);
     let pending_update_error = pending_ingest
         .save(&pending_path)
@@ -1625,59 +1632,65 @@ pub fn ingest_all(
     };
     // A failed writer may have already closed the channel. Joining below keeps that root cause.
     let _ = decision_tx.send(decision);
-    let writer_result = writer_handle
-        .join()
-        .map_err(|_| anyhow!("writer thread panicked"))?;
+    let writer_result = writer_handle.join().map_err(|_| {
+        tail.finish_and_clear();
+        anyhow!("writer thread panicked")
+    })?;
     progress.finish();
-    let writer_outcome =
-        writer_result.context("index writer stopped before ingestion completed")?;
-    parser_result?;
-    if let Some(error) = pending_update_error {
-        return Err(error);
-    }
-    let (records_added, records_embedded) = match writer_outcome {
-        WriterOutcome::Published {
+    tail.set_message("updating analytics…");
+    let outcome = (|| -> Result<IngestReport> {
+        let writer_outcome =
+            writer_result.context("index writer stopped before ingestion completed")?;
+        parser_result?;
+        if let Some(error) = pending_update_error {
+            return Err(error);
+        }
+        let (records_added, records_embedded) = match writer_outcome {
+            WriterOutcome::Published {
+                records_added,
+                records_embedded,
+            } => (records_added, records_embedded),
+            WriterOutcome::Cancelled => {
+                return Err(anyhow!(
+                    "index writer cancelled a successful ingest publication"
+                ));
+            }
+        };
+        if analytics_needs_backfill {
+            let published_index = SearchIndex::open_or_create(&paths.index)?;
+            backfill_from_index(&analytics_db, &published_index)?;
+        } else {
+            AnalyticsStore::open(&analytics_db)?.mark_complete()?;
+        }
+
+        let mut diagnostics = shared_diagnostics.lock().unwrap().clone();
+        let mut updated_files = HashMap::new();
+        while let Ok(update) = rx_update.recv() {
+            updated_files.insert(update.path.clone(), update.state.clone());
+            diagnostics.merge(update.diagnostics);
+            let _ = update.session_id;
+        }
+
+        for (path, update) in updated_files {
+            state.files.insert(path, update);
+        }
+        state.opencode_databases = installed_opencode_states;
+        state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
+        state.save(&state_path)?;
+
+        update_scan_cache(paths, files_scanned, total_bytes)?;
+        finalize_pending_ingest(&pending_path, &deferred_pending_scopes, state.next_doc_id)?;
+
+        Ok(IngestReport {
             records_added,
             records_embedded,
-        } => (records_added, records_embedded),
-        WriterOutcome::Cancelled => {
-            return Err(anyhow!(
-                "index writer cancelled a successful ingest publication"
-            ));
-        }
-    };
-    if analytics_needs_backfill {
-        let published_index = SearchIndex::open_or_create(&paths.index)?;
-        backfill_from_index(&analytics_db, &published_index)?;
-    } else {
-        AnalyticsStore::open(&analytics_db)?.mark_complete()?;
-    }
-
-    let mut diagnostics = shared_diagnostics.lock().unwrap().clone();
-    let mut updated_files = HashMap::new();
-    while let Ok(update) = rx_update.recv() {
-        updated_files.insert(update.path.clone(), update.state.clone());
-        diagnostics.merge(update.diagnostics);
-        let _ = update.session_id;
-    }
-
-    for (path, update) in updated_files {
-        state.files.insert(path, update);
-    }
-    state.opencode_databases = installed_opencode_states;
-    state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
-    state.save(&state_path)?;
-
-    update_scan_cache(paths, files_scanned, total_bytes)?;
-    finalize_pending_ingest(&pending_path, &deferred_pending_scopes, state.next_doc_id)?;
-
-    Ok(IngestReport {
-        records_added,
-        records_embedded,
-        files_scanned,
-        files_skipped: files_skipped + parse_skipped.load(Ordering::Relaxed),
-        diagnostics,
-    })
+            files_scanned,
+            files_skipped: files_skipped + parse_skipped.load(Ordering::Relaxed),
+            diagnostics,
+        })
+    })();
+    tail.finish_and_clear();
+    outcome
 }
 
 fn update_scan_cache(paths: &Paths, files_scanned: usize, total_bytes: u64) -> Result<()> {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,5 +1,6 @@
 use crate::types::SourceKind;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -9,10 +10,12 @@ const SOURCES: [SourceKind; SOURCE_COUNT] = SourceKind::ALL;
 pub struct Progress {
     #[allow(dead_code)] // Kept alive to coordinate progress bars.
     multi: MultiProgress,
-    headers: Vec<ProgressBar>,
-    parse: Vec<ProgressBar>,
-    index: Vec<ProgressBar>,
-    embed: Vec<ProgressBar>,
+    header_style: ProgressStyle,
+    spinner_style: ProgressStyle,
+    headers: Vec<OnceLock<ProgressBar>>,
+    parse: Vec<OnceLock<ProgressBar>>,
+    index: Vec<OnceLock<ProgressBar>>,
+    embed: Vec<OnceLock<ProgressBar>>,
     files_total: [u64; SOURCE_COUNT],
     files_done: [AtomicU64; SOURCE_COUNT],
     produced: [AtomicU64; SOURCE_COUNT],
@@ -33,45 +36,21 @@ impl Progress {
             .unwrap()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
 
-        let mut headers = Vec::with_capacity(SOURCE_COUNT);
-        let mut parse = Vec::with_capacity(SOURCE_COUNT);
-        let mut index = Vec::with_capacity(SOURCE_COUNT);
-        let mut embed = Vec::with_capacity(SOURCE_COUNT);
-
-        for source in SOURCES {
-            let idx = source.idx();
-            let header = multi.add(ProgressBar::new_spinner());
-            header.set_style(header_style.clone());
-            header.set_message(progress_label(source));
-            header.tick();
-            headers.push(header);
-
-            let parse_bar = multi.add(ProgressBar::new_spinner());
-            parse_bar.set_style(spinner_style.clone());
-            parse_bar.set_message(format!("parsed 0 B / {} files", files_total[idx]));
-            parse_bar.enable_steady_tick(Duration::from_millis(80));
-            parse.push(parse_bar);
-
-            let index_bar = multi.add(ProgressBar::new_spinner());
-            index_bar.set_style(spinner_style.clone());
-            index_bar.set_message("indexed 0 rec");
-            index_bar.enable_steady_tick(Duration::from_millis(80));
-            index.push(index_bar);
-
-            let embed_bar = if embeddings {
-                let bar = multi.add(ProgressBar::new_spinner());
-                bar.set_style(spinner_style.clone());
-                bar.set_message("embedded 0");
-                bar.enable_steady_tick(Duration::from_millis(80));
-                bar
-            } else {
-                ProgressBar::hidden()
-            };
-            embed.push(embed_bar);
+        let mut headers: Vec<OnceLock<ProgressBar>> = Vec::with_capacity(SOURCE_COUNT);
+        let mut parse: Vec<OnceLock<ProgressBar>> = Vec::with_capacity(SOURCE_COUNT);
+        let mut index: Vec<OnceLock<ProgressBar>> = Vec::with_capacity(SOURCE_COUNT);
+        let mut embed: Vec<OnceLock<ProgressBar>> = Vec::with_capacity(SOURCE_COUNT);
+        for _ in SOURCES {
+            headers.push(OnceLock::new());
+            parse.push(OnceLock::new());
+            index.push(OnceLock::new());
+            embed.push(OnceLock::new());
         }
 
-        Self {
+        let progress = Self {
             multi,
+            header_style,
+            spinner_style,
             headers,
             parse,
             index,
@@ -82,15 +61,99 @@ impl Progress {
             embed_total: std::array::from_fn(|_| AtomicU64::new(0)),
             embed_pending: std::array::from_fn(|_| AtomicU64::new(0)),
             embeddings_enabled: embeddings,
+        };
+        // Only show sources with file work upfront. Sources with no files stay
+        // hidden until real work arrives (e.g. OpenCode database records or
+        // embedding backfill), so agents that aren't installed don't spin.
+        for source in SOURCES {
+            if files_total[source.idx()] > 0 {
+                progress.ensure_header(source);
+                progress.ensure_parse(source);
+                progress.ensure_index(source);
+                if embeddings {
+                    progress.ensure_embed(source);
+                }
+            }
         }
+        progress
+    }
+
+    fn ensure_header(&self, source: SourceKind) -> ProgressBar {
+        let idx = source.idx();
+        self.headers[idx]
+            .get_or_init(|| {
+                let header = self.multi.add(ProgressBar::new_spinner());
+                header.set_style(self.header_style.clone());
+                header.set_message(progress_label(source));
+                header.tick();
+                header
+            })
+            .clone()
+    }
+
+    fn ensure_parse(&self, source: SourceKind) -> ProgressBar {
+        self.ensure_header(source);
+        let idx = source.idx();
+        self.parse[idx]
+            .get_or_init(|| {
+                let bar = self.multi.add(ProgressBar::new_spinner());
+                bar.set_style(self.spinner_style.clone());
+                bar.set_message(format!("parsed 0 B / {} files", self.files_total[idx]));
+                bar.enable_steady_tick(Duration::from_millis(80));
+                bar
+            })
+            .clone()
+    }
+
+    fn ensure_index(&self, source: SourceKind) -> ProgressBar {
+        self.ensure_header(source);
+        let idx = source.idx();
+        self.index[idx]
+            .get_or_init(|| {
+                let bar = self.multi.add(ProgressBar::new_spinner());
+                bar.set_style(self.spinner_style.clone());
+                bar.set_message("indexed 0 rec");
+                bar.enable_steady_tick(Duration::from_millis(80));
+                bar
+            })
+            .clone()
+    }
+
+    /// A standalone spinner line appended below the per-source bars, for phases
+    /// that aren't per-source work (commit/merge/publish, analytics backfill).
+    pub fn tail_spinner(&self, msg: &'static str) -> ProgressBar {
+        let bar = self.multi.add(ProgressBar::new_spinner());
+        bar.set_style(self.spinner_style.clone());
+        bar.set_message(msg);
+        bar.enable_steady_tick(Duration::from_millis(80));
+        bar
+    }
+
+    fn ensure_embed(&self, source: SourceKind) -> ProgressBar {
+        self.ensure_header(source);
+        let idx = source.idx();
+        self.embed[idx]
+            .get_or_init(|| {
+                if self.embeddings_enabled {
+                    let bar = self.multi.add(ProgressBar::new_spinner());
+                    bar.set_style(self.spinner_style.clone());
+                    bar.set_message("embedded 0");
+                    bar.enable_steady_tick(Duration::from_millis(80));
+                    bar
+                } else {
+                    ProgressBar::hidden()
+                }
+            })
+            .clone()
     }
 
     pub fn add_parsed_bytes(&self, source: SourceKind, bytes: u64) {
         let idx = source.idx();
-        self.parse[idx].inc(bytes);
-        let total = self.parse[idx].position();
+        let bar = self.ensure_parse(source);
+        bar.inc(bytes);
+        let total = bar.position();
         let files_done = self.files_done[idx].load(Ordering::Relaxed);
-        self.parse[idx].set_message(format!(
+        bar.set_message(format!(
             "parsed {} {}/{} files",
             format_bytes(total),
             files_done,
@@ -102,40 +165,62 @@ impl Progress {
         let idx = source.idx();
         let done = self.files_done[idx].fetch_add(count, Ordering::Relaxed) + count;
         if done >= self.files_total[idx] {
-            let bytes = self.parse[idx].position();
-            self.parse[idx].finish_with_message(format!(
-                "parsed {} {} files done",
-                format_bytes(bytes),
-                self.files_total[idx]
-            ));
+            if let Some(bar) = self.parse[idx].get() {
+                let bytes = bar.position();
+                bar.finish_with_message(format!(
+                    "parsed {} {} files done",
+                    format_bytes(bytes),
+                    self.files_total[idx]
+                ));
+            }
+            // Files with no records leave no index work behind; clear a
+            // possibly-visible index line promptly instead of spinning until
+            // the end of the run.
+            if self.produced[idx].load(Ordering::Relaxed) == 0
+                && let Some(bar) = self.index[idx].get()
+                && !bar.is_finished()
+            {
+                bar.finish_and_clear();
+            }
         }
     }
 
     pub fn add_produced(&self, source: SourceKind, count: u64) {
         self.produced[source.idx()].fetch_add(count, Ordering::Relaxed);
+        // Reveal lazily-hidden sources (e.g. OpenCode database records with no
+        // file tasks) as soon as real work arrives.
+        self.ensure_index(source);
     }
 
     pub fn add_indexed(&self, source: SourceKind, count: u64) {
         let idx = source.idx();
-        self.index[idx].inc(count);
-        let indexed = self.index[idx].position();
+        let bar = self.ensure_index(source);
+        bar.inc(count);
+        let indexed = bar.position();
         let produced = self.produced[idx].load(Ordering::Relaxed);
         let files_done = self.files_done[idx].load(Ordering::Relaxed);
-        if files_done >= self.files_total[idx] && indexed >= produced && produced > 0 {
-            self.index[idx]
-                .finish_with_message(format!("indexed {} rec done", format_count(indexed)));
+        if files_done < self.files_total[idx] || indexed < produced {
+            bar.set_message(format!("indexed {} rec", format_count(indexed)));
+        } else if produced == 0 {
+            bar.finish_and_clear();
         } else {
-            self.index[idx].set_message(format!("indexed {} rec", format_count(indexed)));
+            bar.finish_with_message(format!("indexed {} rec done", format_count(indexed)));
         }
     }
 
     pub fn add_embed_total(&self, source: SourceKind, count: u64) {
         self.embed_total[source.idx()].fetch_add(count, Ordering::Relaxed);
+        if self.embeddings_enabled {
+            self.ensure_embed(source);
+        }
         self.update_embed_message(source);
     }
 
     pub fn add_embed_pending(&self, source: SourceKind, count: u64) {
         self.embed_pending[source.idx()].fetch_add(count, Ordering::Relaxed);
+        if self.embeddings_enabled {
+            self.ensure_embed(source);
+        }
         self.update_embed_message(source);
     }
 
@@ -149,8 +234,11 @@ impl Progress {
         if !self.embeddings_enabled {
             return;
         }
+        let Some(bar) = self.embed[source.idx()].get() else {
+            return;
+        };
         let idx = source.idx();
-        let embedded = self.embed[idx].position();
+        let embedded = bar.position();
         let total = self.embed_total[idx].load(Ordering::Relaxed);
         let pending = self.embed_pending[idx].load(Ordering::Relaxed);
         let msg = if total > 0 {
@@ -171,20 +259,20 @@ impl Progress {
         } else {
             format!("embedded {}", format_count(embedded))
         };
-        self.embed[idx].set_message(msg);
+        bar.set_message(msg);
     }
 
     pub fn add_embedded(&self, source: SourceKind, count: u64) {
         let idx = source.idx();
-        self.embed[idx].inc(count);
-        let embedded = self.embed[idx].position();
+        let bar = self.ensure_embed(source);
+        bar.inc(count);
+        let embedded = bar.position();
         let total = self.embed_total[idx].load(Ordering::Relaxed);
         let pending = self.embed_pending[idx].load(Ordering::Relaxed);
-        let indexed = self.index[idx].position();
+        let indexed = self.index[idx].get().map(|b| b.position()).unwrap_or(0);
         let produced = self.produced[idx].load(Ordering::Relaxed);
         if indexed >= produced && pending == 0 && embedded >= total && total > 0 {
-            self.embed[idx]
-                .finish_with_message(format!("embedded {} done", format_count(embedded)));
+            bar.finish_with_message(format!("embedded {} done", format_count(embedded)));
             return;
         }
         self.update_embed_message(source);
@@ -194,10 +282,14 @@ impl Progress {
         if !self.embeddings_enabled {
             return;
         }
+        // Only touch already-visible bars. Creating "ready" lines for idle
+        // sources would reintroduce the spinner noise this hides.
         for source in SOURCES {
             let idx = source.idx();
-            if self.embed_total[idx].load(Ordering::Relaxed) == 0 {
-                self.embed[idx].set_message("embedded 0 ready");
+            if self.embed_total[idx].load(Ordering::Relaxed) == 0
+                && let Some(bar) = self.embed[idx].get()
+            {
+                bar.set_message("embedded 0 ready");
             }
         }
     }
@@ -205,32 +297,39 @@ impl Progress {
     pub fn finish(&self) {
         for source in SOURCES {
             let idx = source.idx();
-            self.headers[idx].finish();
-
-            let parsed = self.parse[idx].position();
-            if parsed > 0 {
-                self.parse[idx].finish_with_message(format!(
-                    "parsed {} {} files",
-                    format_bytes(parsed),
-                    self.files_total[idx]
-                ));
-            } else {
-                self.parse[idx].finish_and_clear();
+            if let Some(bar) = self.headers[idx].get() {
+                bar.finish();
             }
 
-            let indexed = self.index[idx].position();
-            if indexed > 0 {
-                self.index[idx]
-                    .finish_with_message(format!("indexed {} rec", format_count(indexed)));
-            } else {
-                self.index[idx].finish_and_clear();
+            if let Some(bar) = self.parse[idx].get() {
+                let parsed = bar.position();
+                if parsed > 0 {
+                    bar.finish_with_message(format!(
+                        "parsed {} {} files",
+                        format_bytes(parsed),
+                        self.files_total[idx]
+                    ));
+                } else {
+                    bar.finish_and_clear();
+                }
             }
 
-            let embedded = self.embed[idx].position();
-            if self.embeddings_enabled && embedded > 0 {
-                self.embed[idx].finish_with_message(format!("embedded {}", format_count(embedded)));
-            } else {
-                self.embed[idx].finish_and_clear();
+            if let Some(bar) = self.index[idx].get() {
+                let indexed = bar.position();
+                if indexed > 0 {
+                    bar.finish_with_message(format!("indexed {} rec", format_count(indexed)));
+                } else {
+                    bar.finish_and_clear();
+                }
+            }
+
+            if let Some(bar) = self.embed[idx].get() {
+                let embedded = bar.position();
+                if self.embeddings_enabled && embedded > 0 {
+                    bar.finish_with_message(format!("embedded {}", format_count(embedded)));
+                } else {
+                    bar.finish_and_clear();
+                }
             }
         }
     }


### PR DESCRIPTION
Hides per-source spinners for agents with no files so uninstalled sources don't spin the whole run. Sources that produce records later (OpenCode DB spool, embed backfill) reveal lazily; spool records now count as produced so the index line can finish. Adds a tail spinner (committing index / updating analytics) covering commit/merge/publish plus the previously silent analytics backfill and state save.