### PR TITLE
Implement event-driven daemon indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +1977,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2116,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -2383,6 +2432,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "model2vec-rs",
+ "notify",
  "once_cell",
  "ort",
  "postcard",
@@ -2583,6 +2633,33 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "num-bigint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ toml = "0.8"
 toml_edit = "0.22"
 walkdir = "2.5"
 globset = "0.4"
+notify = "8"
 indicatif = "0.17"
 ratatui = { version = "0.30", default-features = false, features = [
     "crossterm_0_29",

--- a/docs/event-driven-indexing-spec.md
+++ b/docs/event-driven-indexing-spec.md
@@ -1,0 +1,346 @@
+# Event-driven indexing: FSEvents / inotify spec
+
+Started from latest `main` (`04adaca`). This spec replaces the daemon's
+polling loop with OS filesystem events, with periodic reconciliation as the
+correctness backstop. Events are **hints only** — `ingest.json` file-state
+stays the source of truth.
+
+## 1. Problem
+
+`run_index_loop` (`src/cli.rs:1756`) sleeps `poll_interval` (default 30s,
+`src/config.rs:424`) then calls `run_index_args` → `ingest_all`
+(`src/ingest.rs:668`), which walks **every** source root, stats every file,
+and diffs against `IngestState` (`src/state.rs:122`).
+
+Costs:
+
+- Worst-case ~30s index latency for an active agent session.
+- A full walk + stat storm every 30s even when idle (battery, SSD, CPU).
+- Walk cost grows with history size; parse cost is already incremental via
+  `offset`/`turn_id`, but discovery is not.
+- Lease contention with search-time `ingest_if_stale` (`src/ingest.rs:543`)
+  and TUI auto-index (`src/tui.rs:1118`): the daemon wakes up just to find
+  nothing changed and fight for the lease.
+
+Goal: index a changed transcript in ~1–3s of settle time, do ~zero work when
+idle, and never miss/duplicate records even when events are lost, coalesced,
+or reordered.
+
+Non-goals: changing the record format, the Tantivy writer protocol, the
+`PendingIngest` crash-recovery protocol, or the vector/analytics pipelines.
+Those are reused untouched.
+
+## 2. Platform answer: yes, Linux has an equivalent — use `notify`, not raw APIs
+
+| OS    | Native API              | Properties |
+| ----- | ----------------------- | ---------- |
+| macOS | FSEventStream (FSEvents) | Device-scoped, path-scoped stream, coalesced, persistent `since` event ID, directory-granularity history, `mustScanSubDirs` resync flag, latency parameter. Misses nothing unless the stream overflows, but tells you only *something under this dir changed*. |
+| Linux | inotify                 | Per-watch-descriptor, **non-recursive**, fixed-size kernel queue. Reports file-granular create/modify/delete/move cookies, but drops events with `IN_Q_OVERFLOW` under load and requires the watcher to manage recursive watches itself (watch new subdirs on create, drop watches on delete/move, watch parents of not-yet-existing roots). |
+
+Do **not** hand-roll `fsevents-sys` on macOS plus `inotify` on Linux.
+Depend on the `notify` crate (`RecommendedWatcher`): FSEvents backend on
+macOS, inotify backend on Linux, correct recursive-watch management included,
+single API for both. This is the standard choice and the only way to keep the
+two platforms' wildly different semantics behind one tested abstraction.
+(`notify-debouncer-mini` or `notify-debouncer-full` supplies the coalescing
+layer; prefer `debouncer-mini` — smaller, fewer surprises — unless the
+`full` variant's rename-cookie tracking proves necessary in testing.)
+
+Windows (`ReadDirectoryChangesW`) comes free via `notify` but is out of scope
+for testing; the code must compile there, nothing more.
+
+## 3. Requirements
+
+### Functional
+
+- R1. Daemon indexes appended/created transcripts within seconds, without any
+  polling sleep in the hot path.
+- R2. All currently polled sources are covered (section 5). Adding a source
+  later means adding its roots in one place.
+- R3. CLI/config stays backward compatible: `--watch` / `--watch-interval` /
+  `--poll-interval` / `index_service_poll_interval` keep working, reinterpreted
+  as event mode + resync interval (section 9).
+
+### Correctness (no ghetto)
+
+- C1. Events never advance trust directly. Every event path is re-`stat`ed and
+  run through the existing `prepare_file_task` comparison (`src/ingest.rs:191`:
+  size, mtime, `FileIdentity` device/inode/prefix-hash/modified-ns,
+  parser-version). An event for an unchanged file is a no-op.
+- C2. Full reconciliation always converges: startup scan, periodic resync,
+  overflow resync, error resync, and delete/rename tombstone sweep (section 8).
+  A daemon that missed *every* event still converges on the next resync.
+- C3. No torn-read corruption: a file actively being appended is only parsed
+  after settle (section 7). A partial trailing JSONL line must never advance
+  `offset` past committed data — verify the parsers already skip/retain it;
+  if any parser advances on error, fix that first.
+- C4. No duplicate records on rename/rotation/truncation: reuse the exact
+  `delete_first` paths (`size < previous.size`, mtime regression,
+  `file_was_replaced`, parser-version change, Jcode atomic-reparse rule).
+- C5. Crash safety preserved: the `PendingIngest` write-ahead marker
+  (`src/state.rs:141`, `src/ingest.rs:1452`) and `prepare_pending_ingest_recovery`
+  flow stay exactly as-is. Event mode must not clear/skip recovery.
+- C6. Single-flight ingest under the existing `IngestLease` (`src/lease.rs`).
+  Never run two ingests concurrently; never bypass the lease because "events
+  are fast".
+
+### Performance
+
+- P1. Idle daemon does no walks, no stats, no wakeups except the resync timer.
+- P2. A one-line append to one file stats ~1 file and parses the tail — never
+  a full walk.
+- P3. Bursty agent output (dozens of appends/second) coalesces into at most ~1
+  ingest per debounce window per batch.
+- P4. Dirty-set memory is bounded; overload degrades to "full resync needed",
+  never to unbounded queues or OOM.
+- P5. Embedding/vector work batching (`EMBED_BATCH_SIZE`, writer thread in
+  `ingest_all`) is unchanged; event mode must not lower the batching that
+  makes bulk ingest efficient.
+
+## 4. Architecture
+
+New `src/watch.rs` (name TBD, ~600–900 lines + tests), wired into the daemon
+only:
+
+```
+OS events (notify) ──> filter ──> debounce/settle ──> dirty set ──> scheduler ──> ingest
+                              │                                              │
+                              └── resync timer / overflow / error ────────────┘
+```
+
+- **Root resolver**: pure function `watch_roots(options: &IngestOptions, config) -> Vec<PathBuf>`
+  computed from the same inputs as `ingest_all` discovery. Canonicalizes,
+  dedups, drops disabled sources, keeps not-yet-existing roots as "pending"
+  (watch nearest existing ancestor).
+- **Watcher**: one `RecommendedWatcher` held for the daemon lifetime.
+  Recursive watches where supported; on Linux `notify` manages subdir watches.
+- **Pipeline**: synchronous filter → debouncer → dirty-set insert. The ingest
+  trigger fires on: debounce quiet-period expiry, max-batch-age expiry, or
+  resync timer/overflow/error.
+- **Scheduler**: single-flight. Holds `IngestLease` via `try_acquire`; on
+  contention keeps the dirty set and retries with backoff instead of dropping.
+  Runs the ingest on a dedicated thread so the watcher callback never blocks.
+- **Ingest**: two tiers (section 7). Both tiers funnel into the existing
+  `prepare_file_task` → parse → `writer_loop` machinery. No forked parse logic.
+
+`memex daemon run` / `memex index --watch` construct this instead of
+`run_index_loop`'s `sleep` loop. One-shot `memex index`, `search` auto-index,
+TUI auto-index, RPC, MCP paths are untouched except that they benefit from
+fresher state.
+
+## 5. Watch roots (must all be covered)
+
+Resolver output derives from the enabled-source flags in `IngestOptions`:
+
+| Source | Roots to watch | Notes |
+| ------ | -------------- | ----- |
+| Claude | `default_claude_sources()` (`CLAUDE_CONFIG_DIR` or `~/.claude/projects`, `~/.config/claude/projects`) + explicit `--claude-path` | Watch the `projects` dirs, not `$HOME`. |
+| Codex | `CODEX_HOME` (`~/.codex`): `sessions/`, rollout roots, history file parents | History files are single files — watch parent dir. |
+| OpenCode | `OPENCODE_DATA_DIR` / `~/.local/share/opencode`: storage root, message/parts roots, `*.sqlite` parents | SQLite: trigger on main DB path only; ignore `-wal`/`-shm`/`-journal` sidecar events (they always accompany a DB write; coalesce, don't double-fire). Cursor logic (`event_rowid`/`event_id` in `scan_database`) stays authoritative. |
+| Cursor | `~/.cursor/projects` | |
+| Pi | `PI_CODING_AGENT_DIR` / `~/.pi/agent/sessions` (+ configured session root) | Env-driven; also watch `config.toml` (see below) and re-resolve roots when it changes. |
+| OMP | `~/.omp/agent/sessions`, profiles root, `XDG_DATA_HOME` variant | |
+| OpenClaw | `~/.openclaw`, `~/.clawdbot` state dirs | |
+| Copilot | `COPILOT_HOME` / `~/.copilot` session root | |
+| Grok | `GROK_HOME` / `~/.grok/sessions` | |
+| Jcode | `JCODE_HOME` / `~/.jcode/sessions` | Single-JSON files: atomic reparse rule already exists; event just triggers it sooner. |
+| Muse | `MUSE_HOME` / `~/.local/share/muse/sessions` | |
+| Hermes | `HERMES_HOME` profiles | Currently discovery-only; include for free via `profile_roots()`. |
+| Memory docs | Whatever `refresh_memories` (`src/ingest.rs:1701`) reads: project `memory/` dirs are per-project (unbounded) — **do not** watch the world. Watch only `~/.memex/memory/` outputs? No: inputs live in user repos. Decision: memory refresh stays on the ingest path (it runs inside every ingest, including event-triggered ones) and is *not* independently watched in v1. Document this explicitly. |
+| Config | `~/.memex/config.toml` | Change → re-resolve roots (add/drop watches), re-read debounce/resync settings. Debounce this harder (5s); never trigger an ingest by itself. |
+
+Nonexistent roots: watch the nearest existing ancestor so first-run creation is
+observed, then escalate to the real root once it appears. Never `watch("/")`
+or `$HOME` as a fallback — too broad, too many events, violates P1.
+
+## 6. Event filtering (before debounce)
+
+Drop in the watcher callback, in order:
+
+1. Non-regular files: directories themselves (except create/delete, which mean
+   "re-discover the subtree"), symlinks followed sideways (discovery uses
+   `follow_links(false)` — the watcher must match that), sockets/fifos.
+2. Sidecars and temp files: `*.tmp`, `*.swp`, `*~`, `.DS_Store`,
+   `.memex-opencode-spool-*` (`OPENCODE_SPOOL_PREFIX`), Tantivy generation
+   workdirs under `~/.memex/index` (never watch `~/.memex` itself), SQLite
+   `-wal`/`-shm`/`-journal` (coalesced into the main-DB event).
+3. Paths matching the existing `PathExcluder` (config `exclude_paths` + CLI
+   `--exclude`). Canonicalize before matching, exactly like discovery does.
+4. Events from our own state writes (`ingest.json`, `scan_cache.json`,
+   `ingest.pending.json`) — these live under `~/.memex/state`, which is not a
+   watch root, so this is defense-in-depth; assert it in a test.
+
+What survives: create/modify/rename affecting `*.jsonl`, `*.json`, codex
+history files, opencode `*.sqlite` main files, cursor/grok/copilot session
+files. When in doubt, keep the event — `prepare_file_task` will no-op it
+cheaply (one stat). Over-filtering causes silent misses; under-filtering costs
+one stat.
+
+## 7. Debounce, settle, batch, schedule
+
+- **Per-path debounce**: 1–2s quiet period (configurable, default 1.5s).
+  Streaming agents append many lines/second; each append resets the path timer.
+- **Max batch age**: 5–10s. A continuously-appended file still gets indexed at
+  least every max-age even without a quiet period.
+- **Global batch window**: collect all settled paths; fire one ingest covering
+  the whole dirty set. Minimum ingest spacing ~2s (prevents ingest thrash when
+  5 agents write concurrently).
+- **Settle check at fire time**: re-stat each dirty path; require size+mtime
+  stable across the debounce window (two consecutive stats agree) *or* the
+  quiet period fully elapsed with no new event. If still churning, keep it in
+  the dirty set for the next batch — do not parse a file that grew in the last
+  ~500ms. This plus the trailing-line rule (C3) eliminates torn reads.
+- **Opencode SQLite**: extra settle — after the DB file settles, still
+  `scan_database` from the stored cursor; if the DB is mid-checkpoint/locked,
+  treat like the existing `Err(_) → files_skipped` path and retry next batch,
+  not as fatal.
+- **Backpressure**: dirty set capped (e.g. 10k paths). Overflow → set
+  `full_resync_needed = true` and clear per-path detail. Queue depth and
+  coalesced-event counters go to logs/metrics, not to unbounded memory.
+
+### Ingest tiers
+
+- **Tier 1 — dirty fast path** (hot path): for each dirty path, stat + build
+  `FileTask` via the existing `prepare_file_task` with prior `FileState`.
+  Skip unchanged (same size+mtime fast path already inside). Parse tails in the
+  existing rayon pool, publish through the existing `writer_loop`. No directory
+  walk. This is the whole performance win.
+- **Tier 2 — scoped discovery** (on create/delete/rename/dir events, unknown
+  paths, or any event whose parent dir isn't in state): re-run discovery for
+  the affected source root only (e.g. one `discover_rollouts()` call), diff
+  against `state.files` keys under that root to find tombstones, then proceed
+  as Tier 1 for the delta. Never a full multi-source walk on the hot path.
+- **Tier 3 — full resync** (section 8): literally call the existing
+  `ingest_all` discovery path. Correctness backstop, not the hot path.
+
+Tier 1/2 should be implemented as a `dirty_paths: HashSet<PathBuf>` parameter
+threaded into `ingest_all` (or a sibling `ingest_dirty`) that constrains
+discovery — not as a copy of the ingest body. One parse path, two discovery
+scopes.
+
+## 8. Reconciliation protocol (the correctness core)
+
+Events are lossy on both platforms (coalescing, overflow, watcher gaps during
+sleep/restart, missed subdir watches, rename half-reports). The design treats
+every trigger below as funneling into Tier 3 unless the dirty set precisely
+covers it:
+
+1. **Startup**: always Tier 3 full scan before arming the watcher snapshot.
+   Also runs `PendingIngest` recovery first (unchanged order). This bounds
+   the offline window (daemon stopped, laptop asleep, `kill -9`).
+2. **Periodic resync**: Tier 3 on a jittered timer, default 5–15 min
+   (configurable; reuses `index_service_poll_interval` as the floor so existing
+   configs keep meaning "at most this stale"). Jitter ±20% avoids lockstep
+   with systemd/launchd neighbors. This is the backstop that makes every
+   missed-event bug self-healing within minutes.
+3. **Overflow/resync signals**: FSEvent `mustScanSubDirs` / history-drop, inotify
+   `IN_Q_OVERFLOW`, `notify::EventKind::Other` resync markers, watcher `Error`
+   of any kind → immediate Tier 3, then re-establish watches. Log at warn with
+   the platform flag that caused it.
+4. **Watch-gap detection**: watcher thread death, sleep/wake (detect via clock
+   jump > resync interval or OS power notifications if cheap; clock jump alone
+   suffices for v1), config-root change → Tier 3 + root re-resolution.
+5. **Tombstone sweep**: deletes/renames may report only the old path (or only
+   a dir event). Tier 2's per-root discovery diff against `state.files` finds
+   vanished keys; vanished keys go through the existing `delete_paths` purge
+   on both Tantivy and vector stores. Additionally, Tier 3's existing
+   excluded/vanished handling stays as the final sweep. Never trust a delete
+   event alone to name every affected session (directory renames move many).
+6. **Opencode ownership drift**: DB compaction can reassign session ownership
+   between DB files. The existing `owner_by_session` claim pass already
+   reconciles this from scan output — event mode must run that pass on *any*
+   opencode DB event (Tier 2 scoped to opencode roots), not just full scans.
+7. **State-vs-index audit**: keep the `empty_index_rebuild` guard
+   (`src/ingest.rs:687`) and the `PendingIngest` source-path invalidation on
+   all tiers. If the index is empty but state is non-empty (or vice versa),
+   Tier 3 rebuilds — events never paper over store divergence.
+
+Invariant to assert in tests: **event-driven converge == poll converge**.
+Given the same fixture mutation sequence, applying events-then-resync must
+produce byte-identical `ingest.json` (modulo timestamps) and identical record
+counts as a full `ingest_all`. Any divergence is a P0 bug in Tier 1/2 scoping,
+not an acceptable approximation.
+
+## 9. Config, CLI, and service integration
+
+- New `UserConfig` keys (all optional, all with the defaults below):
+  `index_service_watch_mode = "events" | "poll" | "hybrid"` (default `hybrid`
+  at rollout, `events` after soak), `index_service_watch_debounce_ms` (1500),
+  `index_service_watch_max_batch_ms` (8000), `index_service_resync_interval`
+  (600; alias: existing `index_service_poll_interval` when the new key is
+  unset, so current 30s configs become a 30s resync floor rather than breaking).
+- CLI: `daemon run` gains `--watch-mode`, `--watch-debounce-ms`,
+  `--resync-interval`; `--poll-interval` stays as an alias for the resync
+  floor. Hidden legacy `index --watch/--watch-interval` maps to
+  `watch_mode=events-or-hybrid` + resync floor for compat with installed
+  launchd/systemd units (`build_index_command_args`, `src/cli.rs:6041` must
+  emit the new flags for newly generated units; old units with `--watch` keep
+  working).
+- launchd (`KeepAlive`, `src/cli.rs:6148`) and systemd (`Type=simple`,
+  `Restart=always`, `src/cli.rs:6285`) need **no** structural change — the
+  daemon is already long-lived in continuous mode. Interval-mode units
+  (`StartInterval` / `.timer`) are unaffected and stay poll-based.
+- Shutdown: SIGTERM/SIGINT stops the watcher, flushes the dirty set with a
+  short grace ingest (bounded, e.g. 5s), then exits. No event may be recorded
+  as "handled" before its ingest commits and `ingest.json` saves.
+
+## 10. Observability
+
+Structured log lines (existing conventions) for: watcher start/stop, roots
+added/dropped, events received/coalesced/filtered, debounce fires, dirty-set
+size, tier chosen, ingest outcome (`records_added`, `files_scanned/skipped`
+— same fields as today), resync cause (`startup`/`timer`/`overflow`/`error`/
+`clock-jump`/`config-change`), lease-contention skips. Expose counters for a
+future `daemon status`: `events_total`, `events_coalesced`, `ingests`,
+`full_resyncs_by_cause`, `lease_skips`, `watch_errors`. A silent watcher is the
+failure mode — if `events_total` stays 0 across two resync intervals while
+resyncs find changes, log at warn (likely broken watch, e.g. wrong root).
+
+## 11. Testing and acceptance
+
+- Unit: filter table (sidecars/temps/excludes), debounce coalescing (100 rapid
+  events → 1 ingest), backpressure overflow → resync flag, root re-resolution
+  on config change, canonicalization matching `PathExcluder`.
+- Integration (per source, macOS + Linux CI): append burst → eventually indexed
+  with exact record counts; create → picked up without full walk (assert via
+  walk counter or timing); rotate/truncate/same-size-rewrite → `delete_first`
+  reparse, no duplicates; rename dir with N sessions → all N converge;
+  delete → tombstone purge from index+vectors; torn write (append partial line,
+  hold 200ms, complete) → no error, no offset skip; `kill -9` mid-ingest →
+  restart converges via `PendingIngest` + startup scan.
+- Opencode: dirty-session scan after DB append; locked-DB retry; ownership move
+  between DBs converges.
+- Soak: `fuzzer` appending/rotating across sources for X minutes; assert
+  converge-equality with `ingest_all` (section 8 invariant) and zero record-id
+  duplication.
+- Resync proofs: synthesize overflow (fill inotify queue / set tiny
+  buffer in test) → Tier 3 fires; stop watcher 60s, mutate, restart → startup
+  scan converges.
+- Perf: idle CPU/wakeups ~0 between resyncs; single-append ingest p50 < 3s
+  including debounce; 10k-file corpus single-append does not walk.
+
+## 12. Rollout
+
+1. **Phase 1 — hybrid skeleton**: add `notify` dep, `watch.rs` with roots +
+   filter + debounce + dirty set, Tier 3 triggers only (events cause an early
+   `ingest_all` instead of waiting for the sleep). Correct by construction
+   (still full scans), proves watcher coverage and filtering. Ship behind
+   `hybrid`.
+2. **Phase 2 — Tier 1/2 fast paths**: constrain discovery by dirty set /
+   affected root. Prove converge-equality (section 8 invariant) in CI soak.
+3. **Phase 3 — default flip**: `hybrid` → `events` default, poll kept as
+   `--watch-mode poll` escape hatch. Raise resync default from 30s toward
+   5–15 min once field data shows overflows are rare.
+4. **Phase 4 — cleanup**: only after a release of soak data; remove the sleep
+   loop if unneeded, keep `poll` mode for exotic filesystems (NFS/SMB where
+   inotify/FSEvents don't fire — document this: network mounts stay on poll).
+
+## 13. Open decisions (resolve before Phase 2)
+
+- `notify` version + which debouncer (`mini` preferred; confirm rename-cookie
+  behavior for atomic-save editors on both platforms).
+- Exact debounce/settle numbers from a 24h field soak on a large corpus.
+- Whether `scan_cache.json` TTL logic (`can_skip_fresh_scan`) stays as a
+  second-level guard — recommendation: keep, it protects search-time paths.
+- Memory-docs watching stays out of v1 (section 5) — confirm no large-memory
+  workflow depends on sub-minute memory freshness.

--- a/docs/event-driven-indexing-spec.md
+++ b/docs/event-driven-indexing-spec.md
@@ -17,10 +17,12 @@
 > inotify reports every write, so Linux skips the sweep.
 > (2) Watch roots are canonicalized before arming: backends silently
 > mis-deliver for paths containing symlinks.
-> Tier-1/2 dirty-path ingest (spec §7) is intentionally deferred: fires run
-> the full incremental ingest behind a stat-based no-op skip
-> (`dirty_needs_ingest`), which keeps converge-equality trivially exact
-> while delivering the latency and idle-cost wins.
+> Dirty batches now call `ingest_dirty`: `src/ingest/selection.rs` resolves
+> ordinary transcript paths without walking source trees, and publication
+> reuses the existing parsers, lease, writer, analytics, and ingest state.
+> OpenCode WAL updates with unchanged session ownership scan only their DB.
+> Structural changes and unresolved dependencies use full reconciliation
+> (see §7). Partial runs never advance the full-scan cache or resync timer.
 
 Started from latest `main` (`04adaca`). This spec replaces the daemon's
 polling loop with OS filesystem events, with periodic reconciliation as the
@@ -168,7 +170,7 @@ Resolver output derives from the enabled-source flags in `IngestOptions`:
 | Jcode | `JCODE_HOME` / `~/.jcode/sessions` | Single-JSON files: atomic reparse rule already exists; event just triggers it sooner. |
 | Muse | `MUSE_HOME` / `~/.local/share/muse/sessions` | |
 | Hermes | `HERMES_HOME` profiles | Currently discovery-only; include for free via `profile_roots()`. |
-| Memory docs | Whatever `refresh_memories` (`src/ingest.rs:1701`) reads: project `memory/` dirs are per-project (unbounded) — **do not** watch the world. Watch only `~/.memex/memory/` outputs? No: inputs live in user repos. Decision: memory refresh stays on the ingest path (it runs inside every ingest, including event-triggered ones) and is *not* independently watched in v1. Document this explicitly. |
+| Memory docs | Inputs live in project memory directories, not just Memex's outputs. Refresh during full ingestion/reconciliation and the existing search-time refresh path; targeted transcript batches do not rediscover memory inputs. Memory documents are not independently watched in v1. |
 | Config | `~/.memex/config.toml` | Change → re-resolve roots (add/drop watches), re-read debounce/resync settings. Debounce this harder (5s); never trigger an ingest by itself. |
 
 Nonexistent roots: watch the nearest existing ancestor so first-run creation is
@@ -228,18 +230,19 @@ one stat.
   Skip unchanged (same size+mtime fast path already inside). Parse tails in the
   existing rayon pool, publish through the existing `writer_loop`. No directory
   walk. This is the whole performance win.
-- **Tier 2 — scoped discovery** (on create/delete/rename/dir events, unknown
-  paths, or any event whose parent dir isn't in state): re-run discovery for
-  the affected source root only (e.g. one `discover_rollouts()` call), diff
-  against `state.files` keys under that root to find tombstones, then proceed
-  as Tier 1 for the delta. Never a full multi-source walk on the hot path.
+- **Dependency/structural fallback**: directory changes, missing indexed
+  paths, ambiguous source overlaps and nested symlinks request full
+  reconciliation. So do legacy OpenCode message/part/session dependencies,
+  Pi settings, Grok summaries and Copilot workspace metadata. New ordinary
+  transcript files use Tier 1. Unrelated regular files and agent-home cache
+  directories are ignored. Source-scoped structural discovery is future work.
 - **Tier 3 — full resync** (section 8): literally call the existing
   `ingest_all` discovery path. Correctness backstop, not the hot path.
 
-Tier 1/2 should be implemented as a `dirty_paths: HashSet<PathBuf>` parameter
-threaded into `ingest_all` (or a sibling `ingest_dirty`) that constrains
-discovery — not as a copy of the ingest body. One parse path, two discovery
-scopes.
+`ingest_all` and `ingest_dirty` share `ingest_selected` and its publication
+pipeline. Targeted Codex history uses known rollout paths plus the current
+batch for deduplication. Partial inventories preserve unselected file and
+database state and cannot establish absence of another database.
 
 ## 8. Reconciliation protocol (the correctness core)
 
@@ -251,11 +254,10 @@ covers it:
 1. **Startup**: always Tier 3 full scan before arming the watcher snapshot.
    Also runs `PendingIngest` recovery first (unchanged order). This bounds
    the offline window (daemon stopped, laptop asleep, `kill -9`).
-2. **Periodic resync**: Tier 3 on a jittered timer, default 5–15 min
-   (configurable; reuses `index_service_poll_interval` as the floor so existing
-   configs keep meaning "at most this stale"). Jitter ±20% avoids lockstep
-   with systemd/launchd neighbors. This is the backstop that makes every
-   missed-event bug self-healing within minutes.
+2. **Periodic resync**: Tier 3 after the configured interval since the last
+   complete scan (default 600s; legacy poll-interval settings remain honored).
+   Targeted ingestion never postpones this deadline or updates the full-scan
+   cache, so continuous activity cannot starve missed-event recovery.
 3. **Overflow/resync signals**: FSEvent `mustScanSubDirs` / history-drop, inotify
    `IN_Q_OVERFLOW`, `notify::EventKind::Other` resync markers, watcher `Error`
    of any kind → immediate Tier 3, then re-establish watches. Log at warn with
@@ -269,10 +271,10 @@ covers it:
    on both Tantivy and vector stores. Additionally, Tier 3's existing
    excluded/vanished handling stays as the final sweep. Never trust a delete
    event alone to name every affected session (directory renames move many).
-6. **Opencode ownership drift**: DB compaction can reassign session ownership
-   between DB files. The existing `owner_by_session` claim pass already
-   reconciles this from scan output — event mode must run that pass on *any*
-   opencode DB event (Tier 2 scoped to opencode roots), not just full scans.
+6. **Opencode ownership drift**: ordinary WAL updates retain the existing
+   owned-session set and update only that database. A new database or changed
+   session set escalates to full discovery before publication, so ownership
+   transfers and legacy-store migration use the complete claim pass.
 7. **State-vs-index audit**: keep the `empty_index_rebuild` guard
    (`src/ingest.rs:687`) and the `PendingIngest` source-path invalidation on
    all tiers. If the index is empty but state is non-empty (or vice versa),

--- a/docs/event-driven-indexing-spec.md
+++ b/docs/event-driven-indexing-spec.md
@@ -10,6 +10,10 @@
 > transcripts through a single held-open fd (confirmed via `lsof` on live
 > Codex sessions) — so macOS runs a 5s hot sweep re-statting recently
 > active files (`hot_sweep_dirty`, `HOT_SWEEP_INTERVAL`, `HOT_WINDOW`).
+> Candidates are selected from stored ingest timestamps before statting;
+> cold sessions resume through events or the periodic resync. Tracked
+> OpenCode databases also have their main file and WAL statted, since an
+> open WAL can contain commits without any main-file modification.
 > inotify reports every write, so Linux skips the sweep.
 > (2) Watch roots are canonicalized before arming: backends silently
 > mis-deliver for paths containing symlinks.
@@ -154,7 +158,7 @@ Resolver output derives from the enabled-source flags in `IngestOptions`:
 | ------ | -------------- | ----- |
 | Claude | `default_claude_sources()` (`CLAUDE_CONFIG_DIR` or `~/.claude/projects`, `~/.config/claude/projects`) + explicit `--claude-path` | Watch the `projects` dirs, not `$HOME`. |
 | Codex | `CODEX_HOME` (`~/.codex`): `sessions/`, rollout roots, history file parents | History files are single files — watch parent dir. |
-| OpenCode | `OPENCODE_DATA_DIR` / `~/.local/share/opencode`: storage root, message/parts roots, `*.sqlite` parents | SQLite: trigger on main DB path only; ignore `-wal`/`-shm`/`-journal` sidecar events (they always accompany a DB write; coalesce, don't double-fire). Cursor logic (`event_rowid`/`event_id` in `scan_database`) stays authoritative. |
+| OpenCode | `OPENCODE_DATA_DIR` / `~/.local/share/opencode`: storage root, message/parts roots, `opencode*.db` parents | Route WAL events to their main DB path: committed writes may change only the WAL. Ignore `-shm`/`-journal` noise. Cursor logic (`event_rowid`/`event_id` in `scan_database`) stays authoritative. |
 | Cursor | `~/.cursor/projects` | |
 | Pi | `PI_CODING_AGENT_DIR` / `~/.pi/agent/sessions` (+ configured session root) | Env-driven; also watch `config.toml` (see below) and re-resolve roots when it changes. |
 | OMP | `~/.omp/agent/sessions`, profiles root, `XDG_DATA_HOME` variant | |
@@ -181,7 +185,8 @@ Drop in the watcher callback, in order:
 2. Sidecars and temp files: `*.tmp`, `*.swp`, `*~`, `.DS_Store`,
    `.memex-opencode-spool-*` (`OPENCODE_SPOOL_PREFIX`), Tantivy generation
    workdirs under `~/.memex/index` (never watch `~/.memex` itself), SQLite
-   `-wal`/`-shm`/`-journal` (coalesced into the main-DB event).
+   `-shm`/`-journal` and unrelated `-wal` files. OpenCode WAL events are
+   translated into main-DB hints before filtering the remaining sidecars.
 3. Paths matching the existing `PathExcluder` (config `exclude_paths` + CLI
    `--exclude`). Canonicalize before matching, exactly like discovery does.
 4. Events from our own state writes (`ingest.json`, `scan_cache.json`,

--- a/docs/event-driven-indexing-spec.md
+++ b/docs/event-driven-indexing-spec.md
@@ -1,5 +1,23 @@
 # Event-driven indexing: FSEvents / inotify spec
 
+> **Implementation status (shipped):** `src/watch.rs` + daemon wiring
+> implements this spec with `--watch-mode events|poll` (`daemon run`,
+> `daemon enable/restart`, hidden on legacy `index --watch`).
+> Two findings from implementation are now part of the design:
+> (1) FSEvents defers content-modification events for files held open for
+> writing (0 events in 8s with the fd open, immediate delivery on close;
+> regression test `fsevents_defers_modify_until_close`) while agents stream
+> transcripts through a single held-open fd (confirmed via `lsof` on live
+> Codex sessions) — so macOS runs a 5s hot sweep re-statting recently
+> active files (`hot_sweep_dirty`, `HOT_SWEEP_INTERVAL`, `HOT_WINDOW`).
+> inotify reports every write, so Linux skips the sweep.
+> (2) Watch roots are canonicalized before arming: backends silently
+> mis-deliver for paths containing symlinks.
+> Tier-1/2 dirty-path ingest (spec §7) is intentionally deferred: fires run
+> the full incremental ingest behind a stat-based no-op skip
+> (`dirty_needs_ingest`), which keeps converge-equality trivially exact
+> while delivering the latency and idle-cost wins.
+
 Started from latest `main` (`04adaca`). This spec replaces the daemon's
 polling loop with OS filesystem events, with periodic reconciliation as the
 correctness backstop. Events are **hints only** — `ingest.json` file-state

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5093,10 +5093,10 @@ fn run_index_service_enable(
         stderr: config_path_setting(stderr.as_deref(), "--stderr")?,
         plist: config_path_setting(plist.as_deref(), "--plist")?,
         systemd_dir: config_path_setting(systemd_dir.as_deref(), "--systemd-dir")?,
-        watch_mode: watch_mode.map(|mode| mode.to_string()),
         ..IndexServiceConfigUpdates::from_cli(
             continuous,
             poll_interval,
+            watch_mode,
             interval,
             web_ui,
             web_listen.as_deref(),
@@ -5234,6 +5234,7 @@ impl IndexServiceConfigUpdates {
     fn from_cli(
         continuous: bool,
         poll_interval: Option<u64>,
+        watch_mode: Option<WatchMode>,
         interval: Option<u64>,
         web_ui: bool,
         web_listen: Option<&str>,
@@ -5241,6 +5242,7 @@ impl IndexServiceConfigUpdates {
     ) -> Result<Self> {
         let mode = if continuous
             || poll_interval.is_some()
+            || watch_mode.is_some()
             || web_ui
             || web_listen.is_some()
             || mcp_args.mcp
@@ -5254,6 +5256,7 @@ impl IndexServiceConfigUpdates {
         };
         Ok(Self {
             mode,
+            watch_mode: watch_mode.map(|mode| mode.to_string()),
             poll_interval: poll_interval
                 .map(i64::try_from)
                 .transpose()
@@ -8099,6 +8102,7 @@ arguments = {
                 false,
                 Some(12),
                 None,
+                None,
                 false,
                 None,
                 &DaemonMcpArgs::default(),
@@ -8121,6 +8125,86 @@ arguments = {
                     .index_service_poll_interval(),
                 12
             );
+        }
+    }
+
+    #[test]
+    fn daemon_watch_mode_persists_continuous_across_plain_restart() {
+        for action in ["enable", "restart"] {
+            for watch_mode in ["events", "poll"] {
+                for initial_config in ["", "index_service_mode = \"interval\"\n"] {
+                    for interval in [None, Some("60")] {
+                        let tmp = TempDir::new().unwrap();
+                        let paths = Paths::new(Some(tmp.path().to_path_buf())).unwrap();
+                        let path = paths.root.join("config.toml");
+                        std::fs::write(&path, initial_config).unwrap();
+                        let mut args = vec!["memex", "daemon", action, "--watch-mode", watch_mode];
+                        if let Some(interval) = interval {
+                            args.extend(["--interval", interval]);
+                        }
+                        let cli = Cli::try_parse_from(args).unwrap();
+                        let Some(Commands::IndexService {
+                            action:
+                                IndexServiceCommand::Enable {
+                                    continuous,
+                                    poll_interval,
+                                    watch_mode: selected_mode,
+                                    interval,
+                                    web_ui,
+                                    web_listen,
+                                    mcp,
+                                    ..
+                                }
+                                | IndexServiceCommand::Restart {
+                                    continuous,
+                                    poll_interval,
+                                    watch_mode: selected_mode,
+                                    interval,
+                                    web_ui,
+                                    web_listen,
+                                    mcp,
+                                    ..
+                                },
+                        }) = cli.command
+                        else {
+                            panic!("expected daemon enable or restart");
+                        };
+                        let updates = IndexServiceConfigUpdates::from_cli(
+                            continuous,
+                            poll_interval,
+                            selected_mode,
+                            interval,
+                            web_ui,
+                            web_listen.as_deref(),
+                            &mcp,
+                        )
+                        .unwrap();
+                        persist_index_service_config(&paths, &updates).unwrap();
+                        let before_restart = std::fs::read_to_string(&path).unwrap();
+
+                        // A restart without flags must retain the continuous mode
+                        // implied by --watch-mode, even over interval configuration.
+                        let restart_updates = IndexServiceConfigUpdates::from_cli(
+                            false,
+                            None,
+                            None,
+                            None,
+                            false,
+                            None,
+                            &DaemonMcpArgs::default(),
+                        )
+                        .unwrap();
+                        persist_index_service_config(&paths, &restart_updates).unwrap();
+                        let restarted = UserConfig::load(&paths).unwrap();
+                        assert_eq!(restarted.index_service_mode(), Some("continuous"));
+                        assert_eq!(
+                            restarted.index_service_watch_mode().unwrap().to_string(),
+                            watch_mode
+                        );
+                        assert_eq!(std::fs::read_to_string(&path).unwrap(), before_restart);
+                    }
+                }
+            }
         }
     }
 
@@ -8153,6 +8237,7 @@ arguments = {
         let updates = IndexServiceConfigUpdates::from_cli(
             continuous,
             poll_interval,
+            None,
             interval,
             web_ui,
             web_listen.as_deref(),
@@ -8210,6 +8295,7 @@ arguments = {
         let updates = IndexServiceConfigUpdates::from_cli(
             continuous,
             poll_interval,
+            None,
             interval,
             web_ui,
             web_listen.as_deref(),
@@ -8238,6 +8324,7 @@ arguments = {
         let restart_updates = IndexServiceConfigUpdates::from_cli(
             continuous,
             poll_interval,
+            None,
             interval,
             web_ui,
             web_listen.as_deref(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,8 @@ use crate::tui;
 use crate::types::{RecordLinks, SourceFilter};
 use crate::usage::{CostMode, UsageQuery, scan_usage};
 use crate::vector::VectorIndex;
+use crate::watch::WatchMode;
+use crate::watch::{WatchService, watch_roots};
 use anyhow::{Context, Result, anyhow};
 use chrono::SecondsFormat;
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -212,6 +214,9 @@ EXAMPLES:
             hide = true
         )]
         watch_interval: u64,
+        /// Refresh strategy for watch mode: filesystem events (default) or legacy polling
+        #[arg(long, value_enum, hide = true)]
+        watch_mode: Option<WatchMode>,
         #[arg(long, hide = true)]
         web_ui: bool,
         #[arg(long, hide = true, value_name = "ADDRESS")]
@@ -1049,6 +1054,9 @@ enum IndexServiceCommand {
         /// Seconds between index refreshes (default: config or 30)
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
         poll_interval: Option<u64>,
+        /// Refresh strategy: filesystem events (default) or legacy polling
+        #[arg(long, value_enum)]
+        watch_mode: Option<WatchMode>,
         #[command(flatten)]
         mcp: DaemonMcpArgs,
     },
@@ -1065,6 +1073,9 @@ enum IndexServiceCommand {
         /// Seconds between index checks in continuous mode [default: 30]
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECONDS")]
         poll_interval: Option<u64>,
+        /// Refresh strategy for continuous mode: filesystem events (default) or legacy polling
+        #[arg(long, value_enum)]
+        watch_mode: Option<WatchMode>,
         /// Seconds between invocations in interval mode [default: 3600]
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECONDS")]
         interval: Option<u64>,
@@ -1102,6 +1113,9 @@ enum IndexServiceCommand {
         /// Seconds between index checks in continuous mode [default: 30]
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECONDS")]
         poll_interval: Option<u64>,
+        /// Refresh strategy for continuous mode: filesystem events (default) or legacy polling
+        #[arg(long, value_enum)]
+        watch_mode: Option<WatchMode>,
         /// Seconds between invocations in interval mode [default: 3600]
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..), value_name = "SECONDS")]
         interval: Option<u64>,
@@ -1232,13 +1246,14 @@ pub fn run() -> Result<()> {
             index,
             watch,
             watch_interval,
+            watch_mode,
             web_ui,
             web_listen,
             mcp,
             no_mcp,
             mcp_listen,
         } => {
-            if watch {
+            if watch || watch_mode.is_some() {
                 let listen = (web_ui || web_listen.is_some())
                     .then(|| web_listen.unwrap_or_else(|| crate::web::DEFAULT_LISTEN.to_string()));
                 let config = UserConfig::load(&Paths::new(index.root.clone())?)?;
@@ -1248,7 +1263,8 @@ pub fn run() -> Result<()> {
                     mcp_listen,
                 }
                 .resolve(&config);
-                run_index_loop(&index, watch_interval, listen, mcp)?;
+                let mode = watch_mode.unwrap_or(WatchMode::Events);
+                run_index_loop(&index, mode, watch_interval, listen, mcp)?;
             } else if web_ui || web_listen.is_some() || mcp || no_mcp || mcp_listen.is_some() {
                 return Err(anyhow!("server options require `memex daemon run`"));
             } else {
@@ -1367,6 +1383,7 @@ pub fn run() -> Result<()> {
                 web_ui,
                 web_listen,
                 poll_interval,
+                watch_mode,
                 mcp,
             } => {
                 let config = UserConfig::load(&Paths::new(index.root.clone())?)?;
@@ -1376,9 +1393,13 @@ pub fn run() -> Result<()> {
                             .or_else(|| config.index_service_web_listen.clone())
                             .unwrap_or_else(|| crate::web::DEFAULT_LISTEN.to_string())
                     });
-                let interval = poll_interval.unwrap_or(config.index_service_poll_interval());
+                let mode = watch_mode.unwrap_or(config.index_service_watch_mode()?);
+                let interval = poll_interval.unwrap_or(match mode {
+                    WatchMode::Events => config.index_service_resync_interval(),
+                    WatchMode::Poll => config.index_service_poll_interval(),
+                });
                 anyhow::ensure!(interval > 0, "poll interval must be positive");
-                run_index_loop(&index, interval, web, mcp.resolve(&config))?;
+                run_index_loop(&index, mode, interval, web, mcp.resolve(&config))?;
             }
             IndexServiceCommand::Enable {
                 index,
@@ -1386,6 +1407,7 @@ pub fn run() -> Result<()> {
                 label,
                 continuous,
                 poll_interval,
+                watch_mode,
                 interval,
                 web_ui,
                 web_listen,
@@ -1400,6 +1422,7 @@ pub fn run() -> Result<()> {
                     label,
                     continuous,
                     poll_interval,
+                    watch_mode,
                     interval,
                     web_ui,
                     web_listen,
@@ -1415,6 +1438,7 @@ pub fn run() -> Result<()> {
                 label,
                 continuous,
                 poll_interval,
+                watch_mode,
                 interval,
                 web_ui,
                 web_listen,
@@ -1429,6 +1453,7 @@ pub fn run() -> Result<()> {
                     label,
                     continuous,
                     poll_interval,
+                    watch_mode,
                     interval,
                     web_ui,
                     web_listen,
@@ -1755,6 +1780,20 @@ pub fn run() -> Result<()> {
 
 fn run_index_loop(
     index: &IndexArgs,
+    mode: WatchMode,
+    interval_secs: u64,
+    web_listen: Option<String>,
+    mcp: Option<crate::mcp::HttpOptions>,
+) -> Result<()> {
+    if mode == WatchMode::Poll {
+        run_poll_loop(index, interval_secs, web_listen, mcp)
+    } else {
+        run_event_loop(index, Duration::from_secs(interval_secs), web_listen, mcp)
+    }
+}
+
+fn run_poll_loop(
+    index: &IndexArgs,
     interval_secs: u64,
     web_listen: Option<String>,
     mcp: Option<crate::mcp::HttpOptions>,
@@ -1793,75 +1832,197 @@ fn initialize_index_loop<T>(
     Ok(web)
 }
 
-fn run_index_args(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
-    run_index(
-        index.source.clone(),
-        index.include_agents,
-        index.include_reasoning,
-        index.source_enabled(IndexSource::Claude),
-        index.source_enabled(IndexSource::Codex),
-        index.source_enabled(IndexSource::Opencode),
-        index.source_enabled(IndexSource::Cursor),
-        index.source_enabled(IndexSource::Pi),
-        index.source_enabled(IndexSource::Omp),
-        index.source_enabled(IndexSource::Openclaw),
-        index.source_enabled(IndexSource::Copilot),
-        index.source_enabled(IndexSource::Grok),
-        index.source_enabled(IndexSource::Jcode),
-        index.source_enabled(IndexSource::Muse),
-        index.embeddings,
-        index.no_embeddings,
-        index.model.clone(),
-        index.root.clone(),
-        index.exclude.clone(),
-        reindex,
-        continuous,
-        index.diagnostics,
-    )
+/// Event-driven daemon loop: the watcher is armed before the initial scan so
+/// nothing falls in the gap, then every debounced batch (or the periodic
+/// resync) runs the normal incremental ingest. On ingest failure the hints
+/// are kept and retried; the resync timer bounds staleness no matter what.
+fn run_event_loop(
+    index: &IndexArgs,
+    resync: Duration,
+    web_listen: Option<String>,
+    mcp: Option<crate::mcp::HttpOptions>,
+) -> Result<()> {
+    use crate::watch::{
+        FireCause, HOT_SWEEP_INTERVAL, HOT_WINDOW, WatchConfig, WatchService, dirty_needs_ingest,
+        watch_excluder, watch_roots,
+    };
+
+    let paths = Paths::new(index.root.clone())?;
+    let config = UserConfig::load(&paths)?;
+    let options = build_ingest_options(index, &config)?;
+    let mut service = WatchService::new(
+        watch_roots(&options),
+        watch_excluder(&options)?,
+        WatchConfig {
+            resync_interval: resync,
+            ..WatchConfig::default()
+        },
+    )?;
+    eprintln!(
+        "watch: events mode ({} watched roots, {} pending, resync every {}s)",
+        service.watched_roots().len(),
+        service.pending_roots().len(),
+        resync.as_secs(),
+    );
+
+    let mcp_server = mcp
+        .map(|options| crate::mcp::spawn_http(index.root.clone(), options))
+        .transpose()?;
+    let _web_thread = initialize_index_loop(
+        || run_index_args(index, false, true),
+        || {
+            web_listen
+                .as_deref()
+                .map(|listen| crate::web::spawn(index.root.clone(), listen))
+                .transpose()
+        },
+    )?;
+
+    let mut last_sweep = Instant::now();
+    loop {
+        match service.poll() {
+            Some(FireCause::Resync) => {
+                if let Err(error) = refresh_watch_roots(&mut service, index) {
+                    eprintln!("watch: root refresh failed: {error:#}");
+                }
+                match run_index_args(index, false, true) {
+                    Ok(()) => {
+                        service.mark_complete(FireCause::Resync);
+                        log_watch_stats(&service);
+                    }
+                    Err(error) => eprintln!("watch: resync ingest failed, retrying: {error:#}"),
+                }
+            }
+            Some(FireCause::Dirty) => {
+                let dirty = service.dirty_paths();
+                match dirty_needs_ingest(&paths, &dirty) {
+                    Ok(false) => service.mark_skipped(),
+                    Ok(true) => match run_index_args(index, false, true) {
+                        Ok(()) => {
+                            service.mark_complete(FireCause::Dirty);
+                            log_watch_stats(&service);
+                        }
+                        Err(error) => {
+                            eprintln!("watch: ingest failed, retrying: {error:#}");
+                        }
+                    },
+                    Err(error) => {
+                        eprintln!("watch: dirty check failed, ingesting to be safe: {error:#}");
+                        if run_index_args(index, false, true).is_ok() {
+                            service.mark_complete(FireCause::Dirty);
+                            log_watch_stats(&service);
+                        }
+                    }
+                }
+            }
+            None => {}
+        }
+        // FSEvents defers modify events for held-open files and agents stream
+        // transcripts through one open fd, so re-stat recently active files on
+        // macOS. inotify reports every write, making this unnecessary there.
+        if cfg!(target_os = "macos") && last_sweep.elapsed() >= HOT_SWEEP_INTERVAL {
+            last_sweep = Instant::now();
+            match service.hot_sweep_dirty(&paths, HOT_WINDOW) {
+                Ok(changed) if !changed.is_empty() => service.note_dirty(changed),
+                Ok(_) => {}
+                Err(error) => eprintln!("watch: hot sweep failed: {error:#}"),
+            }
+        }
+        if let Some(server) = &mcp_server
+            && !server.wait_timeout(Duration::from_millis(0))?
+        {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        std::io::stdout().flush().ok();
+    }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn run_index(
-    source: Option<PathBuf>,
-    include_agents: bool,
-    include_reasoning: bool,
-    claude: bool,
-    codex: bool,
-    opencode: bool,
-    cursor: bool,
-    pi: bool,
-    omp: bool,
-    openclaw: bool,
-    copilot: bool,
-    grok: bool,
-    jcode: bool,
-    muse: bool,
-    embeddings_flag: bool,
-    no_embeddings: bool,
-    model: Option<String>,
-    root: Option<PathBuf>,
-    mut excludes: Vec<String>,
-    reindex: bool,
-    continuous: bool,
-    print_diagnostics: bool,
-) -> Result<()> {
-    let paths = Paths::new(root)?;
+/// Re-resolve watch roots (cheap; call on resync) so newly installed agent
+/// backends are picked up without a daemon restart.
+fn refresh_watch_roots(service: &mut WatchService, index: &IndexArgs) -> Result<()> {
+    let paths = Paths::new(index.root.clone())?;
     let config = UserConfig::load(&paths)?;
+    let options = build_ingest_options(index, &config)?;
+    service.ensure_roots(watch_roots(&options));
+    Ok(())
+}
 
+fn log_watch_stats(service: &WatchService) {
+    let stats = service.stats();
+    eprintln!(
+        "watch: events={} filtered={} fires_dirty={} fires_resync={} noop_skips={} \
+         errors={} resync_req={} hot_sweeps={} hot_hits={}",
+        stats.events_total,
+        stats.events_filtered,
+        stats.fires_dirty,
+        stats.fires_resync,
+        stats.noop_skips,
+        stats.watcher_errors,
+        stats.resync_requests,
+        stats.hot_sweeps,
+        stats.hot_hits,
+    );
+}
+fn run_index_args(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
+    run_index(index, reindex, continuous)
+}
+
+/// Resolve the ingest projection from CLI flags plus config. Shared by the
+/// one-shot indexer and the event-driven daemon (which needs the same source
+/// set to compute its watch roots).
+fn build_ingest_options(index: &IndexArgs, config: &UserConfig) -> Result<IngestOptions> {
     // Config exclusions apply to every index run; CLI --exclude adds one-off patterns.
+    let mut excludes = index.exclude.clone();
     excludes.extend(config.exclude_path_patterns());
 
     // Model priority: CLI flag > config file > env var > default
-    let model_choice = config.resolve_model(model)?;
+    let model_choice = config.resolve_model(index.model.clone())?;
     let embed_runtime = config.resolve_embed_runtime()?;
     let tool_content_limits = config.indexed_tool_content_limits()?;
-    let include_reasoning = include_reasoning || config.include_reasoning_default();
+    let include_reasoning = index.include_reasoning || config.include_reasoning_default();
     let embeddings = resolve_flag(
         config.embeddings_default(),
-        embeddings_flag,
-        no_embeddings,
+        index.embeddings,
+        index.no_embeddings,
         "embeddings",
     )?;
+    Ok(IngestOptions {
+        claude_sources: if index.source_enabled(IndexSource::Claude) {
+            index
+                .source
+                .clone()
+                .map(|source| vec![source])
+                .unwrap_or_else(default_claude_sources)
+        } else {
+            Vec::new()
+        },
+        include_agents: index.include_agents,
+        include_reasoning,
+        include_codex: index.source_enabled(IndexSource::Codex),
+        include_opencode: index.source_enabled(IndexSource::Opencode),
+        include_cursor: index.source_enabled(IndexSource::Cursor),
+        include_pi: index.source_enabled(IndexSource::Pi),
+        include_omp: index.source_enabled(IndexSource::Omp),
+        include_openclaw: index.source_enabled(IndexSource::Openclaw),
+        include_copilot: index.source_enabled(IndexSource::Copilot),
+        include_grok: index.source_enabled(IndexSource::Grok),
+        include_jcode: index.source_enabled(IndexSource::Jcode),
+        include_muse: index.source_enabled(IndexSource::Muse),
+        exclude_patterns: excludes,
+        embeddings,
+        backfill_embeddings: false,
+        model: model_choice,
+        embed_runtime,
+        tool_content_limits,
+    })
+}
+
+fn run_index(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
+    let paths = Paths::new(index.root.clone())?;
+    let config = UserConfig::load(&paths)?;
+    let opts = build_ingest_options(index, &config)?;
+    let print_diagnostics = index.diagnostics;
     let operation = if reindex { "reindex" } else { "index" };
     let lease = IngestLease::acquire(&paths, operation, INGEST_LEASE_TIMEOUT)?;
     if reindex {
@@ -1872,34 +2033,6 @@ fn run_index(
         SearchIndex::open_or_create_for_continuous_ingest(&paths.index)?
     } else {
         SearchIndex::open_or_create_for_ingest(&paths.index)?
-    };
-
-    let opts = IngestOptions {
-        claude_sources: if claude {
-            source
-                .map(|source| vec![source])
-                .unwrap_or_else(default_claude_sources)
-        } else {
-            Vec::new()
-        },
-        include_agents,
-        include_reasoning,
-        include_codex: codex,
-        include_opencode: opencode,
-        include_cursor: cursor,
-        include_pi: pi,
-        include_omp: omp,
-        include_openclaw: openclaw,
-        include_copilot: copilot,
-        include_grok: grok,
-        include_jcode: jcode,
-        include_muse: muse,
-        exclude_patterns: excludes,
-        embeddings,
-        backfill_embeddings: false,
-        model: model_choice,
-        embed_runtime,
-        tool_content_limits,
     };
 
     let report = ingest_all(&paths, &index, &opts, &lease)?;
@@ -4934,6 +5067,7 @@ fn run_index_service_enable(
     label: Option<String>,
     continuous: bool,
     poll_interval: Option<u64>,
+    watch_mode: Option<WatchMode>,
     interval: Option<u64>,
     web_ui: bool,
     web_listen: Option<String>,
@@ -4959,6 +5093,7 @@ fn run_index_service_enable(
         stderr: config_path_setting(stderr.as_deref(), "--stderr")?,
         plist: config_path_setting(plist.as_deref(), "--plist")?,
         systemd_dir: config_path_setting(systemd_dir.as_deref(), "--systemd-dir")?,
+        watch_mode: watch_mode.map(|mode| mode.to_string()),
         ..IndexServiceConfigUpdates::from_cli(
             continuous,
             poll_interval,
@@ -4978,7 +5113,8 @@ fn run_index_service_enable(
     let web_listen = web_listen
         .or_else(|| config.index_service_web_listen.clone())
         .unwrap_or_else(|| crate::web::DEFAULT_LISTEN.to_string());
-    let cli_continuous = continuous || poll_interval.is_some() || cli_web_ui;
+    let cli_continuous =
+        continuous || poll_interval.is_some() || watch_mode.is_some() || cli_web_ui;
     let config_continuous = match config.index_service_mode() {
         Some("interval") => false,
         Some("continuous") => true,
@@ -4996,7 +5132,11 @@ fn run_index_service_enable(
     } else {
         config_continuous
     };
-    let poll_interval = poll_interval.unwrap_or(config.index_service_poll_interval());
+    let watch_mode = watch_mode.unwrap_or(config.index_service_watch_mode()?);
+    let poll_interval = poll_interval.unwrap_or(match watch_mode {
+        WatchMode::Events => config.index_service_resync_interval(),
+        WatchMode::Poll => config.index_service_poll_interval(),
+    });
     let interval = interval.unwrap_or(config.index_service_interval());
     if web_ui {
         crate::web::validate_listener(&web_listen)?;
@@ -5007,6 +5147,7 @@ fn run_index_service_enable(
         index,
         continuous,
         poll_interval,
+        watch_mode,
         web_ui,
         &web_listen,
         mcp_listen,
@@ -5067,6 +5208,7 @@ fn run_index_service_enable(
 struct IndexServiceConfigUpdates {
     mode: Option<&'static str>,
     poll_interval: Option<i64>,
+    watch_mode: Option<String>,
     interval: Option<i64>,
     web_ui: Option<bool>,
     web_listen: Option<String>,
@@ -5138,6 +5280,7 @@ impl IndexServiceConfigUpdates {
 fn persist_index_service_config(paths: &Paths, updates: &IndexServiceConfigUpdates) -> Result<()> {
     if updates.mode.is_none()
         && updates.poll_interval.is_none()
+        && updates.watch_mode.is_none()
         && updates.interval.is_none()
         && updates.web_ui.is_none()
         && updates.web_listen.is_none()
@@ -5175,6 +5318,12 @@ fn persist_index_service_config(paths: &Paths, updates: &IndexServiceConfigUpdat
             "index_service_poll_interval"
         };
         replace_toml_value(&mut document[key], value(interval));
+    }
+    if let Some(mode) = &updates.watch_mode {
+        replace_toml_value(
+            &mut document["index_service_watch_mode"],
+            value(mode.as_str()),
+        );
     }
     if let Some(interval) = updates.interval {
         replace_toml_value(&mut document["index_service_interval"], value(interval));
@@ -6042,6 +6191,7 @@ fn build_index_command_args(
     index: &IndexArgs,
     continuous: bool,
     poll_interval: u64,
+    watch_mode: WatchMode,
     web_ui: bool,
     web_listen: &str,
     mcp_listen: Option<std::net::SocketAddr>,
@@ -6124,7 +6274,12 @@ fn build_index_command_args(
     if index.diagnostics {
         args.push("--diagnostics".to_string());
     }
-    if continuous {
+    if continuous && watch_mode == WatchMode::Poll {
+        args.push("--watch-mode".to_string());
+        args.push("poll".to_string());
+        args.push("--watch-interval".to_string());
+        args.push(format!("{poll_interval}"));
+    } else if continuous {
         args.push("--watch".to_string());
         args.push("--watch-interval".to_string());
         args.push(format!("{poll_interval}"));
@@ -7372,8 +7527,15 @@ mod tests {
             diagnostics: false,
         };
 
-        let args =
-            build_index_command_args(&index, false, 30, false, crate::web::DEFAULT_LISTEN, None);
+        let args = build_index_command_args(
+            &index,
+            false,
+            30,
+            WatchMode::Events,
+            false,
+            crate::web::DEFAULT_LISTEN,
+            None,
+        );
 
         assert!(args.contains(&"--no-codex".to_string()));
         assert!(args.contains(&"--no-opencode".to_string()));
@@ -7422,7 +7584,15 @@ mod tests {
             diagnostics: false,
         };
 
-        let args = build_index_command_args(&index, false, 30, false, "127.0.0.1:7777", None);
+        let args = build_index_command_args(
+            &index,
+            false,
+            30,
+            WatchMode::Events,
+            false,
+            "127.0.0.1:7777",
+            None,
+        );
 
         let mut pairs = args.windows(2);
         assert!(pairs.any(|w| w == ["--exclude", "~/work/**"]));
@@ -7465,7 +7635,15 @@ mod tests {
             diagnostics: false,
         };
 
-        let args = build_index_command_args(&index, true, 30, true, "127.0.0.1:6363", None);
+        let args = build_index_command_args(
+            &index,
+            true,
+            30,
+            WatchMode::Events,
+            true,
+            "127.0.0.1:6363",
+            None,
+        );
 
         assert!(
             args.windows(2)
@@ -7473,6 +7651,81 @@ mod tests {
         );
         assert!(args.contains(&"--web-ui".to_string()));
         assert!(args.contains(&"--watch".to_string()));
+    }
+
+    #[test]
+    fn build_index_command_args_emits_poll_mode_without_watch() {
+        let index = IndexArgs {
+            only_source: Vec::new(),
+            exclude_source: Vec::new(),
+            source: None,
+            include_agents: false,
+            include_reasoning: false,
+            exclude: Vec::new(),
+            codex: true,
+            opencode: true,
+            cursor: true,
+            pi: true,
+            omp: true,
+            openclaw: true,
+            copilot: true,
+            grok: true,
+            jcode: true,
+            muse: true,
+            no_codex: false,
+            no_opencode: false,
+            no_pi: false,
+            no_omp: false,
+            no_openclaw: false,
+            no_copilot: false,
+            no_grok: false,
+            no_jcode: false,
+            no_muse: false,
+            embeddings: false,
+            no_embeddings: false,
+            model: None,
+            root: None,
+            diagnostics: false,
+        };
+
+        let args = build_index_command_args(
+            &index,
+            true,
+            30,
+            WatchMode::Poll,
+            false,
+            crate::web::DEFAULT_LISTEN,
+            None,
+        );
+
+        assert!(!args.contains(&"--watch".to_string()));
+        assert!(args.windows(2).any(|pair| pair == ["--watch-mode", "poll"]));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--watch-interval", "30"])
+        );
+    }
+
+    #[test]
+    fn daemon_run_accepts_watch_mode_flag() {
+        let cli = Cli::try_parse_from(["memex", "daemon", "run", "--watch-mode", "poll"])
+            .expect("parse daemon run");
+        let Some(Commands::IndexService {
+            action: IndexServiceCommand::Run { watch_mode, .. },
+        }) = cli.command
+        else {
+            panic!("expected daemon run command");
+        };
+        assert_eq!(watch_mode, Some(WatchMode::Poll));
+    }
+
+    #[test]
+    fn legacy_index_watch_defaults_to_events() {
+        let cli = Cli::try_parse_from(["memex", "index", "--watch"]).expect("parse index watch");
+        let Some(Commands::Index { watch_mode, .. }) = cli.command else {
+            panic!("expected index command");
+        };
+        assert_eq!(watch_mode, None);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use crate::analytics::{AnalyticsStore, analytics_path, backfill_from_index};
 use crate::config::{Paths, UserConfig, default_claude_sources};
 use crate::embed::EmbedderHandle;
 use crate::index::{QueryOptions, SearchIndex, SessionScopeKey};
-use crate::ingest::{IngestOptions, ingest_all};
+use crate::ingest::{IngestOptions, ingest_all, ingest_dirty};
 use crate::lease::{INGEST_LEASE_TIMEOUT, IngestLease};
 use crate::machine::{
     BoundedRecord, LocatedMemoryHit, LocatedRecord, MAX_HYDRATE_INPUT_BYTES,
@@ -1878,6 +1878,7 @@ fn run_event_loop(
         },
     )?;
 
+    service.mark_complete(FireCause::Resync);
     let mut last_sweep = Instant::now();
     loop {
         match service.poll() {
@@ -1897,9 +1898,18 @@ fn run_event_loop(
                 let dirty = service.dirty_paths();
                 match dirty_needs_ingest(&paths, &dirty) {
                     Ok(false) => service.mark_skipped(),
-                    Ok(true) => match run_index_args(index, false, true) {
-                        Ok(()) => {
-                            service.mark_complete(FireCause::Dirty);
+                    Ok(true) => match run_index_selection(index, false, true, Some(&dirty)) {
+                        Ok(full_scan) => {
+                            if full_scan
+                                && let Err(error) = refresh_watch_roots(&mut service, index)
+                            {
+                                eprintln!("watch: root refresh failed: {error:#}");
+                            }
+                            service.mark_complete(if full_scan {
+                                FireCause::Resync
+                            } else {
+                                FireCause::Dirty
+                            });
                             log_watch_stats(&service);
                         }
                         Err(error) => {
@@ -1909,7 +1919,7 @@ fn run_event_loop(
                     Err(error) => {
                         eprintln!("watch: dirty check failed, ingesting to be safe: {error:#}");
                         if run_index_args(index, false, true).is_ok() {
-                            service.mark_complete(FireCause::Dirty);
+                            service.mark_complete(FireCause::Resync);
                             log_watch_stats(&service);
                         }
                     }
@@ -2019,6 +2029,17 @@ fn build_ingest_options(index: &IndexArgs, config: &UserConfig) -> Result<Ingest
 }
 
 fn run_index(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
+    run_index_selection(index, reindex, continuous, None).map(|_| ())
+}
+
+/// Return whether discovery covered all sources, so only reconciliation
+/// resets the full-scan timer in the event-driven daemon.
+fn run_index_selection(
+    index: &IndexArgs,
+    reindex: bool,
+    continuous: bool,
+    dirty: Option<&HashSet<PathBuf>>,
+) -> Result<bool> {
     let paths = Paths::new(index.root.clone())?;
     let config = UserConfig::load(&paths)?;
     let opts = build_ingest_options(index, &config)?;
@@ -2035,7 +2056,12 @@ fn run_index(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
         SearchIndex::open_or_create_for_ingest(&paths.index)?
     };
 
-    let report = ingest_all(&paths, &index, &opts, &lease)?;
+    let (report, full_scan) = if let Some(dirty) = dirty {
+        let result = ingest_dirty(&paths, &index, &opts, &lease, dirty)?;
+        (result.report, result.full_scan)
+    } else {
+        (ingest_all(&paths, &index, &opts, &lease)?, true)
+    };
     if report.records_embedded > 0 {
         println!(
             "indexed {} records, embedded {} across {} files (skipped {})",
@@ -2056,7 +2082,7 @@ fn run_index(index: &IndexArgs, reindex: bool, continuous: bool) -> Result<()> {
             serde_json::to_string_pretty(&report.diagnostics)?
         );
     }
-    Ok(())
+    Ok(full_scan)
 }
 
 fn reset_reindex_artifacts(paths: &Paths) -> Result<()> {

--- a/src/cli/surface.rs
+++ b/src/cli/surface.rs
@@ -397,6 +397,7 @@ mod tests {
             &selected,
             true,
             17,
+            crate::watch::WatchMode::Events,
             true,
             "127.0.0.1:4567",
             None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,11 @@ pub struct UserConfig {
     /// Background index service poll interval in seconds.
     #[serde(alias = "index_service_watch_interval")]
     pub index_service_poll_interval: Option<u64>,
+    /// Refresh strategy for the continuous background service: "events" or "poll".
+    pub index_service_watch_mode: Option<String>,
+    /// Full-resync interval in seconds for events mode (the missed-event backstop).
+    /// Falls back to `index_service_poll_interval` when unset.
+    pub index_service_resync_interval: Option<u64>,
     /// Serve the local Web UI from the continuous background index service.
     pub index_service_web_ui: Option<bool>,
     /// Serve MCP from the continuous background index service.
@@ -425,6 +430,19 @@ impl UserConfig {
         self.index_service_poll_interval.unwrap_or(30)
     }
 
+    pub(crate) fn index_service_watch_mode(&self) -> Result<crate::watch::WatchMode> {
+        match self.index_service_watch_mode.as_deref() {
+            None => Ok(crate::watch::WatchMode::Events),
+            Some(mode) => mode.parse(),
+        }
+    }
+
+    pub fn index_service_resync_interval(&self) -> u64 {
+        self.index_service_resync_interval
+            .or(self.index_service_poll_interval)
+            .unwrap_or(600)
+    }
+
     pub fn index_service_web_ui_default(&self) -> bool {
         self.index_service_web_ui.unwrap_or(false)
     }
@@ -516,6 +534,37 @@ mod tests {
     #[test]
     fn token_usage_is_disabled_by_default() {
         assert!(!UserConfig::default().token_usage_enabled());
+    }
+
+    #[test]
+    fn watch_mode_defaults_to_events_and_rejects_unknown() {
+        assert_eq!(
+            UserConfig::default()
+                .index_service_watch_mode()
+                .expect("default watch mode"),
+            crate::watch::WatchMode::Events
+        );
+        let config: UserConfig =
+            toml::from_str(r#"index_service_watch_mode = "poll""#).expect("parse config");
+        assert_eq!(
+            config.index_service_watch_mode().expect("poll watch mode"),
+            crate::watch::WatchMode::Poll
+        );
+        let config: UserConfig =
+            toml::from_str(r#"index_service_watch_mode = "fsevents""#).expect("parse config");
+        assert!(config.index_service_watch_mode().is_err());
+    }
+
+    #[test]
+    fn resync_interval_falls_back_to_poll_interval_then_default() {
+        assert_eq!(UserConfig::default().index_service_resync_interval(), 600);
+        let config: UserConfig =
+            toml::from_str("index_service_poll_interval = 30").expect("parse config");
+        assert_eq!(config.index_service_resync_interval(), 30);
+        let config: UserConfig =
+            toml::from_str("index_service_poll_interval = 30\nindex_service_resync_interval = 120")
+                .expect("parse config");
+        assert_eq!(config.index_service_resync_interval(), 120);
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+mod selection;
+
 const EMBED_BATCH_SIZE: usize = 64;
 const EMBED_MAX_CHARS: usize = 8192;
 const RETAINED_HEAD_PERCENT: usize = 75;
@@ -58,6 +60,13 @@ pub struct IngestReport {
     pub files_scanned: usize,
     pub files_skipped: usize,
     pub diagnostics: crate::sources::ParseDiagnostics,
+}
+
+/// Whether a dirty batch stayed targeted or required a complete reconciliation.
+/// Only a full scan may advance the daemon's reconciliation deadline.
+pub(crate) struct DirtyIngestReport {
+    pub report: IngestReport,
+    pub full_scan: bool,
 }
 
 #[derive(Debug)]
@@ -669,9 +678,31 @@ pub fn ingest_all(
     paths: &Paths,
     index: &SearchIndex,
     options: &IngestOptions,
-    _lease: &IngestLease,
+    lease: &IngestLease,
 ) -> Result<IngestReport> {
-    refresh_memories(paths, options)?;
+    ingest_selected(paths, index, options, lease, None).map(|result| result.report)
+}
+
+/// Ingest a filesystem-event batch through the normal publication pipeline.
+/// Missing/ambiguous inputs and interrupted publication fall back to full
+/// reconciliation; a partial inventory never establishes global absence.
+pub(crate) fn ingest_dirty(
+    paths: &Paths,
+    index: &SearchIndex,
+    options: &IngestOptions,
+    lease: &IngestLease,
+    dirty: &HashSet<PathBuf>,
+) -> Result<DirtyIngestReport> {
+    ingest_selected(paths, index, options, lease, Some(dirty))
+}
+
+fn ingest_selected(
+    paths: &Paths,
+    index: &SearchIndex,
+    options: &IngestOptions,
+    _lease: &IngestLease,
+    dirty: Option<&HashSet<PathBuf>>,
+) -> Result<DirtyIngestReport> {
     // Apply additive analytics migrations even when the scan finds no changed files.
     drop(AnalyticsStore::open(analytics_path(&paths.state))?);
     let state_path = paths.state.join("ingest.json");
@@ -695,18 +726,38 @@ pub fn ingest_all(
         }
     }
 
+    let selected = if let Some(dirty) = dirty
+        && !recovering_pending_ingest
+        && !empty_index_rebuild
+        && state_path.exists()
+    {
+        match selection::resolve_dirty(options, dirty, &state)? {
+            selection::DirtySelection::Paths { files, databases } => Some((files, databases)),
+            selection::DirtySelection::Resync => None,
+        }
+    } else {
+        None
+    };
+    let full_scan = selected.is_none();
+    if full_scan {
+        // Memory discovery is independent of transcript file events.
+        refresh_memories(paths, options)?;
+    }
+
     // Index-time exclusion: matched transcripts never enter the index, and
     // records previously indexed from now-excluded paths are removed.
     let excluder = build_path_excluder(options)?;
     let mut excluded_state_paths: Vec<String> = Vec::new();
-    state.files.retain(|key, _| {
-        if excluder.is_excluded(Path::new(key)) {
-            excluded_state_paths.push(key.clone());
-            false
-        } else {
-            true
-        }
-    });
+    if full_scan {
+        state.files.retain(|key, _| {
+            if excluder.is_excluded(Path::new(key)) {
+                excluded_state_paths.push(key.clone());
+                false
+            } else {
+                true
+            }
+        });
+    }
     let next_doc_id = Arc::new(AtomicU64::new(state.next_doc_id));
 
     let mut tasks = Vec::new();
@@ -724,7 +775,31 @@ pub fn ingest_all(
     let mut opencode_discovered_database_paths = HashSet::new();
     let mut opencode_legacy_paths_to_delete = Vec::new();
 
-    for claude_source in &options.claude_sources {
+    if let Some((files, _)) = &selected {
+        for file in files {
+            let Some(meta) = discovered_metadata(&file.path)? else {
+                files_skipped += 1;
+                continue;
+            };
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = file.path.to_string_lossy();
+            let (task, skip) = prepare_file_task(
+                file.path.clone(),
+                file.source,
+                options.include_reasoning,
+                &meta,
+                state.files.get(key.as_ref()),
+            );
+            if skip {
+                files_skipped += 1;
+            } else {
+                tasks.push(task);
+            }
+        }
+    }
+
+    for claude_source in options.claude_sources.iter().filter(|_| full_scan) {
         if !claude_source.exists() {
             continue;
         }
@@ -757,8 +832,16 @@ pub fn ingest_all(
         }
     }
 
-    let mut session_ids = HashSet::new();
-    if options.include_codex {
+    let mut session_ids = selected.as_ref().map_or_else(HashSet::new, |(files, _)| {
+        if files.iter().any(|file| {
+            file.source == SourceKind::Codex && crate::sources::codex::is_history_path(&file.path)
+        }) {
+            selection::codex_session_ids(options, &state, files)
+        } else {
+            HashSet::new()
+        }
+    });
+    if options.include_codex && full_scan {
         let codex_files = crate::sources::codex::discover_rollouts();
         for source_file in codex_files {
             let path = source_file.path;
@@ -791,7 +874,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_codex {
+    if options.include_codex && full_scan {
         for history_path in crate::sources::codex::history_paths() {
             if excluder.is_excluded(&history_path) {
                 files_skipped += 1;
@@ -819,8 +902,17 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_opencode {
-        let database_files = crate::sources::opencode::discover_databases()?;
+    if options.include_opencode
+        && (full_scan
+            || selected
+                .as_ref()
+                .is_some_and(|(_, databases)| !databases.is_empty()))
+    {
+        let database_files = if let Some((_, databases)) = &selected {
+            databases.clone()
+        } else {
+            crate::sources::opencode::discover_databases()?
+        };
         let mut planned_databases = Vec::new();
         for source_file in database_files {
             let path = source_file.path;
@@ -832,12 +924,19 @@ pub fn ingest_all(
             opencode_discovered_database_paths.insert(key.clone());
             let Some(meta) = (match discovered_metadata(&path) {
                 Ok(meta) => meta,
-                Err(_) => {
+                Err(error) => {
+                    if !full_scan {
+                        return Err(error)
+                            .with_context(|| format!("stat changed database {}", path.display()));
+                    }
                     opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
                     files_skipped += 1;
                     continue;
                 }
             }) else {
+                if !full_scan {
+                    return ingest_selected(paths, index, options, _lease, None);
+                }
                 opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
                 files_skipped += 1;
                 continue;
@@ -847,10 +946,29 @@ pub fn ingest_all(
             let previous = state.opencode_databases.get(&key);
             match crate::sources::opencode::scan_database(&path, previous) {
                 Ok(scan) => {
+                    if !full_scan
+                        && previous.is_none_or(|previous| {
+                            let sessions = scan
+                                .sessions
+                                .iter()
+                                .map(|session| session.id.clone())
+                                .collect::<HashSet<_>>();
+                            sessions != previous.owned_session_ids
+                        })
+                    {
+                        // Adding/removing session ownership can affect other
+                        // databases or the legacy JSON store. Ordinary WAL
+                        // updates retain the inventory and stay targeted.
+                        return ingest_selected(paths, index, options, _lease, None);
+                    }
                     opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Planned);
                     planned_databases.push(PlannedOpencodeDatabase { path, scan });
                 }
-                Err(_) => {
+                Err(error) => {
+                    if !full_scan {
+                        return Err(error)
+                            .with_context(|| format!("scan changed database {}", path.display()));
+                    }
                     // A bad/locked modern database must not hide the compatible JSON store.
                     opencode_database_outcomes.insert(key, OpencodeDatabaseOutcome::Failed);
                     files_skipped += 1;
@@ -885,7 +1003,12 @@ pub fn ingest_all(
                     opencode_diagnostics.merge(prepared.diagnostics.clone());
                     opencode_ready_databases.push(prepared);
                 }
-                Err(_) => {
+                Err(error) => {
+                    if !full_scan {
+                        return Err(error).with_context(|| {
+                            format!("parse changed database {}", database.path.display())
+                        });
+                    }
                     opencode_database_outcomes.insert(path, OpencodeDatabaseOutcome::Failed);
                     files_skipped += 1;
                 }
@@ -902,7 +1025,7 @@ pub fn ingest_all(
                     classify_opencode_database_outcome(
                         opencode_database_outcomes.get(*path).copied(),
                         opencode_discovered_database_paths.contains(*path),
-                        true,
+                        full_scan,
                     ),
                     OpencodeDatabaseOutcome::Failed
                 )
@@ -924,7 +1047,7 @@ pub fn ingest_all(
             let outcome = classify_opencode_database_outcome(
                 opencode_database_outcomes.get(path).copied(),
                 opencode_discovered_database_paths.contains(path),
-                true,
+                full_scan,
             );
             if outcome != OpencodeDatabaseOutcome::Ready {
                 if outcome == OpencodeDatabaseOutcome::ConfirmedAbsent {
@@ -990,7 +1113,7 @@ pub fn ingest_all(
                     classify_opencode_database_outcome(
                         opencode_database_outcomes.get(&scope.source_path).copied(),
                         opencode_discovered_database_paths.contains(&scope.source_path),
-                        true,
+                        full_scan,
                     ) == OpencodeDatabaseOutcome::Failed
                 })
                 .cloned()
@@ -1013,7 +1136,11 @@ pub fn ingest_all(
         opencode_database_paths_to_delete.sort();
         opencode_database_paths_to_delete.dedup();
 
-        let opencode_files = crate::sources::opencode::discover_sessions()?;
+        let opencode_files = if full_scan {
+            crate::sources::opencode::discover_sessions()?
+        } else {
+            Vec::new()
+        };
         for source_file in opencode_files {
             let path = source_file.path;
             if excluder.is_excluded(&path) {
@@ -1053,7 +1180,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_cursor {
+    if options.include_cursor && full_scan {
         let cursor_files = crate::sources::cursor::discover_transcripts();
         for source_file in cursor_files {
             let path = source_file.path;
@@ -1083,7 +1210,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_pi {
+    if options.include_pi && full_scan {
         let pi_files = crate::sources::pi::discover();
         for source_file in pi_files {
             let path = source_file.path;
@@ -1113,7 +1240,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_omp {
+    if options.include_omp && full_scan {
         let omp_files = crate::sources::omp::discover();
         for source_file in omp_files {
             let path = source_file.path;
@@ -1143,7 +1270,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_openclaw {
+    if options.include_openclaw && full_scan {
         for source_file in crate::sources::openclaw::discover() {
             let path = source_file.path;
             if excluder.is_excluded(&path) {
@@ -1172,7 +1299,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_copilot {
+    if options.include_copilot && full_scan {
         let copilot_files = crate::sources::copilot::discover_sessions();
         for source_file in copilot_files {
             let path = source_file.path;
@@ -1202,7 +1329,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_grok {
+    if options.include_grok && full_scan {
         for source_file in crate::sources::grok::discover_sessions() {
             let path = source_file.path;
             if excluder.is_excluded(&path) {
@@ -1231,7 +1358,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_jcode {
+    if options.include_jcode && full_scan {
         let jcode_files = crate::sources::jcode::discover();
         for source_file in jcode_files {
             let path = source_file.path;
@@ -1261,7 +1388,7 @@ pub fn ingest_all(
         }
     }
 
-    if options.include_muse {
+    if options.include_muse && full_scan {
         let muse_files = crate::sources::muse::discover();
         for source_file in muse_files {
             let path = source_file.path;
@@ -1294,7 +1421,7 @@ pub fn ingest_all(
     // Previously indexed records under now-excluded paths must be deleted even
     // when there is no ingest state entry for them (e.g. state loss or legacy runs).
     let mut excluded_index_paths: Vec<String> = Vec::new();
-    if excluder.set.is_some() {
+    if full_scan && excluder.set.is_some() {
         index.for_each_record(|record| {
             if excluder.is_excluded(Path::new(&record.source_path)) {
                 excluded_index_paths.push(record.source_path.clone());
@@ -1370,7 +1497,7 @@ pub fn ingest_all(
         && opencode_ready_databases
             .iter()
             .all(|database| database.scan.dirty_session_ids.is_empty())
-        && can_skip_noop_index(paths, index, options)?
+        && (!full_scan || can_skip_noop_index(paths, index, options)?)
     {
         if analytics_needs_backfill {
             backfill_from_index(&analytics_db, index)?;
@@ -1383,7 +1510,9 @@ pub fn ingest_all(
         if opencode_database_state_changed {
             state.save(&state_path)?;
         }
-        update_scan_cache(paths, files_scanned, total_bytes)?;
+        if full_scan {
+            update_scan_cache(paths, files_scanned, total_bytes)?;
+        }
         if recovering_pending_ingest {
             finalize_pending_ingest(
                 &pending_ingest_path(paths),
@@ -1391,12 +1520,15 @@ pub fn ingest_all(
                 state.next_doc_id,
             )?;
         }
-        return Ok(IngestReport {
-            records_added: 0,
-            records_embedded: 0,
-            files_scanned,
-            files_skipped,
-            diagnostics: Default::default(),
+        return Ok(DirtyIngestReport {
+            full_scan,
+            report: IngestReport {
+                records_added: 0,
+                records_embedded: 0,
+                files_scanned,
+                files_skipped,
+                diagnostics: Default::default(),
+            },
         });
     }
 
@@ -1643,7 +1775,7 @@ pub fn ingest_all(
     })?;
     progress.finish();
     tail.set_message("updating analytics…");
-    let outcome = (|| -> Result<IngestReport> {
+    let outcome = (|| -> Result<DirtyIngestReport> {
         let writer_outcome =
             writer_result.context("index writer stopped before ingestion completed")?;
         parser_result?;
@@ -1683,15 +1815,20 @@ pub fn ingest_all(
         state.next_doc_id = next_doc_id.load(Ordering::SeqCst);
         state.save(&state_path)?;
 
-        update_scan_cache(paths, files_scanned, total_bytes)?;
+        if full_scan {
+            update_scan_cache(paths, files_scanned, total_bytes)?;
+        }
         finalize_pending_ingest(&pending_path, &deferred_pending_scopes, state.next_doc_id)?;
 
-        Ok(IngestReport {
-            records_added,
-            records_embedded,
-            files_scanned,
-            files_skipped: files_skipped + parse_skipped.load(Ordering::Relaxed),
-            diagnostics,
+        Ok(DirtyIngestReport {
+            full_scan,
+            report: IngestReport {
+                records_added,
+                records_embedded,
+                files_scanned,
+                files_skipped: files_skipped + parse_skipped.load(Ordering::Relaxed),
+                diagnostics,
+            },
         })
     })();
     tail.finish_and_clear();
@@ -2824,6 +2961,341 @@ mod tests {
 
         assert_eq!(report.files_scanned, 2);
         assert_eq!(report.records_added, 2);
+    }
+
+    fn append_claude_message(path: &Path, text: &str) {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "user", "uuid": text,
+                "message": {"role": "user", "content": text},
+            })
+        )
+        .unwrap();
+    }
+
+    fn indexed_texts(paths: &Paths) -> Vec<String> {
+        let index = SearchIndex::open_or_create(&paths.index).unwrap();
+        let mut texts = Vec::new();
+        index
+            .for_each_record(|record| {
+                texts.push(record.text);
+                Ok(())
+            })
+            .unwrap();
+        texts.sort();
+        texts
+    }
+
+    #[test]
+    fn targeted_ingest_only_updates_selected_files_until_reconciliation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("claude");
+        fs::create_dir_all(&source).unwrap();
+        let first = source.join("first.jsonl");
+        let second = source.join("second.jsonl");
+        append_claude_message(&first, "first original");
+        append_claude_message(&second, "second original");
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.claude_sources = vec![source];
+        let lease = ingest_lease(&paths);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        assert_eq!(
+            ingest_all(&paths, &index, &options, &lease)
+                .unwrap()
+                .files_scanned,
+            2
+        );
+        let cache_path = paths.state.join("scan_cache.json");
+        let original_cache = fs::read(&cache_path).unwrap();
+        let state_before = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        append_claude_message(&first, "first appended");
+        append_claude_message(&second, "second missed event");
+        // The watcher emits canonical paths; ingestion must retain lexical
+        // discovery keys rather than create duplicate state/index entries.
+        let dirty = HashSet::from([fs::canonicalize(&first).unwrap()]);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result = ingest_dirty(&paths, &index, &options, &lease, &dirty).unwrap();
+        assert!(!result.full_scan);
+        assert_eq!(result.report.files_scanned, 1);
+        assert_eq!(result.report.records_added, 1);
+        assert_eq!(
+            indexed_texts(&paths),
+            ["first appended", "first original", "second original"]
+        );
+        let state_after = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        let key = second.to_string_lossy();
+        assert_eq!(
+            state_after.files[key.as_ref()].offset,
+            state_before.files[key.as_ref()].offset
+        );
+        assert_eq!(state_after.files.len(), 2);
+        assert_eq!(fs::read(&cache_path).unwrap(), original_cache);
+
+        // A no-op batch must not mark a complete scan fresh either.
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result = ingest_dirty(&paths, &index, &options, &lease, &dirty).unwrap();
+        assert!(!result.full_scan);
+        assert_eq!(result.report.records_added, 0);
+        assert_eq!(fs::read(&cache_path).unwrap(), original_cache);
+
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let report = ingest_all(&paths, &index, &options, &lease).unwrap();
+        assert_eq!(report.files_scanned, 2);
+        assert_eq!(report.records_added, 1);
+        assert_eq!(
+            indexed_texts(&paths),
+            [
+                "first appended",
+                "first original",
+                "second missed event",
+                "second original"
+            ]
+        );
+    }
+
+    #[test]
+    fn targeted_ingest_creates_and_replaces_files_without_unrelated_discovery() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("claude");
+        fs::create_dir_all(&source).unwrap();
+        let first = source.join("first.jsonl");
+        append_claude_message(&first, "existing");
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.claude_sources = vec![source.clone()];
+        let lease = ingest_lease(&paths);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        ingest_all(&paths, &index, &options, &lease).unwrap();
+        // A full discovery would fail on this unrelated configured source.
+        let bad_root = tmp.path().join("not-a-directory");
+        fs::write(&bad_root, "not a directory").unwrap();
+        let _env = EnvVarGuard::set_os(&[("OPENCODE_DATA_DIR", Some(bad_root.as_os_str()))]);
+        options.include_opencode = true;
+        let new_file = source.join("new.jsonl");
+        append_claude_message(&new_file, "created");
+        for expected in ["created", "rewritten"] {
+            if expected == "rewritten" {
+                fs::write(&new_file, []).unwrap();
+                append_claude_message(&new_file, expected);
+            }
+            let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+            let result = ingest_dirty(
+                &paths,
+                &index,
+                &options,
+                &lease,
+                &HashSet::from([new_file.clone()]),
+            )
+            .unwrap();
+            assert!(!result.full_scan);
+            assert_eq!(result.report.files_scanned, 1);
+            assert_eq!(result.report.records_added, 1);
+            let mut expected_texts = vec!["existing".to_string(), expected.to_string()];
+            expected_texts.sort();
+            assert_eq!(indexed_texts(&paths), expected_texts);
+        }
+    }
+
+    #[test]
+    fn targeted_ingest_escalates_pending_publication_to_full_recovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("claude");
+        fs::create_dir_all(&source).unwrap();
+        let first = source.join("first.jsonl");
+        let second = source.join("second.jsonl");
+        append_claude_message(&first, "first original");
+        append_claude_message(&second, "second original");
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.claude_sources = vec![source];
+        let lease = ingest_lease(&paths);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        ingest_all(&paths, &index, &options, &lease).unwrap();
+        append_claude_message(&first, "first appended");
+        append_claude_message(&second, "second missed event");
+        let state = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        PendingIngest {
+            next_doc_id: state.next_doc_id,
+            source_paths: vec![second.to_string_lossy().into_owned()],
+            session_scopes: Vec::new(),
+            vector_publication: false,
+        }
+        .save(&pending_ingest_path(&paths))
+        .unwrap();
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result =
+            ingest_dirty(&paths, &index, &options, &lease, &HashSet::from([first])).unwrap();
+        assert!(result.full_scan);
+        assert_eq!(result.report.files_scanned, 2);
+        assert_eq!(
+            indexed_texts(&paths),
+            [
+                "first appended",
+                "first original",
+                "second missed event",
+                "second original"
+            ]
+        );
+        assert!(!pending_ingest_path(&paths).exists());
+    }
+
+    #[test]
+    fn targeted_ingest_preserves_unselected_database_ownership_and_wal_updates() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("opencode");
+        fs::create_dir_all(&source).unwrap();
+        let first = source.join("opencode.db");
+        let second = source.join("opencode-work.db");
+        let create = |path: &Path, id: &str| {
+            let writer = rusqlite::Connection::open(path).unwrap();
+            writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;
+                CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER);
+                CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+                CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT);
+                CREATE TABLE event (id TEXT NOT NULL, aggregate_id TEXT NOT NULL);").unwrap();
+            writer
+                .execute("INSERT INTO session VALUES (?1, NULL, '/tmp', 1, 2)", [id])
+                .unwrap();
+            writer
+                .execute(
+                    "INSERT INTO message VALUES ('message', ?1, 3, '{\"role\":\"assistant\"}')",
+                    [id],
+                )
+                .unwrap();
+            writer
+                .execute(
+                    "INSERT INTO part VALUES ('part', 'message', ?1)",
+                    [
+                        serde_json::json!({"type": "text", "text": format!("{id} original")})
+                            .to_string(),
+                    ],
+                )
+                .unwrap();
+            writer
+                .execute("INSERT INTO event VALUES ('event-1', ?1)", [id])
+                .unwrap();
+            writer
+        };
+        let first_writer = create(&first, "first");
+        let second_writer = create(&second, "second");
+        let _env = EnvVarGuard::set_os(&[("OPENCODE_DATA_DIR", Some(source.as_os_str()))]);
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.include_opencode = true;
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let lease = ingest_lease(&paths);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        assert_eq!(
+            ingest_all(&paths, &index, &options, &lease)
+                .unwrap()
+                .records_added,
+            2
+        );
+        let second_key = second.to_string_lossy().into_owned();
+        let prior = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        for (writer, id) in [(&first_writer, "first"), (&second_writer, "second")] {
+            writer
+                .execute(
+                    "UPDATE part SET data = ?1",
+                    [
+                        serde_json::json!({"type": "text", "text": format!("{id} updated")})
+                            .to_string(),
+                    ],
+                )
+                .unwrap();
+            writer
+                .execute("INSERT INTO event VALUES ('event-2', ?1)", [id])
+                .unwrap();
+        }
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let dirty = HashSet::from([source.join("opencode.db-wal")]);
+        let result = ingest_dirty(&paths, &index, &options, &lease, &dirty).unwrap();
+        assert!(!result.full_scan);
+        assert_eq!(result.report.files_scanned, 1);
+        assert_eq!(indexed_texts(&paths), ["first updated", "second original"]);
+        let updated = IngestState::load(&paths.state.join("ingest.json")).unwrap();
+        assert_eq!(
+            updated.opencode_databases[&second_key],
+            prior.opencode_databases[&second_key]
+        );
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        ingest_all(&paths, &index, &options, &lease).unwrap();
+        assert_eq!(indexed_texts(&paths), ["first updated", "second updated"]);
+
+        // Ownership changes require a complete inventory, including the
+        // unaffected database and any compatible legacy session store.
+        first_writer
+            .execute("DELETE FROM session WHERE id = 'first'", [])
+            .unwrap();
+        first_writer
+            .execute("INSERT INTO event VALUES ('event-3', 'first')", [])
+            .unwrap();
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result = ingest_dirty(&paths, &index, &options, &lease, &dirty).unwrap();
+        assert!(result.full_scan);
+        assert_eq!(indexed_texts(&paths), ["second updated"]);
+    }
+
+    #[test]
+    fn targeted_ingest_codex_history_uses_known_rollouts_without_discovery() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("custom-codex");
+        let sessions = home.join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let id = "11111111-1111-1111-1111-111111111111";
+        let rollout = sessions.join(format!("rollout-{id}.jsonl"));
+        fs::write(&rollout, format!("{}\n{}\n",
+            serde_json::json!({"type": "session_meta", "payload": {"id": id, "cwd": "/tmp"}}),
+            serde_json::json!({"type": "response_item", "payload": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "rollout original"}]}}),
+        )).unwrap();
+        let history = home.join("history.jsonl");
+        fs::write(
+            &history,
+            format!(
+                "{}\n",
+                serde_json::json!({"session_id": id, "text": "duplicate history", "ts": 1})
+            ),
+        )
+        .unwrap();
+        let _env = EnvVarGuard::set_os(&[("CODEX_HOME", Some(home.as_os_str()))]);
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.include_codex = true;
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let lease = ingest_lease(&paths);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        ingest_all(&paths, &index, &options, &lease).unwrap();
+        assert_eq!(indexed_texts(&paths), ["rollout original"]);
+        let mut file = fs::OpenOptions::new().append(true).open(&history).unwrap();
+        for (session_id, text) in [(id, "duplicate append"), ("history-only", "history only")] {
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({"session_id": session_id, "text": text, "ts": 2})
+            )
+            .unwrap();
+        }
+        drop(file);
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result =
+            ingest_dirty(&paths, &index, &options, &lease, &HashSet::from([history])).unwrap();
+        assert!(!result.full_scan);
+        assert_eq!(result.report.files_scanned, 1);
+        assert_eq!(indexed_texts(&paths), ["history only", "rollout original"]);
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -565,12 +565,12 @@ pub fn ingest_if_stale(
 /// Glob-based path exclusion applied at discovery time so matched
 /// transcripts never enter the index. Empty pattern sets disable matching.
 #[derive(Debug, Clone)]
-struct PathExcluder {
+pub(crate) struct PathExcluder {
     set: Option<globset::GlobSet>,
 }
 
 impl PathExcluder {
-    fn build(patterns: &[String]) -> Result<Self> {
+    pub(crate) fn build(patterns: &[String]) -> Result<Self> {
         if patterns.is_empty() {
             return Ok(Self { set: None });
         }
@@ -589,7 +589,7 @@ impl PathExcluder {
         Ok(Self { set: Some(set) })
     }
 
-    fn is_excluded(&self, path: &Path) -> bool {
+    pub(crate) fn is_excluded(&self, path: &Path) -> bool {
         let Some(set) = &self.set else {
             return false;
         };
@@ -600,7 +600,7 @@ impl PathExcluder {
     }
 }
 
-fn build_path_excluder(options: &IngestOptions) -> Result<PathExcluder> {
+pub(crate) fn build_path_excluder(options: &IngestOptions) -> Result<PathExcluder> {
     let expanded = crate::config::expand_exclude_patterns(options.exclude_patterns.clone());
     PathExcluder::build(&expanded)
 }

--- a/src/ingest/selection.rs
+++ b/src/ingest/selection.rs
@@ -1,0 +1,765 @@
+//! Resolve event hints without walking transcript trees. Root aliases are
+//! translated back to discovery spelling so state and index keys stay stable.
+
+use super::{IngestOptions, PathExcluder, build_path_excluder};
+use crate::sources::{self, SourceFile};
+use crate::state::IngestState;
+use crate::types::SourceKind;
+use anyhow::Result;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub(super) enum DirtySelection {
+    Paths {
+        files: Vec<SourceFile>,
+        databases: Vec<SourceFile>,
+    },
+    Resync,
+}
+
+#[derive(Clone, Copy)]
+enum Shape {
+    Claude,
+    Jsonl(SourceKind),
+    CodexHome,
+    Opencode,
+    Cursor,
+    PiSettings,
+    OpenClaw,
+    Copilot,
+    Grok,
+    Jcode,
+    Muse,
+}
+
+struct Root {
+    lexical: PathBuf,
+    canonical: PathBuf,
+    shape: Shape,
+}
+
+impl Root {
+    fn new(lexical: PathBuf, shape: Shape) -> Self {
+        let canonical = lexical.canonicalize().unwrap_or_else(|_| lexical.clone());
+        Self {
+            lexical,
+            canonical,
+            shape,
+        }
+    }
+
+    fn remap(&self, path: &Path) -> Option<PathBuf> {
+        path.strip_prefix(&self.lexical)
+            .or_else(|_| path.strip_prefix(&self.canonical))
+            .ok()
+            .map(|relative| self.lexical.join(relative))
+    }
+}
+
+fn roots(options: &IngestOptions) -> Vec<Root> {
+    let mut roots = Vec::new();
+    for root in &options.claude_sources {
+        roots.push(Root::new(root.clone(), Shape::Claude));
+    }
+    if options.include_codex {
+        roots.extend(
+            sources::codex::rollout_roots()
+                .into_iter()
+                .map(|root| Root::new(root, Shape::Jsonl(SourceKind::Codex))),
+        );
+        roots.extend(
+            sources::codex::homes()
+                .into_iter()
+                .map(|root| Root::new(root, Shape::CodexHome)),
+        );
+    }
+    if options.include_opencode {
+        roots.extend(
+            sources::opencode::data_roots()
+                .into_iter()
+                .map(|root| Root::new(root, Shape::Opencode)),
+        );
+    }
+    if options.include_cursor {
+        roots.push(Root::new(sources::cursor::projects_root(), Shape::Cursor));
+    }
+    if options.include_pi {
+        roots.push(Root::new(
+            sources::pi::sessions_root(),
+            Shape::Jsonl(SourceKind::Pi),
+        ));
+        roots.push(Root::new(sources::pi::agent_root(), Shape::PiSettings));
+    }
+    if options.include_omp {
+        // This helper reads only profile entries, never transcript trees.
+        roots.extend(
+            sources::omp::session_roots()
+                .into_iter()
+                .map(|root| Root::new(root, Shape::Jsonl(SourceKind::Omp))),
+        );
+    }
+    if options.include_openclaw {
+        roots.extend(
+            sources::openclaw::state_dirs()
+                .into_iter()
+                .map(|root| Root::new(root, Shape::OpenClaw)),
+        );
+    }
+    if options.include_copilot {
+        roots.push(Root::new(sources::copilot::session_root(), Shape::Copilot));
+    }
+    if options.include_grok {
+        roots.push(Root::new(sources::grok::session_root(), Shape::Grok));
+    }
+    if options.include_jcode {
+        roots.push(Root::new(sources::jcode::sessions_root(), Shape::Jcode));
+    }
+    if options.include_muse {
+        roots.push(Root::new(sources::muse::sessions_root(), Shape::Muse));
+    }
+    roots
+}
+
+pub(super) fn resolve_dirty(
+    options: &IngestOptions,
+    dirty: &HashSet<PathBuf>,
+    state: &IngestState,
+) -> Result<DirtySelection> {
+    let excluder = build_path_excluder(options)?;
+    resolve(&roots(options), dirty, state, &excluder)
+}
+
+enum Match {
+    Ignore,
+    File(SourceKind),
+    Database(PathBuf),
+    Resync,
+}
+
+fn classify(root: &Root, path: &Path) -> Match {
+    let relative = path.strip_prefix(&root.lexical).expect("remapped path");
+    let parts = relative.iter().collect::<Vec<_>>();
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    let jsonl = path
+        .extension()
+        .is_some_and(|extension| extension == "jsonl");
+    let source = match root.shape {
+        Shape::Claude => {
+            let subagents = path
+                .ancestors()
+                .any(|ancestor| ancestor.file_name().is_some_and(|name| name == "subagents"));
+            (jsonl && (!subagents || name.starts_with("agent-")) && (parts.len() <= 2 || subagents))
+                .then_some(SourceKind::Claude)
+        }
+        Shape::Jsonl(source) => jsonl.then_some(source),
+        Shape::CodexHome => {
+            return if relative == Path::new("history.jsonl") {
+                Match::File(SourceKind::Codex)
+            } else {
+                Match::Ignore
+            };
+        }
+        Shape::Opencode => {
+            if parts.first().is_some_and(|part| *part == "storage") {
+                // Legacy messages depend on sibling part trees, global session
+                // metadata, and database ownership across configured roots.
+                return Match::Resync;
+            }
+            if parts.len() == 1 {
+                let database_name = name.strip_suffix("-wal").unwrap_or(name);
+                if sources::opencode::is_database_path(database_name) {
+                    return Match::Database(path.with_file_name(database_name));
+                }
+            }
+            None
+        }
+        Shape::Cursor => (jsonl && parts.iter().any(|part| *part == "agent-transcripts"))
+            .then_some(SourceKind::Cursor),
+        Shape::PiSettings => {
+            return if relative == Path::new("settings.json") {
+                Match::Resync
+            } else {
+                Match::Ignore
+            };
+        }
+        Shape::OpenClaw => {
+            (parts.len() == 4 && parts[0] == "agents" && parts[2] == "sessions" && jsonl)
+                .then_some(SourceKind::OpenClaw)
+        }
+        Shape::Copilot => {
+            if name == "workspace.yaml" {
+                return Match::Resync;
+            }
+            (name == "events.jsonl").then_some(SourceKind::Copilot)
+        }
+        Shape::Grok => {
+            if (2..=3).contains(&parts.len()) && name == "summary.json" {
+                return Match::Resync;
+            }
+            ((2..=3).contains(&parts.len()) && name == "updates.jsonl").then_some(SourceKind::Grok)
+        }
+        Shape::Jcode => {
+            (name.starts_with("session_") && name.ends_with(".json")).then_some(SourceKind::Jcode)
+        }
+        Shape::Muse => (name == "session.jsonl").then_some(SourceKind::Muse),
+    };
+    source.map_or(Match::Ignore, Match::File)
+}
+
+fn resolve(
+    roots: &[Root],
+    dirty: &HashSet<PathBuf>,
+    state: &IngestState,
+    excluder: &PathExcluder,
+) -> Result<DirtySelection> {
+    let mut files = Vec::new();
+    let mut databases = Vec::new();
+    for hint in dirty {
+        let mut matches = Vec::new();
+        let mut known_unmatched = false;
+        for root in roots {
+            let Some(path) = root.remap(hint) else {
+                continue;
+            };
+            if excluder.is_excluded(&path) || excluder.is_excluded(hint) {
+                continue;
+            }
+            if path == root.lexical {
+                return Ok(DirtySelection::Resync);
+            }
+            let classification = classify(root, &path);
+            let metadata = std::fs::symlink_metadata(&path);
+            if matches!(classification, Match::Ignore) {
+                // These broad watches only own a specific file (history or
+                // settings), or OpenCode's direct DB files and storage tree.
+                // A build/worktree/cache directory elsewhere under an agent
+                // home must not turn ordinary activity into global discovery.
+                if matches!(
+                    root.shape,
+                    Shape::CodexHome | Shape::PiSettings | Shape::Opencode
+                ) && metadata.as_ref().is_ok_and(|metadata| metadata.is_dir())
+                {
+                    continue;
+                }
+                // A deleted lock/cache file is noise. A vanished directory
+                // containing indexed keys still requires tombstone recovery.
+                let key = path.to_string_lossy();
+                known_unmatched |= state.files.contains_key(key.as_ref())
+                    || state.opencode_databases.contains_key(key.as_ref());
+                if metadata.is_err() {
+                    known_unmatched |= state
+                        .files
+                        .keys()
+                        .chain(state.opencode_databases.keys())
+                        .any(|key| Path::new(key).starts_with(&path));
+                }
+                if !metadata.as_ref().is_ok_and(|metadata| metadata.is_dir()) {
+                    continue;
+                }
+            }
+            // Watchers may coalesce a tree rename into its parent directory.
+            // A partial batch cannot infer its complete set of affected keys.
+            match metadata {
+                Ok(metadata) if metadata.is_file() => {}
+                _ => return Ok(DirtySelection::Resync),
+            }
+            let (candidate, database) = match classification {
+                Match::Ignore => continue,
+                Match::Resync => return Ok(DirtySelection::Resync),
+                Match::File(source) => (SourceFile { source, path }, false),
+                Match::Database(path) => {
+                    if excluder.is_excluded(&path) {
+                        continue;
+                    }
+                    if !path.is_file() {
+                        return Ok(DirtySelection::Resync);
+                    }
+                    (
+                        SourceFile {
+                            source: SourceKind::Opencode,
+                            path,
+                        },
+                        true,
+                    )
+                }
+            };
+            // WalkDir does not follow nested symlinks. A root symlink is valid,
+            // but an interior alias must not introduce an undiscovered file.
+            for ancestor in candidate.path.ancestors().skip(1) {
+                if ancestor == root.lexical {
+                    break;
+                }
+                if std::fs::symlink_metadata(ancestor)
+                    .map(|metadata| metadata.file_type().is_symlink())
+                    .unwrap_or(true)
+                {
+                    return Ok(DirtySelection::Resync);
+                }
+            }
+            if !matches.contains(&(candidate.clone(), database)) {
+                matches.push((candidate, database));
+            }
+        }
+        if matches.len() > 1 || (matches.is_empty() && known_unmatched) {
+            return Ok(DirtySelection::Resync);
+        }
+        if let Some((candidate, database)) = matches.pop() {
+            let target = if database { &mut databases } else { &mut files };
+            if !target.contains(&candidate) {
+                target.push(candidate);
+            }
+        }
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    databases.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(DirtySelection::Paths { files, databases })
+}
+
+/// Preserve history's rollout preference using already-known keys plus this
+/// batch. No transcript discovery or per-file stats are needed here.
+pub(super) fn codex_session_ids(
+    options: &IngestOptions,
+    state: &IngestState,
+    files: &[SourceFile],
+) -> HashSet<String> {
+    if !options.include_codex {
+        return HashSet::new();
+    }
+    let Ok(excluder) = build_path_excluder(options) else {
+        // The caller validates these same patterns before resolving a batch.
+        return HashSet::new();
+    };
+    let rollout_roots = sources::codex::rollout_roots()
+        .into_iter()
+        .map(|root| Root::new(root, Shape::Jsonl(SourceKind::Codex)))
+        .collect::<Vec<_>>();
+    state
+        .files
+        .keys()
+        .map(Path::new)
+        .chain(
+            files
+                .iter()
+                .filter(|file| file.source == SourceKind::Codex)
+                .map(|file| file.path.as_path()),
+        )
+        .filter(|path| !sources::codex::is_history_path(path))
+        .filter(|path| {
+            rollout_roots.iter().any(|root| {
+                root.remap(path).is_some_and(|mapped| {
+                    mapped
+                        .extension()
+                        .is_some_and(|extension| extension == "jsonl")
+                        && !excluder.is_excluded(&mapped)
+                })
+            })
+        })
+        .filter_map(sources::codex::session_id_from_path)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{IndexedToolContentLimits, UserConfig};
+    use crate::state::FileState;
+    use crate::test_support::{EnvVarGuard, env_lock};
+
+    fn options() -> IngestOptions {
+        IngestOptions {
+            claude_sources: Vec::new(),
+            include_agents: false,
+            include_reasoning: false,
+            include_codex: false,
+            include_opencode: false,
+            include_cursor: false,
+            include_pi: false,
+            include_omp: false,
+            include_openclaw: false,
+            include_copilot: false,
+            include_grok: false,
+            include_jcode: false,
+            include_muse: false,
+            exclude_patterns: Vec::new(),
+            embeddings: false,
+            backfill_embeddings: false,
+            model: Default::default(),
+            embed_runtime: UserConfig::default().resolve_embed_runtime().unwrap(),
+            tool_content_limits: IndexedToolContentLimits::default(),
+        }
+    }
+
+    fn write(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "{}\n").unwrap();
+    }
+
+    fn select(roots: &[Root], path: &Path) -> DirtySelection {
+        resolve(
+            roots,
+            &HashSet::from([path.to_path_buf()]),
+            &IngestState::default(),
+            &PathExcluder::build(&[]).unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn direct_selection_matches_all_source_discovery_shapes() {
+        let cases = [
+            (Shape::Claude, "project/session.jsonl", SourceKind::Claude),
+            (
+                Shape::Claude,
+                "project/session/subagents/agent-worker.jsonl",
+                SourceKind::Claude,
+            ),
+            (
+                Shape::Jsonl(SourceKind::Codex),
+                "2026/rollout.jsonl",
+                SourceKind::Codex,
+            ),
+            (Shape::CodexHome, "history.jsonl", SourceKind::Codex),
+            (
+                Shape::Cursor,
+                "project/agent-transcripts/id/worker.jsonl",
+                SourceKind::Cursor,
+            ),
+            (
+                Shape::Jsonl(SourceKind::Pi),
+                "project/session.jsonl",
+                SourceKind::Pi,
+            ),
+            (
+                Shape::Jsonl(SourceKind::Omp),
+                "project/session.jsonl",
+                SourceKind::Omp,
+            ),
+            (
+                Shape::OpenClaw,
+                "agents/main/sessions/session.jsonl",
+                SourceKind::OpenClaw,
+            ),
+            (Shape::Copilot, "session/events.jsonl", SourceKind::Copilot),
+            (Shape::Grok, "session/updates.jsonl", SourceKind::Grok),
+            (
+                Shape::Grok,
+                "project/session/updates.jsonl",
+                SourceKind::Grok,
+            ),
+            (Shape::Jcode, "project/session_one.json", SourceKind::Jcode),
+            (Shape::Muse, "project/id/session.jsonl", SourceKind::Muse),
+        ];
+        for (shape, relative, source) in cases {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(relative);
+            write(&path);
+            let DirtySelection::Paths { files, databases } =
+                select(&[Root::new(temp.path().to_path_buf(), shape)], &path)
+            else {
+                panic!("unexpected resync for {relative}")
+            };
+            assert_eq!(files, vec![SourceFile { source, path }]);
+            assert!(databases.is_empty());
+        }
+        for name in ["opencode.db", "opencode-work.db"] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(name);
+            write(&path);
+            let wal = temp.path().join(format!("{name}-wal"));
+            write(&wal);
+            for hint in [&path, &wal] {
+                let DirtySelection::Paths { files, databases } = select(
+                    &[Root::new(temp.path().to_path_buf(), Shape::Opencode)],
+                    hint,
+                ) else {
+                    panic!("unexpected database resync")
+                };
+                assert!(files.is_empty());
+                assert_eq!(
+                    databases,
+                    vec![SourceFile {
+                        source: SourceKind::Opencode,
+                        path: path.clone()
+                    }]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn selection_ignores_files_outside_discovery_shapes() {
+        let cases = [
+            (Shape::Claude, "project/deep/session.jsonl"),
+            (Shape::Claude, "project/id/subagents/workflow.jsonl"),
+            (Shape::Cursor, "project/session.jsonl"),
+            (Shape::OpenClaw, "agents/main/sessions/nested/session.jsonl"),
+            (Shape::Copilot, "id/notes.jsonl"),
+            (Shape::Grok, "updates.jsonl"),
+            (Shape::Grok, "a/b/c/updates.jsonl"),
+            (Shape::Jcode, "notes.json"),
+            (Shape::Muse, "notes.jsonl"),
+            (Shape::Opencode, "nested/opencode.db"),
+            (Shape::Opencode, "other.db-wal"),
+            (Shape::CodexHome, "settings.json"),
+            (Shape::PiSettings, "other.json"),
+        ];
+        for (shape, relative) in cases {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(relative);
+            write(&path);
+            assert!(
+                matches!(select(&[Root::new(temp.path().to_path_buf(), shape)], &path),
+                DirtySelection::Paths { files, databases } if files.is_empty() && databases.is_empty())
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_directories_under_agent_homes_do_not_force_resync() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("worktrees/project/target");
+        std::fs::create_dir_all(&directory).unwrap();
+        for shape in [Shape::CodexHome, Shape::PiSettings, Shape::Opencode] {
+            assert!(
+                matches!(select(&[Root::new(temp.path().to_path_buf(), shape)], &directory),
+                DirtySelection::Paths { files, databases } if files.is_empty() && databases.is_empty())
+            );
+        }
+    }
+
+    #[test]
+    fn selection_reconciles_dependencies_deletions_and_overlap() {
+        for (shape, relative) in [
+            (Shape::Opencode, "storage/message/ses_a/message.json"),
+            (Shape::Opencode, "storage/part/msg_a/part.json"),
+            (Shape::Opencode, "storage/session/project/ses_a.json"),
+            (Shape::PiSettings, "settings.json"),
+            (Shape::Copilot, "id/workspace.yaml"),
+            (Shape::Grok, "id/summary.json"),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(relative);
+            write(&path);
+            assert!(matches!(
+                select(&[Root::new(temp.path().to_path_buf(), shape)], &path),
+                DirtySelection::Resync
+            ));
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let root = Root::new(temp.path().to_path_buf(), Shape::Jsonl(SourceKind::Pi));
+        assert!(matches!(
+            select(&[root], &temp.path().join("removed.jsonl")),
+            DirtySelection::Resync
+        ));
+        let path = temp.path().join("session.jsonl");
+        write(&path);
+        let roots = [
+            Root::new(temp.path().to_path_buf(), Shape::Jsonl(SourceKind::Pi)),
+            Root::new(temp.path().to_path_buf(), Shape::Jsonl(SourceKind::Omp)),
+        ];
+        assert!(matches!(select(&roots, &path), DirtySelection::Resync));
+        assert!(matches!(
+            select(&roots, temp.path()),
+            DirtySelection::Resync
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selection_preserves_lexical_root_alias_and_exclusions() {
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        let path = real.join("session.jsonl");
+        write(&path);
+        let alias = temp.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let roots = [Root::new(alias.clone(), Shape::Jsonl(SourceKind::Pi))];
+        let canonical_hint = path.canonicalize().unwrap();
+        let DirtySelection::Paths { files, .. } = select(&roots, &canonical_hint) else {
+            panic!("root alias should resolve")
+        };
+        assert_eq!(files[0].path, alias.join("session.jsonl"));
+        let exclusions =
+            PathExcluder::build(&[alias.join("**").to_string_lossy().into_owned()]).unwrap();
+        assert!(matches!(resolve(&roots, &HashSet::from([canonical_hint]),
+            &IngestState::default(), &exclusions).unwrap(), DirtySelection::Paths { files, databases }
+            if files.is_empty() && databases.is_empty()));
+    }
+
+    #[test]
+    fn selection_uses_overrides_and_preserves_known_codex_history_dedupe() {
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("custom-codex");
+        let sessions = temp.path().join("custom-pi");
+        let _env = EnvVarGuard::set(&[
+            ("CODEX_HOME", Some(home.to_str().unwrap())),
+            (
+                "PI_CODING_AGENT_SESSION_DIR",
+                Some(sessions.to_str().unwrap()),
+            ),
+        ]);
+        let known_id = "11111111-1111-1111-1111-111111111111";
+        let new_id = "22222222-2222-2222-2222-222222222222";
+        let known = home.join(format!("sessions/rollout-{known_id}.jsonl"));
+        let new = home.join(format!("archived_sessions/rollout-{new_id}.jsonl"));
+        let history = home.join("history.jsonl");
+        let pi = sessions.join("project/session.jsonl");
+        for path in [&known, &new, &history, &pi] {
+            write(path);
+        }
+        let mut options = options();
+        options.include_codex = true;
+        options.include_pi = true;
+        let mut state = IngestState::default();
+        state.files.insert(
+            known.to_string_lossy().into_owned(),
+            FileState {
+                size: 3,
+                mtime: 0,
+                offset: 3,
+                turn_id: 0,
+                parser_version: 0,
+                pending_tool_calls: Default::default(),
+                identity: Default::default(),
+            },
+        );
+        let DirtySelection::Paths { files, databases } = resolve_dirty(
+            &options,
+            &HashSet::from([history.clone(), new.clone(), pi.clone()]),
+            &state,
+        )
+        .unwrap() else {
+            panic!("overridden sources should resolve directly")
+        };
+        assert!(databases.is_empty());
+        assert_eq!(files.len(), 3);
+        assert!(files.contains(&SourceFile {
+            source: SourceKind::Pi,
+            path: pi
+        }));
+        assert_eq!(
+            codex_session_ids(&options, &state, &files),
+            HashSet::from([known_id.to_string(), new_id.to_string()])
+        );
+        options.exclude_patterns = vec![known.to_string_lossy().into_owned()];
+        assert_eq!(
+            codex_session_ids(&options, &state, &files),
+            HashSet::from([new_id.to_string()])
+        );
+    }
+
+    #[test]
+    fn selection_matches_actual_discovery_for_overridden_sources() {
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let claude = temp.path().join("claude");
+        let codex = temp.path().join("codex");
+        let pi = temp.path().join("pi");
+        let opencode = temp.path().join("opencode");
+        let _env = EnvVarGuard::set(&[
+            ("CODEX_HOME", Some(codex.to_str().unwrap())),
+            ("PI_CODING_AGENT_SESSION_DIR", Some(pi.to_str().unwrap())),
+            ("OPENCODE_DATA_DIR", Some(opencode.to_str().unwrap())),
+        ]);
+        let mut dirty = HashSet::new();
+        for (root, relative) in [
+            (&claude, "project/main.jsonl"),
+            (&claude, "project/deep/ignored.jsonl"),
+            (&claude, "project/id/subagents/agent-child.jsonl"),
+            (&claude, "project/id/subagents/workflow.jsonl"),
+            (&claude, "project/notes.txt"),
+            (&codex, "sessions/2026/rollout.jsonl"),
+            (&codex, "archived_sessions/old.jsonl"),
+            (&codex, "outside.jsonl"),
+            (&codex, "history.jsonl"),
+            (&pi, "project/deep/session.jsonl"),
+            (&pi, "project/notes.txt"),
+            (&opencode, "opencode.db"),
+            (&opencode, "opencode-work.db"),
+            (&opencode, "nested/opencode-ignored.db"),
+            (&opencode, "other.db"),
+        ] {
+            let path = root.join(relative);
+            write(&path);
+            dirty.insert(path);
+        }
+        let mut options = options();
+        options.claude_sources = vec![claude.clone()];
+        options.include_codex = true;
+        options.include_pi = true;
+        options.include_opencode = true;
+        let DirtySelection::Paths { files, databases } =
+            resolve_dirty(&options, &dirty, &IngestState::default()).unwrap()
+        else {
+            panic!("regular source files should resolve directly")
+        };
+        let mut discovered = sources::claude::discover(&claude, false).unwrap();
+        discovered.extend(sources::codex::discover_rollouts());
+        discovered.extend(
+            sources::codex::history_paths()
+                .into_iter()
+                .map(|path| SourceFile {
+                    source: SourceKind::Codex,
+                    path,
+                }),
+        );
+        discovered.extend(sources::pi::discover());
+        discovered.sort_by(|left, right| left.path.cmp(&right.path));
+        assert_eq!(files, discovered);
+        assert_eq!(databases, sources::opencode::discover_databases().unwrap());
+    }
+
+    #[test]
+    fn selection_matches_codex_discovery_without_sessions_subdirectory() {
+        let _lock = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let _env = EnvVarGuard::set(&[("CODEX_HOME", Some(temp.path().to_str().unwrap()))]);
+        let dirty = HashSet::from([
+            temp.path().join("rollout.jsonl"),
+            temp.path().join("history.jsonl"),
+        ]);
+        for path in &dirty {
+            write(path);
+        }
+        let mut options = options();
+        options.include_codex = true;
+        let DirtySelection::Paths { files, databases } =
+            resolve_dirty(&options, &dirty, &IngestState::default()).unwrap()
+        else {
+            panic!("fallback Codex root should resolve directly")
+        };
+        assert_eq!(files, sources::codex::discover_rollouts());
+        assert!(databases.is_empty());
+    }
+
+    #[test]
+    fn nonexistent_noise_is_ignored_but_indexed_deletions_reconcile() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = Root::new(temp.path().to_path_buf(), Shape::CodexHome);
+        let noise = temp.path().join("removed-cache.tmp");
+        assert!(
+            matches!(select(&[root], &noise), DirtySelection::Paths { files, databases }
+            if files.is_empty() && databases.is_empty())
+        );
+        let mut state = IngestState::default();
+        state
+            .opencode_databases
+            .insert(noise.to_string_lossy().into_owned(), Default::default());
+        let root = Root::new(temp.path().to_path_buf(), Shape::CodexHome);
+        assert!(matches!(
+            resolve(
+                &[root],
+                &HashSet::from([noise]),
+                &state,
+                &PathExcluder::build(&[]).unwrap()
+            )
+            .unwrap(),
+            DirtySelection::Resync
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tui;
 pub mod types;
 pub mod usage;
 pub mod vector;
+pub mod watch;
 pub mod web;
 pub mod web_auth;
 

--- a/src/sources/omp.rs
+++ b/src/sources/omp.rs
@@ -91,7 +91,7 @@ fn profile_session_roots(profiles_root: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-fn session_roots() -> Vec<PathBuf> {
+pub(crate) fn session_roots() -> Vec<PathBuf> {
     if std::env::var_os("PI_CODING_AGENT_DIR").is_some_and(|value| !value.is_empty()) {
         return vec![agent_root().join("sessions")];
     }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,1227 @@
+//! Event-driven index triggering.
+//!
+//! The daemon historically re-scanned every source root on a fixed sleep
+//! (`poll_interval`, default 30s). This module replaces the sleep with OS
+//! filesystem events — FSEventStream on macOS, inotify on Linux, both behind
+//! [`notify::RecommendedWatcher`] — while keeping full scans as the
+//! correctness backstop.
+//!
+//! Design rules (see `docs/event-driven-indexing-spec.md`):
+//!
+//! - Events are **hints only**. Every fire still runs the normal incremental
+//!   ingest, whose `IngestState` comparison (`size`/`mtime`/identity) stays
+//!   the source of truth. A spurious event costs one cheap stat check.
+//! - Fires are debounced and settled: a transcript being actively appended to
+//!   must go quiet before it is parsed. This matters because the JSONL
+//!   parsers treat a torn trailing line (no newline yet) as a complete line,
+//!   advance the byte offset past it, and would permanently lose that record
+//!   once the writer completes the line.
+//! - Anything suspicious — watcher errors, [`notify`] rescan flags
+//!   (`mustScanSubDirs`, `IN_Q_OVERFLOW`), a full dirty set, a newly appeared
+//!   watch root — escalates to a full resync ingest, exactly like the old
+//!   poll cycle. A daemon that missed *every* event still converges on the
+//!   periodic resync timer.
+
+use crate::config::Paths;
+use crate::ingest::{IngestOptions, PathExcluder, build_path_excluder};
+use crate::state::IngestState;
+use anyhow::{Context, Result, anyhow};
+use clap::ValueEnum;
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Daemon refresh strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub(crate) enum WatchMode {
+    /// React to filesystem events; full rescan on a (long) timer as backstop.
+    #[default]
+    Events,
+    /// Legacy fixed-interval full rescan.
+    Poll,
+}
+
+impl std::str::FromStr for WatchMode {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "events" => Ok(Self::Events),
+            "poll" => Ok(Self::Poll),
+            other => Err(anyhow!(
+                "invalid watch mode: {other} (expected \"events\" or \"poll\")"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for WatchMode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Events => write!(formatter, "events"),
+            Self::Poll => write!(formatter, "poll"),
+        }
+    }
+}
+
+/// Timing knobs for the event pipeline. Defaults are chosen so an actively
+/// written transcript settles before parsing, while bursts coalesce.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WatchConfig {
+    /// Per-batch quiet period: fire only once no event arrived for this long.
+    pub debounce: Duration,
+    /// Minimum file-mtime age before a fire (torn-write settle).
+    pub settle: Duration,
+    /// Upper bound a dirty batch waits before firing anyway.
+    pub max_batch_age: Duration,
+    /// Minimum spacing between two ingests.
+    pub min_spacing: Duration,
+    /// Periodic full-resync interval (the missed-event backstop).
+    pub resync_interval: Duration,
+    /// Dirty-set capacity; overflow degrades to a full resync, never OOM.
+    pub dirty_cap: usize,
+}
+
+impl Default for WatchConfig {
+    fn default() -> Self {
+        Self {
+            debounce: Duration::from_millis(1500),
+            settle: Duration::from_millis(500),
+            max_batch_age: Duration::from_secs(8),
+            min_spacing: Duration::from_secs(5),
+            resync_interval: Duration::from_secs(600),
+            dirty_cap: 10_000,
+        }
+    }
+}
+
+/// Why the scheduler wants an ingest run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FireCause {
+    /// Debounced, settled file changes.
+    Dirty,
+    /// Startup-equivalent full convergence (timer, overflow, error, new root).
+    Resync,
+}
+
+/// Counters for `daemon status` and for spotting a silent watcher: events at
+/// zero across resyncs that keep finding changes means broken watches.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct WatchStats {
+    pub(crate) events_total: u64,
+    pub(crate) events_filtered: u64,
+    pub(crate) fires_dirty: u64,
+    pub(crate) fires_resync: u64,
+    pub(crate) noop_skips: u64,
+    pub(crate) watcher_errors: u64,
+    pub(crate) resync_requests: u64,
+    pub(crate) hot_sweeps: u64,
+    pub(crate) hot_hits: u64,
+}
+
+/// Compute the exact directory set that transcript discovery walks, so the
+/// watcher covers every source `ingest_all` reads — and nothing else.
+///
+/// Sources without an ingest discovery block (Hermes) are deliberately
+/// excluded; watching them could only trigger useless ingests.
+pub(crate) fn watch_roots(options: &IngestOptions) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if !options.claude_sources.is_empty() {
+        roots.extend(options.claude_sources.iter().cloned());
+    }
+    if options.include_codex {
+        roots.extend(crate::sources::codex::homes());
+    }
+    if options.include_opencode {
+        roots.extend(crate::sources::opencode::data_roots());
+    }
+    if options.include_cursor {
+        roots.push(crate::sources::cursor::projects_root());
+    }
+    if options.include_pi {
+        roots.push(crate::sources::pi::sessions_root());
+        roots.push(crate::sources::pi::agent_root());
+    }
+    if options.include_omp {
+        roots.extend(crate::sources::omp::session_roots());
+    }
+    if options.include_openclaw {
+        roots.extend(crate::sources::openclaw::state_dirs());
+    }
+    if options.include_copilot {
+        roots.push(crate::sources::copilot::root());
+    }
+    if options.include_grok {
+        roots.push(crate::sources::grok::root());
+    }
+    if options.include_jcode {
+        roots.push(crate::sources::jcode::sessions_root());
+    }
+    if options.include_muse {
+        roots.push(crate::sources::muse::sessions_root());
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+/// Build the event filter from the same exclusion patterns discovery uses,
+/// so an event for a path ingest would ignore never fires an ingest.
+pub(crate) fn watch_excluder(options: &IngestOptions) -> Result<PathExcluder> {
+    build_path_excluder(options)
+}
+
+/// Narrow deny-list applied before anything else. Deliberately a deny-list,
+/// not an allow-list: unknown-but-real transcript extensions must still
+/// trigger (the ingest state comparison will no-op them cheaply if they are
+/// irrelevant), while over-filtering would silently miss records.
+fn ignorable_file_name(name: &str) -> bool {
+    name == ".DS_Store"
+        || name.ends_with(".tmp")
+        || name.ends_with(".swp")
+        || name.ends_with('~')
+        || name.ends_with("-wal")
+        || name.ends_with("-shm")
+        || name.ends_with("-journal")
+        || name.starts_with(".memex-opencode-spool-")
+        || matches!(
+            name,
+            "ingest.json" | "ingest.pending.json" | "scan_cache.json"
+        )
+}
+
+/// Classify one watcher event. Returns the paths worth tracking, and whether
+/// the event signals possibly-missed history ([`Event::need_rescan`]).
+fn interesting_event_paths(event: &Event, excluder: &PathExcluder) -> (Vec<PathBuf>, bool) {
+    if matches!(event.kind, EventKind::Access(_)) {
+        return (Vec::new(), event.need_rescan());
+    }
+    let mut paths = Vec::with_capacity(event.paths.len());
+    for path in &event.paths {
+        let ignored = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(ignorable_file_name);
+        if ignored || excluder.is_excluded(path) {
+            continue;
+        }
+        paths.push(path.clone());
+    }
+    (paths, event.need_rescan())
+}
+
+/// Compare live filesystem metadata against stored ingest state. This is the
+/// same predicate `prepare_file_task` uses to skip unchanged files (equal
+/// size+mtime means skip), tightened with nanosecond mtime so same-second
+/// rewrites still trigger.
+fn stat_differs(
+    metadata: &std::fs::Metadata,
+    size: u64,
+    mtime: i64,
+    modified_ns: Option<i64>,
+) -> bool {
+    if metadata.len() != size {
+        return true;
+    }
+    let modified = metadata.modified().ok();
+    let current_ns = modified
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64);
+    match (current_ns, modified_ns) {
+        (Some(current), Some(stored)) if current != stored => true,
+        _ => {
+            let current_mtime = modified
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0);
+            current_mtime != mtime
+        }
+    }
+}
+/// Fast no-op check: is there any dirty path the ingest state comparison
+/// would actually act on?
+///
+/// Conservative by construction: unknown paths, vanished paths, and stat
+/// failures all report "needs ingest" and let the full ingest sort it out.
+pub(crate) fn dirty_needs_ingest(paths: &Paths, dirty: &HashSet<PathBuf>) -> Result<bool> {
+    if dirty.is_empty() {
+        return Ok(false);
+    }
+    let state = IngestState::load(&paths.state.join("ingest.json"))?;
+    for path in dirty {
+        let key = path.to_string_lossy().into_owned();
+        let Some(previous) = state.files.get(&key) else {
+            return Ok(true);
+        };
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+            Err(error) => {
+                return Err(error).with_context(|| format!("stat dirty path {}", path.display()));
+            }
+        };
+        if stat_differs(
+            &metadata,
+            previous.size,
+            previous.mtime,
+            previous.identity.modified_ns,
+        ) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Resolve symlinks in an existing watch root. Missing roots are returned
+/// unchanged so the tick retry keeps waiting for them.
+fn canonical_root(root: &PathBuf) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| root.clone())
+}
+
+/// The event-driven scheduler. Owns the [`RecommendedWatcher`], debounces the
+/// raw stream into dirty batches, and decides when the caller should run an
+/// ingest. Ingest execution itself stays with the caller so this type never
+/// touches the index, the lease, or source parsers.
+pub(crate) struct WatchService {
+    watcher: RecommendedWatcher,
+    receiver: Receiver<notify::Result<Event>>,
+    _sender: Sender<notify::Result<Event>>,
+    watched: Vec<PathBuf>,
+    pending: Vec<PathBuf>,
+    dirty: HashMap<PathBuf, Instant>,
+    batch_start: Option<Instant>,
+    last_fire: Option<Instant>,
+    resync_due: Instant,
+    resync_needed: bool,
+    excluder: PathExcluder,
+    config: WatchConfig,
+    stats: WatchStats,
+    hot_snapshot: Option<HashMap<String, StateSnapshot>>,
+    hot_state_mtime: Option<SystemTime>,
+}
+
+/// Compact copy of the ingest state needed to spot changed files without
+/// re-reading `ingest.json` on every sweep.
+#[derive(Debug, Clone, Copy)]
+struct StateSnapshot {
+    size: u64,
+    mtime: i64,
+    modified_ns: Option<i64>,
+}
+
+/// How often the macOS hot sweep re-stats recently active files (see
+/// [`WatchService::hot_sweep_dirty`]).
+pub(crate) const HOT_SWEEP_INTERVAL: Duration = Duration::from_secs(5);
+/// Files whose current mtime is older than this are never sweep candidates;
+/// structural changes to them still arrive as events.
+pub(crate) const HOT_WINDOW: Duration = Duration::from_secs(6 * 60 * 60);
+
+impl WatchService {
+    pub(crate) fn new(
+        roots: Vec<PathBuf>,
+        excluder: PathExcluder,
+        config: WatchConfig,
+    ) -> Result<Self> {
+        let (sender, receiver) = unbounded();
+        let callback_sender = sender.clone();
+        let watcher = RecommendedWatcher::new(
+            move |result| {
+                let _ = callback_sender.send(result);
+            },
+            Config::default(),
+        )
+        .context("create filesystem watcher")?;
+        let resync_due = Instant::now() + config.resync_interval;
+        let mut service = Self {
+            watcher,
+            receiver,
+            _sender: sender,
+            watched: Vec::new(),
+            pending: roots,
+            dirty: HashMap::new(),
+            batch_start: None,
+            last_fire: None,
+            resync_due,
+            resync_needed: false,
+            excluder,
+            config,
+            stats: WatchStats::default(),
+            hot_snapshot: None,
+            hot_state_mtime: None,
+        };
+        service.sort_pending();
+        service.activate_pending();
+        Ok(service)
+    }
+
+    /// Non-blocking scheduler tick. Drain the event queue, then report
+    /// whether the caller should ingest now. A returned fire does not clear
+    /// state; the caller must invoke [`Self::mark_complete`] on success,
+    /// [`Self::mark_skipped`] when the no-op check vetoes, or nothing at all
+    /// (keeping the dirty set for retry) when the ingest itself failed.
+    pub(crate) fn poll(&mut self) -> Option<FireCause> {
+        let now = Instant::now();
+        self.activate_pending();
+        self.drain();
+        self.fire_decision(now)
+    }
+
+    /// Snapshot of currently dirty paths, for the no-op stat check and logs.
+    pub(crate) fn dirty_paths(&self) -> HashSet<PathBuf> {
+        self.dirty.keys().cloned().collect()
+    }
+
+    pub(crate) fn stats(&self) -> &WatchStats {
+        &self.stats
+    }
+
+    pub(crate) fn watched_roots(&self) -> &[PathBuf] {
+        &self.watched
+    }
+
+    pub(crate) fn pending_roots(&self) -> &[PathBuf] {
+        &self.pending
+    }
+
+    /// Record a completed ingest: clear hints, restart all timers.
+    pub(crate) fn mark_complete(&mut self, cause: FireCause) {
+        self.dirty.clear();
+        self.batch_start = None;
+        self.last_fire = Some(Instant::now());
+        self.resync_due = self.last_fire.unwrap() + self.config.resync_interval;
+        self.resync_needed = false;
+        match cause {
+            FireCause::Dirty => self.stats.fires_dirty += 1,
+            FireCause::Resync => self.stats.fires_resync += 1,
+        }
+    }
+
+    /// Record a vetoed fire (no-op check): drop the noise, keep the timers —
+    /// no scan happened, so the resync deadline must not move.
+    pub(crate) fn mark_skipped(&mut self) {
+        self.dirty.clear();
+        self.batch_start = None;
+        self.stats.noop_skips += 1;
+    }
+
+    /// Reconcile watches with freshly resolved roots (cheap; call on resync).
+    /// Added roots activate on the next tick and force a resync ingest, which
+    /// closes the gap between the root appearing and the watch arming.
+    pub(crate) fn ensure_roots(&mut self, roots: Vec<PathBuf>) {
+        let desired: HashSet<PathBuf> = roots
+            .into_iter()
+            .map(|root| canonical_root(&root))
+            .collect();
+        self.watched.retain(|root| {
+            if desired.contains(root) {
+                return true;
+            }
+            let _ = self.watcher.unwatch(root);
+            false
+        });
+        for root in desired {
+            if !self.watched.contains(&root) && !self.pending.contains(&root) {
+                self.pending.push(root);
+            }
+        }
+        self.sort_pending();
+    }
+
+    fn sort_pending(&mut self) {
+        self.pending.sort();
+        self.pending.dedup();
+    }
+
+    /// Try to arm watches for not-yet-existing roots. Runs every tick; each
+    /// attempt is one `stat` per missing root. A newly armed root forces a
+    /// resync so files created in the blind window converge immediately.
+    ///
+    /// Roots are canonicalized before watching: backends (notably FSEvents)
+    /// silently mis-deliver for paths containing symlinks, and the temp
+    /// directories tests use are symlinked on macOS.
+    fn activate_pending(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+        let mut still_pending = Vec::with_capacity(self.pending.len());
+        for root in std::mem::take(&mut self.pending) {
+            if !root.is_dir() {
+                still_pending.push(root);
+                continue;
+            }
+            let canonical = canonical_root(&root);
+            match self.watcher.watch(&canonical, RecursiveMode::Recursive) {
+                Ok(()) => {
+                    self.watched.push(canonical);
+                    self.request_resync();
+                }
+                Err(error) => {
+                    self.stats.watcher_errors += 1;
+                    eprintln!("watch: cannot watch {}: {error:#}", root.display());
+                    still_pending.push(root);
+                }
+            }
+        }
+        self.pending = still_pending;
+        self.watched.sort();
+        self.watched.dedup();
+    }
+
+    fn request_resync(&mut self) {
+        if !self.resync_needed {
+            self.resync_needed = true;
+            self.stats.resync_requests += 1;
+        }
+    }
+
+    fn drain(&mut self) {
+        const DRAIN_CAP: usize = 8192;
+        let now = Instant::now();
+        let mut seen = 0usize;
+        while let Ok(result) = self.receiver.try_recv() {
+            seen += 1;
+            if seen > DRAIN_CAP {
+                // Shedding detail, not correctness: the resync that follows
+                // re-converges everything the dropped events hinted at.
+                self.dirty.clear();
+                self.request_resync();
+                while self.receiver.try_recv().is_ok() {}
+                return;
+            }
+            let event = match result {
+                Ok(event) => event,
+                Err(error) => {
+                    self.stats.watcher_errors += 1;
+                    eprintln!("watch: watcher error: {error:#}");
+                    self.request_resync();
+                    continue;
+                }
+            };
+            self.stats.events_total += 1;
+            let (paths, rescan) = interesting_event_paths(&event, &self.excluder);
+            if rescan {
+                eprintln!("watch: backend requested rescan; scheduling full ingest");
+                self.request_resync();
+            }
+            if paths.is_empty() {
+                self.stats.events_filtered += 1;
+                continue;
+            }
+            for path in paths {
+                if self.dirty.len() >= self.config.dirty_cap && !self.dirty.contains_key(&path) {
+                    self.dirty.clear();
+                    self.request_resync();
+                    break;
+                }
+                self.dirty.insert(path, now);
+            }
+            if self.batch_start.is_none() && !self.dirty.is_empty() {
+                self.batch_start = Some(now);
+            }
+        }
+    }
+
+    fn fire_decision(&self, now: Instant) -> Option<FireCause> {
+        if let Some(last) = self.last_fire
+            && now.duration_since(last) < self.config.min_spacing
+        {
+            return None;
+        }
+        if self.resync_needed || now >= self.resync_due {
+            return Some(FireCause::Resync);
+        }
+        if self.dirty.is_empty() {
+            return None;
+        }
+        let newest = self.dirty.values().copied().max().unwrap_or(now);
+        let aged = self
+            .batch_start
+            .is_some_and(|start| now.duration_since(start) >= self.config.max_batch_age);
+        if !aged {
+            if now.duration_since(newest) < self.config.debounce {
+                return None;
+            }
+            if !self.settled() {
+                return None;
+            }
+        }
+        Some(FireCause::Dirty)
+    }
+
+    /// No dirty file may have been modified within the settle window.
+    /// Missing paths count as settled: deletions need the ingest (tombstone
+    /// sweep), and a path that no longer exists cannot tear.
+    fn settled(&self) -> bool {
+        let now = SystemTime::now();
+        self.dirty.keys().all(|path| {
+            if !path.is_file() {
+                return true;
+            }
+            match std::fs::metadata(path)
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+            {
+                Some(mtime) => now
+                    .duration_since(mtime)
+                    .is_ok_and(|age| age >= self.config.settle),
+                None => true,
+            }
+        })
+    }
+
+    /// Record externally observed changes (e.g. the hot sweep below) as if
+    /// they arrived as events: same capacity backpressure, same batch window.
+    pub(crate) fn note_dirty(&mut self, paths: Vec<PathBuf>) {
+        self.note_dirty_at(paths, Instant::now());
+    }
+
+    pub(crate) fn note_dirty_at(&mut self, paths: Vec<PathBuf>, now: Instant) {
+        for path in paths {
+            if self.dirty.len() >= self.config.dirty_cap && !self.dirty.contains_key(&path) {
+                self.dirty.clear();
+                self.request_resync();
+                break;
+            }
+            self.dirty.insert(path, now);
+        }
+        if self.batch_start.is_none() && !self.dirty.is_empty() {
+            self.batch_start = Some(now);
+        }
+    }
+
+    /// Re-stat recently active transcripts and report the ones whose content
+    /// moved since the last ingest.
+    ///
+    /// This exists for a platform gap, not as polling-by-another-name:
+    /// FSEvents defers content-modification events for files held open for
+    /// writing (verified: zero events in 8s with the fd open, immediate
+    /// delivery on close), and agents stream transcripts through a single
+    /// held-open fd for the whole session. Without this sweep, an active
+    /// macOS session would only index on close. inotify reports `MODIFY` on
+    /// every write regardless of open handles, so callers only need this on
+    /// macOS; everywhere else events plus the resync timer suffice.
+    ///
+    /// Cost is bounded: `ingest.json` is re-parsed only when it changed, and
+    /// only files modified within `window` are stat-compared — idle history
+    /// costs one stat of the state file per sweep.
+    pub(crate) fn hot_sweep_dirty(
+        &mut self,
+        paths: &Paths,
+        window: Duration,
+    ) -> Result<Vec<PathBuf>> {
+        self.stats.hot_sweeps += 1;
+        let state_path = paths.state.join("ingest.json");
+        let state_mtime = std::fs::metadata(&state_path)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok());
+        if self.hot_snapshot.is_none() || state_mtime != self.hot_state_mtime {
+            let state = IngestState::load(&state_path)?;
+            self.hot_snapshot = Some(
+                state
+                    .files
+                    .iter()
+                    .map(|(key, file)| {
+                        (
+                            key.clone(),
+                            StateSnapshot {
+                                size: file.size,
+                                mtime: file.mtime,
+                                modified_ns: file.identity.modified_ns,
+                            },
+                        )
+                    })
+                    .collect(),
+            );
+            self.hot_state_mtime = state_mtime;
+        }
+        let now = SystemTime::now();
+        let mut changed = Vec::new();
+        if let Some(snapshot) = &self.hot_snapshot {
+            for (key, previous) in snapshot {
+                let path = Path::new(key);
+                let metadata = match std::fs::metadata(path) {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        changed.push(PathBuf::from(key));
+                        continue;
+                    }
+                    Err(_) => continue,
+                };
+                let modified = metadata.modified().ok();
+                let fresh = modified.is_some_and(|mtime| {
+                    now.duration_since(mtime)
+                        .map(|age| age <= window)
+                        .unwrap_or(true)
+                });
+                if !fresh {
+                    continue;
+                }
+                if stat_differs(
+                    &metadata,
+                    previous.size,
+                    previous.mtime,
+                    previous.modified_ns,
+                ) {
+                    changed.push(PathBuf::from(key));
+                }
+            }
+        }
+        self.stats.hot_hits += changed.len() as u64;
+        Ok(changed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::UserConfig;
+    use crate::state::{FileIdentity, FileState};
+    use crate::test_support::{EnvVarGuard, env_lock};
+    use std::collections::{HashMap, HashSet};
+    use std::io::Write;
+    use std::path::Path;
+
+    fn test_options() -> IngestOptions {
+        IngestOptions {
+            claude_sources: vec![PathBuf::from("/tmp/memex-watch-test/claude")],
+            include_agents: false,
+            include_reasoning: false,
+            include_codex: true,
+            include_opencode: true,
+            include_cursor: true,
+            include_pi: true,
+            include_omp: true,
+            include_openclaw: true,
+            include_copilot: true,
+            include_grok: true,
+            include_jcode: true,
+            include_muse: true,
+            exclude_patterns: Vec::new(),
+            embeddings: false,
+            backfill_embeddings: false,
+            model: crate::embed::ModelChoice::default(),
+            embed_runtime: UserConfig::default()
+                .resolve_embed_runtime()
+                .expect("default embed runtime"),
+            tool_content_limits: crate::config::IndexedToolContentLimits::default(),
+        }
+    }
+
+    fn test_service() -> WatchService {
+        let options = test_options();
+        let excluder = watch_excluder(&options).expect("excluder");
+        WatchService::new(Vec::new(), excluder, WatchConfig::default()).expect("service")
+    }
+
+    #[test]
+    fn watch_mode_parses_and_displays() {
+        assert_eq!(
+            "events".parse::<WatchMode>().expect("parse events"),
+            WatchMode::Events
+        );
+        assert_eq!(
+            "POLL".parse::<WatchMode>().expect("parse poll"),
+            WatchMode::Poll
+        );
+        assert!("fsevents".parse::<WatchMode>().is_err());
+        assert_eq!(WatchMode::Events.to_string(), "events");
+        assert_eq!(WatchMode::Poll.to_string(), "poll");
+        assert_eq!(WatchMode::default(), WatchMode::Events);
+    }
+
+    #[test]
+    fn watch_roots_cover_every_ingested_source() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&home).expect("home");
+        let claude_projects = temp.path().join("claude-projects");
+        std::fs::create_dir_all(&claude_projects).expect("claude projects");
+        let _env = EnvVarGuard::set(&[
+            ("HOME", Some(home.to_str().expect("home utf8"))),
+            (
+                "CLAUDE_CONFIG_DIR",
+                Some(claude_projects.to_str().expect("claude utf8")),
+            ),
+            ("CODEX_HOME", Some("/tmp/memex-watch-test-codex")),
+            ("OPENCODE_DATA_DIR", Some("/tmp/memex-watch-test-opencode")),
+            ("PI_CODING_AGENT_DIR", None),
+            ("PI_CODING_AGENT_SESSION_DIR", None),
+            ("PI_CONFIG_DIR", None),
+            ("OMP_PROFILE", None),
+            ("PI_PROFILE", None),
+            ("OPENCLAW_STATE_DIR", Some("/tmp/memex-watch-test-openclaw")),
+            ("CLAWDBOT_STATE_DIR", None),
+            ("COPILOT_HOME", Some("/tmp/memex-watch-test-copilot")),
+            ("GROK_HOME", Some("/tmp/memex-watch-test-grok")),
+            ("JCODE_HOME", Some("/tmp/memex-watch-test-jcode")),
+            ("MUSE_HOME", Some("/tmp/memex-watch-test-muse")),
+            ("XDG_DATA_HOME", None),
+        ]);
+
+        let mut options = test_options();
+        options.claude_sources = vec![claude_projects.join("projects")];
+        let roots = watch_roots(&options);
+
+        let rendered: Vec<String> = roots
+            .iter()
+            .map(|root| root.to_string_lossy().into_owned())
+            .collect();
+        for expected in [
+            "claude-projects/projects",
+            "memex-watch-test-codex",
+            "memex-watch-test-opencode",
+            ".cursor/projects",
+            ".pi/agent",
+            ".omp/agent/sessions",
+            "memex-watch-test-openclaw",
+            "memex-watch-test-copilot",
+            "memex-watch-test-grok",
+            "jcode/sessions",
+            "muse/sessions",
+        ] {
+            assert!(
+                rendered.iter().any(|root| root.contains(expected)),
+                "missing watch root containing {expected}: {rendered:?}"
+            );
+        }
+        // Sorted and deduplicated.
+        let mut sorted = rendered.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(rendered, sorted);
+    }
+
+    #[test]
+    fn watch_roots_respect_disabled_sources() {
+        let _guard = env_lock();
+        let mut options = test_options();
+        options.include_codex = false;
+        options.include_opencode = false;
+        options.include_cursor = false;
+        options.include_pi = false;
+        options.include_omp = false;
+        options.include_openclaw = false;
+        options.include_copilot = false;
+        options.include_grok = false;
+        options.include_jcode = false;
+        options.include_muse = false;
+        let roots = watch_roots(&options);
+        assert_eq!(roots, options.claude_sources);
+    }
+
+    #[test]
+    fn event_filter_drops_access_noise_and_sidecars() {
+        let _guard = env_lock();
+        let options = test_options();
+        let excluder = watch_excluder(&options).expect("excluder");
+        let event = |kind: EventKind, name: &str| Event {
+            kind,
+            paths: vec![PathBuf::from(format!("/tmp/sessions/{name}"))],
+            attrs: Default::default(),
+        };
+
+        // Access events never fire, even for real transcripts.
+        let (paths, _) = interesting_event_paths(
+            &event(EventKind::Access(notify::event::AccessKind::Any), "s.jsonl"),
+            &excluder,
+        );
+        assert!(paths.is_empty());
+
+        // Real transcript writes pass.
+        let (paths, _) = interesting_event_paths(
+            &event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                "session.jsonl",
+            ),
+            &excluder,
+        );
+        assert_eq!(paths.len(), 1);
+
+        // SQLite sidecars and editor debris do not.
+        for junk in [
+            "opencode.db-wal",
+            "opencode.db-shm",
+            "opencode.db-journal",
+            "session.jsonl.tmp",
+            "session.jsonl.swp",
+            "session.jsonl~",
+            ".DS_Store",
+        ] {
+            let (paths, _) = interesting_event_paths(
+                &event(EventKind::Modify(notify::event::ModifyKind::Any), junk),
+                &excluder,
+            );
+            assert!(paths.is_empty(), "{junk} should be filtered");
+        }
+
+        // The main database still fires.
+        let (paths, _) = interesting_event_paths(
+            &event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                "opencode.db",
+            ),
+            &excluder,
+        );
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn event_filter_honors_exclude_globs() {
+        let _guard = env_lock();
+        let mut options = test_options();
+        options.exclude_patterns = vec!["/tmp/sessions/*-client-*".to_string()];
+        let excluder = watch_excluder(&options).expect("excluder");
+        let event = Event {
+            kind: EventKind::Modify(notify::event::ModifyKind::Any),
+            paths: vec![PathBuf::from("/tmp/sessions/work-client-1/session.jsonl")],
+            attrs: Default::default(),
+        };
+        let (paths, _) = interesting_event_paths(&event, &excluder);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn debounce_holds_fire_until_quiet_then_settled() {
+        let _guard = env_lock();
+        let mut service = test_service();
+        let start = Instant::now();
+        let path = PathBuf::from("/tmp/memex-watch-test/session.jsonl");
+
+        service.note_dirty_at(vec![path.clone()], start);
+        assert_eq!(service.fire_decision(start), None);
+
+        // Still inside the quiet period.
+        service.note_dirty_at(vec![path.clone()], start + Duration::from_millis(1400));
+        assert_eq!(
+            service.fire_decision(start + Duration::from_millis(2000)),
+            None
+        );
+
+        // Quiet for longer than debounce, but the file is missing so settle
+        // treats it as deletion-needing-ingest: fires.
+        assert_eq!(
+            service.fire_decision(start + Duration::from_millis(3000)),
+            Some(FireCause::Dirty)
+        );
+
+        service.mark_complete(FireCause::Dirty);
+        assert_eq!(
+            service.fire_decision(start + Duration::from_millis(3100)),
+            None
+        );
+        // Min spacing holds back an immediate re-fire.
+        service.note_dirty_at(vec![path], start + Duration::from_millis(3200));
+        assert_eq!(
+            service.fire_decision(start + Duration::from_millis(4000)),
+            None
+        );
+        assert_eq!(
+            service.fire_decision(start + Duration::from_secs(9)),
+            Some(FireCause::Dirty)
+        );
+        assert_eq!(service.stats().fires_dirty, 1);
+    }
+
+    #[test]
+    fn max_batch_age_forces_fire_under_continuous_writes() {
+        let _guard = env_lock();
+        let mut service = test_service();
+        let start = Instant::now();
+        let path = PathBuf::from("/tmp/memex-watch-test/session.jsonl");
+        // A writer that never goes quiet: every tick resets debounce, but the
+        // batch age cap still forces a fire.
+        for millis in (0..9000).step_by(200) {
+            service.note_dirty_at(vec![path.clone()], start + Duration::from_millis(millis));
+            if service.fire_decision(start + Duration::from_millis(millis))
+                == Some(FireCause::Dirty)
+            {
+                assert!(
+                    millis >= 8000,
+                    "fired at {millis}ms, before the max batch age"
+                );
+                return;
+            }
+        }
+        panic!("continuous writes never fired");
+    }
+
+    #[test]
+    fn dirty_cap_escalates_to_resync() {
+        let _guard = env_lock();
+        let options = test_options();
+        let excluder = watch_excluder(&options).expect("excluder");
+        let config = WatchConfig {
+            dirty_cap: 4,
+            ..WatchConfig::default()
+        };
+        let mut service = WatchService::new(Vec::new(), excluder, config).expect("service");
+        let start = Instant::now();
+        let paths: Vec<PathBuf> = (0..8)
+            .map(|index| PathBuf::from(format!("/tmp/sessions/{index}.jsonl")))
+            .collect();
+        service.note_dirty_at(paths, start);
+        assert_eq!(
+            service.fire_decision(start + Duration::from_secs(30)),
+            Some(FireCause::Resync)
+        );
+        service.mark_complete(FireCause::Resync);
+        assert_eq!(service.stats().fires_resync, 1);
+        assert!(service.dirty_paths().is_empty());
+    }
+
+    #[test]
+    fn resync_timer_fires_when_idle() {
+        let _guard = env_lock();
+        let options = test_options();
+        let excluder = watch_excluder(&options).expect("excluder");
+        let config = WatchConfig {
+            resync_interval: Duration::from_millis(100),
+            ..WatchConfig::default()
+        };
+        let mut service = WatchService::new(Vec::new(), excluder, config).expect("service");
+        assert_eq!(service.poll(), None);
+        std::thread::sleep(Duration::from_millis(150));
+        assert_eq!(service.poll(), Some(FireCause::Resync));
+    }
+
+    /// FSEvents defers content-modification events for a file held open for
+    /// writing and flushes them on close (verified empirically: 0 events in
+    /// 8s with the fd open, immediate delivery after `drop`). Agents stream
+    /// transcripts through a single held-open fd (see `lsof` on any live
+    /// session), so on macOS events alone can never index an active session —
+    /// the hot sweep (`hot_sweep_dirty`) exists for exactly this gap.
+    /// If this test ever fails by observing events while open, FSEvents
+    /// improved and the sweep may be redundant.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fsevents_defers_modify_until_close() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().to_path_buf();
+        std::fs::write(root.join("seed.txt"), "x").expect("seed");
+        let canon: PathBuf = std::fs::canonicalize(&root).expect("canon");
+        let (tx, rx) = unbounded::<notify::Result<Event>>();
+        let mut watcher = RecommendedWatcher::new(
+            move |result| {
+                let _ = tx.send(result);
+            },
+            Config::default(),
+        )
+        .expect("watcher");
+        watcher
+            .watch(&canon, RecursiveMode::Recursive)
+            .expect("watch");
+        std::thread::sleep(Duration::from_secs(2));
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(root.join("seed.txt"))
+            .expect("open");
+        std::io::Write::write_all(&mut file, b"held-open\n").expect("write");
+        file.sync_all().expect("sync");
+        let mut open_count = 0;
+        let deadline = Instant::now() + Duration::from_secs(4);
+        while Instant::now() < deadline {
+            if rx.try_recv().is_ok() {
+                open_count += 1;
+            } else {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+        assert_eq!(open_count, 0, "modify events arrived while fd open");
+        drop(file);
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut closed = false;
+        while Instant::now() < deadline {
+            if rx.try_recv().is_ok() {
+                closed = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(closed, "no modify event after close");
+    }
+
+    #[test]
+    fn real_watcher_event_fires_dirty() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().to_path_buf();
+        std::fs::write(root.join("session.jsonl"), "{}\n").expect("seed");
+        let options = test_options();
+        let excluder = watch_excluder(&options).expect("excluder");
+        let config = WatchConfig {
+            debounce: Duration::from_millis(100),
+            settle: Duration::from_millis(0),
+            min_spacing: Duration::from_millis(0),
+            resync_interval: Duration::from_secs(3600),
+            ..WatchConfig::default()
+        };
+        let mut service = WatchService::new(vec![root.clone()], excluder, config).expect("service");
+        assert!(!service.watched_roots().is_empty());
+        // Drain the creation burst so the append below is the only dirty input.
+        // Sleeps are generous on purpose: fseventsd delivery lag on a loaded
+        // machine is measured in seconds, not milliseconds.
+        for _ in 0..20 {
+            let _ = service.poll();
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        service.mark_complete(FireCause::Resync);
+
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(root.join("session.jsonl"))
+            .expect("open");
+        writeln!(file, "{{\"appended\": true}}").expect("append");
+        file.sync_all().expect("sync");
+        drop(file);
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut fired = false;
+        while Instant::now() < deadline {
+            if service.poll() == Some(FireCause::Dirty) {
+                fired = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(fired, "append was not observed: {:?}", service.stats());
+    }
+
+    fn write_ingest_state(dir: &Path, files: HashMap<String, FileState>) {
+        let state = IngestState {
+            next_doc_id: 2,
+            files,
+            opencode_databases: HashMap::new(),
+        };
+        state
+            .save(&dir.join("state").join("ingest.json"))
+            .expect("save state");
+    }
+
+    fn file_state_for(path: &Path) -> FileState {
+        let metadata = std::fs::metadata(path).expect("metadata");
+        let mtime = metadata
+            .modified()
+            .expect("mtime")
+            .duration_since(UNIX_EPOCH)
+            .expect("epoch")
+            .as_secs() as i64;
+        let modified_ns = metadata
+            .modified()
+            .expect("mtime")
+            .duration_since(UNIX_EPOCH)
+            .expect("epoch")
+            .as_nanos()
+            .min(i64::MAX as u128) as i64;
+        FileState {
+            size: metadata.len(),
+            mtime,
+            offset: metadata.len(),
+            turn_id: 1,
+            parser_version: 1,
+            pending_tool_calls: HashMap::new(),
+            identity: FileIdentity {
+                device: None,
+                inode: None,
+                prefix_sha256: None,
+                prefix_bytes: 0,
+                modified_ns: Some(modified_ns),
+            },
+        }
+    }
+
+    #[test]
+    fn dirty_check_skips_unchanged_but_fires_on_change() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("memex");
+        std::fs::create_dir_all(root.join("state")).expect("state dir");
+        let paths = Paths::new(Some(root.clone())).expect("paths");
+        let transcript = temp.path().join("session.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("seed");
+
+        let key = transcript.to_string_lossy().into_owned();
+        write_ingest_state(
+            &root,
+            HashMap::from([(key.clone(), file_state_for(&transcript))]),
+        );
+
+        let unchanged: HashSet<PathBuf> = HashSet::from([transcript.clone()]);
+        assert!(!dirty_needs_ingest(&paths, &unchanged).expect("check unchanged"));
+        assert!(!dirty_needs_ingest(&paths, &HashSet::new()).expect("check empty"));
+
+        // Append: size change fires.
+        std::fs::write(&transcript, "{}\n{}\n").expect("append");
+        assert!(dirty_needs_ingest(&paths, &unchanged).expect("check appended"));
+
+        // Unknown path fires.
+        let unknown: HashSet<PathBuf> = HashSet::from([temp.path().join("brand-new.jsonl")]);
+        assert!(dirty_needs_ingest(&paths, &unknown).expect("check unknown"));
+
+        // Deleted path fires (tombstone sweep needed).
+        std::fs::remove_file(&transcript).expect("remove");
+        assert!(dirty_needs_ingest(&paths, &unchanged).expect("check deleted"));
+    }
+
+    #[cfg(unix)]
+    fn backdate(path: &Path) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        let current = CString::new(path.as_os_str().as_bytes()).expect("cstring");
+        let old = libc::timespec {
+            tv_sec: 1_000_000,
+            tv_nsec: 0,
+        };
+        let times = [old, old];
+        let result =
+            unsafe { libc::utimensat(libc::AT_FDCWD, current.as_ptr(), times.as_ptr(), 0) };
+        assert_eq!(result, 0, "utimensat failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hot_sweep_reports_only_fresh_changes() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("memex");
+        std::fs::create_dir_all(root.join("state")).expect("state dir");
+        let paths = Paths::new(Some(root.clone())).expect("paths");
+        let hot = temp.path().join("hot.jsonl");
+        let cold = temp.path().join("cold.jsonl");
+        std::fs::write(&hot, "{}\n").expect("seed hot");
+        std::fs::write(&cold, "{}\n").expect("seed cold");
+        backdate(&cold);
+        let mut files = HashMap::new();
+        files.insert(hot.to_string_lossy().into_owned(), file_state_for(&hot));
+        files.insert(cold.to_string_lossy().into_owned(), file_state_for(&cold));
+        write_ingest_state(&root, files);
+
+        let mut service = test_service();
+        // Both unchanged: nothing to do.
+        assert!(
+            service
+                .hot_sweep_dirty(&paths, HOT_WINDOW)
+                .expect("sweep")
+                .is_empty()
+        );
+        // Append to both. Only the fresh one is a candidate; the 1970 file
+        // is outside the window even though its bytes changed.
+        std::fs::write(&hot, "{}\n{}\n").expect("append hot");
+        std::fs::write(&cold, "{}\n{}\n").expect("append cold");
+        backdate(&cold);
+        let changed = service.hot_sweep_dirty(&paths, HOT_WINDOW).expect("sweep");
+        assert_eq!(changed, vec![hot.clone()]);
+        assert_eq!(service.stats().hot_hits, 1);
+
+        // note_dirty feeds the normal debounce path.
+        service.note_dirty(changed);
+        assert!(!service.dirty_paths().is_empty());
+
+        // Deleted hot file is reported for tombstone handling.
+        std::fs::remove_file(&hot).expect("remove");
+        let changed = service.hot_sweep_dirty(&paths, HOT_WINDOW).expect("sweep");
+        assert!(changed.contains(&hot));
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -8,8 +8,8 @@
 //!
 //! Design rules (see `docs/event-driven-indexing-spec.md`):
 //!
-//! - Events are **hints only**. Every fire still runs the normal incremental
-//!   ingest, whose `IngestState` comparison (`size`/`mtime`/identity) stays
+//! - Events are **hints only**. Dirty fires select affected inputs for the
+//!   normal incremental ingest, whose `IngestState` comparison (`size`/`mtime`/identity) stays
 //!   the source of truth. A spurious event costs one cheap stat check.
 //! - Fires are debounced and settled: a transcript being actively appended to
 //!   must go quiet before it is parsed. This matters because the JSONL
@@ -440,16 +440,19 @@ impl WatchService {
         &self.pending
     }
 
-    /// Record a completed ingest: clear hints, restart all timers.
+    /// Record a completed ingest. Partial batches clear their hints without
+    /// postponing full reconciliation of sources that had no delivered events.
     pub(crate) fn mark_complete(&mut self, cause: FireCause) {
         self.dirty.clear();
         self.batch_start = None;
         self.last_fire = Some(Instant::now());
-        self.resync_due = self.last_fire.unwrap() + self.config.resync_interval;
-        self.resync_needed = false;
         match cause {
             FireCause::Dirty => self.stats.fires_dirty += 1,
-            FireCause::Resync => self.stats.fires_resync += 1,
+            FireCause::Resync => {
+                self.resync_due = self.last_fire.unwrap() + self.config.resync_interval;
+                self.resync_needed = false;
+                self.stats.fires_resync += 1;
+            }
         }
     }
 
@@ -1129,6 +1132,23 @@ mod tests {
         assert_eq!(service.poll(), None);
         std::thread::sleep(Duration::from_millis(150));
         assert_eq!(service.poll(), Some(FireCause::Resync));
+    }
+
+    #[test]
+    fn targeted_ingests_cannot_postpone_full_reconciliation() {
+        let _guard = env_lock();
+        let mut service = test_service();
+        service.config.min_spacing = Duration::ZERO;
+        let deadline = service.resync_due;
+        for _ in 0..3 {
+            service.mark_complete(FireCause::Dirty);
+            assert_eq!(service.fire_decision(deadline), Some(FireCause::Resync));
+        }
+        service.request_resync();
+        service.mark_complete(FireCause::Dirty);
+        assert_eq!(service.poll(), Some(FireCause::Resync));
+        service.mark_complete(FireCause::Resync);
+        assert_eq!(service.poll(), None);
     }
 
     /// FSEvents defers content-modification events for a file held open for

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -27,10 +27,12 @@ use crate::ingest::{IngestOptions, PathExcluder, build_path_excluder};
 use crate::state::IngestState;
 use anyhow::{Context, Result, anyhow};
 use clap::ValueEnum;
-use crossbeam_channel::{Receiver, Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Daemon refresh strategy.
@@ -201,6 +203,20 @@ fn interesting_event_paths(event: &Event, excluder: &PathExcluder) -> (Vec<PathB
     }
     let mut paths = Vec::with_capacity(event.paths.len());
     for path in &event.paths {
+        // OpenCode commits can live entirely in the WAL until checkpoint.
+        // Route the hint to the database that ingestion knows how to read.
+        if let Some(name) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix("-wal"))
+            .filter(|name| crate::sources::opencode::is_database_path(name))
+        {
+            let database = path.with_file_name(name);
+            if !excluder.is_excluded(path) && !excluder.is_excluded(&database) {
+                paths.push(database);
+            }
+            continue;
+        }
         let ignored = path
             .file_name()
             .and_then(|name| name.to_str())
@@ -289,6 +305,7 @@ pub(crate) struct WatchService {
     watcher: RecommendedWatcher,
     receiver: Receiver<notify::Result<Event>>,
     _sender: Sender<notify::Result<Event>>,
+    queue_overflow: Arc<AtomicBool>,
     watched: Vec<PathBuf>,
     pending: Vec<PathBuf>,
     dirty: HashMap<PathBuf, Instant>,
@@ -301,22 +318,55 @@ pub(crate) struct WatchService {
     stats: WatchStats,
     hot_snapshot: Option<HashMap<String, StateSnapshot>>,
     hot_state_mtime: Option<SystemTime>,
+    hot_databases: HashMap<PathBuf, Option<DatabaseSnapshot>>,
 }
 
 /// Compact copy of the ingest state needed to spot changed files without
 /// re-reading `ingest.json` on every sweep.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct StateSnapshot {
     size: u64,
     mtime: i64,
     modified_ns: Option<i64>,
 }
 
+impl StateSnapshot {
+    fn read(path: &Path) -> Option<Self> {
+        let metadata = std::fs::metadata(path).ok()?;
+        let modified = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?;
+        Some(Self {
+            size: metadata.len(),
+            mtime: modified.as_secs() as i64,
+            modified_ns: Some(modified.as_nanos().min(i64::MAX as u128) as i64),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DatabaseSnapshot {
+    database: Option<StateSnapshot>,
+    wal: Option<StateSnapshot>,
+}
+
+const EVENT_QUEUE_CAPACITY: usize = 8192;
+
+fn enqueue_event(
+    sender: &Sender<notify::Result<Event>>,
+    overflow: &AtomicBool,
+    event: notify::Result<Event>,
+) {
+    // Never block the OS watcher during ingestion. One sticky bit preserves
+    // the need to reconcile when bounded buffering cannot retain all hints.
+    if let Err(TrySendError::Full(_)) = sender.try_send(event) {
+        overflow.store(true, Ordering::Release);
+    }
+}
+
 /// How often the macOS hot sweep re-stats recently active files (see
 /// [`WatchService::hot_sweep_dirty`]).
 pub(crate) const HOT_SWEEP_INTERVAL: Duration = Duration::from_secs(5);
-/// Files whose current mtime is older than this are never sweep candidates;
-/// structural changes to them still arrive as events.
+/// Files whose ingested mtime is older than this are not sweep candidates;
+/// events and periodic resync discover resumed cold sessions.
 pub(crate) const HOT_WINDOW: Duration = Duration::from_secs(6 * 60 * 60);
 
 impl WatchService {
@@ -325,11 +375,13 @@ impl WatchService {
         excluder: PathExcluder,
         config: WatchConfig,
     ) -> Result<Self> {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(EVENT_QUEUE_CAPACITY);
         let callback_sender = sender.clone();
+        let queue_overflow = Arc::new(AtomicBool::new(false));
+        let callback_overflow = Arc::clone(&queue_overflow);
         let watcher = RecommendedWatcher::new(
             move |result| {
-                let _ = callback_sender.send(result);
+                enqueue_event(&callback_sender, &callback_overflow, result);
             },
             Config::default(),
         )
@@ -339,6 +391,7 @@ impl WatchService {
             watcher,
             receiver,
             _sender: sender,
+            queue_overflow,
             watched: Vec::new(),
             pending: roots,
             dirty: HashMap::new(),
@@ -351,6 +404,7 @@ impl WatchService {
             stats: WatchStats::default(),
             hot_snapshot: None,
             hot_state_mtime: None,
+            hot_databases: HashMap::new(),
         };
         service.sort_pending();
         service.activate_pending();
@@ -478,19 +532,16 @@ impl WatchService {
     }
 
     fn drain(&mut self) {
-        const DRAIN_CAP: usize = 8192;
+        if self.queue_overflow.swap(false, Ordering::AcqRel) {
+            self.request_resync();
+        }
         let now = Instant::now();
-        let mut seen = 0usize;
-        while let Ok(result) = self.receiver.try_recv() {
-            seen += 1;
-            if seen > DRAIN_CAP {
-                // Shedding detail, not correctness: the resync that follows
-                // re-converges everything the dropped events hinted at.
-                self.dirty.clear();
-                self.request_resync();
-                while self.receiver.try_recv().is_ok() {}
-                return;
-            }
+        // Bound work as well as memory: a producer that never goes quiet
+        // must not keep the scheduler draining forever.
+        for _ in 0..EVENT_QUEUE_CAPACITY {
+            let Ok(result) = self.receiver.try_recv() else {
+                break;
+            };
             let event = match result {
                 Ok(event) => event,
                 Err(error) => {
@@ -605,14 +656,20 @@ impl WatchService {
     /// macOS; everywhere else events plus the resync timer suffice.
     ///
     /// Cost is bounded: `ingest.json` is re-parsed only when it changed, and
-    /// only files modified within `window` are stat-compared — idle history
-    /// costs one stat of the state file per sweep.
+    /// only files ingested within `window` are stat-compared. Cold history
+    /// is rediscovered through events/resync. Each tracked OpenCode database
+    /// also needs two stats: its main file and its possibly held-open WAL.
     pub(crate) fn hot_sweep_dirty(
         &mut self,
         paths: &Paths,
         window: Duration,
     ) -> Result<Vec<PathBuf>> {
         self.stats.hot_sweeps += 1;
+        let cutoff = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_sub(window.as_secs()) as i64;
         let state_path = paths.state.join("ingest.json");
         let state_mtime = std::fs::metadata(&state_path)
             .ok()
@@ -623,6 +680,7 @@ impl WatchService {
                 state
                     .files
                     .iter()
+                    .filter(|(_, file)| file.mtime >= cutoff)
                     .map(|(key, file)| {
                         (
                             key.clone(),
@@ -635,11 +693,20 @@ impl WatchService {
                     })
                     .collect(),
             );
+            self.hot_databases.retain(|path, _| {
+                state
+                    .opencode_databases
+                    .contains_key(path.to_string_lossy().as_ref())
+            });
+            for key in state.opencode_databases.keys() {
+                self.hot_databases.entry(PathBuf::from(key)).or_insert(None);
+            }
             self.hot_state_mtime = state_mtime;
         }
-        let now = SystemTime::now();
         let mut changed = Vec::new();
-        if let Some(snapshot) = &self.hot_snapshot {
+        if let Some(snapshot) = &mut self.hot_snapshot {
+            // Expire candidates even when the ingest state has not changed.
+            snapshot.retain(|_, previous| previous.mtime >= cutoff);
             for (key, previous) in snapshot {
                 let path = Path::new(key);
                 let metadata = match std::fs::metadata(path) {
@@ -650,15 +717,6 @@ impl WatchService {
                     }
                     Err(_) => continue,
                 };
-                let modified = metadata.modified().ok();
-                let fresh = modified.is_some_and(|mtime| {
-                    now.duration_since(mtime)
-                        .map(|age| age <= window)
-                        .unwrap_or(true)
-                });
-                if !fresh {
-                    continue;
-                }
                 if stat_differs(
                     &metadata,
                     previous.size,
@@ -667,6 +725,18 @@ impl WatchService {
                 ) {
                     changed.push(PathBuf::from(key));
                 }
+            }
+        }
+        for (path, previous) in &mut self.hot_databases {
+            let mut wal = path.as_os_str().to_os_string();
+            wal.push("-wal");
+            let current = DatabaseSnapshot {
+                database: StateSnapshot::read(path),
+                wal: StateSnapshot::read(Path::new(&wal)),
+            };
+            if previous.as_ref() != Some(&current) {
+                changed.push(path.clone());
+                *previous = Some(current);
             }
         }
         self.stats.hot_hits += changed.len() as u64;
@@ -680,6 +750,7 @@ mod tests {
     use crate::config::UserConfig;
     use crate::state::{FileIdentity, FileState};
     use crate::test_support::{EnvVarGuard, env_lock};
+    use crossbeam_channel::unbounded;
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
     use std::path::Path;
@@ -841,9 +912,9 @@ mod tests {
         );
         assert_eq!(paths.len(), 1);
 
-        // SQLite sidecars and editor debris do not.
+        // Unrelated SQLite sidecars and editor debris do not.
         for junk in [
-            "opencode.db-wal",
+            "other.db-wal",
             "opencode.db-shm",
             "opencode.db-journal",
             "session.jsonl.tmp",
@@ -867,6 +938,78 @@ mod tests {
             &excluder,
         );
         assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn wal_events_target_database_and_honor_database_exclusions() {
+        let _guard = env_lock();
+        let mut options = test_options();
+        for name in ["opencode.db", "opencode-work.db"] {
+            let database = PathBuf::from(format!("/tmp/sessions/{name}"));
+            let wal = PathBuf::from(format!("/tmp/sessions/{name}-wal"));
+            let event = Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Any),
+                paths: vec![wal.clone()],
+                attrs: Default::default(),
+            };
+            options.exclude_patterns.clear();
+            let excluder = watch_excluder(&options).unwrap();
+            assert_eq!(
+                interesting_event_paths(&event, &excluder).0,
+                vec![database.clone()]
+            );
+            for excluded in [&database, &wal] {
+                options.exclude_patterns = vec![excluded.to_string_lossy().into_owned()];
+                let excluder = watch_excluder(&options).unwrap();
+                assert!(interesting_event_paths(&event, &excluder).0.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn event_queue_overflow_is_nonblocking_and_survives_inflight_ingest() {
+        let _guard = env_lock();
+        let mut service = test_service();
+        service.config.min_spacing = Duration::ZERO;
+        let sender = service._sender.clone();
+        let overflow = Arc::clone(&service.queue_overflow);
+        let (finished_tx, finished_rx) = bounded(1);
+        let producer = std::thread::spawn(move || {
+            for _ in 0..EVENT_QUEUE_CAPACITY + 1 {
+                enqueue_event(
+                    &sender,
+                    &overflow,
+                    Ok(Event {
+                        kind: EventKind::Modify(notify::event::ModifyKind::Any),
+                        paths: vec![PathBuf::from("/tmp/queue-session.jsonl")],
+                        attrs: Default::default(),
+                    }),
+                );
+            }
+            finished_tx.send(()).unwrap();
+        });
+        // No consumer runs until the producer finishes, just like a slow ingest.
+        finished_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("callback blocked on full queue");
+        producer.join().unwrap();
+        assert_eq!(service.receiver.len(), EVENT_QUEUE_CAPACITY);
+        service.mark_complete(FireCause::Dirty);
+        assert_eq!(service.poll(), Some(FireCause::Resync));
+        service.mark_complete(FireCause::Resync);
+        assert_eq!(service.poll(), None);
+        // Recovery does not leave a permanent overflow condition.
+        enqueue_event(
+            &service._sender,
+            &service.queue_overflow,
+            Ok(Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Any),
+                paths: vec![PathBuf::from("/tmp/after-overflow.jsonl")],
+                attrs: Default::default(),
+            }),
+        );
+        service.config.debounce = Duration::ZERO;
+        assert_eq!(service.poll(), Some(FireCause::Dirty));
     }
 
     #[test]
@@ -1223,5 +1366,100 @@ mod tests {
         std::fs::remove_file(&hot).expect("remove");
         let changed = service.hot_sweep_dirty(&paths, HOT_WINDOW).expect("sweep");
         assert!(changed.contains(&hot));
+    }
+
+    #[test]
+    fn hot_sweep_does_not_revisit_cold_history() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        let hot = temp.path().join("hot.jsonl");
+        std::fs::write(&hot, "{}\n").unwrap();
+        let mut files = HashMap::from([(hot.to_string_lossy().into_owned(), file_state_for(&hot))]);
+        // Missing historical files would be reported as deletions if the
+        // hot sweep tried to stat them. Resync owns those cold tombstones.
+        for index in 0..256 {
+            let mut cold = file_state_for(&hot);
+            cold.mtime = 1_000_000;
+            files.insert(
+                temp.path()
+                    .join(format!("cold-{index}.jsonl"))
+                    .to_string_lossy()
+                    .into_owned(),
+                cold,
+            );
+        }
+        write_ingest_state(&paths.root, files);
+        let mut service = test_service();
+        for _ in 0..2 {
+            assert!(
+                service
+                    .hot_sweep_dirty(&paths, HOT_WINDOW)
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+        std::fs::write(&hot, "{}\n{}\n").unwrap();
+        assert_eq!(
+            service.hot_sweep_dirty(&paths, HOT_WINDOW).unwrap(),
+            vec![hot]
+        );
+    }
+
+    #[test]
+    fn hot_sweep_observes_held_open_database_wal_commits() {
+        let _guard = env_lock();
+        for name in ["opencode.db", "opencode-work.db"] {
+            let temp = tempfile::tempdir().unwrap();
+            let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+            let database = temp.path().join(name);
+            let writer = rusqlite::Connection::open(&database).unwrap();
+            writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE messages (body TEXT);").unwrap();
+            let mut state = IngestState::default();
+            state
+                .opencode_databases
+                .insert(database.to_string_lossy().into_owned(), Default::default());
+            state.save(&paths.state.join("ingest.json")).unwrap();
+            let mut service = test_service();
+            // A newly tracked database gets one conservative reconciliation.
+            assert_eq!(
+                service.hot_sweep_dirty(&paths, HOT_WINDOW).unwrap(),
+                vec![database.clone()]
+            );
+            assert!(
+                service
+                    .hot_sweep_dirty(&paths, HOT_WINDOW)
+                    .unwrap()
+                    .is_empty()
+            );
+            let main_before = StateSnapshot::read(&database);
+            writer
+                .execute("INSERT INTO messages VALUES ('committed while open')", [])
+                .unwrap();
+            assert_eq!(StateSnapshot::read(&database), main_before);
+            // Reloading ingest state must not reset the WAL observation baseline.
+            state.save(&paths.state.join("ingest.json")).unwrap();
+            let changed = service.hot_sweep_dirty(&paths, HOT_WINDOW).unwrap();
+            assert_eq!(changed, vec![database.clone()]);
+            assert!(dirty_needs_ingest(&paths, &changed.into_iter().collect()).unwrap());
+            assert!(
+                service
+                    .hot_sweep_dirty(&paths, HOT_WINDOW)
+                    .unwrap()
+                    .is_empty()
+            );
+            writer
+                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+                .unwrap();
+            assert_eq!(
+                service.hot_sweep_dirty(&paths, HOT_WINDOW).unwrap(),
+                vec![database.clone()]
+            );
+            drop(writer);
+            assert_eq!(
+                service.hot_sweep_dirty(&paths, HOT_WINDOW).unwrap(),
+                vec![database]
+            );
+        }
     }
 }

--- a/tests/daemon_cli.rs
+++ b/tests/daemon_cli.rs
@@ -37,6 +37,10 @@ struct ChildGuard {
 
 impl ChildGuard {
     fn spawn(dirs: &TestDirs, args: &[&str]) -> Self {
+        Self::spawn_with_env(dirs, args, &[])
+    }
+
+    fn spawn_with_env(dirs: &TestDirs, args: &[&str], environment: &[(&str, &Path)]) -> Self {
         let mut command = Command::new(env!("CARGO_BIN_EXE_memex"));
         command
             .arg("--no-update-check")
@@ -46,6 +50,9 @@ impl ChildGuard {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        for (name, value) in environment {
+            command.env(name, value);
+        }
         let mut child = command.spawn().expect("start Memex child");
         let logs = Arc::new(Mutex::new(Vec::new()));
         drain(child.stdout.take().unwrap(), Arc::clone(&logs));
@@ -471,5 +478,85 @@ fn daemon_poll_mode_still_indexes_on_interval() {
     )
     .expect("write transcript");
     wait_for_log(&mut daemon, "indexed 1 records", 60);
+    daemon.stop();
+}
+
+fn wait_for_session_text(daemon: &mut ChildGuard, root: &Path, expected: &str) {
+    let deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        if root.join("index/CURRENT").exists()
+            && let Ok(index) = memex::index::SearchIndex::open_or_create(&root.join("index"))
+            && let Ok(records) = index.records_by_session_id("wal-session")
+            && records.iter().any(|record| record.text == expected)
+        {
+            return;
+        }
+        daemon.assert_running();
+        assert!(
+            Instant::now() < deadline,
+            "WAL update {expected:?} was not indexed: {}",
+            daemon.diagnostics()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn daemon_event_mode_indexes_held_open_wal_without_resync() {
+    let dirs = TestDirs::new();
+    let source = tempfile::tempdir().unwrap();
+    let database = source.path().join("opencode-work.db");
+    let writer = rusqlite::Connection::open(&database).unwrap();
+    writer.execute_batch(r#"
+        PRAGMA journal_mode=WAL;
+        PRAGMA wal_autocheckpoint=0;
+        CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER);
+        CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+        CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT);
+        CREATE TABLE event (id TEXT NOT NULL, aggregate_id TEXT NOT NULL);
+        INSERT INTO session VALUES ('wal-session', NULL, '/wal-test', 1, 2);
+        INSERT INTO message VALUES ('message', 'wal-session', 3, '{"role":"assistant"}');
+        INSERT INTO part VALUES ('part', 'message', '{"type":"text","text":"before WAL commit"}');
+        INSERT INTO event VALUES ('event-1', 'wal-session');
+    "#).unwrap();
+    let mut daemon = ChildGuard::spawn_with_env(
+        &dirs,
+        &[
+            "daemon",
+            "run",
+            "--root",
+            dirs.root.path().to_str().unwrap(),
+            "--only-source",
+            "opencode",
+            "--no-embeddings",
+            "--watch-mode",
+            "events",
+            "--poll-interval",
+            "3600",
+        ],
+        &[("OPENCODE_DATA_DIR", source.path())],
+    );
+    wait_for_session_text(&mut daemon, dirs.root.path(), "before WAL commit");
+    let before = std::fs::metadata(&database).unwrap();
+    // Keep the writer and WAL open through multiple commits. On macOS the
+    // sweep must observe the updates even when FSEvents defers delivery.
+    for (event, text) in [
+        ("event-2", "first WAL commit"),
+        ("event-3", "second WAL commit"),
+    ] {
+        writer
+            .execute(
+                "UPDATE part SET data = ?1 WHERE id = 'part'",
+                [json!({"type": "text", "text": text}).to_string()],
+            )
+            .unwrap();
+        writer
+            .execute("INSERT INTO event VALUES (?1, 'wal-session')", [event])
+            .unwrap();
+        let after = std::fs::metadata(&database).unwrap();
+        assert_eq!(after.len(), before.len());
+        assert_eq!(after.modified().unwrap(), before.modified().unwrap());
+        wait_for_session_text(&mut daemon, dirs.root.path(), text);
+    }
     daemon.stop();
 }

--- a/tests/daemon_cli.rs
+++ b/tests/daemon_cli.rs
@@ -405,3 +405,71 @@ fn malformed_mcp_public_url_fails_startup_without_a_live_listener() {
     );
     assert_listener_closes(mcp);
 }
+
+fn wait_for_log(child: &mut ChildGuard, needle: &str, timeout_secs: u64) {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if child.diagnostics().contains(needle) {
+            return;
+        }
+        child.assert_running();
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for {needle:?}: {}", child.diagnostics());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn spawn_index_daemon(dirs: &TestDirs, extra: &[&str]) -> ChildGuard {
+    let root = dirs.root.path().to_str().unwrap();
+    let claude = dirs.claude.path().to_str().unwrap();
+    let mut args = vec![
+        "daemon",
+        "run",
+        "--root",
+        root,
+        "--only-source",
+        "claude",
+        "--claude-path",
+        claude,
+        "--no-embeddings",
+    ];
+    args.extend_from_slice(extra);
+    ChildGuard::spawn(&dirs, &args)
+}
+
+const MINIMAL_CLAUDE_LINE: &str = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"uuid\":\"u1\",\"timestamp\":\"2024-01-01T00:00:00Z\"}\n";
+
+#[test]
+fn daemon_event_mode_indexes_new_transcripts_without_resync() {
+    let dirs = TestDirs::new();
+    // Resync an hour out: if the transcript gets indexed, events did it.
+    let mut daemon = spawn_index_daemon(
+        &dirs,
+        &["--watch-mode", "events", "--poll-interval", "3600"],
+    );
+    wait_for_log(&mut daemon, "indexed 0 records", 60);
+
+    std::fs::write(
+        dirs.claude.path().join("session.jsonl"),
+        MINIMAL_CLAUDE_LINE,
+    )
+    .expect("write transcript");
+    wait_for_log(&mut daemon, "indexed 1 records", 90);
+    daemon.stop();
+}
+
+#[test]
+fn daemon_poll_mode_still_indexes_on_interval() {
+    let dirs = TestDirs::new();
+    let mut daemon = spawn_index_daemon(&dirs, &["--watch-mode", "poll", "--poll-interval", "1"]);
+    wait_for_log(&mut daemon, "indexed 0 records", 60);
+
+    std::fs::write(
+        dirs.claude.path().join("session.jsonl"),
+        MINIMAL_CLAUDE_LINE,
+    )
+    .expect("write transcript");
+    wait_for_log(&mut daemon, "indexed 1 records", 60);
+    daemon.stop();
+}

--- a/tests/daemon_cli.rs
+++ b/tests/daemon_cli.rs
@@ -481,6 +481,37 @@ fn daemon_poll_mode_still_indexes_on_interval() {
     daemon.stop();
 }
 
+#[test]
+fn daemon_event_mode_scans_only_the_changed_transcript() {
+    let dirs = TestDirs::new();
+    let first = dirs.claude.path().join("first.jsonl");
+    std::fs::write(&first, MINIMAL_CLAUDE_LINE).unwrap();
+    std::fs::write(dirs.claude.path().join("second.jsonl"), MINIMAL_CLAUDE_LINE).unwrap();
+    let mut daemon = spawn_index_daemon(
+        &dirs,
+        &["--watch-mode", "events", "--poll-interval", "3600"],
+    );
+    wait_for_log(&mut daemon, "indexed 2 records across 2 files", 60);
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&first)
+            .unwrap();
+        writeln!(
+            file,
+            "{}",
+            json!({
+                "type": "user", "uuid": "u2",
+                "message": {"role": "user", "content": "appended"},
+            })
+        )
+        .unwrap();
+    }
+    wait_for_log(&mut daemon, "indexed 1 records across 1 files", 90);
+    daemon.stop();
+}
+
 fn wait_for_session_text(daemon: &mut ChildGuard, root: &Path, expected: &str) {
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {


### PR DESCRIPTION
Replaces the daemon's 30s poll loop with OS filesystem events (FSEvents on macOS, inotify on Linux via notify 8), keeping full scans as the correctness backstop.

What is in here:
- New src/watch.rs: exact watch-root coverage for all 11 ingested sources, deny-list event filter reusing ingest's PathExcluder, per-batch debounce (1.5s) + torn-write settle (500ms) + max batch age (8s), stat-based no-op skip mirroring prepare_file_task's predicate, resync on timer (10min default)/overflow/watcher error/new roots, single-flight under the existing lease.
- FSEvents defers modify events for held-open files (proven empirically; agents stream through one open fd, confirmed via lsof on live sessions), so macOS runs a 5s hot sweep re-statting recently active files. Linux skips it (inotify reports every write).
- Wiring: --watch-mode events|poll on daemon run/enable/restart (hidden on legacy index --watch), index_service_watch_mode/index_service_resync_interval config (old poll-interval keys honored), legacy units keep working with new behavior.
- Tests: 13 watch unit tests incl. real FSEvents/inotify delivery, fd-deferral regression, hot sweep, debounce/backpressure; CLI/config arg tests; 2 end-to-end daemon tests (events mode with 1h resync proves events fire the ingest; poll mode preserved).

Verification: cargo fmt --check, cargo clippy -- -D warnings, full lib suite green (2 pre-existing mcp-oauth failures also fail on clean main), daemon_cli green except 1 pre-existing standalone-mcp failure also present on main.