### PR TITLE
Add Antigravity source indexing (.db stores and overview.txt logs)

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1382,6 +1382,11 @@ fn resolve_session_cwd_from_parts(
     {
         return Some(cwd.to_string_lossy().to_string());
     }
+    if source == SourceKind::Antigravity
+        && let Some(cwd) = crate::sources::antigravity::session_cwd(Path::new(source_path))
+    {
+        return Some(cwd.to_string_lossy().to_string());
+    }
     let file = std::fs::File::open(source_path).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut fallback: Option<String> = None;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,6 +165,12 @@ struct IndexArgs {
     /// Skip indexing Muse sessions
     #[arg(long = "no-muse", default_value_t = false, hide = true)]
     no_muse: bool,
+    /// Index Antigravity conversations from ~/.gemini [default: true]
+    #[arg(long, default_value_t = true, hide = true)]
+    antigravity: bool,
+    /// Skip indexing Antigravity conversations
+    #[arg(long = "no-antigravity", default_value_t = false, hide = true)]
+    no_antigravity: bool,
     /// Generate embeddings for semantic search during indexing
     #[arg(long, help_heading = "Embeddings")]
     embeddings: bool,
@@ -2149,6 +2155,7 @@ fn build_ingest_options(index: &IndexArgs, config: &UserConfig) -> Result<Ingest
         include_grok: index.source_enabled(IndexSource::Grok),
         include_jcode: index.source_enabled(IndexSource::Jcode),
         include_muse: index.source_enabled(IndexSource::Muse),
+        include_antigravity: index.source_enabled(IndexSource::Antigravity),
         exclude_patterns: excludes,
         embeddings,
         backfill_embeddings: false,
@@ -5473,6 +5480,7 @@ fn run_share(session_id: String, title: Option<String>, root: Option<PathBuf>) -
         crate::types::SourceKind::Hermes => "hermes",
         crate::types::SourceKind::Jcode => "jcode",
         crate::types::SourceKind::Muse => "muse",
+        crate::types::SourceKind::Antigravity => "antigravity",
     };
     let source_path = &record.source_path;
 
@@ -8126,6 +8134,7 @@ mod tests {
             grok: false,
             jcode: false,
             muse: false,
+            antigravity: false,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -8135,6 +8144,7 @@ mod tests {
             no_grok: false,
             no_jcode: false,
             no_muse: false,
+            no_antigravity: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -8183,6 +8193,7 @@ mod tests {
             grok: true,
             jcode: true,
             muse: true,
+            antigravity: true,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -8192,6 +8203,7 @@ mod tests {
             no_grok: false,
             no_jcode: false,
             no_muse: false,
+            no_antigravity: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -8234,6 +8246,7 @@ mod tests {
             grok: true,
             jcode: true,
             muse: true,
+            antigravity: true,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -8243,6 +8256,7 @@ mod tests {
             no_grok: false,
             no_jcode: false,
             no_muse: false,
+            no_antigravity: false,
             embeddings: false,
             no_embeddings: false,
             model: None,
@@ -8287,6 +8301,7 @@ mod tests {
             grok: true,
             jcode: true,
             muse: true,
+            antigravity: true,
             no_codex: false,
             no_opencode: false,
             no_pi: false,
@@ -8296,6 +8311,7 @@ mod tests {
             no_grok: false,
             no_jcode: false,
             no_muse: false,
+            no_antigravity: false,
             embeddings: false,
             no_embeddings: false,
             model: None,

--- a/src/cli/surface.rs
+++ b/src/cli/surface.rs
@@ -174,6 +174,7 @@ pub(super) enum IndexSource {
     Grok,
     Jcode,
     Muse,
+    Antigravity,
 }
 
 impl IndexArgs {
@@ -190,6 +191,7 @@ impl IndexArgs {
             IndexSource::Grok => self.grok && !self.no_grok,
             IndexSource::Jcode => self.jcode && !self.no_jcode,
             IndexSource::Muse => self.muse && !self.no_muse,
+            IndexSource::Antigravity => self.antigravity && !self.no_antigravity,
         };
         legacy_enabled
             && (self.only_source.is_empty() || self.only_source.contains(&source))
@@ -435,6 +437,7 @@ mod tests {
             "--no-grok",
             "--no-jcode",
             "--no-muse",
+            "--no-antigravity",
         ]);
         assert_eq!(
             selected.source.as_deref(),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -45,6 +45,7 @@ pub struct IngestOptions {
     pub include_grok: bool,
     pub include_jcode: bool,
     pub include_muse: bool,
+    pub include_antigravity: bool,
     pub exclude_patterns: Vec<String>,
     pub embeddings: bool,
     pub backfill_embeddings: bool,
@@ -254,6 +255,10 @@ fn prepare_file_task(
         // atomically instead: delete_first purges the stale rows first, so
         // growing files can neither duplicate records nor inflate counts.
         Some(_) if source == SourceKind::Jcode => (0, 0, true, HashMap::new(), false),
+        // An antigravity .db/overview.txt file is rewritten wholesale as the
+        // conversation grows (SQLite stores the WAL separately); a byte offset
+        // cannot resume mid-file, so reparse atomically instead.
+        Some(_) if source == SourceKind::Antigravity => (0, 0, true, HashMap::new(), false),
         Some(previous) => (
             previous.offset,
             previous.turn_id,
@@ -1418,6 +1423,36 @@ fn ingest_selected(
         }
     }
 
+    if options.include_antigravity && full_scan {
+        let antigravity_files = crate::sources::antigravity::discover();
+        for source_file in antigravity_files {
+            let path = source_file.path;
+            if excluder.is_excluded(&path) {
+                files_skipped += 1;
+                continue;
+            }
+            let Some(meta) = discovered_metadata(&path)? else {
+                files_skipped += 1;
+                continue;
+            };
+            files_scanned += 1;
+            total_bytes += meta.len();
+            let key = path.to_string_lossy().to_string();
+            let (task, skip) = prepare_file_task(
+                path,
+                SourceKind::Antigravity,
+                options.include_reasoning,
+                &meta,
+                state.files.get(&key),
+            );
+            if skip {
+                files_skipped += 1;
+                continue;
+            }
+            tasks.push(task);
+        }
+    }
+
     // Previously indexed records under now-excluded paths must be deleted even
     // when there is no ingest state entry for them (e.g. state loss or legacy runs).
     let mut excluded_index_paths: Vec<String> = Vec::new();
@@ -1721,6 +1756,14 @@ fn ingest_selected(
                     &progress,
                 ),
                 SourceKind::Muse => parse_muse_file(
+                    task,
+                    options.include_reasoning,
+                    &tx_record,
+                    &tx_update,
+                    &next_doc_id,
+                    &progress,
+                ),
+                SourceKind::Antigravity => parse_antigravity_file(
                     task,
                     options.include_reasoning,
                     &tx_record,
@@ -2430,6 +2473,39 @@ fn parse_muse_file(
     )
 }
 
+fn parse_antigravity_file(
+    task: &FileTask,
+    include_reasoning: bool,
+    tx_record: &RecordSender,
+    tx_update: &Sender<FileUpdate>,
+    next_doc_id: &AtomicU64,
+    progress: &Arc<Progress>,
+) -> Result<()> {
+    let source_path = task.path.to_string_lossy().to_string();
+    let parsed = crate::sources::antigravity::parse_index_records(
+        &task.path,
+        crate::sources::IndexParseState {
+            offset: task.offset,
+            turn_id: task.turn_id,
+            pending_tool_calls: task.pending_tool_calls.clone(),
+        },
+        include_reasoning,
+        next_doc_id,
+        |record| {
+            progress.add_produced(SourceKind::Antigravity, 1);
+            tx_record.send(record)
+        },
+    )?;
+    finish_source_parse(
+        task,
+        tx_update,
+        progress,
+        SourceKind::Antigravity,
+        source_path,
+        parsed,
+    )
+}
+
 fn parse_cursor_file(
     task: &FileTask,
     tx_record: &RecordSender,
@@ -2796,6 +2872,7 @@ mod tests {
             include_grok: false,
             include_jcode: false,
             include_muse: false,
+            include_antigravity: false,
             embeddings,
             backfill_embeddings: false,
             model,
@@ -5147,6 +5224,7 @@ mod tests {
             include_grok: false,
             include_jcode: false,
             include_muse: false,
+            include_antigravity: false,
             embeddings: false,
             backfill_embeddings: false,
             model: ModelChoice::default(),
@@ -5589,6 +5667,7 @@ mod tests {
             include_grok: false,
             include_jcode: false,
             include_muse: false,
+            include_antigravity: false,
             embeddings: false,
             backfill_embeddings: false,
             model: ModelChoice::default(),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -156,6 +156,7 @@ fn file_identity(path: &Path, metadata: &std::fs::Metadata, prefix_bytes: usize)
     };
 
     FileIdentity {
+        sqlite_wal: None,
         #[cfg(unix)]
         device: Some(metadata.dev()),
         #[cfg(not(unix))]
@@ -222,7 +223,10 @@ fn prepare_file_task(
         })
         .unwrap_or_else(|| size.min(FILE_IDENTITY_PREFIX_BYTES as u64))
         .min(size) as usize;
-    let identity = file_identity(&path, metadata, prefix_bytes);
+    let mut identity = file_identity(&path, metadata, prefix_bytes);
+    if source == SourceKind::Antigravity && crate::sources::antigravity::is_db_path(&path) {
+        identity.sqlite_wal = Some(crate::state::SqliteWalIdentity::read(&path));
+    }
     let parser_version = crate::sources::index_state_version_for(source, include_reasoning);
     let parser_version_invalidated =
         previous.is_some_and(|previous| previous.parser_version != parser_version);
@@ -233,6 +237,7 @@ fn prepare_file_task(
                 || mtime < previous.mtime
                 || previous.parser_version != parser_version
                 || file_was_replaced(&previous.identity, &identity)
+                || previous.identity.sqlite_wal != identity.sqlite_wal
                 || (size == previous.size
                     && previous
                         .identity
@@ -3327,6 +3332,74 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_ingest_tracks_wal_updates_and_checkpoint_without_duplicates() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("gemini");
+        let database = source.join("antigravity-ide/conversations/session.db");
+        fs::create_dir_all(database.parent().unwrap()).unwrap();
+        let _env = EnvVarGuard::set_os(&[("ANTIGRAVITY_HOME", Some(source.as_os_str()))]);
+        let writer = rusqlite::Connection::open(&database).unwrap();
+        writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;
+            CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER, step_payload BLOB);").unwrap();
+        // Protobuf user step: field 19 { field 2: text }.
+        let put = |text: &str| {
+            let mut payload = vec![0x9a, 0x01, (text.len() + 2) as u8, 0x12, text.len() as u8];
+            payload.extend_from_slice(text.as_bytes());
+            writer
+                .execute(
+                    "INSERT OR REPLACE INTO steps VALUES (0, 14, 3, ?1)",
+                    [payload],
+                )
+                .unwrap();
+        };
+        put("original");
+        let mut options = ingest_options(false, ModelChoice::Gemma);
+        options.include_antigravity = true;
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let lease = ingest_lease(&paths);
+        let full = || {
+            let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+            ingest_all(&paths, &index, &options, &lease).unwrap()
+        };
+        assert_eq!(full().records_added, 1);
+        assert_eq!(indexed_texts(&paths), ["original"]);
+        assert_eq!(full().records_added, 0);
+        let before = database.metadata().unwrap();
+        put("updated");
+        assert_eq!(
+            database.metadata().unwrap().modified().unwrap(),
+            before.modified().unwrap()
+        );
+        assert_eq!(database.metadata().unwrap().len(), before.len());
+        assert!(
+            crate::watch::dirty_needs_ingest(&paths, &HashSet::from([database.clone()])).unwrap()
+        );
+        let wal = database.with_file_name("session.db-wal");
+        let index = SearchIndex::open_or_create_for_continuous_ingest(&paths.index).unwrap();
+        let result = ingest_dirty(&paths, &index, &options, &lease, &HashSet::from([wal])).unwrap();
+        assert!(!result.full_scan);
+        assert_eq!(result.report.records_added, 1);
+        assert_eq!(indexed_texts(&paths), ["updated"]);
+        assert!(
+            !crate::watch::dirty_needs_ingest(&paths, &HashSet::from([database.clone()])).unwrap()
+        );
+        put("full scan update");
+        assert_eq!(full().records_added, 1);
+        assert_eq!(indexed_texts(&paths), ["full scan update"]);
+        writer
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        full();
+        assert_eq!(indexed_texts(&paths), ["full scan update"]);
+        drop(writer);
+        full();
+        assert_eq!(indexed_texts(&paths), ["full scan update"]);
+        assert_eq!(full().records_added, 0);
+    }
+
+    #[test]
     fn targeted_ingest_codex_history_uses_known_rollouts_without_discovery() {
         let _guard = env_lock();
         let tmp = tempfile::tempdir().unwrap();
@@ -4946,6 +5019,7 @@ mod tests {
             prefix_sha256: Some("same".to_string()),
             prefix_bytes: 4,
             modified_ns: Some(3),
+            sqlite_wal: None,
         };
         let current = FileIdentity {
             device: Some(4),
@@ -4963,6 +5037,7 @@ mod tests {
             prefix_sha256: Some("original".to_string()),
             prefix_bytes: 8,
             modified_ns: Some(3),
+            sqlite_wal: None,
         };
         let different_inode = FileIdentity {
             device: Some(4),

--- a/src/ingest/selection.rs
+++ b/src/ingest/selection.rs
@@ -31,6 +31,7 @@ enum Shape {
     Grok,
     Jcode,
     Muse,
+    Antigravity,
 }
 
 struct Root {
@@ -117,6 +118,12 @@ fn roots(options: &IngestOptions) -> Vec<Root> {
     }
     if options.include_muse {
         roots.push(Root::new(sources::muse::sessions_root(), Shape::Muse));
+    }
+    if options.include_antigravity {
+        roots.push(Root::new(
+            sources::antigravity::sessions_root(),
+            Shape::Antigravity,
+        ));
     }
     roots
 }
@@ -206,6 +213,26 @@ fn classify(root: &Root, path: &Path) -> Match {
             (name.starts_with("session_") && name.ends_with(".json")).then_some(SourceKind::Jcode)
         }
         Shape::Muse => (name == "session.jsonl").then_some(SourceKind::Muse),
+        Shape::Antigravity => {
+            let in_profile = parts.first().is_some_and(|part| {
+                *part == "antigravity-ide"
+                    || *part == "antigravity"
+                    || *part == "antigravity-backup"
+            });
+            if !in_profile {
+                None
+            } else if (name.ends_with(".db")
+                && !name.ends_with("-wal.db")
+                && !name.ends_with("-shm.db")
+                && parts.get(1).is_some_and(|part| *part == "conversations"))
+                || (name == "overview.txt"
+                    && path.to_string_lossy().contains(".system_generated/logs/"))
+            {
+                Some(SourceKind::Antigravity)
+            } else {
+                None
+            }
+        }
     };
     source.map_or(Match::Ignore, Match::File)
 }
@@ -384,6 +411,7 @@ mod tests {
             include_grok: false,
             include_jcode: false,
             include_muse: false,
+            include_antigravity: false,
             exclude_patterns: Vec::new(),
             embeddings: false,
             backfill_embeddings: false,
@@ -452,6 +480,16 @@ mod tests {
             ),
             (Shape::Jcode, "project/session_one.json", SourceKind::Jcode),
             (Shape::Muse, "project/id/session.jsonl", SourceKind::Muse),
+            (
+                Shape::Antigravity,
+                "antigravity-ide/conversations/abc.db",
+                SourceKind::Antigravity,
+            ),
+            (
+                Shape::Antigravity,
+                "antigravity-ide/brain/comp/.system_generated/logs/overview.txt",
+                SourceKind::Antigravity,
+            ),
         ];
         for (shape, relative, source) in cases {
             let temp = tempfile::tempdir().unwrap();

--- a/src/ingest/selection.rs
+++ b/src/ingest/selection.rs
@@ -255,6 +255,19 @@ fn resolve(
             if excluder.is_excluded(&path) || excluder.is_excluded(hint) {
                 continue;
             }
+            let path = if matches!(root.shape, Shape::Antigravity) {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(|name| name.strip_suffix("-wal"))
+                    .filter(|name| name.ends_with(".db"))
+                    .map(|name| path.with_file_name(name))
+                    .unwrap_or(path)
+            } else {
+                path
+            };
+            if excluder.is_excluded(&path) {
+                continue;
+            }
             if path == root.lexical {
                 return Ok(DirtySelection::Resync);
             }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -2558,6 +2558,7 @@ fn index_local(paths: &Paths, config: &UserConfig, stale_only: bool) -> Result<I
         include_grok: true,
         include_jcode: true,
         include_muse: true,
+        include_antigravity: true,
         exclude_patterns: config.exclude_path_patterns(),
         embeddings: config.embeddings_default(),
         backfill_embeddings: false,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -349,6 +349,7 @@ fn progress_label(source: SourceKind) -> &'static str {
         SourceKind::Hermes => "hermes",
         SourceKind::Jcode => "jcode",
         SourceKind::Muse => "muse",
+        SourceKind::Antigravity => "antigravity",
     }
 }
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -35,6 +35,7 @@ pub fn resume_template(config: &UserConfig, source: SourceKind, remote: bool) ->
         SourceKind::Hermes => None,
         SourceKind::Jcode => config.jcode_resume_cmd.clone(),
         SourceKind::Muse => config.muse_resume_cmd.clone(),
+        SourceKind::Antigravity => None,
     };
     configured.or_else(|| default_resume_template(source.label(), remote))
 }

--- a/src/sources/antigravity.rs
+++ b/src/sources/antigravity.rs
@@ -33,10 +33,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
-    // Rebuild analytics metadata after adding session cwd extraction.
-    identity: 2,
+    // Rebuild analytics metadata with decoded project directory URLs.
+    identity: 3,
     // Bumped whenever record extraction logic changes; forces a full re-parse.
-    index: 1,
+    index: 2,
     usage: 1,
 };
 
@@ -69,7 +69,7 @@ pub fn sessions_root() -> PathBuf {
         .unwrap_or_else(|| super::common::home().join(".gemini"))
 }
 
-fn is_db_path(path: &Path) -> bool {
+pub(crate) fn is_db_path(path: &Path) -> bool {
     path.extension().and_then(|ext| ext.to_str()) == Some("db")
         && !is_wal_or_shm(path.file_name().and_then(|n| n.to_str()).unwrap_or(""))
 }
@@ -335,7 +335,7 @@ fn index_db_file(
                         .unwrap_or_else(|| SourceKind::Antigravity.label().to_string()),
                     session_id: session_id.clone(),
                     turn_id,
-                    role: "assistant".to_string(),
+                    role: "tool_use".to_string(),
                     text,
                     tool_name: Some(tool_name),
                     tool_input: Some(args),
@@ -446,7 +446,7 @@ fn index_overview_file(
                     project: SourceKind::Antigravity.label().to_string(),
                     session_id: session_id.clone(),
                     turn_id,
-                    role: "assistant".to_string(),
+                    role: "tool_use".to_string(),
                     text: tool_input.clone(),
                     tool_name: Some(kind.to_lowercase()),
                     tool_input: Some(tool_input),
@@ -527,18 +527,20 @@ pub(crate) fn session_cwd(path: &Path) -> Option<PathBuf> {
         let Some(url) = project_root_from_payload(&payload) else {
             continue;
         };
-        let root = url.strip_prefix("file://")?;
-        return Some(PathBuf::from(root));
+        if let Some(root) = file_url_path(&url) {
+            return Some(root);
+        }
     }
     None
 }
 
-/// Strip a `file://` URL down to the leaf directory of the referenced path.
+fn file_url_path(url: &str) -> Option<PathBuf> {
+    url::Url::parse(url).ok()?.to_file_path().ok()
+}
+
+/// Decode a `file://` URL and return the referenced path's leaf directory.
 fn parse_file_url_leaf(url: &str) -> Option<String> {
-    let path = url.strip_prefix("file://")?;
-    let path = path.trim_end_matches(['\n', '\r', ' ', ']']);
-    let path = path.split('?').next().unwrap_or(path);
-    Path::new(path)
+    file_url_path(url)?
         .file_name()
         .and_then(|n| n.to_str())
         .map(str::to_string)
@@ -885,7 +887,7 @@ mod tests {
         assert_eq!(user.project, "antigravity");
         assert_eq!(records[1].role, "assistant");
         assert_eq!(records[1].text, "response text");
-        assert_eq!(records[2].role, "assistant");
+        assert_eq!(records[2].role, "tool_use");
         assert_eq!(records[2].tool_name.as_deref(), Some("bash"));
         assert!(
             records[2]
@@ -916,6 +918,80 @@ mod tests {
         msg.extend(field_bytes(5, &field_bytes(1, &timestamp_msg(1, 0))));
         msg.extend(field_bytes(19, &inner4));
         assert_eq!(project_from_user_payload(&msg).as_deref(), Some("repo-api"));
+    }
+
+    #[test]
+    fn all_tool_step_types_emit_tool_use_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = write_store(temp.path());
+        let conn = Connection::open(&db).unwrap();
+        conn.execute("DELETE FROM steps", []).unwrap();
+        for (idx, step_type) in TOOL_STEP_TYPES.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, ?2, ?3)",
+                rusqlite::params![idx as i64, *step_type as i64, tool_step()],
+            )
+            .unwrap();
+        }
+        let (records, _) = emit_collect(&db, false);
+        assert_eq!(records.len(), TOOL_STEP_TYPES.len());
+        for record in records {
+            assert_eq!(record.role, "tool_use");
+            assert_eq!(record.tool_name.as_deref(), Some("bash"));
+            assert_eq!(record.tool_input.as_deref(), Some(r#"{"command":"ls"}"#));
+        }
+    }
+
+    #[test]
+    fn project_and_cwd_decode_file_urls() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = write_store(temp.path());
+        let conn = Connection::open(&db).unwrap();
+        let cwd = temp.path().join("My project #1 café%done");
+        fs::create_dir(&cwd).unwrap();
+        let url = url::Url::from_directory_path(&cwd).unwrap();
+        let mut user = field_bytes(2, b"hello");
+        user.extend(field_bytes(
+            4,
+            &field_bytes(2, &field_bytes(13, url.as_str().as_bytes())),
+        ));
+        let payload = field_bytes(19, &user);
+        conn.execute(
+            "UPDATE steps SET step_payload = ?1 WHERE idx = 0",
+            rusqlite::params![payload],
+        )
+        .unwrap();
+
+        assert_eq!(session_cwd(&db).as_deref(), Some(cwd.as_path()));
+        assert!(session_cwd(&db).unwrap().is_dir());
+        let (records, _) = emit_collect(&db, false);
+        assert!(
+            records
+                .iter()
+                .all(|r| r.project == "My project #1 café%done")
+        );
+    }
+
+    #[test]
+    fn session_cwd_skips_invalid_project_urls() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = write_store(temp.path());
+        let conn = Connection::open(&db).unwrap();
+        for (idx, url) in ["not a URL", "https://example.com/repo", "file:///tmp/repo"]
+            .iter()
+            .enumerate()
+        {
+            let payload = field_bytes(
+                19,
+                &field_bytes(4, &field_bytes(2, &field_bytes(13, url.as_bytes()))),
+            );
+            conn.execute(
+                "INSERT INTO steps (idx, step_type, step_payload) VALUES (?1, 14, ?2)",
+                rusqlite::params![idx as i64 + 4, payload],
+            )
+            .unwrap();
+        }
+        assert_eq!(session_cwd(&db).as_deref(), Some(Path::new("/tmp/repo")));
     }
 
     #[test]
@@ -992,6 +1068,33 @@ mod tests {
         assert_eq!(records[1].text, "hi there");
         assert_eq!(records[0].ts, 1_779_194_148_000);
         assert!(output.session_id.is_some());
+    }
+
+    #[test]
+    fn overview_tool_kinds_emit_tool_use_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let overview = temp.path().join("overview.txt");
+        fs::write(
+            &overview,
+            r#"{"type":"RUN_COMMAND","content":"ls"}
+{"type":"VIEW_FILE","content":"README.md"}
+{"type":"CODE_ACTION","content":"edit README.md"}
+{"type":"RUN_COMMAND","tool_calls":[{"command":"pwd"}]}"#,
+        )
+        .unwrap();
+        let (records, _) = emit_collect(&overview, false);
+        assert_eq!(records.len(), 4);
+        for (record, (name, input)) in records.iter().zip([
+            ("run_command", "ls"),
+            ("view_file", "README.md"),
+            ("code_action", "edit README.md"),
+            ("run_command", r#"[{"command":"pwd"}]"#),
+        ]) {
+            assert_eq!(record.role, "tool_use");
+            assert_eq!(record.tool_name.as_deref(), Some(name));
+            assert_eq!(record.tool_input.as_deref(), Some(input));
+            assert_eq!(record.text, input);
+        }
     }
 
     #[test]

--- a/src/sources/antigravity.rs
+++ b/src/sources/antigravity.rs
@@ -1,0 +1,961 @@
+//! Antigravity conversation discovery and indexing.
+//!
+//! Antigravity keeps two human-readable projections alongside the encrypted
+//! `.pb` trajectories, neither of which needs decryption:
+//!
+//! * `conversations/<uuid>.db` — per-conversation SQLite stores (default
+//!   `~/.gemini/antigravity-ide`). The `steps` table orders the plaintext
+//!   twin of the encrypted trajectory by `idx`; each `step_payload` is a
+//!   protobuf message of the same "step" shape as the decrypted `.pb` steps:
+//!   * `step_type 14`  - user message (text at payload `19.f2`).
+//!   * `step_type 23`  - model response (text at payload `30.f4`).
+//!   * `step_type 15`  - model reasoning (text at payload `20.f3`).
+//!   * `step_type 5/7/8/9/17/21/101/132` - tool executions (name at
+//!     `5.f4.2`, JSON args at `5.f4.3`, `toolAction`/`toolSummary` inside).
+//!   * timestamps at payload `5.1` as `{1: seconds, 2: nanos}`.
+//! * `brain/*/.system_generated/logs/overview.txt` — JSONL activity logs with
+//!   `USER_INPUT`, `PLANNER_RESPONSE`, `RUN_COMMAND`, `VIEW_FILE` and
+//!   `CODE_ACTION` records; this also covers the legacy `~/.gemini/antigravity`
+//!   profile, which only writes encrypted `.pb` files plus overview logs.
+//!
+//! A `.db` store is rewritten wholesale as the conversation grows, so the
+//! parser replays the whole file every time (like jcode) and `prepare_file_task`
+//! pairs it with atomic delete-first re-parses.
+
+use super::{IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions, SourceFile};
+use crate::types::{Record, RecordLinks, SourceKind};
+use crate::usage::UsageEvent;
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use walkdir::WalkDir;
+
+pub const VERSIONS: ParserVersions = ParserVersions {
+    identity: 1,
+    // Bumped whenever record extraction logic changes; forces a full re-parse.
+    index: 1,
+    usage: 1,
+};
+
+/// The tool-bearing `step_type` values observed in real stores.
+const TOOL_STEP_TYPES: &[u64] = &[5, 7, 8, 9, 17, 21, 101, 132];
+
+/// Profiles searched for `conversations/` stores and `brain/` overview logs.
+const PROFILES: &[&str] = &["antigravity-ide", "antigravity"];
+
+fn is_wal_or_shm(name: &str) -> bool {
+    name.ends_with("-wal.db") || name.ends_with("-shm.db") || name.ends_with(".tmp")
+}
+
+pub fn matches_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    let in_gemini = normalized.contains(".gemini/") || normalized.contains("antigravity");
+    if !in_gemini {
+        return false;
+    }
+    if normalized.ends_with(".db") || normalized.ends_with(".pb") {
+        return normalized.contains("conversations/") && !is_wal_or_shm(&normalized);
+    }
+    normalized.ends_with("overview.txt") && normalized.contains(".system_generated/logs/")
+}
+
+/// Root of all Antigravity profiles: `~/.gemini` by default.
+pub fn sessions_root() -> PathBuf {
+    std::env::var_os("ANTIGRAVITY_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::common::home().join(".gemini"))
+}
+
+fn is_db_path(path: &Path) -> bool {
+    path.extension().and_then(|ext| ext.to_str()) == Some("db")
+        && !is_wal_or_shm(path.file_name().and_then(|n| n.to_str()).unwrap_or(""))
+}
+
+fn is_overview_path(path: &Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some("overview.txt")
+}
+
+pub fn discover() -> Vec<SourceFile> {
+    let base = sessions_root();
+    let mut files = Vec::new();
+    for profile in PROFILES {
+        let conversations = base.join(profile).join("conversations");
+        if conversations.is_dir()
+            && let Ok(entries) = std::fs::read_dir(&conversations)
+        {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if is_db_path(&path) {
+                    files.push(SourceFile {
+                        source: SourceKind::Antigravity,
+                        path,
+                    });
+                }
+            }
+        }
+        let brains = base.join(profile).join("brain");
+        if brains.is_dir() {
+            for entry in WalkDir::new(&brains).into_iter().flatten() {
+                let path = entry.path();
+                if entry.file_type().is_file()
+                    && is_overview_path(path)
+                    && path.to_string_lossy().contains(".system_generated/logs/")
+                {
+                    files.push(SourceFile {
+                        source: SourceKind::Antigravity,
+                        path: path.to_path_buf(),
+                    });
+                }
+            }
+        }
+    }
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    files.dedup_by(|a, b| a.path == b.path);
+    files
+}
+
+pub fn usage_files() -> Vec<PathBuf> {
+    discover().into_iter().map(|file| file.path).collect()
+}
+
+pub(crate) fn parse_usage_file(_path: &Path) -> Result<Vec<UsageEvent>> {
+    // Token counts are embedded in the protobuf step payloads but their exact
+    // buckets are not yet validated; reporting none beats reporting wrong
+    // numbers. Refine once real usage can be cross-checked.
+    Ok(Vec::new())
+}
+
+pub(crate) fn parse_index_records(
+    path: &Path,
+    state: IndexParseState,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    mut emit: impl FnMut(Record) -> Result<()>,
+) -> Result<IndexParseOutput> {
+    // Whole-document formats: `prepare_file_task` pairs these with delete-first
+    // re-parses, so `state.offset` is intentionally ignored below.
+    let source_path = path.to_string_lossy().to_string();
+    let mut diagnostics = ParseDiagnostics::default();
+    let (session_id, turn_id, offset) = if is_db_path(path) {
+        index_db_file(
+            path,
+            include_reasoning,
+            next_doc_id,
+            &mut emit,
+            &source_path,
+            &mut diagnostics,
+            state.turn_id,
+        )?
+    } else if is_overview_path(path) {
+        index_overview_file(
+            path,
+            next_doc_id,
+            &mut emit,
+            &source_path,
+            &mut diagnostics,
+            state.turn_id,
+        )?
+    } else {
+        anyhow::bail!(
+            "unsupported antigravity file {} (expected a conversation .db or overview.txt)",
+            path.display()
+        );
+    };
+    Ok(IndexParseOutput {
+        offset,
+        turn_id,
+        pending_tool_calls: state.pending_tool_calls,
+        session_id: Some(session_id),
+        diagnostics,
+    })
+}
+
+fn index_db_file(
+    path: &Path,
+    include_reasoning: bool,
+    next_doc_id: &AtomicU64,
+    emit: &mut impl FnMut(Record) -> Result<()>,
+    source_path: &str,
+    diagnostics: &mut ParseDiagnostics,
+    start_turn_id: u32,
+) -> Result<(String, u32, u64)> {
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open antigravity store {}", path.display()))?;
+    let store_id = |query: &str| {
+        conn.prepare(query).ok().and_then(|mut stmt| {
+            stmt.query_row([], |row| row.get::<_, Option<String>>(0))
+                .ok()
+                .flatten()
+        })
+    };
+    let session_id = store_id("SELECT trajectory_id FROM trajectory_meta LIMIT 1")
+        .or_else(|| store_id("SELECT cascade_id FROM trajectory_meta LIMIT 1"))
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Project heuristic: the user payload carries the active project root as a
+    // `file://` URL (payload `19.4.2.*.13`); take its leaf directory name.
+    let mut project: Option<String> = None;
+
+    let mut stmt = conn
+        .prepare("SELECT step_type, status, step_payload FROM steps ORDER BY idx")
+        .with_context(|| format!("query steps in {}", path.display()))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Option<Vec<u8>>>(2)?.unwrap_or_default(),
+            ))
+        })
+        .with_context(|| format!("read steps in {}", path.display()))?;
+
+    let file_len = std::fs::metadata(path)?.len();
+    let mut turn_id = start_turn_id;
+    for row in rows {
+        let (step_type, _status, payload) =
+            row.with_context(|| format!("iterate steps in {}", path.display()))?;
+        if payload.is_empty() {
+            continue;
+        }
+        let step_type = step_type.max(0) as u64;
+        let ts = step_timestamp(&payload);
+        let message_id = step_message_id(&payload);
+        if project.is_none() && step_type == 14 {
+            project = project_from_user_payload(&payload);
+        }
+        match step_type {
+            14 => {
+                let Some(text) = user_text(&payload) else {
+                    continue;
+                };
+                let mut links = RecordLinks::default();
+                if let Some(ref id) = message_id {
+                    links.event_id = Some(id.clone());
+                }
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: project
+                        .clone()
+                        .unwrap_or_else(|| SourceKind::Antigravity.label().to_string()),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "user".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            23 => {
+                let Some(text) = model_text(&payload) else {
+                    continue;
+                };
+                let mut links = RecordLinks::default();
+                if let Some(ref id) = message_id {
+                    links.event_id = Some(id.clone());
+                }
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: project
+                        .clone()
+                        .unwrap_or_else(|| SourceKind::Antigravity.label().to_string()),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            15 => {
+                if !include_reasoning {
+                    continue;
+                }
+                let Some(text) = reasoning_text(&payload) else {
+                    continue;
+                };
+                let mut links = RecordLinks::default();
+                if let Some(ref id) = message_id {
+                    links.event_id = Some(format!("{id}:reasoning"));
+                }
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: project
+                        .clone()
+                        .unwrap_or_else(|| SourceKind::Antigravity.label().to_string()),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "reasoning".to_string(),
+                    text,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links,
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            _ if TOOL_STEP_TYPES.contains(&step_type) => {
+                let Some((tool_name, args)) = tool_call(&payload) else {
+                    continue;
+                };
+                let (action, summary) = tool_action_summary(&args);
+                let text = summary.clone().or(action).unwrap_or_else(|| args.clone());
+                let mut links = RecordLinks::default();
+                if let Some(ref id) = message_id {
+                    links.event_id = Some(id.clone());
+                }
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: project
+                        .clone()
+                        .unwrap_or_else(|| SourceKind::Antigravity.label().to_string()),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text,
+                    tool_name: Some(tool_name),
+                    tool_input: Some(args),
+                    tool_output: summary,
+                    links,
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            // System/status notes (e.g. step_type 90) are ephemeral and skipped.
+            90 => {}
+            other => diagnostics.increment_unknown_top_level(&format!("step_type_{other}")),
+        }
+    }
+
+    Ok((session_id, turn_id, file_len))
+}
+
+fn index_overview_file(
+    path: &Path,
+    next_doc_id: &AtomicU64,
+    emit: &mut impl FnMut(Record) -> Result<()>,
+    source_path: &str,
+    diagnostics: &mut ParseDiagnostics,
+    start_turn_id: u32,
+) -> Result<(String, u32, u64)> {
+    let text = std::fs::read_to_string(path)?;
+    let file_len = text.len() as u64;
+    let session_id = path.to_string_lossy().to_string();
+    let mut turn_id = start_turn_id;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            diagnostics.malformed_json_lines += 1;
+            continue;
+        };
+        let Some(kind) = value.get("type").and_then(|v| v.as_str()) else {
+            diagnostics.non_object_json_lines += 1;
+            continue;
+        };
+        let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        let ts = value
+            .get("created_at")
+            .and_then(|v| v.as_str())
+            .and_then(super::common::parse_iso_millis)
+            .unwrap_or(0);
+        let content = value
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if content.is_empty() && kind != "RUN_COMMAND" {
+            continue;
+        }
+        match kind {
+            "USER_INPUT" if status == "DONE" => {
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: SourceKind::Antigravity.label().to_string(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "user".to_string(),
+                    text: content,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            "PLANNER_RESPONSE" => {
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: SourceKind::Antigravity.label().to_string(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text: content,
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            "RUN_COMMAND" | "VIEW_FILE" | "CODE_ACTION" => {
+                let tool_input = if content.is_empty() {
+                    value.get("tool_calls").map(|v| v.to_string())
+                } else {
+                    Some(content)
+                };
+                let Some(tool_input) = tool_input else {
+                    continue;
+                };
+                emit(Record {
+                    source: SourceKind::Antigravity,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts,
+                    project: SourceKind::Antigravity.label().to_string(),
+                    session_id: session_id.clone(),
+                    turn_id,
+                    role: "assistant".to_string(),
+                    text: tool_input.clone(),
+                    tool_name: Some(kind.to_lowercase()),
+                    tool_input: Some(tool_input),
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: source_path.to_string(),
+                })?;
+                turn_id += 1;
+            }
+            other => diagnostics.increment_unknown_top_level(other),
+        }
+    }
+    Ok((session_id, turn_id, file_len))
+}
+
+/// Project name from a user step payload: the first `file://` project root at
+/// payload `19.4.2.*.13`. Returns the referenced path's leaf directory (the
+/// repo dir).
+fn project_from_user_payload(payload: &[u8]) -> Option<String> {
+    let url = project_root_from_payload(payload)?;
+    parse_file_url_leaf(&url)
+}
+
+/// The first `file://` project root at payload `19.4.2.*.13`, if any. Public for
+/// cross-module use (e.g. transfer's cwd resolution).
+pub(crate) fn project_root_from_payload(payload: &[u8]) -> Option<String> {
+    let fields = parse(payload)?;
+    fields
+        .into_iter()
+        .find(|field| field.field == 19)
+        .as_ref()
+        .and_then(|field| field.bytes.as_deref())
+        .and_then(parse)
+        .and_then(|user| {
+            let mut roots = Vec::new();
+            for field in user {
+                if field.field == 4
+                    && let Some(blocks) = field.bytes.as_deref()
+                    && let Some(block_fields) = parse(blocks)
+                {
+                    for block in block_fields {
+                        if block.field == 2
+                            && let Some(file_fields) = block.bytes.as_deref()
+                            && let Some(file_fields) = parse(file_fields)
+                        {
+                            for file in file_fields {
+                                if file.field == 13
+                                    && let Some(url) = file.bytes_string()
+                                {
+                                    roots.push(url);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            roots.into_iter().next()
+        })
+}
+
+/// Strip a `file://` URL down to the leaf directory of the referenced path.
+fn parse_file_url_leaf(url: &str) -> Option<String> {
+    let path = url.strip_prefix("file://")?;
+    let path = path.trim_end_matches(['\n', '\r', ' ', ']']);
+    let path = path.split('?').next().unwrap_or(path);
+    Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+}
+
+fn user_text(payload: &[u8]) -> Option<String> {
+    // payload `19.f2`
+    parse(payload)?
+        .into_iter()
+        .find(|field| field.field == 19)
+        .and_then(|field| field.bytes.as_deref().and_then(parse))
+        .and_then(|sub| {
+            sub.into_iter()
+                .find(|field| field.field == 2)
+                .and_then(|field| field.bytes_string())
+        })
+}
+
+fn reasoning_text(payload: &[u8]) -> Option<String> {
+    // payload `20.f3`
+    parse(payload)?
+        .into_iter()
+        .find(|field| field.field == 20)
+        .and_then(|field| field.bytes.as_deref().and_then(parse))
+        .and_then(|sub| {
+            sub.into_iter()
+                .find(|field| field.field == 3)
+                .and_then(|field| field.bytes_string())
+        })
+}
+
+fn model_text(payload: &[u8]) -> Option<String> {
+    // payload `30.f4`
+    parse(payload)?
+        .into_iter()
+        .find(|field| field.field == 30)
+        .and_then(|field| field.bytes.as_deref().and_then(parse))
+        .and_then(|sub| {
+            sub.into_iter()
+                .find(|field| field.field == 4)
+                .and_then(|field| field.bytes_string())
+        })
+}
+
+fn tool_call(payload: &[u8]) -> Option<(String, String)> {
+    // payload `5.f4.{2: name, 3: args-json}`
+    let fields = parse(payload)?;
+    let tool_field = fields.into_iter().find(|field| field.field == 5)?;
+    let tool_bytes = tool_field.bytes?;
+    let tool_fields = parse(&tool_bytes)?;
+    let detail_field = tool_fields.into_iter().find(|field| field.field == 4)?;
+    let detail_bytes = detail_field.bytes?;
+    let detail = parse(&detail_bytes)?;
+    let mut name = None;
+    let mut args = None;
+    for field in detail {
+        match field.field {
+            2 => name = field.bytes_string(),
+            3 => args = field.bytes_string(),
+            _ => {}
+        }
+    }
+    Some((name?, args?))
+}
+
+fn tool_action_summary(args: &str) -> (Option<String>, Option<String>) {
+    let Ok(value) = serde_json::from_str::<Value>(args) else {
+        return (None, None);
+    };
+    let action = value
+        .get("toolAction")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let summary = value
+        .get("toolSummary")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    (action, summary)
+}
+
+/// Message timestamp from the step payload: `5.1.{1: seconds, 2: nanos}` as
+/// epoch milliseconds.
+fn step_timestamp(payload: &[u8]) -> u64 {
+    let Some(fields) = parse(payload) else {
+        return 0;
+    };
+    let Some(meta_field) = fields.into_iter().find(|field| field.field == 5) else {
+        return 0;
+    };
+    let Some(meta_bytes) = meta_field.bytes else {
+        return 0;
+    };
+    let Some(meta) = parse(&meta_bytes) else {
+        return 0;
+    };
+    let Some(time_field) = meta.into_iter().find(|field| field.field == 1) else {
+        return 0;
+    };
+    let Some(time_bytes) = time_field.bytes else {
+        return 0;
+    };
+    let Some(time) = parse(&time_bytes) else {
+        return 0;
+    };
+    let mut seconds = 0u64;
+    let mut nanos = 0u64;
+    for field in time {
+        match field.field {
+            1 => seconds = field.varint.unwrap_or(0),
+            2 => nanos = field.varint.unwrap_or(0),
+            _ => {}
+        }
+    }
+    seconds
+        .saturating_mul(1000)
+        .saturating_add(nanos / 1_000_000)
+}
+
+/// Message UUID embedded in the step metadata (`5.12`), used as the record
+/// event id so searches can link back to the originating message.
+fn step_message_id(payload: &[u8]) -> Option<String> {
+    let fields = parse(payload)?;
+    let meta_field = fields.into_iter().find(|field| field.field == 5)?;
+    let meta_bytes = meta_field.bytes?;
+    let meta = parse(&meta_bytes)?;
+    meta.into_iter()
+        .find(|field| field.field == 12)
+        .and_then(|field| field.bytes_string())
+}
+
+// --- bare-minimum protobuf wire reader (varint + length-delimited) ---
+
+struct Field {
+    field: u64,
+    varint: Option<u64>,
+    bytes: Option<Vec<u8>>,
+}
+
+impl Field {
+    fn bytes_string(self) -> Option<String> {
+        let bytes = self.bytes.as_ref()?;
+        String::from_utf8(bytes.clone()).ok()
+    }
+}
+
+fn parse(data: &[u8]) -> Option<Vec<Field>> {
+    let mut fields = Vec::new();
+    let mut pos = 0usize;
+    while pos < data.len() {
+        let (tag, next) = read_varint(data, pos)?;
+        pos = next;
+        let field = tag >> 3;
+        match tag & 7 {
+            0 => {
+                let (value, next) = read_varint(data, pos)?;
+                pos = next;
+                fields.push(Field {
+                    field,
+                    varint: Some(value),
+                    bytes: None,
+                });
+            }
+            2 => {
+                let (len, next) = read_varint(data, pos)?;
+                pos = next;
+                let len = len as usize;
+                let end = pos.checked_add(len)?;
+                if end > data.len() {
+                    return None;
+                }
+                fields.push(Field {
+                    field,
+                    varint: None,
+                    bytes: Some(data[pos..end].to_vec()),
+                });
+                pos = end;
+            }
+            1 => pos = pos.checked_add(8)?,
+            5 => pos = pos.checked_add(4)?,
+            _ => return None,
+        }
+    }
+    Some(fields)
+}
+
+fn read_varint(data: &[u8], mut pos: usize) -> Option<(u64, usize)> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    loop {
+        let byte = *data.get(pos)?;
+        pos += 1;
+        value |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, pos));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{EnvVarGuard, env_lock};
+    use std::fs;
+
+    fn field_varint(field: u64, value: u64) -> Vec<u8> {
+        let mut out = encode_varint(field << 3);
+        out.extend(encode_varint(value));
+        out
+    }
+
+    fn field_bytes(field: u64, bytes: &[u8]) -> Vec<u8> {
+        let mut out = encode_varint((field << 3) | 2);
+        out.extend(encode_varint(bytes.len() as u64));
+        out.extend(bytes);
+        out
+    }
+
+    fn encode_varint(mut value: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return out;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    fn timestamp_msg(seconds: u64, nanos: u64) -> Vec<u8> {
+        let mut out = field_varint(1, seconds);
+        out.extend(field_varint(2, nanos));
+        out
+    }
+
+    fn user_step(prompt: &str) -> Vec<u8> {
+        let mut msg = field_varint(1, 14);
+        let mut meta = field_bytes(1, &timestamp_msg(1_780_894_247, 226_543_000));
+        meta.extend(field_bytes(12, b"user-msg-uuid"));
+        msg.extend(field_bytes(5, &meta));
+        msg.extend(field_bytes(19, &field_bytes(2, prompt.as_bytes())));
+        msg
+    }
+
+    fn model_step(response: &str) -> Vec<u8> {
+        let mut msg = field_varint(1, 23);
+        let meta = field_bytes(1, &timestamp_msg(1_780_894_248, 918_951_000));
+        msg.extend(field_bytes(5, &meta));
+        msg.extend(field_bytes(30, &field_bytes(4, response.as_bytes())));
+        msg
+    }
+
+    fn reasoning_step(thinking: &str) -> Vec<u8> {
+        let mut msg = field_varint(1, 15);
+        let meta = field_bytes(1, &timestamp_msg(1_780_894_249, 100_000_000));
+        msg.extend(field_bytes(5, &meta));
+        msg.extend(field_bytes(20, &field_bytes(3, thinking.as_bytes())));
+        msg
+    }
+
+    fn tool_step() -> Vec<u8> {
+        let mut msg = field_varint(1, 8);
+        let mut meta = field_bytes(1, &timestamp_msg(1_780_894_250, 0));
+        let mut detail = field_bytes(2, b"bash");
+        detail.extend(field_bytes(3, br#"{"command":"ls"}"#));
+        meta.extend(field_bytes(4, &detail));
+        msg.extend(field_bytes(5, &meta));
+        msg
+    }
+
+    fn write_store(dir: &Path) -> PathBuf {
+        fs::create_dir_all(dir.join("antigravity-ide/conversations")).unwrap();
+        let db = dir.join("antigravity-ide/conversations/conv-1.db");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE trajectory_meta (trajectory_id TEXT, cascade_id TEXT);
+             CREATE TABLE steps (
+                idx INTEGER PRIMARY KEY,
+                step_type INTEGER NOT NULL DEFAULT 0,
+                status INTEGER NOT NULL DEFAULT 0,
+                has_subtrajectory NUMERIC NOT NULL DEFAULT false,
+                step_payload BLOB
+             );
+             INSERT INTO trajectory_meta (trajectory_id, cascade_id) VALUES ('traj-1', 'cascade-1');",
+        )
+        .unwrap();
+        let insert = |idx: i64, step_type: i64, payload: &[u8]| {
+            conn.execute(
+                "INSERT INTO steps (idx, step_type, status, has_subtrajectory, step_payload)
+                 VALUES (?1, ?2, 3, false, ?3)",
+                rusqlite::params![idx, step_type, payload],
+            )
+            .unwrap();
+        };
+        insert(
+            0,
+            14,
+            &user_step("@[file:///Users/x/src/repo-api/README.md] do it"),
+        );
+        insert(1, 15, &reasoning_step("thinking hard"));
+        insert(2, 23, &model_step("response text"));
+        insert(3, 8, &tool_step());
+        db
+    }
+
+    fn emit_collect(path: &Path, include_reasoning: bool) -> (Vec<Record>, IndexParseOutput) {
+        let next_doc_id = AtomicU64::new(0);
+        let mut records = Vec::new();
+        let output = parse_index_records(
+            path,
+            IndexParseState::default(),
+            include_reasoning,
+            &next_doc_id,
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        (records, output)
+    }
+
+    #[test]
+    fn parses_stores_users_models_and_tools() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = write_store(temp.path());
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("ANTIGRAVITY_HOME", Some(temp.path().to_str().unwrap()))]);
+        let (records, output) = emit_collect(&db, false);
+
+        assert_eq!(output.session_id.as_deref(), Some("traj-1"));
+        assert_eq!(records.len(), 3); // user, model, tool; reasoning skipped
+        let user = &records[0];
+        assert_eq!(user.role, "user");
+        assert_eq!(user.text, "@[file:///Users/x/src/repo-api/README.md] do it");
+        assert_eq!(user.ts, 1_780_894_247_226);
+        // Project from the `file://` project root at 19.4.<i>.2.<i>.13;
+        // this fixture has no _13 root field, so it falls back to "antigravity".
+        assert_eq!(user.project, "antigravity");
+        assert_eq!(records[1].role, "assistant");
+        assert_eq!(records[1].text, "response text");
+        assert_eq!(records[2].role, "assistant");
+        assert_eq!(records[2].tool_name.as_deref(), Some("bash"));
+        assert!(
+            records[2]
+                .tool_input
+                .as_deref()
+                .unwrap()
+                .contains("\"command\"")
+        );
+
+        // Reasoning appears only with include_reasoning.
+        let (with_reasoning, _) = emit_collect(&db, true);
+        let reasoning = with_reasoning
+            .iter()
+            .find(|record| record.role == "reasoning")
+            .expect("reasoning record");
+        assert_eq!(reasoning.text, "thinking hard");
+        assert_eq!(reasoning.ts, 1_780_894_249_100);
+    }
+
+    #[test]
+    fn project_looks_for_file_project_root_field() {
+        // Index under the 19.4.2.13 shaped envelope.
+        // Build: 19 { 4 { 2 { 13: "file:///Users/x/src/repo-api" } } } merged with text.
+        let project_block = field_bytes(13, b"file:///Users/x/src/repo-api");
+        let inner2 = field_bytes(2, &project_block);
+        let inner4 = field_bytes(4, &inner2);
+        let mut msg = field_varint(1, 14);
+        msg.extend(field_bytes(5, &field_bytes(1, &timestamp_msg(1, 0))));
+        msg.extend(field_bytes(19, &inner4));
+        assert_eq!(project_from_user_payload(&msg).as_deref(), Some("repo-api"));
+    }
+
+    #[test]
+    fn discovers_stores_and_overview_logs() {
+        let temp = tempfile::tempdir().unwrap();
+        let _guard = env_lock();
+        let _env = EnvVarGuard::set(&[("ANTIGRAVITY_HOME", Some(temp.path().to_str().unwrap()))]);
+        write_store(temp.path());
+        let logs = temp
+            .path()
+            .join("antigravity-ide/brain/comp-a/.system_generated/logs");
+        fs::create_dir_all(&logs).unwrap();
+        fs::write(
+            logs.join("overview.txt"),
+            r#"{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-05-19T12:35:48Z","content":"hello"}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp.path()
+                .join("antigravity-ide/conversations/conv-1.db-wal"),
+            b"wal",
+        )
+        .unwrap();
+
+        let files = discover();
+        let names = files
+            .iter()
+            .map(|file| file.path.file_name().unwrap().to_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"conv-1.db".to_string()));
+        assert!(names.contains(&"overview.txt".to_string()));
+        assert!(!names.iter().any(|name| name.ends_with("-wal")));
+    }
+
+    #[test]
+    fn parses_overview_log() {
+        let temp = tempfile::tempdir().unwrap();
+        let logs = temp.path().join("brain/comp-a/.system_generated/logs");
+        fs::create_dir_all(&logs).unwrap();
+        let overview = logs.join("overview.txt");
+        fs::write(
+            &overview,
+            r#"{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-05-19T12:35:48Z","content":"<USER_REQUEST>\nhello\n</USER_REQUEST>"}
+{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-05-19T12:36:00Z","content":"hi there"}"#,
+        )
+        .unwrap();
+        let (records, output) = emit_collect(&overview, false);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].role, "user");
+        assert!(records[0].text.contains("hello"));
+        assert_eq!(records[1].role, "assistant");
+        assert_eq!(records[1].text, "hi there");
+        assert_eq!(records[0].ts, 1_779_194_148_000);
+        assert!(output.session_id.is_some());
+    }
+
+    #[test]
+    fn matches_path_classifies_antigravity_paths() {
+        assert!(matches_path(
+            "/Users/x/.gemini/antigravity-ide/conversations/abc.db"
+        ));
+        assert!(matches_path(
+            "/Users/x/.gemini/antigravity/brain/comp/.system_generated/logs/overview.txt"
+        ));
+        assert!(!matches_path(
+            "/Users/x/.gemini/antigravity-ide/conversations/abc.db-wal"
+        ));
+        assert!(!matches_path("/Users/x/.claude/projects/abc.jsonl"));
+    }
+}

--- a/src/sources/antigravity.rs
+++ b/src/sources/antigravity.rs
@@ -33,7 +33,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
-    identity: 1,
+    // Rebuild analytics metadata after adding session cwd extraction.
+    identity: 2,
     // Bumped whenever record extraction logic changes; forces a full re-parse.
     index: 1,
     usage: 1,
@@ -506,6 +507,32 @@ pub(crate) fn project_root_from_payload(payload: &[u8]) -> Option<String> {
         })
 }
 
+/// Best-effort working directory for an Antigravity conversation store.
+///
+/// Antigravity records the active project root as a `file://` URL on user
+/// steps. This is used by analytics to resolve the enclosing Git repository.
+pub(crate) fn session_cwd(path: &Path) -> Option<PathBuf> {
+    if !is_db_path(path) {
+        return None;
+    }
+    let conn =
+        Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let mut stmt = conn
+        .prepare("SELECT step_payload FROM steps WHERE step_type = 14 ORDER BY idx")
+        .ok()?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, Option<Vec<u8>>>(0))
+        .ok()?;
+    for payload in rows.flatten().flatten() {
+        let Some(url) = project_root_from_payload(&payload) else {
+            continue;
+        };
+        let root = url.strip_prefix("file://")?;
+        return Some(PathBuf::from(root));
+    }
+    None
+}
+
 /// Strip a `file://` URL down to the leaf directory of the referenced path.
 fn parse_file_url_leaf(url: &str) -> Option<String> {
     let path = url.strip_prefix("file://")?;
@@ -889,6 +916,28 @@ mod tests {
         msg.extend(field_bytes(5, &field_bytes(1, &timestamp_msg(1, 0))));
         msg.extend(field_bytes(19, &inner4));
         assert_eq!(project_from_user_payload(&msg).as_deref(), Some("repo-api"));
+    }
+
+    #[test]
+    fn session_cwd_reads_project_root_from_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = write_store(temp.path());
+        let project_block = field_bytes(13, b"file:///Users/x/src/repo-api");
+        let inner2 = field_bytes(2, &project_block);
+        let inner4 = field_bytes(4, &inner2);
+        let payload = field_bytes(19, &inner4);
+        let conn = Connection::open(&db).unwrap();
+        conn.execute(
+            "INSERT INTO steps (idx, step_type, status, has_subtrajectory, step_payload) \
+             VALUES (4, 14, 3, false, ?1)",
+            rusqlite::params![payload],
+        )
+        .unwrap();
+
+        assert_eq!(
+            session_cwd(&db).as_deref(),
+            Some(Path::new("/Users/x/src/repo-api"))
+        );
     }
 
     #[test]

--- a/src/sources/audit.rs
+++ b/src/sources/audit.rs
@@ -101,6 +101,13 @@ pub fn audit_installed_sources(source: Option<SourceFilter>) -> Result<Vec<Sourc
             .map(|file| file.path)
             .collect(),
     );
+    push(
+        SourceKind::Antigravity,
+        super::antigravity::discover()
+            .into_iter()
+            .map(|file| file.path)
+            .collect(),
+    );
 
     push(
         SourceKind::Omp,
@@ -134,6 +141,14 @@ fn audit_files(source: SourceKind, files: &[PathBuf]) -> SourceAudit {
             // Hermes usage truth is SQLite aggregate data. Audit must not
             // reinterpret the database as JSON, and in particular must not
             // read transcript/message columns: count the file, skip content.
+            continue;
+        }
+        if source == SourceKind::Antigravity
+            && file.file_name().and_then(|name| name.to_str()) != Some("overview.txt")
+        {
+            // Antigravity conversation stores are SQLite. Audit must not
+            // reinterpret the database as JSON: count the file, skip content.
+            // overview.txt transcripts are JSONL and audit normally below.
             continue;
         }
         let Ok(file) = std::fs::File::open(file) else {
@@ -332,6 +347,12 @@ fn record_semantics(source: SourceKind, value: &Value, top_level: &str, audit: &
         SourceKind::Hermes => {
             if value.get("records").and_then(Value::as_array).is_some() {
                 increment(&mut audit.semantic_types, "records");
+            }
+        }
+        SourceKind::Antigravity => {
+            increment(&mut audit.semantic_types, top_level);
+            if value.get("tool_calls").and_then(Value::as_array).is_some() {
+                increment(&mut audit.semantic_types, "tool_calls");
             }
         }
     }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -4,6 +4,7 @@
 //! adapters in this module make them share source identity, discovery, hierarchy, and
 //! parser-version rules without introducing a persisted normalized transcript store.
 
+pub mod antigravity;
 pub mod audit;
 pub mod claude;
 pub mod codex;
@@ -255,6 +256,7 @@ pub fn versions(source: SourceKind) -> ParserVersions {
         SourceKind::Hermes => hermes::VERSIONS,
         SourceKind::Jcode => jcode::VERSIONS,
         SourceKind::Muse => muse::VERSIONS,
+        SourceKind::Antigravity => antigravity::VERSIONS,
     }
 }
 
@@ -276,6 +278,7 @@ pub fn index_state_version_for(source: SourceKind, include_reasoning: bool) -> u
                 | SourceKind::Jcode
                 | SourceKind::Muse
                 | SourceKind::Grok
+                | SourceKind::Antigravity
         );
     (versions.identity.saturating_mul(10_000) + versions.index)
         .saturating_mul(2)
@@ -293,6 +296,8 @@ pub fn classify_path(path: &str) -> SourceKind {
         SourceKind::Jcode
     } else if muse::matches_path(path) {
         SourceKind::Muse
+    } else if antigravity::matches_path(path) {
+        SourceKind::Antigravity
     } else if grok::matches_path(path) {
         SourceKind::Grok
     } else if cursor::matches_path(path) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,6 +7,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileIdentity {
+    /// SQLite commits can change only the WAL while the main file stays unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sqlite_wal: Option<SqliteWalIdentity>,
     /// Stable filesystem identity when the platform exposes one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub device: Option<u64>,
@@ -22,6 +25,37 @@ pub struct FileIdentity {
     /// Nanosecond-resolution modification marker for detecting same-size rewrites.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modified_ns: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SqliteWalIdentity {
+    pub exists: bool,
+    pub size: u64,
+    pub modified_ns: Option<i64>,
+}
+
+impl SqliteWalIdentity {
+    pub fn read(database: &Path) -> Self {
+        let mut wal = database.as_os_str().to_os_string();
+        wal.push("-wal");
+        let Ok(metadata) = fs::metadata(Path::new(&wal)) else {
+            return Self::default();
+        };
+        // Opening a checkpointed WAL-mode database can create an empty WAL.
+        // Its creation/removal contains no commits and must not cause a reparse loop.
+        if metadata.len() == 0 {
+            return Self::default();
+        }
+        Self {
+            exists: true,
+            size: metadata.len(),
+            modified_ns: metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1546,8 +1546,31 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
         SourceKind::Muse => {
             crate::sources::muse::cwd_from_muse_session(Path::new(&first.source_path))
         }
+        SourceKind::Antigravity => antigravity_cwd(Path::new(&first.source_path)),
     }
     .filter(|path| path.is_dir())
+}
+
+/// Best-effort cwd for an antigravity session: derive it from the message's
+/// `file://` project root stored in the store.
+fn antigravity_cwd(path: &Path) -> Option<PathBuf> {
+    use rusqlite::Connection;
+    let conn =
+        Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let mut stmt = conn
+        .prepare("SELECT step_payload FROM steps WHERE step_type = 14 ORDER BY idx LIMIT 8")
+        .ok()?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, Option<Vec<u8>>>(0))
+        .ok()?;
+    for row in rows.flatten().flatten() {
+        let Some(url) = crate::sources::antigravity::project_root_from_payload(&row) else {
+            continue;
+        };
+        let root = url.trim_start_matches("file://");
+        return Some(PathBuf::from(root));
+    }
+    None
 }
 
 fn cwd_from_jsonl(path: &Path) -> Option<PathBuf> {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1546,31 +1546,11 @@ fn resolve_cwd_from_source(records: &[Record]) -> Option<PathBuf> {
         SourceKind::Muse => {
             crate::sources::muse::cwd_from_muse_session(Path::new(&first.source_path))
         }
-        SourceKind::Antigravity => antigravity_cwd(Path::new(&first.source_path)),
+        SourceKind::Antigravity => {
+            crate::sources::antigravity::session_cwd(Path::new(&first.source_path))
+        }
     }
     .filter(|path| path.is_dir())
-}
-
-/// Best-effort cwd for an antigravity session: derive it from the message's
-/// `file://` project root stored in the store.
-fn antigravity_cwd(path: &Path) -> Option<PathBuf> {
-    use rusqlite::Connection;
-    let conn =
-        Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
-    let mut stmt = conn
-        .prepare("SELECT step_payload FROM steps WHERE step_type = 14 ORDER BY idx LIMIT 8")
-        .ok()?;
-    let rows = stmt
-        .query_map([], |row| row.get::<_, Option<Vec<u8>>>(0))
-        .ok()?;
-    for row in rows.flatten().flatten() {
-        let Some(url) = crate::sources::antigravity::project_root_from_payload(&row) else {
-            continue;
-        };
-        let root = url.trim_start_matches("file://");
-        return Some(PathBuf::from(root));
-    }
-    None
 }
 
 fn cwd_from_jsonl(path: &Path) -> Option<PathBuf> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -417,6 +417,7 @@ enum SourceChoice {
     Hermes,
     Jcode,
     Muse,
+    Antigravity,
 }
 
 impl SourceChoice {
@@ -434,7 +435,8 @@ impl SourceChoice {
             SourceChoice::Grok => SourceChoice::Hermes,
             SourceChoice::Hermes => SourceChoice::Jcode,
             SourceChoice::Jcode => SourceChoice::Muse,
-            SourceChoice::Muse => SourceChoice::All,
+            SourceChoice::Muse => SourceChoice::Antigravity,
+            SourceChoice::Antigravity => SourceChoice::All,
         }
     }
 
@@ -453,6 +455,7 @@ impl SourceChoice {
             SourceChoice::Hermes => Some(SourceFilter::Hermes),
             SourceChoice::Jcode => Some(SourceFilter::Jcode),
             SourceChoice::Muse => Some(SourceFilter::Muse),
+            SourceChoice::Antigravity => Some(SourceFilter::Antigravity),
         }
     }
 
@@ -471,6 +474,7 @@ impl SourceChoice {
             SourceChoice::Hermes => "hermes",
             SourceChoice::Jcode => "jcode",
             SourceChoice::Muse => "muse",
+            SourceChoice::Antigravity => "antigravity",
         }
     }
 
@@ -488,6 +492,7 @@ impl SourceChoice {
             SourceKind::Hermes => SourceChoice::Hermes,
             SourceKind::Jcode => SourceChoice::Jcode,
             SourceKind::Muse => SourceChoice::Muse,
+            SourceKind::Antigravity => SourceChoice::Antigravity,
         }
     }
 }
@@ -1163,6 +1168,7 @@ impl App {
                     include_grok: true,
                     include_jcode: true,
                     include_muse: true,
+                    include_antigravity: true,
                     exclude_patterns: config.exclude_path_patterns(),
                     embeddings: embeddings_default,
                     backfill_embeddings: false,
@@ -2651,6 +2657,7 @@ impl App {
             SourceKind::Hermes => "hermes",
             SourceKind::Jcode => "jcode",
             SourceKind::Muse => "muse",
+            SourceKind::Antigravity => "antigravity",
         };
         let source_path = session.source_path.clone();
 
@@ -4107,6 +4114,7 @@ fn source_choice_matches_storage_label(choice: SourceChoice, label: &str) -> boo
         SourceChoice::Hermes => label == "hermes",
         SourceChoice::Jcode => label == "jcode",
         SourceChoice::Muse => label == "muse",
+        SourceChoice::Antigravity => label == "antigravity",
         SourceChoice::All => false,
     }
 }
@@ -4125,6 +4133,7 @@ fn source_color(source: SourceKind) -> Color {
         SourceKind::Hermes => Color::Rgb(190, 150, 220),
         SourceKind::Jcode => Color::Rgb(220, 140, 180),
         SourceKind::Muse => Color::Rgb(180, 130, 240),
+        SourceKind::Antigravity => Color::Rgb(120, 200, 140),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,10 +17,11 @@ pub enum SourceKind {
     Hermes,
     Jcode,
     Muse,
+    Antigravity,
 }
 
 impl SourceKind {
-    pub const ALL: [SourceKind; 12] = [
+    pub const ALL: [SourceKind; 13] = [
         SourceKind::Claude,
         SourceKind::Codex,
         SourceKind::Opencode,
@@ -33,6 +34,7 @@ impl SourceKind {
         SourceKind::Hermes,
         SourceKind::Jcode,
         SourceKind::Muse,
+        SourceKind::Antigravity,
     ];
     pub const COUNT: usize = Self::ALL.len();
 
@@ -50,6 +52,7 @@ impl SourceKind {
             SourceKind::Hermes => 9,
             SourceKind::Jcode => 10,
             SourceKind::Muse => 11,
+            SourceKind::Antigravity => 12,
         }
     }
 
@@ -67,6 +70,7 @@ impl SourceKind {
             9 => Some(SourceKind::Hermes),
             10 => Some(SourceKind::Jcode),
             11 => Some(SourceKind::Muse),
+            12 => Some(SourceKind::Antigravity),
             _ => None,
         }
     }
@@ -85,6 +89,7 @@ impl SourceKind {
             SourceKind::Hermes => "hermes",
             SourceKind::Jcode => "jcode",
             SourceKind::Muse => "muse",
+            SourceKind::Antigravity => "antigravity",
         }
     }
 
@@ -102,6 +107,7 @@ impl SourceKind {
             SourceKind::Hermes => "hermes",
             SourceKind::Jcode => "jcode",
             SourceKind::Muse => "muse",
+            SourceKind::Antigravity => "antigravity",
         }
     }
 
@@ -123,6 +129,7 @@ impl SourceKind {
             "hermes" => Some(SourceKind::Hermes),
             "jcode" => Some(SourceKind::Jcode),
             "muse" => Some(SourceKind::Muse),
+            "antigravity" => Some(SourceKind::Antigravity),
             _ => None,
         }
     }
@@ -145,6 +152,7 @@ pub enum SourceFilter {
     Hermes,
     Jcode,
     Muse,
+    Antigravity,
 }
 
 impl SourceFilter {
@@ -162,6 +170,7 @@ impl SourceFilter {
             SourceFilter::Hermes => source == SourceKind::Hermes,
             SourceFilter::Jcode => source == SourceKind::Jcode,
             SourceFilter::Muse => source == SourceKind::Muse,
+            SourceFilter::Antigravity => source == SourceKind::Antigravity,
         }
     }
 
@@ -179,6 +188,7 @@ impl SourceFilter {
             SourceFilter::Hermes => &["hermes"],
             SourceFilter::Jcode => &["jcode"],
             SourceFilter::Muse => &["muse"],
+            SourceFilter::Antigravity => &["antigravity"],
         }
     }
 
@@ -196,6 +206,7 @@ impl SourceFilter {
             SourceFilter::Hermes => "hermes",
             SourceFilter::Jcode => "jcode",
             SourceFilter::Muse => "muse",
+            SourceFilter::Antigravity => "antigravity",
         }
     }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -518,7 +518,7 @@ fn assemble_usage_events(
     };
     type SourceScanner =
         fn(&mut Vec<UsageEvent>, &mut Vec<String>, Option<&mut UsageCache>) -> Result<()>;
-    const SCANNERS: [(SourceFilter, SourceScanner); 12] = [
+    const SCANNERS: [(SourceFilter, SourceScanner); 13] = [
         (SourceFilter::Claude, scan_claude),
         (SourceFilter::Codex, scan_codex),
         (SourceFilter::Opencode, scan_opencode),
@@ -531,6 +531,7 @@ fn assemble_usage_events(
         (SourceFilter::Hermes, scan_hermes),
         (SourceFilter::Jcode, scan_jcode),
         (SourceFilter::Muse, scan_muse),
+        (SourceFilter::Antigravity, scan_antigravity),
     ];
     for (filter, scanner) in SCANNERS {
         if source.is_none_or(|selected| selected == filter) {
@@ -1484,6 +1485,27 @@ fn scan_muse(
         warnings,
         out,
         |path| crate::sources::muse::parse_usage_file(path).map(FileParse::cacheable),
+    );
+    Ok(())
+}
+
+fn scan_antigravity(
+    out: &mut Vec<UsageEvent>,
+    warnings: &mut Vec<String>,
+    cache: Option<&mut UsageCache>,
+) -> Result<()> {
+    let files = crate::sources::antigravity::usage_files();
+    scan_files_cached(
+        SourceScan {
+            source: "antigravity",
+            parser_version: crate::sources::antigravity::VERSIONS.usage,
+            volatile_reuse_ms: |_| None,
+        },
+        &files,
+        cache,
+        warnings,
+        out,
+        |path| crate::sources::antigravity::parse_usage_file(path).map(FileParse::cacheable),
     );
     Ok(())
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -621,6 +621,8 @@ fn usage_project_key(value: &str) -> String {
 /// Reuse cached Cursor state databases this long even when their metadata changed: a
 /// running Cursor rewrites its (potentially multi-GB) databases continuously, and
 /// re-reading them on every scan makes live scans unusable.
+/// Expiry forces a read even when main-file metadata is unchanged: committed
+/// SQLite writes can remain entirely in the WAL until checkpoint.
 const VOLATILE_DB_REUSE_MS: i64 = 60_000;
 /// Cache rows are persisted after every chunk of parsed files, not once per source, so an
 /// interrupted cold scan resumes from the last completed chunk instead of starting over.
@@ -1065,11 +1067,10 @@ fn scan_files_cached_with(
             // copy appeared) invalidates the cached result even when the file itself is
             // unchanged, so it must re-parse.
             Some(row)
-                if ((row.size, row.mtime_ns) == metadata
-                    || volatile_reuse_ms(path).is_some_and(|window| {
-                        now_ms.saturating_sub(row.scanned_at_ms) < window
-                    }))
-                    && row.deps.iter().all(UsageFileDep::is_current)
+                if volatile_reuse_ms(path).map_or_else(
+                    || (row.size, row.mtime_ns) == metadata,
+                    |window| now_ms.saturating_sub(row.scanned_at_ms) < window,
+                ) && row.deps.iter().all(UsageFileDep::is_current)
                     && deps_current(&row.deps) =>
             {
                 hits.push((index, key, row.events_blob));
@@ -1657,6 +1658,90 @@ mod tests {
     use super::*;
     use std::fs;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn volatile_sqlite_usage_refreshes_held_open_wal_after_reuse_window() {
+        for source in ["opencode", "cursor"] {
+            let temp = tempfile::tempdir().unwrap();
+            let database = temp.path().join(if source == "opencode" {
+                "opencode.db"
+            } else {
+                "state.vscdb"
+            });
+            let writer = Connection::open(&database).unwrap();
+            writer
+                .execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;")
+                .unwrap();
+            if source == "opencode" {
+                writer
+                    .execute_batch(
+                        "CREATE TABLE message (id TEXT, session_id TEXT, data TEXT);
+                     INSERT INTO message VALUES ('m', 's', '{\"tokens\":{\"input\":10}}');",
+                    )
+                    .unwrap();
+            } else {
+                writer
+                    .execute_batch(
+                        "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);
+                     INSERT INTO cursorDiskKV VALUES ('composerData:s',
+                     '{\"generationUUID\":\"g\",\"inputTokens\":10}');",
+                    )
+                    .unwrap();
+            }
+            writer
+                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+                .unwrap();
+            let metadata = usage_file_metadata(&database).unwrap();
+            let mut cache = UsageCache::open(&temp.path().join("usage-cache.sqlite3")).unwrap();
+            let run = |cache: &mut UsageCache| {
+                let mut warnings = Vec::new();
+                let mut events = Vec::new();
+                scan_files_cached(
+                    SourceScan {
+                        source,
+                        parser_version: 1,
+                        volatile_reuse_ms: |_| Some(VOLATILE_DB_REUSE_MS),
+                    },
+                    std::slice::from_ref(&database),
+                    Some(cache),
+                    &mut warnings,
+                    &mut events,
+                    |path| {
+                        if source == "opencode" {
+                            crate::sources::opencode::parse_usage_file(path)
+                        } else {
+                            crate::sources::cursor::parse_usage_database(path)
+                        }
+                        .map(FileParse::cacheable)
+                    },
+                );
+                assert!(warnings.is_empty(), "{source}: {warnings:?}");
+                events
+                    .iter()
+                    .map(|event| event.tokens.additive_total())
+                    .sum::<u64>()
+            };
+            assert_eq!(run(&mut cache), 10, "{source} cold read");
+            if source == "opencode" {
+                writer
+                    .execute(
+                        "UPDATE message SET data = '{\"tokens\":{\"input\":20}}'",
+                        [],
+                    )
+                    .unwrap();
+            } else {
+                writer.execute("UPDATE cursorDiskKV SET value = '{\"generationUUID\":\"g\",\"inputTokens\":20}'", []).unwrap();
+            }
+            assert_eq!(usage_file_metadata(&database).unwrap(), metadata);
+            assert_eq!(run(&mut cache), 10, "{source} preserves reuse window");
+            cache
+                .connection
+                .execute("UPDATE usage_file_cache SET scanned_at_ms = 0", [])
+                .unwrap();
+            assert_eq!(run(&mut cache), 20, "{source} refreshes WAL after expiry");
+            assert_eq!(usage_file_metadata(&database).unwrap(), metadata);
+        }
+    }
 
     #[test]
     fn usage_event_layout_change_rebuilds_cached_rows() {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -206,13 +206,18 @@ fn interesting_event_paths(event: &Event, excluder: &PathExcluder) -> (Vec<PathB
     }
     let mut paths = Vec::with_capacity(event.paths.len());
     for path in &event.paths {
-        // OpenCode commits can live entirely in the WAL until checkpoint.
+        // SQLite commits can live entirely in the WAL until checkpoint.
         // Route the hint to the database that ingestion knows how to read.
         if let Some(name) = path
             .file_name()
             .and_then(|name| name.to_str())
             .and_then(|name| name.strip_suffix("-wal"))
-            .filter(|name| crate::sources::opencode::is_database_path(name))
+            .filter(|name| {
+                let database = path.with_file_name(name);
+                crate::sources::opencode::is_database_path(name)
+                    || (crate::sources::antigravity::is_db_path(&database)
+                        && crate::sources::antigravity::matches_path(&database.to_string_lossy()))
+            })
         {
             let database = path.with_file_name(name);
             if !excluder.is_excluded(path) && !excluder.is_excluded(&database) {
@@ -275,6 +280,11 @@ pub(crate) fn dirty_needs_ingest(paths: &Paths, dirty: &HashSet<PathBuf>) -> Res
         let Some(previous) = state.files.get(&key) else {
             return Ok(true);
         };
+        if let Some(wal) = &previous.identity.sqlite_wal
+            && *wal != crate::state::SqliteWalIdentity::read(path)
+        {
+            return Ok(true);
+        }
         let metadata = match std::fs::metadata(path) {
             Ok(metadata) => metadata,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
@@ -662,9 +672,9 @@ impl WatchService {
     /// macOS; everywhere else events plus the resync timer suffice.
     ///
     /// Cost is bounded: `ingest.json` is re-parsed only when it changed, and
-    /// only files ingested within `window` are stat-compared. Cold history
-    /// is rediscovered through events/resync. Each tracked OpenCode database
-    /// also needs two stats: its main file and its possibly held-open WAL.
+    /// ordinary files are stat-compared only within `window`. Cold file history
+    /// is rediscovered through events/resync. Each tracked OpenCode or Antigravity
+    /// database also needs two stats regardless of age: its main file and WAL.
     pub(crate) fn hot_sweep_dirty(
         &mut self,
         paths: &Paths,
@@ -686,7 +696,7 @@ impl WatchService {
                 state
                     .files
                     .iter()
-                    .filter(|(_, file)| file.mtime >= cutoff)
+                    .filter(|(_, file)| file.mtime >= cutoff && file.identity.sqlite_wal.is_none())
                     .map(|(key, file)| {
                         (
                             key.clone(),
@@ -699,13 +709,24 @@ impl WatchService {
                     })
                     .collect(),
             );
-            self.hot_databases.retain(|path, _| {
-                state
-                    .opencode_databases
-                    .contains_key(path.to_string_lossy().as_ref())
-            });
-            for key in state.opencode_databases.keys() {
-                self.hot_databases.entry(PathBuf::from(key)).or_insert(None);
+            // Keep databases even when their main-file mtime is old: active
+            // writers may commit exclusively to the WAL for the whole session.
+            let databases = state
+                .opencode_databases
+                .keys()
+                .chain(
+                    state
+                        .files
+                        .iter()
+                        .filter(|(_, file)| file.identity.sqlite_wal.is_some())
+                        .map(|(key, _)| key),
+                )
+                .map(PathBuf::from)
+                .collect::<HashSet<_>>();
+            self.hot_databases
+                .retain(|path, _| databases.contains(path));
+            for path in databases {
+                self.hot_databases.entry(path).or_insert(None);
             }
             self.hot_state_mtime = state_mtime;
         }
@@ -952,7 +973,11 @@ mod tests {
     fn wal_events_target_database_and_honor_database_exclusions() {
         let _guard = env_lock();
         let mut options = test_options();
-        for name in ["opencode.db", "opencode-work.db"] {
+        for name in [
+            "opencode.db",
+            "opencode-work.db",
+            "antigravity-ide/conversations/session.db",
+        ] {
             let database = PathBuf::from(format!("/tmp/sessions/{name}"));
             let wal = PathBuf::from(format!("/tmp/sessions/{name}-wal"));
             let event = Event {
@@ -1292,6 +1317,7 @@ mod tests {
             parser_version: 1,
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity {
+                sqlite_wal: None,
                 device: None,
                 inode: None,
                 prefix_sha256: None,
@@ -1434,16 +1460,31 @@ mod tests {
     #[test]
     fn hot_sweep_observes_held_open_database_wal_commits() {
         let _guard = env_lock();
-        for name in ["opencode.db", "opencode-work.db"] {
+        for name in [
+            "opencode.db",
+            "opencode-work.db",
+            "antigravity-ide/conversations/session.db",
+        ] {
             let temp = tempfile::tempdir().unwrap();
             let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
             let database = temp.path().join(name);
+            std::fs::create_dir_all(database.parent().unwrap()).unwrap();
             let writer = rusqlite::Connection::open(&database).unwrap();
             writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE messages (body TEXT);").unwrap();
             let mut state = IngestState::default();
-            state
-                .opencode_databases
-                .insert(database.to_string_lossy().into_owned(), Default::default());
+            if name.starts_with("antigravity") {
+                let mut file = file_state_for(&database);
+                file.identity.sqlite_wal = Some(crate::state::SqliteWalIdentity::read(&database));
+                // Main DB age must not remove WAL-backed databases from the sweep.
+                file.mtime = 1;
+                state
+                    .files
+                    .insert(database.to_string_lossy().into_owned(), file);
+            } else {
+                state
+                    .opencode_databases
+                    .insert(database.to_string_lossy().into_owned(), Default::default());
+            }
             state.save(&paths.state.join("ingest.json")).unwrap();
             let mut service = test_service();
             // A newly tracked database gets one conservative reconciliation.

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -165,6 +165,9 @@ pub(crate) fn watch_roots(options: &IngestOptions) -> Vec<PathBuf> {
     if options.include_muse {
         roots.push(crate::sources::muse::sessions_root());
     }
+    if options.include_antigravity {
+        roots.push(crate::sources::antigravity::sessions_root());
+    }
     roots.sort();
     roots.dedup();
     roots
@@ -773,6 +776,7 @@ mod tests {
             include_grok: true,
             include_jcode: true,
             include_muse: true,
+            include_antigravity: true,
             exclude_patterns: Vec::new(),
             embeddings: false,
             backfill_embeddings: false,
@@ -883,6 +887,7 @@ mod tests {
         options.include_grok = false;
         options.include_jcode = false;
         options.include_muse = false;
+        options.include_antigravity = false;
         let roots = watch_roots(&options);
         assert_eq!(roots, options.claude_sources);
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1207,6 +1207,7 @@ fn parse_source(value: &str) -> Result<SourceFilter> {
         "hermes" => Ok(SourceFilter::Hermes),
         "jcode" => Ok(SourceFilter::Jcode),
         "muse" => Ok(SourceFilter::Muse),
+        "antigravity" => Ok(SourceFilter::Antigravity),
         _ => Err(anyhow!("unknown source: {value}")),
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `antigravity` source to memex, indexing the plaintext projections Antigravity keeps alongside its encrypted `.pb` trajectories — no decryption needed:

- **`conversations/<uuid>.db`** — per-conversation SQLite stores (default `~/.gemini/antigravity-ide`). Each `steps.step_payload` is the protobuf "step" message; the parser extracts user (`19.f2`), model (`30.f4`), reasoning (`20.f3`), tool calls (`5.f4.{2,3}` + `toolAction`/`toolSummary`), timestamps (`5.1`), and the message UUID (`5.12`).
- **`brain/*/.system_generated/logs/overview.txt`** — JSONL activity logs (`USER_INPUT`, `PLANNER_RESPONSE`, `RUN_COMMAND`, `VIEW_FILE`, `CODE_ACTION`); this also covers the legacy `~/.gemini/antigravity` profile, which only writes `.pb` plus overview logs.

Includes a self-contained protobuf wire reader (varint + length-delimited, skips 64-/32-bit fields), with the extraction table documented and unit-tested.

## Wiring

- `SourceKind::Antigravity` / `SourceFilter::Antigravity` (label `"antigravity"`), no resume command (like Hermes)
- CLI `--antigravity` / `--no-antigravity` (default on), `--only-source`/`--exclude-source`, TUI source choice + color, watch roots, web API source parsing, audit, progress, transfer cwd resolution, agentexport labeling, usage scanning (token buckets not yet validated → empty events)
- Whole-document parse with atomic delete-first re-parses (jcode pattern); `prepare_file_task` pairs it accordingly
- Reasoning indexed only with `--include-reasoning`, matching other sources' default

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings`, and the lib suite: **701 passed; 2 failed** — the 2 failures (`mcp::oauth`) are pre-existing on `main` (also fail at `b58869f`).
- Real-data run against `~/.gemini`: **32,457 records across 125 files** (fresh scratch index, no mutation of the live index).
- Cross-checked the reference conversation against the `ag-formats` reference tool: contentful tool extraction matches 1:1 (215/215); the remaining 24 `step_type 5/8/21` payloads are sub-trajectory references with no tool name/args, correctly dropped rather than emitted as empty records. Unhandled step types surface in `--diagnostics`.

## Notes for reviewers

- `cargo clippy --all-targets` has 4 pre-existing lints in `tests/` integration files (fail on `main` with rustc 1.98; unrelated to this change).
- No Cargo changes (`rusqlite` already a dependency).