### PR TITLE
Fix PTY test hangs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: cargo build --verbose
 
       - name: Run unit and integration tests
+        timeout-minutes: 10
         run: cargo test --verbose -- --test-threads=1
 
   clippy:

--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -158,6 +158,10 @@ struct PtyOutput {
 }
 
 fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
+    run_pty_with_tui_input(command, input, b"")
+}
+
+fn run_pty_with_tui_input(command: &mut Command, input: &[u8], tui_input: &[u8]) -> PtyOutput {
     let mut master_fd = -1;
     let mut slave_fd = -1;
     let mut size = libc::winsize {
@@ -199,12 +203,39 @@ fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
         });
     }
     let mut child = command.spawn().unwrap();
+    // Command retains its configured Stdio handles after spawn. Close the parent's
+    // slave copies so the master reader can finish when the child exits on Linux.
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     drop(slave);
     let mut reader = master.try_clone().unwrap();
-    let output = std::thread::spawn(move || {
+    let (output_tx, output_rx) = std::sync::mpsc::channel();
+    let tui_input = tui_input.to_vec();
+    std::thread::spawn(move || {
         let mut bytes = Vec::new();
-        let _ = reader.read_to_end(&mut bytes);
-        String::from_utf8_lossy(&bytes).into_owned()
+        let mut buffer = [0; 4096];
+        let mut cursor_replied = false;
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(len) => {
+                    bytes.extend_from_slice(&buffer[..len]);
+                    // Ratatui queries the cursor when entering the TUI. Emulate
+                    // that terminal response before sending interactive keys.
+                    if !cursor_replied && bytes.windows(4).any(|part| part == b"\x1b[6n") {
+                        cursor_replied = true;
+                        let _ = reader.write_all(b"\x1b[1;1R");
+                        let _ = reader.write_all(&tui_input);
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                // Linux reports EIO when the PTY slave closes.
+                Err(_) => break,
+            }
+        }
+        let _ = output_tx.send(String::from_utf8_lossy(&bytes).into_owned());
     });
     master.write_all(input).unwrap();
     master.flush().unwrap();
@@ -223,8 +254,21 @@ fn run_pty(command: &mut Command, input: &[u8]) -> PtyOutput {
     drop(master);
     PtyOutput {
         status,
-        output: output.join().unwrap(),
+        output: output_rx
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .expect("PTY output did not close within 10 seconds"),
     }
+}
+
+#[test]
+fn pty_output_closes_after_child_exit_while_command_is_alive() {
+    let mut command = Command::new("sh");
+    command.args(["-c", "printf pty-finished"]);
+    let output = run_pty(&mut command, b"");
+    assert!(output.status.success());
+    assert_eq!(output.output, "pty-finished");
+    // Keep Command alive through collection, as the interactive fixtures do.
+    assert_eq!(command.get_program(), "sh");
 }
 
 #[test]
@@ -254,7 +298,8 @@ fn bare_human_startup_accepts_cached_update_before_tui() {
 fn declining_startup_update_enters_tui_without_mutation() {
     let fixture = Fixture::new();
     fixture.cache_update();
-    let output = run_pty(&mut fixture.command(), b"n\rq");
+    // Ctrl-C is the global quit binding; plain 'q' is home-screen search input.
+    let output = run_pty_with_tui_input(&mut fixture.command(), b"n\r", b"\x03");
     assert!(output.status.success(), "{}", output.output);
     assert!(
         output

--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -322,6 +322,8 @@ fn agent_and_non_interactive_ptys_show_help_without_prompting() {
         let fixture = Fixture::new();
         fixture.cache_update();
         let mut command = fixture.command();
+        // Assert help text independently of the host's terminal color settings.
+        command.env("NO_COLOR", "1");
         if agent {
             command.env("CODEX_THREAD_ID", "fixture-thread");
         } else {
@@ -329,8 +331,12 @@ fn agent_and_non_interactive_ptys_show_help_without_prompting() {
         }
         let output = run_pty(&mut command, b"");
         assert!(output.status.success(), "{}", output.output);
-        assert!(output.output.contains("Usage: memex"));
-        assert!(output.output.contains("Find and read:"));
+        assert!(output.output.contains("Usage: memex"), "{}", output.output);
+        assert!(
+            output.output.contains("Find and read:"),
+            "{}",
+            output.output
+        );
         assert!(output.output.contains("update: memex v99.0.0 is available"));
         assert!(
             !output


### PR DESCRIPTION
The update CLI tests could hang after the child exited because Command retained PTY slave descriptors, preventing the output reader from closing. Close those handles after spawning and bound output collection by the existing deadline.

Also repair the interactive fixture to answer the terminal cursor query and use the current Ctrl-C quit binding, add a regression for output collection while Command remains alive, and cap the CI test step at ten minutes.

The original helper reproduced the hang on Linux; the patched helper completes. All seven update CLI tests, formatting, and standard/focused Clippy pass locally.
