### PR TITLE
feat(profiling): add compile-time index tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
         timeout-minutes: 10
         run: cargo test --verbose -- --test-threads=1
 
+      - name: Test profiling feature
+        timeout-minutes: 10
+        run: cargo test --features profiling --verbose -- --test-threads=1
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/nicosuave/memex"
 
 [features]
 default = []
+profiling = []
 cuda = ["ort/cuda", "dep:libloading"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Agents can use Memex through its MCP server or CLI skill. Ask about a previous s
 
 Includes a TUI for browsing, finding and resuming agent CLI sessions, with optional [token usage](#token-usage) tracking.
 
+Developer profiling: [index/search traces and flamegraphs](docs/profiling.md).
+
 ![memex tui](docs/tui.png?raw=1&v=4)
 
 A native macOS companion is available in [apps/macos](apps/macos/README.md), with

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,60 @@
+# Index and search profiling
+
+Profiling is opt-in at compile time. Default builds contain no capture backend, profiling environment checks, timers, counters, or evaluation of instrumentation arguments. The `profiling` feature adds the recorder; `MEMEX_PROFILE` enables one capture in that build.
+
+```sh
+cargo build --release --features profiling
+MEMEX_PROFILE=/tmp/memex-refresh.json target/release/memex \
+  --no-update-check --non-interactive search 'your query' --machine local
+python3 scripts/profile_report.py /tmp/memex-refresh.json
+```
+
+The destination must not exist. On Unix it is created with mode `0600`. Search output stays on stdout. The profile is serialized after the command returns, including ordinary command errors. Panics, signals, `process::exit`, and forced termination do not guarantee a completed file. Long-running commands produce their report only when they return normally.
+
+## Reading the capture
+
+The JSON contains Chrome Trace Event `X` spans, in microseconds, on separate thread tracks. Open the local file in a compatible trace viewer. No upload or viewer launch is automatic.
+
+`profile_report.py` reports inclusive and visible exclusive wall time by thread and phase, plus work counters. Wall time includes waits; it is not CPU time. Parent spans include their children. Concurrent thread durations must not be summed as request latency. `ingest.writer_wait` overlaps the writer thread's work.
+
+To render a wall-time flamegraph with an installed Inferno CLI:
+
+```sh
+python3 scripts/profile_report.py /tmp/memex-refresh.json --folded > /tmp/memex-refresh.folded
+inferno-flamegraph --countname microseconds /tmp/memex-refresh.folded > /tmp/memex-refresh.svg
+```
+
+Use `--thread ID` with `--folded` to render one thread's work separately. The JSON summary lists thread IDs. This avoids combining concurrent waits and work into a misleading request-latency total.
+
+Use a sampling profiler separately for CPU stacks inside Tantivy, SQLite, embedding runtimes, and system calls. On macOS, `sample PID 5 1 -file /tmp/memex.sample` can attach to a running process. Sampling and tracing add overhead; compare uninstrumented and instrumented binaries on the same workload.
+
+## Cost boundaries
+
+- `cli.run`, `cli.search`, `search.local`: end-to-end command and local search.
+- `ingest.lease_wait`, `ingest.freshness`, `ingest.discovery`, `ingest.file_check`: synchronization and discovery.
+- `opencode.plan`, `opencode.hydrate`, `opencode.discover_legacy`: database and legacy-source work.
+- `memory.refresh`, `git.metadata`, `analytics.resolve_metadata`: memory and repository metadata.
+- `ingest.parse_file`, `ingest.writer`, `ingest.writer_wait`: producer/consumer work and waiting.
+- `lexical.reader_open`, `lexical.source_ids`, `lexical.walk_records`, `lexical.search`: reader creation, cleanup lookups, full-record walks, and retrieval.
+- `analytics.delete_path`, `analytics.delete_scope`, `analytics.flush`: SQLite deletion and accumulated writes.
+- `lexical.stage`, `lexical.commit`, `lexical.merge_wait`, `lexical.publish`: lexical publication.
+- `embeddings.model_init`, `embeddings.batch`, `vectors.coverage_check`, `vectors.backfill`, `vectors.load`, `vectors.stage`, `vectors.publish`: semantic indexing.
+- `state.*`: ingestion, pending-publication, and scan-cache persistence.
+
+Counters distinguish scheduled cleanup from actual work: legacy/database/scope deletion targets, source-ID queries and IDs found, SQLite deletion calls and rows deleted, reader opens, records walked/added/embedded, prefix reads/bytes, and files scanned/skipped/queued. Repeated scheduled deletions with zero matching IDs and zero deleted rows remain visible.
+
+## Bounds and privacy
+
+Capture is limited to 64 participating threads and 8,192 spans per thread. Counters continue accumulating when a thread's span buffer fills. The report includes dropped spans, refused threads, and unfinished spans. A partial capture is not a complete cost model; missing children inflate reported exclusive time. Buffers are per-thread, with no shared event-stream lock on the hot path. JSON conversion and file writes happen after measurement.
+
+Only literal phase/counter names and numeric measurements are recorded. Query text, record bodies, source paths, session IDs, Git arguments, and thread names are excluded. The output path is not included in the report.
+
+## Workload checks
+
+Measure these separately:
+
+1. Initial index creation or interrupted-publication recovery.
+2. A repeated call within the scan-cache TTL.
+3. A call after new messages and TTL expiry, with retrieval of the new content verified.
+
+Record source-file and record counts, OpenCode legacy/SQLite coexistence, memory-document presence, segment count, and embedding model. Preserve the normal configuration and separate trace-export time from captured command time. Synthetic no-op fixtures alone do not establish live incremental latency.

--- a/scripts/profile_report.py
+++ b/scripts/profile_report.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Summarize MEMEX_PROFILE spans, or emit wall-time folded stacks for Inferno."""
+
+import argparse
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import sys
+
+
+def report(document):
+    if document.get("schema_version") != 1:
+        raise ValueError("unsupported profiling schema")
+    threads = defaultdict(list)
+    for event in document["traceEvents"]:
+        if event["ph"] == "X":
+            threads[event["tid"]].append(event)
+    phases = defaultdict(lambda: {"calls": 0, "inclusive_us": 0, "self_us": 0})
+    folded = Counter()
+    for tid, events in threads.items():
+        stack = []
+        frames = []
+        for event in sorted(events, key=lambda e: (e["ts"], -e["dur"])):
+            start, duration = event["ts"], event["dur"]
+            end = start + duration
+            while stack and start >= stack[-1]["end"]:
+                stack.pop()
+            if stack and end > stack[-1]["end"]:
+                raise ValueError(f"overlapping non-nested spans on thread {tid}")
+            path = [frame["name"] for frame in stack] + [event["name"]]
+            frame = {"name": event["name"], "end": end,
+                     "self_us": duration, "path": path}
+            if stack:
+                stack[-1]["self_us"] -= duration
+            frames.append(frame)
+            stack.append(frame)
+            phase = phases[(tid, event["name"])]
+            phase["calls"] += 1
+            phase["inclusive_us"] += duration
+        for frame in frames:
+            if frame["self_us"] < 0:
+                raise ValueError("negative exclusive span duration")
+            phases[(tid, frame["name"])]["self_us"] += frame["self_us"]
+            if frame["self_us"]:
+                folded[";".join([f"thread-{tid}", *frame["path"]])] += frame["self_us"]
+    counters = Counter()
+    for thread in document["threads"]:
+        counters.update(thread["counters"])
+    summary = {
+        "capture_duration_us": document["capture_duration_us"],
+        "dropped_spans": sum(t["dropped_spans"] for t in document["threads"]),
+        "refused_threads": document["refused_threads"],
+        "incomplete_spans": document["incomplete_spans"],
+        "counters": dict(sorted(counters.items())),
+        "phases": [{"tid": tid, "name": name, **values}
+                   for (tid, name), values in sorted(phases.items())],
+    }
+    return summary, folded
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", type=Path)
+    parser.add_argument("--folded", action="store_true")
+    parser.add_argument("--thread", type=int, help="restrict folded stacks to one thread ID")
+    args = parser.parse_args()
+    if args.thread is not None and not args.folded:
+        parser.error("--thread requires --folded")
+    summary, folded = report(json.loads(args.trace.read_text()))
+    if any(summary[key] for key in ("dropped_spans", "refused_threads", "incomplete_spans")):
+        print("Warning: partial capture; missing child spans inflate reported self time.", file=sys.stderr)
+    if args.folded:
+        for stack, duration in sorted(folded.items()):
+            if args.thread is None or stack.startswith(f"thread-{args.thread};"):
+                print(f"{stack} {duration}")
+    else:
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -298,15 +298,20 @@ impl AnalyticsStore {
     }
 
     pub fn delete_source_path(&self, source_path: &str) -> Result<()> {
-        self.conn.execute(
+        crate::profiling::span!("analytics.delete_path");
+        crate::profiling::count!("analytics.delete_path.calls", 1);
+        let _rows_deleted = self.conn.execute(
             "DELETE FROM sessions WHERE source_path = ?1",
             params![source_path],
         )?;
+        crate::profiling::count!("analytics.delete_path.rows", _rows_deleted);
         Ok(())
     }
 
     pub fn delete_session_scope(&self, scope: &SessionScope) -> Result<()> {
-        self.conn.execute(
+        crate::profiling::span!("analytics.delete_scope");
+        crate::profiling::count!("analytics.delete_scope.calls", 1);
+        let _rows_deleted = self.conn.execute(
             "DELETE FROM sessions WHERE source = ?1 AND source_path = ?2 AND session_id = ?3",
             params![
                 SourceKind::Opencode.storage_label(),
@@ -314,6 +319,7 @@ impl AnalyticsStore {
                 scope.session_id
             ],
         )?;
+        crate::profiling::count!("analytics.delete_scope.rows", _rows_deleted);
         Ok(())
     }
 
@@ -1041,6 +1047,7 @@ impl AnalyticsWriter {
     }
 
     pub fn flush(&mut self) -> Result<()> {
+        crate::profiling::span!("analytics.flush");
         if self.sessions.is_empty() {
             return Ok(());
         }
@@ -1126,6 +1133,7 @@ impl AnalyticsWriter {
     }
 
     fn resolve_metadata(&mut self, key: &SessionKey) -> SessionMetadata {
+        crate::profiling::span!("analytics.resolve_metadata");
         if let Some(cached) = self.metadata_cache.get(key) {
             return cached.clone();
         }
@@ -1168,6 +1176,7 @@ struct GitMetadata {
 }
 
 fn git_metadata_for_cwd(cwd: &str) -> GitMetadata {
+    crate::profiling::span!("git.metadata");
     let deadline = Instant::now() + GIT_METADATA_TIMEOUT;
     let root = git_rev_parse(cwd, &["rev-parse", "--show-toplevel"], deadline);
     let common_dir = git_rev_parse(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1282,6 +1282,7 @@ enum IndexServiceCommand {
 }
 
 pub fn run() -> Result<()> {
+    crate::profiling::span!("cli.run");
     let cli = Cli::parse();
     let interactive = interaction_allowed(
         cli.non_interactive,
@@ -2573,6 +2574,7 @@ fn run_search(
     machines: Vec<String>,
     trace: bool,
 ) -> Result<()> {
+    crate::profiling::span!("cli.search");
     let format = if json_array && !verbose {
         SearchFormat::Json
     } else {

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -574,6 +574,7 @@ impl EmbedderHandle {
         choice: ModelChoice,
         runtime: &EmbedRuntimeConfig,
     ) -> Result<Self> {
+        crate::profiling::span!("embeddings.model_init");
         if let Some((model_type, dims)) = choice.fastembed_config() {
             let requested_provider = runtime.execution_provider;
             let effective_provider = requested_provider.effective();
@@ -610,6 +611,7 @@ impl EmbedderHandle {
     }
 
     pub fn embed_texts(&mut self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        crate::profiling::span!("embeddings.batch");
         if texts.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -514,6 +514,7 @@ impl SearchIndex {
         dir: &Path,
         suppress_automatic_merges: bool,
     ) -> Result<Self> {
+        crate::profiling::span!("lexical.stage");
         fs::create_dir_all(dir)?;
         let generations = dir.join(GENERATIONS_DIR);
         fs::create_dir_all(&generations)?;
@@ -581,6 +582,7 @@ impl SearchIndex {
     }
 
     pub fn writer(&self) -> Result<IndexWriter> {
+        crate::profiling::span!("lexical.writer_open");
         if !self.writable {
             bail!("cannot create a writer for a sealed index generation");
         }
@@ -592,11 +594,14 @@ impl SearchIndex {
     }
 
     pub fn reader(&self) -> Result<IndexReader> {
-        Ok(self
+        crate::profiling::span!("lexical.reader_open");
+        let reader: IndexReader = self
             .index
             .reader_builder()
             .reload_policy(ReloadPolicy::Manual)
-            .try_into()?)
+            .try_into()?;
+        crate::profiling::count!("lexical.readers_opened", 1);
+        Ok(reader)
     }
 
     /// Open-time snapshot identity. It remains stable for this instance; writable callers must
@@ -658,6 +663,7 @@ impl SearchIndex {
     }
 
     pub(crate) fn publish_generation(&self) -> Result<()> {
+        crate::profiling::span!("lexical.publish");
         let Some(pending) = &self.pending_generation else {
             return Ok(());
         };
@@ -716,6 +722,7 @@ impl SearchIndex {
     }
 
     fn doc_ids_matching_query(&self, query: Box<dyn Query>) -> Result<Vec<u64>> {
+        crate::profiling::span!("lexical.source_ids");
         let reader = self.reader()?;
         let searcher = reader.searcher();
         let limit = (searcher.num_docs() as usize).max(1);
@@ -731,6 +738,8 @@ impl SearchIndex {
             }
         }
         doc_ids.sort_unstable();
+        crate::profiling::count!("lexical.source_id_queries", 1);
+        crate::profiling::count!("lexical.source_ids_found", doc_ids.len());
         Ok(doc_ids)
     }
 
@@ -951,6 +960,7 @@ impl SearchIndex {
     }
 
     pub fn search(&self, options: &QueryOptions) -> Result<Vec<(f32, Record)>> {
+        crate::profiling::span!("lexical.search");
         let reader = self.reader()?;
         let searcher = reader.searcher();
         let query = build_query(&self.fields, options, &self.index)?;
@@ -1586,6 +1596,7 @@ impl SearchIndex {
     where
         F: FnMut(Record) -> Result<()>,
     {
+        crate::profiling::span!("lexical.walk_records");
         let reader = self.reader()?;
         let searcher = reader.searcher();
         for segment_reader in searcher.segment_readers() {
@@ -1593,6 +1604,7 @@ impl SearchIndex {
             for doc in store.iter::<TantivyDocument>(segment_reader.alive_bitset()) {
                 let doc = doc?;
                 let record = record_from_doc(&self.fields, &doc);
+                crate::profiling::count!("lexical.records_walked", 1);
                 f(record)?;
             }
         }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -150,6 +150,8 @@ fn file_identity(path: &Path, metadata: &std::fs::Metadata, prefix_bytes: usize)
         File::open(path).ok().and_then(|mut file| {
             let mut bytes = vec![0; prefix_bytes];
             let read = file.read(&mut bytes).ok()?;
+            crate::profiling::count!("ingest.prefix_reads", 1);
+            crate::profiling::count!("ingest.prefix_bytes", read);
             bytes.truncate(read);
             Some(format!("{:x}", Sha256::digest(&bytes)))
         })
@@ -208,6 +210,7 @@ fn prepare_file_task(
     metadata: &std::fs::Metadata,
     previous: Option<&FileState>,
 ) -> (FileTask, bool) {
+    crate::profiling::span!("ingest.file_check");
     let size = metadata.len();
     let mtime = metadata
         .modified()
@@ -456,6 +459,7 @@ fn prehydrate_opencode_database(
     next_doc_id: &AtomicU64,
     state_dir: &Path,
 ) -> Result<PreparedOpencodeDatabase> {
+    crate::profiling::span!("opencode.hydrate");
     let mut spool = tempfile::Builder::new()
         .prefix(OPENCODE_SPOOL_PREFIX)
         .tempfile_in(state_dir)
@@ -624,10 +628,12 @@ pub fn ingest_if_stale(
     ttl_seconds: u64,
     lease: &IngestLease,
 ) -> Result<Option<IngestReport>> {
+    crate::profiling::span!("ingest.freshness");
     let cache_path = paths.state.join("scan_cache.json");
     let cache = ScanCache::load(&cache_path)?;
 
     if can_skip_fresh_scan(&cache, paths, index, options, ttl_seconds)? {
+        crate::profiling::count!("ingest.fresh_cache_hits", 1);
         // The transcript scan cache cannot detect edits in a Markdown memory
         // file. Refresh these small documents even when transcript discovery is
         // still within its TTL, under the same ingestion lease.
@@ -635,6 +641,7 @@ pub fn ingest_if_stale(
         return Ok(None);
     }
 
+    crate::profiling::count!("ingest.fresh_cache_misses", 1);
     let report = ingest_all(paths, index, options, lease)?;
     Ok(Some(report))
 }
@@ -773,6 +780,7 @@ fn ingest_selected(
     _lease: &IngestLease,
     dirty: Option<&HashSet<PathBuf>>,
 ) -> Result<DirtyIngestReport> {
+    crate::profiling::span!("ingest.all");
     // Apply additive analytics migrations even when the scan finds no changed files.
     drop(AnalyticsStore::open(analytics_path(&paths.state))?);
     let state_path = paths.state.join("ingest.json");
@@ -816,6 +824,8 @@ fn ingest_selected(
 
     // Index-time exclusion: matched transcripts never enter the index, and
     // records previously indexed from now-excluded paths are removed.
+    #[cfg(feature = "profiling")]
+    let discovery_profile = crate::profiling::Scope::enter("ingest.discovery");
     let excluder = build_path_excluder(options)?;
     let mut excluded_state_paths: Vec<String> = Vec::new();
     if full_scan {
@@ -1649,6 +1659,23 @@ fn ingest_selected(
     installed_opencode_states.extend(opencode_database_states.clone());
     let opencode_database_state_changed = installed_opencode_states != state.opencode_databases;
 
+    #[cfg(feature = "profiling")]
+    drop(discovery_profile);
+    crate::profiling::count!("ingest.files_scanned", files_scanned);
+    crate::profiling::count!("ingest.files_skipped", files_skipped);
+    crate::profiling::count!("ingest.parse_tasks", tasks.len());
+    crate::profiling::count!(
+        "opencode.legacy_deletes_scheduled",
+        opencode_legacy_paths_to_delete.len()
+    );
+    crate::profiling::count!(
+        "opencode.scope_deletes_scheduled",
+        opencode_scope_targets.len()
+    );
+    crate::profiling::count!(
+        "opencode.database_deletes_scheduled",
+        opencode_database_paths_to_delete.len()
+    );
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     let analytics_db = analytics_path(&paths.state);
@@ -1679,6 +1706,7 @@ fn ingest_selected(
         if analytics_needs_backfill {
             backfill_from_index(&analytics_db, index)?;
         }
+        crate::profiling::count!("ingest.noop_returns", 1);
         index.publish_generation_if_uninitialized()?;
         state.opencode_databases = installed_opencode_states;
         if recovering_pending_ingest || empty_index_rebuild {
@@ -1802,6 +1830,7 @@ fn ingest_selected(
     let parser_pool = parser_thread_pool()?;
     let parser_result = parser_pool.install(|| {
         tasks_arc.par_iter().try_for_each(|task| -> Result<()> {
+            crate::profiling::span!("ingest.parse_file");
             let result = match task.source {
                 SourceKind::Claude => parse_claude_file(
                     task,
@@ -1944,10 +1973,14 @@ fn ingest_selected(
     };
     // A failed writer may have already closed the channel. Joining below keeps that root cause.
     let _ = decision_tx.send(decision);
+    #[cfg(feature = "profiling")]
+    let writer_wait_profile = crate::profiling::Scope::enter("ingest.writer_wait");
     let writer_result = writer_handle.join().map_err(|_| {
         tail.finish_and_clear();
         anyhow!("writer thread panicked")
     })?;
+    #[cfg(feature = "profiling")]
+    drop(writer_wait_profile);
     progress.finish();
     tail.set_message("updating analytics…");
     let outcome = (|| -> Result<DirtyIngestReport> {
@@ -2011,6 +2044,7 @@ fn ingest_selected(
 }
 
 fn refresh_memories(paths: &Paths, options: &IngestOptions) -> Result<()> {
+    crate::profiling::span!("memory.refresh");
     let mut enabled_sources = HashSet::new();
     if !options.claude_sources.is_empty() {
         enabled_sources.insert(SourceKind::Claude);
@@ -2105,6 +2139,7 @@ fn can_skip_noop_index(
     index: &SearchIndex,
     options: &IngestOptions,
 ) -> Result<bool> {
+    crate::profiling::span!("vectors.compatibility");
     if !options.embeddings {
         return Ok(true);
     }
@@ -2127,6 +2162,7 @@ fn vector_index_covers_embeddable_records(
     index: &SearchIndex,
     vector_index: &crate::vector::VectorIndex,
 ) -> Result<bool> {
+    crate::profiling::span!("vectors.coverage_check");
     let mut covers_all = true;
     index.for_each_record(|record| {
         if record_needs_embedding(&record) && !vector_index.contains(record.doc_id) {
@@ -2162,6 +2198,7 @@ fn writer_loop(
     delete_paths: Vec<String>,
     ctx: WriterContext,
 ) -> Result<WriterOutcome> {
+    crate::profiling::span!("ingest.writer");
     let WriterContext {
         embeddings,
         do_backfill_embeddings,
@@ -2290,7 +2327,10 @@ fn writer_loop(
         analytics.delete_source_path(&path)?;
     }
     analytics.flush()?;
-    writer.commit()?;
+    {
+        crate::profiling::span!("lexical.commit");
+        writer.commit()?;
+    }
     index.maybe_compact_continuous_segments(&mut writer)?;
     let mut staged_vectors = None;
     if reconcile_vector_ids {
@@ -2336,11 +2376,16 @@ fn writer_loop(
     if let Some(handle) = embedder.take() {
         std::mem::forget(handle);
     }
-    writer.wait_merging_threads()?;
+    {
+        crate::profiling::span!("lexical.merge_wait");
+        writer.wait_merging_threads()?;
+    }
     index.publish_generation()?;
     if let Some(staged) = staged_vectors {
         staged.publish()?;
     }
+    crate::profiling::count!("ingest.records_added", count);
+    crate::profiling::count!("ingest.records_embedded", embedded_count);
     Ok(WriterOutcome::Published {
         records_added: count,
         records_embedded: embedded_count,
@@ -2353,6 +2398,7 @@ fn backfill_embeddings(
     vector_index: &mut crate::vector::VectorIndex,
     progress: &Arc<Progress>,
 ) -> Result<usize> {
+    crate::profiling::span!("vectors.backfill");
     use std::cell::Cell;
     let embedded_count = Cell::new(0usize);
     let mut embed_buffer: Vec<(u64, String, SourceKind)> = Vec::new();

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -44,6 +44,7 @@ impl IngestLease {
     }
 
     pub fn acquire(paths: &Paths, operation: impl Into<String>, timeout: Duration) -> Result<Self> {
+        crate::profiling::span!("ingest.lease_wait");
         let path = lease_path(paths);
         let operation = operation.into();
         let started = Instant::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod memory;
 pub mod memory_search;
 #[cfg(unix)]
 mod native;
+#[doc(hidden)]
+pub mod profiling;
 pub mod progress;
 pub mod read_budget;
 pub mod resume;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -2450,6 +2450,7 @@ fn search_local(
     spec: &SearchSpec,
     auto_index: bool,
 ) -> Result<Vec<(f32, Record)>> {
+    crate::profiling::span!("search.local");
     if auto_index {
         ensure_local_index(paths, config)?;
     }
@@ -2659,6 +2660,7 @@ fn ensure_local_index(paths: &Paths, config: &UserConfig) -> Result<()> {
 }
 
 fn index_local(paths: &Paths, config: &UserConfig, stale_only: bool) -> Result<IngestReport> {
+    crate::profiling::span!("index.local");
     paths.ensure_dirs()?;
     let lease = IngestLease::acquire(paths, "RPC index", INGEST_LEASE_TIMEOUT)?;
     let index = SearchIndex::open_or_create_for_ingest(&paths.index)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
 fn main() -> anyhow::Result<()> {
-    memex::cli::run()
+    #[cfg(feature = "profiling")]
+    let profile = memex::profiling::Session::from_env()?;
+    let result = memex::cli::run();
+    #[cfg(feature = "profiling")]
+    {
+        let trace_result = profile.finish();
+        result?;
+        trace_result
+    }
+    #[cfg(not(feature = "profiling"))]
+    result
 }

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "profiling")]
+mod capture;
+#[cfg(feature = "profiling")]
+pub use capture::Session;
+#[cfg(feature = "profiling")]
+pub(crate) use capture::{Scope, record_count};
+
+#[cfg(feature = "profiling")]
+macro_rules! span {
+    ($name:literal) => {
+        let _profile_scope = $crate::profiling::Scope::enter($name);
+    };
+}
+#[cfg(not(feature = "profiling"))]
+macro_rules! span {
+    ($name:literal) => {{}};
+}
+
+#[cfg(feature = "profiling")]
+macro_rules! count {
+    ($name:literal, $value:expr) => {
+        $crate::profiling::record_count($name, $value as u64)
+    };
+}
+#[cfg(not(feature = "profiling"))]
+macro_rules! count {
+    ($name:literal, $value:expr) => {{}};
+}
+
+pub(crate) use {count, span};
+
+#[cfg(all(test, not(feature = "profiling")))]
+mod tests {
+    #[test]
+    fn disabled_arguments_are_not_evaluated_or_type_checked() {
+        super::count!("unused", nonexistent_function());
+        super::count!("unused", panic!("disabled instrumentation ran"));
+        super::span!("unused");
+    }
+}

--- a/src/profiling/capture.rs
+++ b/src/profiling/capture.rs
@@ -1,0 +1,242 @@
+use anyhow::{Context, Result, bail};
+use serde_json::json;
+use std::cell::OnceCell;
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Instant;
+
+const MAX_THREADS: usize = 64;
+const EVENTS_PER_THREAD: usize = 8192;
+static ACTIVE: OnceLock<Arc<Capture>> = OnceLock::new();
+type SharedBuffer = Arc<Mutex<Buffer>>;
+thread_local! {
+    static BUFFER: OnceCell<Option<SharedBuffer>> = const { OnceCell::new() };
+}
+
+struct Capture {
+    start: Instant,
+    buffers: Mutex<Vec<SharedBuffer>>,
+    refused_threads: AtomicU64,
+}
+
+#[derive(Default)]
+struct Buffer {
+    events: Vec<Event>,
+    counters: BTreeMap<&'static str, u64>,
+    dropped_events: u64,
+}
+
+struct Event {
+    name: &'static str,
+    start_us: u64,
+    duration_us: Option<u64>,
+}
+
+pub struct Session {
+    output: Option<File>,
+}
+
+impl Session {
+    pub fn from_env() -> Result<Self> {
+        let Some(path) = std::env::var_os("MEMEX_PROFILE") else {
+            return Ok(Self { output: None });
+        };
+        if ACTIVE.get().is_some() {
+            bail!("a profiling session is already active");
+        }
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let output = options
+            .open(&path)
+            .context("create MEMEX_PROFILE output (must not already exist)")?;
+        ACTIVE
+            .set(Arc::new(Capture::new()))
+            .map_err(|_| anyhow::anyhow!("a profiling session is already active"))?;
+        Ok(Self {
+            output: Some(output),
+        })
+    }
+
+    pub fn finish(self) -> Result<()> {
+        let Some(output) = self.output else {
+            return Ok(());
+        };
+        let capture = ACTIVE.get().expect("profiling session initialized");
+        let end_us = capture.elapsed_us();
+        let document = capture.snapshot(end_us);
+        let mut output = BufWriter::new(output);
+        serde_json::to_writer(&mut output, &document).context("serialize profiling output")?;
+        output.write_all(b"\n")?;
+        output.flush().context("flush profiling output")
+    }
+}
+
+impl Capture {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            buffers: Mutex::new(Vec::new()),
+            refused_threads: AtomicU64::new(0),
+        }
+    }
+
+    fn elapsed_us(&self) -> u64 {
+        self.start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64
+    }
+
+    fn register_thread(&self) -> Option<SharedBuffer> {
+        let mut buffers = self.buffers.lock().unwrap();
+        if buffers.len() == MAX_THREADS {
+            self.refused_threads.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
+        let buffer = Arc::new(Mutex::new(Buffer::default()));
+        buffers.push(Arc::clone(&buffer));
+        Some(buffer)
+    }
+
+    fn snapshot(&self, end_us: u64) -> serde_json::Value {
+        let mut events = Vec::new();
+        let mut threads = Vec::new();
+        let mut incomplete_spans = 0;
+        for (tid, shared) in self.buffers.lock().unwrap().iter().enumerate() {
+            let buffer = shared.lock().unwrap();
+            for event in &buffer.events {
+                if event.start_us > end_us {
+                    continue;
+                }
+                let incomplete = event.duration_us.is_none();
+                incomplete_spans += usize::from(incomplete);
+                let available = end_us.saturating_sub(event.start_us);
+                events.push(json!({
+                    "name": event.name, "cat": "memex", "ph": "X",
+                    "pid": 1, "tid": tid, "ts": event.start_us,
+                    "dur": event.duration_us.unwrap_or(available).min(available),
+                    "args": { "incomplete": incomplete }
+                }));
+            }
+            threads.push(json!({
+                "tid": tid, "counters": buffer.counters,
+                "dropped_spans": buffer.dropped_events
+            }));
+        }
+        json!({
+            "schema_version": 1,
+            "displayTimeUnit": "ms",
+            "traceEvents": events,
+            "capture_duration_us": end_us,
+            "limits": { "threads": MAX_THREADS, "spans_per_thread": EVENTS_PER_THREAD },
+            "refused_threads": self.refused_threads.load(Ordering::Relaxed),
+            "incomplete_spans": incomplete_spans,
+            "threads": threads
+        })
+    }
+}
+
+pub(crate) struct Scope {
+    record: Option<(SharedBuffer, usize)>,
+    _thread_bound: PhantomData<Rc<()>>,
+}
+
+impl Scope {
+    pub(crate) fn enter(name: &'static str) -> Self {
+        let record = ACTIVE.get().and_then(|capture| {
+            BUFFER.with(|local| {
+                let shared = local.get_or_init(|| capture.register_thread()).as_ref()?;
+                let entry = shared.lock().unwrap().enter(name, capture.elapsed_us())?;
+                Some((Arc::clone(shared), entry))
+            })
+        });
+        Self {
+            record,
+            _thread_bound: PhantomData,
+        }
+    }
+}
+
+impl Drop for Scope {
+    fn drop(&mut self) {
+        if let Some((shared, entry)) = &self.record {
+            let end = ACTIVE.get().expect("active span has capture").elapsed_us();
+            shared.lock().unwrap().close(*entry, end);
+        }
+    }
+}
+
+impl Buffer {
+    fn enter(&mut self, name: &'static str, start_us: u64) -> Option<usize> {
+        if self.events.len() == EVENTS_PER_THREAD {
+            self.dropped_events += 1;
+            return None;
+        }
+        let entry = self.events.len();
+        self.events.push(Event {
+            name,
+            start_us,
+            duration_us: None,
+        });
+        Some(entry)
+    }
+
+    fn close(&mut self, entry: usize, end_us: u64) {
+        let event = &mut self.events[entry];
+        event.duration_us = Some(end_us.saturating_sub(event.start_us));
+    }
+}
+
+pub(crate) fn record_count(name: &'static str, amount: u64) {
+    if let Some(capture) = ACTIVE.get() {
+        BUFFER.with(|local| {
+            if let Some(shared) = local.get_or_init(|| capture.register_thread()) {
+                let mut buffer = shared.lock().unwrap();
+                let value = buffer.counters.entry(name).or_default();
+                *value = value.saturating_add(amount);
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_spans_preserve_outer_closes_and_count_drops() {
+        let mut buffer = Buffer::default();
+        let outer = buffer.enter("outer", 1).unwrap();
+        for _ in 1..EVENTS_PER_THREAD {
+            let entry = buffer.enter("inner", 2).unwrap();
+            buffer.close(entry, 3);
+        }
+        assert!(buffer.enter("overflow", 4).is_none());
+        buffer.close(outer, 5);
+        assert_eq!(buffer.events.len(), EVENTS_PER_THREAD);
+        assert_eq!(buffer.dropped_events, 1);
+        assert_eq!(buffer.events[outer].duration_us, Some(4));
+    }
+
+    #[test]
+    fn thread_limit_and_incomplete_spans_are_reported() {
+        let capture = Capture::new();
+        for _ in 0..MAX_THREADS {
+            let thread = capture.register_thread().unwrap();
+            thread.lock().unwrap().enter("unfinished", 1);
+        }
+        assert!(capture.register_thread().is_none());
+        let snapshot = capture.snapshot(10);
+        assert_eq!(snapshot["refused_threads"], 1);
+        assert_eq!(snapshot["incomplete_spans"], MAX_THREADS);
+        assert_eq!(snapshot["traceEvents"][0]["dur"], 9);
+        assert_eq!(snapshot["traceEvents"][0]["args"]["incomplete"], true);
+    }
+}

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -75,6 +75,7 @@ fn parts_root_for_session(session_dir: &Path) -> PathBuf {
 }
 
 pub fn discover_sessions() -> anyhow::Result<Vec<SourceFile>> {
+    crate::profiling::span!("opencode.discover_legacy");
     discover_sessions_from_roots(&data_roots())
 }
 
@@ -116,6 +117,7 @@ pub fn discover_sessions_from_root(root: &Path) -> anyhow::Result<Vec<SourceFile
 /// OpenCode's data directory may be configured as a comma-separated list, so discovery is
 /// deliberately performed against every configured root and sorted globally for stable output.
 pub fn discover_databases() -> anyhow::Result<Vec<SourceFile>> {
+    crate::profiling::span!("opencode.discover_databases");
     discover_databases_from_roots(&data_roots())
 }
 
@@ -389,6 +391,7 @@ pub fn scan_database(
     path: &Path,
     previous: Option<&OpencodeDatabaseState>,
 ) -> Result<DatabaseScan> {
+    crate::profiling::span!("opencode.plan");
     let connection = open_read_only_database(path)?;
     connection
         .execute_batch("BEGIN")

--- a/src/state.rs
+++ b/src/state.rs
@@ -118,6 +118,7 @@ pub struct ScanCache {
 
 impl ScanCache {
     pub fn load(path: &Path) -> anyhow::Result<Self> {
+        crate::profiling::span!("state.scan_cache.load");
         if !path.exists() {
             return Ok(Self::default());
         }
@@ -127,6 +128,7 @@ impl ScanCache {
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        crate::profiling::span!("state.scan_cache.save");
         let data = serde_json::to_string(self)?;
         atomic_write(path, data.as_bytes())
     }
@@ -210,6 +212,7 @@ impl Default for IngestState {
 
 impl IngestState {
     pub fn load(path: &Path) -> anyhow::Result<Self> {
+        crate::profiling::span!("state.ingest.load");
         if !path.exists() {
             return Ok(Self::default());
         }
@@ -219,6 +222,7 @@ impl IngestState {
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        crate::profiling::span!("state.ingest.save");
         let data = serde_json::to_string_pretty(self)?;
         atomic_write(path, data.as_bytes())
     }
@@ -226,6 +230,7 @@ impl IngestState {
 
 impl PendingIngest {
     pub fn load(path: &Path) -> anyhow::Result<Option<Self>> {
+        crate::profiling::span!("state.pending.load");
         if !path.exists() {
             return Ok(None);
         }
@@ -234,6 +239,7 @@ impl PendingIngest {
     }
 
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        crate::profiling::span!("state.pending.save");
         let data = serde_json::to_string_pretty(self)?;
         atomic_write(path, data.as_bytes())
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -48,6 +48,7 @@ pub(crate) struct StagedVectorGeneration {
 
 impl StagedVectorGeneration {
     pub(crate) fn publish(mut self) -> Result<()> {
+        crate::profiling::span!("vectors.publish");
         // Once publication starts, keep the generation even on error: current.json may have
         // changed before the error was reported. A later successful save collects it safely.
         self.cleanup_on_drop = false;
@@ -152,6 +153,7 @@ impl VectorIndex {
     }
 
     fn open_from_storage(root: &Path, storage: &ActiveStorage) -> Result<Self> {
+        crate::profiling::span!("vectors.load");
         let index_path = storage.path.join("usearch.index");
         let ids_path = storage.path.join("doc_ids.bin");
         let index = Index::new(&IndexOptions::default())?;
@@ -282,6 +284,7 @@ impl VectorIndex {
     }
 
     pub(crate) fn stage(&self) -> Result<StagedVectorGeneration> {
+        crate::profiling::span!("vectors.stage");
         fs::create_dir_all(&self.root)?;
         let generations = self.root.join(GENERATIONS_DIR);
         fs::create_dir_all(&generations)?;

--- a/tests/profiling_cli.rs
+++ b/tests/profiling_cli.rs
@@ -1,0 +1,160 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run(home: &Path, root: &Path, trace: Option<&Path>, query: &str) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_memex"));
+    command
+        .env_clear()
+        .env("HOME", home)
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("CLAUDE_CONFIG_DIR", home.join(".claude"))
+        .env("CODEX_HOME", home.join(".codex"))
+        .env("OPENCODE_DATA_DIR", home.join("opencode"))
+        .args([
+            "--no-update-check",
+            "--non-interactive",
+            "search",
+            query,
+            "--machine",
+            "local",
+            "--root",
+        ])
+        .arg(root);
+    if let Some(trace) = trace {
+        command.env("MEMEX_PROFILE", trace);
+    }
+    command.output().unwrap()
+}
+
+fn fixture() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join(".claude/projects/private-project");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(project.join("private-session.jsonl"),
+        "{\"type\":\"user\",\"uuid\":\"private-event\",\"timestamp\":\"2026-09-01T00:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"privateneedle\"}}\n").unwrap();
+    fs::create_dir(temp.path().join("index")).unwrap();
+    fs::write(
+        temp.path().join("index/config.toml"),
+        "embeddings = false\nscan_cache_ttl = 0\n",
+    )
+    .unwrap();
+    temp
+}
+
+#[cfg(not(feature = "profiling"))]
+#[test]
+fn default_build_ignores_trace_environment_entirely() {
+    let temp = fixture();
+    let invalid = temp.path().join("missing/trace.json");
+    let output = run(
+        temp.path(),
+        &temp.path().join("index"),
+        Some(&invalid),
+        "privateneedle",
+    );
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("privateneedle"));
+    assert!(!invalid.exists());
+}
+
+#[cfg(feature = "profiling")]
+#[test]
+fn trace_covers_worker_threads_without_recording_private_data() {
+    let temp = fixture();
+    let trace = temp.path().join("trace.json");
+    let output = run(
+        temp.path(),
+        &temp.path().join("index"),
+        Some(&trace),
+        "privateneedle",
+    );
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("privateneedle"));
+    let text = fs::read_to_string(&trace).unwrap();
+    assert!(!text.contains("private"));
+    assert!(!text.contains(temp.path().to_str().unwrap()));
+    let document: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let events = document["traceEvents"].as_array().unwrap();
+    for name in [
+        "cli.run",
+        "ingest.all",
+        "ingest.parse_file",
+        "ingest.writer",
+        "lexical.commit",
+        "lexical.merge_wait",
+        "lexical.search",
+    ] {
+        assert!(events.iter().any(|e| e["name"] == name), "missing {name}");
+    }
+    let thread = |name: &str| {
+        events.iter().find(|e| e["name"] == name).unwrap()["tid"]
+            .as_u64()
+            .unwrap()
+    };
+    assert_ne!(thread("cli.run"), thread("ingest.writer"));
+    assert_ne!(thread("ingest.writer"), thread("ingest.parse_file"));
+    assert_eq!(document["incomplete_spans"], 0);
+    let counters = document["threads"].as_array().unwrap();
+    assert_eq!(
+        counters
+            .iter()
+            .filter_map(|t| t["counters"]["ingest.records_added"].as_u64())
+            .sum::<u64>(),
+        1
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(&trace).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[cfg(feature = "profiling")]
+#[test]
+fn capture_is_opt_in_and_existing_files_are_never_overwritten() {
+    let temp = fixture();
+    let root = temp.path().join("index");
+    assert!(
+        run(temp.path(), &root, None, "privateneedle")
+            .status
+            .success()
+    );
+    let trace = temp.path().join("trace.json");
+    fs::write(&trace, "sentinel").unwrap();
+    assert!(
+        !run(temp.path(), &root, Some(&trace), "privateneedle")
+            .status
+            .success()
+    );
+    assert_eq!(fs::read_to_string(&trace).unwrap(), "sentinel");
+}
+
+#[cfg(feature = "profiling")]
+#[test]
+fn failed_commands_still_finish_the_trace() {
+    let temp = fixture();
+    let trace = temp.path().join("trace.json");
+    let output = run(temp.path(), &temp.path().join("index"), Some(&trace), "(");
+    assert!(!output.status.success());
+    let document: serde_json::Value = serde_json::from_slice(&fs::read(trace).unwrap()).unwrap();
+    assert_eq!(document["incomplete_spans"], 0);
+    assert!(
+        document["traceEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["name"] == "cli.run")
+    );
+}


### PR DESCRIPTION
**This series rewrites the ingest/index pipeline so keeping search fresh no longer requires a resident indexing daemon.** A CLI or MCP request should be able to catch up on demand, pay for the files that changed, and leave compaction to a short-lived background process.

The measured results across the series are:

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Warm no-op search, internal time | 82 ms | 23–30 ms | 2.7–3.6× faster |
| Full rebuild, 737–744k records | 57 s | 18.3 s | 3.1× faster |
| Full rebuild, 200 files / 67k records | 14.7 s | 1.6 s | 9.2× faster |
| Explicit indexing, same 67k-record corpus | 10.3 s | 1.6 s | 6.4× faster |
| Twenty-record search-triggered refresh, median | 457.32 ms | 311.04 ms | 32% lower |
| Rebuilt segment storage after schema changes | 4.0 GB | 2.3 GB | 42.5% smaller |

Each row is a separate workload measured during development, before the 0.19.4 rebase. The individual PRs explain the relevant experiment and implementation.

The old pipeline repeatedly paid costs proportional to accumulated history: walking source trees, rewriting whole checkpoint files, copying or linking inherited index segments, and merging on the request path. The series replaces that with change-based discovery, sparse checkpoints, shared immutable segments, lazy writers, and detached compaction. The daemon remains useful for continuous watching and hosted services; ordinary search freshness should stand on its own.

This first PR supplies the instrumentation that made those costs visible. In one warm capture, a **1,467 ms call added zero records**, yet performed **264 reader opens** during source-ID lookups and **264 analytics path deletions that deleted zero rows**. Phase spans and work counters let the later PRs identify and test the work they eliminate.

Tracing is compiled out of default builds. With the `profiling` feature, `MEMEX_PROFILE` enables bounded per-thread captures; output excludes query text, record bodies, source paths, and session IDs. This PR includes the report tool, output-safety tests, and profiling CI coverage.

Series: #155 tracing → #166 schema → #169 ingest architecture → #170 discovery → #171 shared segments → #172 checkpoints → #173 detached compaction → #174 journal replay → #175 parallel rebuilds.

Validation: formatting and required Clippy checks pass. The completed series passes all six profiling integration tests; full-stack test results are recorded in #175.

---

Step 1/9 of the [ingest/index rewrite](https://github.com/nicosuave/memex/pull/155). The current upstream base is `main`, so the PR diff includes preceding steps until the bases are retargeted.
