### PR TITLE
Group memory search across repository worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ use `--content all` to search memories and conversations together. Use
 `--content` remains conversation-only. Provider selection remains independent:
 `--source claude` selects the provider, not the content type. Memory results carry
 document/section references, source paths, scope, freshness, and content versions.
+For scoped memories, `--project` uses the repository name across Git worktrees;
+`--cwd` selects the exact checkout. Each memory keeps its own source path and ID.
 Their timestamp filters use file modification time; dates explicitly recorded
 inside a note are separate metadata and do not imply that its claims are current.
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -255,6 +255,7 @@ impl MemoryStore {
             .map(|document| (document.stable_id.clone(), document))
             .collect::<HashMap<_, _>>();
         let mut documents = Vec::with_capacity(discovery.candidates.len());
+        let mut repository_projects = HashMap::new();
 
         for candidate in discovery.candidates {
             let stable_id = memory_stable_id(candidate.provider, &candidate.source_path);
@@ -267,10 +268,20 @@ impl MemoryStore {
                             && document.version_sha256 == version
                     }) {
                         document.mtime_ms = modified_millis(&metadata)?;
+                        document.scope = resolve_memory_scope(
+                            &candidate,
+                            &parse_source_metadata(&content),
+                            &mut repository_projects,
+                        );
                         documents.push(document);
                         report.unchanged += 1;
                     } else {
-                        documents.push(parse_memory_content(&candidate, content, &metadata)?);
+                        documents.push(parse_memory_content(
+                            &candidate,
+                            content,
+                            &metadata,
+                            &mut repository_projects,
+                        )?);
                         report.parsed += 1;
                     }
                 }
@@ -413,7 +424,7 @@ pub fn discover_memory_documents(options: &MemoryDiscoveryOptions) -> Result<Mem
 
 pub fn parse_memory_document(candidate: &MemoryCandidate) -> Result<MemoryDocument> {
     let (content, metadata) = read_consistent(&candidate.source_path)?;
-    parse_memory_content(candidate, content, &metadata)
+    parse_memory_content(candidate, content, &metadata, &mut HashMap::new())
 }
 
 /// Re-read a snapshot-known source without mutating either the source or memory snapshot.
@@ -437,28 +448,14 @@ fn parse_memory_content(
     candidate: &MemoryCandidate,
     content: String,
     metadata: &fs::Metadata,
+    repository_projects: &mut HashMap<PathBuf, Option<String>>,
 ) -> Result<MemoryDocument> {
     let mtime_ms = modified_millis(metadata)?;
     let version_sha256 = sha256_hex(content.as_bytes());
     let stable_id = memory_stable_id(candidate.provider, &candidate.source_path);
     let (sections, title) = parse_sections(&content);
     let source_metadata = parse_source_metadata(&content);
-    let mut scope = candidate.scope.clone();
-    if candidate.provider == SourceKind::Codex && candidate.kind == MemoryDocumentKind::Summary {
-        if scope.cwd.is_none() {
-            scope.cwd = source_metadata.cwd.clone();
-        }
-        if scope.project.is_none() {
-            scope.project = scope
-                .cwd
-                .as_deref()
-                .and_then(Path::file_name)
-                .and_then(|name| name.to_str())
-                .map(str::to_string);
-        }
-    }
-
-    scope.cwd = scope.cwd.map(|cwd| canonicalize_with_missing(&cwd));
+    let scope = resolve_memory_scope(candidate, &source_metadata, repository_projects);
 
     Ok(MemoryDocument {
         provider: candidate.provider,
@@ -481,6 +478,36 @@ fn parse_memory_content(
         sections,
         freshness: MemoryFreshness::Fresh,
     })
+}
+
+fn resolve_memory_scope(
+    candidate: &MemoryCandidate,
+    source_metadata: &ParsedSourceMetadata,
+    repository_projects: &mut HashMap<PathBuf, Option<String>>,
+) -> MemoryScope {
+    let mut scope = candidate.scope.clone();
+    if candidate.provider == SourceKind::Codex && candidate.kind == MemoryDocumentKind::Summary {
+        // Source metadata owns summary scope, including when live reads reparse an old snapshot.
+        scope.cwd = source_metadata.cwd.clone();
+        scope.project = scope
+            .cwd
+            .as_deref()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .map(str::to_string);
+    }
+    if let Some(cwd) = scope.cwd.as_mut() {
+        *cwd = canonicalize_with_missing(cwd);
+        // Share the session repository resolver, but retain the exact checkout for cwd filters.
+        // One Git lookup per cwd per refresh avoids repeating it for every note in a project.
+        if let Some(project) = repository_projects
+            .entry(cwd.clone())
+            .or_insert_with(|| crate::analytics::repository_project_for_cwd(&cwd.to_string_lossy()))
+        {
+            scope.project = Some(project.clone());
+        }
+    }
+    scope
 }
 
 pub fn memory_stable_id(provider: SourceKind, canonical_source_path: &Path) -> String {

--- a/tests/memory_project_scope.rs
+++ b/tests/memory_project_scope.rs
@@ -1,0 +1,247 @@
+use memex::{
+    config::Paths,
+    memory::{MemoryDiscoveryOptions, MemoryStore},
+    memory_search::{MemoryReadRequest, MemorySearchOptions, read_memory, search_memory},
+    types::SourceKind,
+};
+use serde_json::json;
+use std::{collections::HashSet, fs, path::Path, process::Command};
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let result = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+fn options(root: &Path) -> MemoryDiscoveryOptions {
+    MemoryDiscoveryOptions {
+        claude_project_roots: vec![root.join("claude/projects")],
+        codex_homes: vec![root.join("codex")],
+        enabled_sources: HashSet::from([SourceKind::Claude, SourceKind::Codex]),
+        exclude_patterns: vec![],
+    }
+}
+
+fn claude_note(root: &Path, name: &str, cwd: &Path) {
+    let project = root.join("claude/projects").join(name);
+    write(
+        &project.join("session.jsonl"),
+        &format!(
+            "{}\n",
+            json!({
+                "type": "user", "sessionId": name, "cwd": cwd,
+                "message": {"role": "user", "content": "scope"}
+            })
+        ),
+    );
+    write(
+        &project.join("memory/MEMORY.md"),
+        "# Decision\n\ncontinuity evidence\n",
+    );
+}
+
+fn codex_note(root: &Path, name: &str, cwd: &Path) {
+    write(
+        &root
+            .join("codex/memories/rollout_summaries")
+            .join(format!("{name}.md")),
+        &format!(
+            "cwd: {}\n\n# Decision\n\ncontinuity evidence\n",
+            cwd.display()
+        ),
+    );
+}
+
+#[test]
+fn memory_project_search_groups_worktrees_and_refreshes_existing_scopes() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let repo = root.join("memex");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "--quiet"]);
+    git(
+        &repo,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "fixture",
+            "--quiet",
+        ],
+    );
+    let first = root.join("exciting-morse");
+    let second = root.join("sleepy-curie");
+    for (branch, path) in [("first", &first), ("second", &second)] {
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "--quiet",
+                "-b",
+                branch,
+                path.to_str().unwrap(),
+            ],
+        );
+    }
+    for (name, cwd) in [("main", &repo), ("first", &first), ("second", &second)] {
+        claude_note(root, name, cwd);
+        codex_note(root, name, cwd);
+    }
+    let paths = Paths::new(Some(root.join("store"))).unwrap();
+    let store = MemoryStore::new(paths.root.join("memory/documents.json"));
+    let discovery = options(root);
+    let original = store.refresh(&discovery).unwrap().snapshot;
+    assert_eq!(original.documents.len(), 6);
+    assert!(
+        original
+            .documents
+            .iter()
+            .all(|doc| doc.scope.project.as_deref() == Some("memex"))
+    );
+    let query = MemorySearchOptions {
+        query: "continuity".into(),
+        project: Some("memex".into()),
+        recency_weight: 0.0,
+        ..Default::default()
+    };
+    let all = search_memory(&paths, &query).unwrap();
+    assert_eq!(all.len(), 6);
+    assert_eq!(
+        all.iter()
+            .map(|hit| &hit.memory_id)
+            .collect::<HashSet<_>>()
+            .len(),
+        6
+    );
+    let checkout = search_memory(
+        &paths,
+        &MemorySearchOptions {
+            cwd: Some(first.canonicalize().unwrap()),
+            ..query
+        },
+    )
+    .unwrap();
+    assert_eq!(checkout.len(), 2);
+    for hit in &checkout {
+        let read = read_memory(
+            &paths,
+            &MemoryReadRequest {
+                memory_id: hit.memory_id.clone(),
+                section_ref: Some(hit.section_ref.clone()),
+                content_version: Some(hit.content_version.clone()),
+                offset_chars: 0,
+                max_chars: 128,
+            },
+        )
+        .unwrap();
+        assert_eq!(read.project.as_deref(), Some("memex"));
+        assert_eq!(read.cwd, Some(first.canonicalize().unwrap()));
+        assert!(read.text.contains("continuity"));
+    }
+
+    // Upgrade a pre-resolver snapshot without touching the source memories.
+    let mut legacy = original.clone();
+    for doc in &mut legacy.documents {
+        doc.scope.project = doc
+            .scope
+            .cwd
+            .as_ref()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .map(str::to_string);
+    }
+    fs::write(store.snapshot_path(), serde_json::to_vec(&legacy).unwrap()).unwrap();
+    let refreshed = store.refresh(&discovery).unwrap();
+    assert!(refreshed.changed);
+    assert_eq!(refreshed.unchanged, 6);
+    assert_eq!(refreshed.parsed, 0);
+    assert_eq!(refreshed.snapshot, original);
+    assert!(!store.refresh(&discovery).unwrap().changed);
+}
+
+#[test]
+fn memory_scope_preserves_non_git_and_global_notes_with_deleted_worktree_fallback() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let missing = root.join("atm-backend/.claude/worktrees/exciting-morse");
+    let ordinary = root.join("research-notes");
+    fs::create_dir(&ordinary).unwrap();
+    claude_note(root, "missing", &missing);
+    claude_note(root, "ordinary", &ordinary);
+    codex_note(root, "missing", &missing);
+    codex_note(root, "ordinary", &ordinary);
+    write(
+        &root.join("codex/memories/MEMORY.md"),
+        "# Global\n\ncontinuity evidence\n",
+    );
+    let paths = Paths::new(Some(root.join("store"))).unwrap();
+    let store = MemoryStore::new(paths.root.join("memory/documents.json"));
+    let docs = store.refresh(&options(root)).unwrap().snapshot.documents;
+    assert_eq!(
+        docs.iter()
+            .filter(|doc| doc.scope.project.as_deref() == Some("atm-backend"))
+            .count(),
+        2
+    );
+    assert_eq!(
+        docs.iter()
+            .filter(|doc| doc.scope.project.as_deref() == Some("research-notes"))
+            .count(),
+        2
+    );
+    let global = docs.iter().find(|doc| doc.scope.cwd.is_none()).unwrap();
+    assert_eq!(global.scope.project, None);
+}
+
+#[test]
+fn live_codex_read_uses_current_summary_scope() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let old = root.join("old-project");
+    let new = root.join("new-project");
+    fs::create_dir(&old).unwrap();
+    fs::create_dir(&new).unwrap();
+    codex_note(root, "summary", &old);
+    let paths = Paths::new(Some(root.join("store"))).unwrap();
+    let store = MemoryStore::new(paths.root.join("memory/documents.json"));
+    let doc = store
+        .refresh(&options(root))
+        .unwrap()
+        .snapshot
+        .documents
+        .remove(0);
+    codex_note(root, "summary", &new);
+    let current = read_memory(
+        &paths,
+        &MemoryReadRequest {
+            memory_id: doc.stable_id,
+            section_ref: None,
+            content_version: Some(doc.version_sha256),
+            offset_chars: 0,
+            max_chars: 256,
+        },
+    )
+    .unwrap();
+    assert!(current.changed_since_search);
+    assert_eq!(current.project.as_deref(), Some("new-project"));
+    assert_eq!(current.cwd, Some(new.canonicalize().unwrap()));
+}


### PR DESCRIPTION
Memory project filters now use the same repository resolver as session grouping. For example, memories from a checkout named `exciting-morse` become searchable with `--project memex` when that worktree belongs to the memex repository. `--cwd` continues to select the exact checkout; documents, source paths, and content versions remain distinct.

Ordinary refreshes also correct project scope in existing snapshots without requiring source edits. Resolution is cached per cwd during each refresh, and live Codex reads derive scope from the current summary metadata. The existing fallback for deleted Claude worktrees is reused; non-Git and global memories retain their existing scope semantics.

Regression coverage exercises real Git worktrees across Claude and Codex, project search versus exact-cwd filtering, unchanged-content snapshot upgrades, deleted-worktree fallback, global/non-Git notes, and live summary scope changes. Local Clippy was not run, as requested; CI provides Clippy validation.

Validation: all 3 new integration tests and all 33 focused memory library tests passed. Formatting/diff checks passed. Clippy passed in CI for commit 4d122e2; it was not run locally.
