### PR TITLE
Improve native conversation reading and loading

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -12,19 +12,46 @@ and can be reset together. Project counts remain full-index, all-history totals 
 Press Command-F in the reader for literal find across the complete conversation,
 including earlier pages and tool contents. Command-G and Shift-Command-G navigate
 matches; Escape closes find. Results appear incrementally while scanning.
-Source-only matches hidden by Markdown still reveal the containing message.
-Tool activity and session instructions, including generated environment context, start collapsed.
-Expanded tools show labeled JSON fields, literal code, and decoded output lines.
+Source-only matches hidden by Markdown reveal and select the original text.
+Tool activity and session context start collapsed. Recognized injected plugin,
+AGENTS.md, environment, permissions, and harness sections are separated from the
+actual request, including mixed records. Quoted examples and arbitrary HTML stay visible.
+Activity rows use tool icons and compact summaries derived from recognized arguments;
+groups count logical operations rather than counting calls and results separately.
+Explicitly failed, cancelled, or interrupted operations stay visible between compact
+routine groups. Missing results do not imply a running or successful operation.
+Completed work collapses around the final answer only when the same source turn
+has explicit completion and final-answer metadata. Older or incomplete records
+retain their visible assistant messages.
+Expanded tools show labeled JSON fields, native command/file/diff cards, literal code, and decoded output lines.
 Long encoded payloads stay compact; Show raw content reveals the complete source.
-Find automatically uses raw tool content to retain exact matches. Each tool call and its result share
+Find automatically uses raw tool content to retain exact matches. Hover or focus a
+message to reveal its copy icon. Source access stays in the toolbar; full raw
+transcript access stays in the header context menu.
+The header's context menu offers Raw transcript, exposing every normalized CLI record, including
+unrecognized fields, with normal bidirectional paging. Reveal source opens the original local log.
+Each tool call and its result share
 one expandable row; single operations and instructions have no extra outer disclosure. Both the session list and
 transcript load additional pages as you scroll, without load buttons. Browsing
 opens at the newest messages; scrolling up loads earlier context. Search opens at
 the matched message, with paging in both directions. Returning to a conversation
 restores its reading position during the current app session (up to 20 recent views).
 Messages render Markdown headings, emphasis, lists, links, quotes, and code blocks
-as native attributed text. XML-style prompt wrappers become labeled sections with
-subtle borders and formatted content; fenced code stays literal.
+as native content. Top-level fenced code gets syntax colors, a language label,
+copy control, and horizontal scrolling. Long messages and outputs start bounded;
+Show all reveals their full content, and copying preserves the full source.
+Typed provider images and documents, Markdown images, and local file cards retain
+their original references. Local images and embedded image data have thumbnails
+and enlargement; remote URLs open explicitly. Paths from another machine never
+resolve against this machine. Local file links with line numbers open a native
+read-only source preview at that line.
+Expanded/raw states and viewport anchors survive paging, resizing, and switching conversations.
+The reader has no secondary navigation bar.
+
+New Codex turn/phase/lifecycle and Codex/Claude typed attachment metadata is stored
+in optional record fields. Old indexes remain readable; their next ingestion
+rebuilds a private generation before publishing the refreshed metadata. Remote
+machines need the updated backend and indexing before those fields are available.
 The Projects sidebar uses full-index session counts and latest activity from
 `memex projects`. Its ellipsis menu sorts by recent activity, conversation count,
 or name. Cached projects and the selected sort survive restarts; an immediate
@@ -183,6 +210,13 @@ lists, counts, search, and transcript reads proceed independently. This avoids
 launching a CLI process for each request; query collectors still open their
 readers per operation so published index generations remain visible.
 
+Fresh browsing uses the session list's `message_count` to request the latest page
+with its current total in one call (`session_page` over the socket, or
+`session --full --page-info --limit 60` through the CLI). The list count is a hint;
+if the returned total changes the final page offset, the reader fetches that page.
+This uses the existing remote page RPC, so remote peers do not need an upgrade.
+Older local CLI overrides fall back to separate record and metadata reads.
+
 If the daemon is absent, older, or unavailable, requests use the bundled CLI.
 The app does not enable or restart the daemon or change service settings. An older running daemon needs an updated binary and a normal restart
 before it provides the socket. Local socket reads do not trigger auto-indexing;
@@ -209,5 +243,6 @@ The normal build targets the local machine and signs ad hoc for development;
 the app release commands above build universal bundles for distribution.
 
 The SwiftUI shell embeds an AppKit NSTableView transcript with native text selection.
-The transcript has no LazyVStack; row measurements retain TextKit glyph layout across resizes. Messages display their full text; tool bodies are only
-constructed when opened and then display their full input and output. The app never launches itself after you quit it.
+The transcript has no LazyVStack; row measurements retain TextKit glyph layout across resizes. Tool bodies are only
+constructed when opened. Bounded displays preserve full source and selection;
+Find expands the matching content automatically. The app never launches itself after you quit it.

--- a/apps/macos/Sources/Memex/ActivityPresentation.swift
+++ b/apps/macos/Sources/Memex/ActivityPresentation.swift
@@ -27,6 +27,7 @@ extension TranscriptActivity {
         }.first
         let failed = records.contains { entry in
             let message = entry.record
+            if message.role == "tool_result", message.toolResultIsError == true { return true }
             // A call's arguments may themselves contain error/status fields.
             if let output = message.toolOutput, Self.explicitFailure(output) { return true }
             return ["tool_result", "tool"].contains(message.role) && Self.explicitFailure(message.text)

--- a/apps/macos/Sources/Memex/ActivityPresentation.swift
+++ b/apps/macos/Sources/Memex/ActivityPresentation.swift
@@ -1,0 +1,109 @@
+import CoreFoundation
+import Foundation
+
+/// Display-only metadata. The original records remain the source for details and Find.
+struct ActivityPresentation: Equatable, Sendable {
+    let title: String
+    let symbolName: String
+    let hasFailure: Bool
+    let category: String?
+    var isInterrupted = false
+    var needsAttention: Bool { hasFailure || isInterrupted }
+}
+
+extension TranscriptActivity {
+    var presentation: ActivityPresentation {
+        let message = records.first(where: { $0.record.role == "tool_use" })?.record ?? records[0].record
+        let interruption = records.lazy.compactMap { entry -> String? in
+            let message = entry.record
+            let output = message.toolOutput ?? (["tool_result", "tool"].contains(message.role) ? message.text : "")
+            guard let status = Self.object(output)?["status"] as? String else { return nil }
+            switch status.lowercased() {
+            case "cancelled", "canceled": return "Cancelled"
+            case "interrupted": return "Interrupted"
+            case "incomplete": return "Incomplete"
+            default: return nil
+            }
+        }.first
+        let failed = records.contains { entry in
+            let message = entry.record
+            // A call's arguments may themselves contain error/status fields.
+            if let output = message.toolOutput, Self.explicitFailure(output) { return true }
+            return ["tool_result", "tool"].contains(message.role) && Self.explicitFailure(message.text)
+        }
+        func value(_ title: String, _ symbol: String, _ category: String? = nil) -> ActivityPresentation {
+            ActivityPresentation(title: interruption.map { $0 + " · " + title } ?? (failed ? "Failed · " + title : title),
+                                 symbolName: interruption == nil ? symbol : "pause.circle", hasFailure: failed, category: category,
+                                 isInterrupted: interruption != nil)
+        }
+        if let label = message.contextLabel { return value(label, "doc.text") }
+        if message.isEnvironmentContext { return value("Environment context", "info.circle") }
+        if message.isInstruction { return value(message.role.capitalized + " instructions", "doc.text") }
+        if message.role == "reasoning" { return value("Reasoning", "ellipsis.bubble") }
+        if message.role == "assistant" { return value(Self.compact(message.text), "text.bubble") }
+
+        // Match a complete tool name, including the final component of provider namespaces.
+        // Arbitrary executable source (such as functions.exec JavaScript) is never parsed.
+        let name = (message.toolName ?? "").components(separatedBy: "__").last?
+            .components(separatedBy: ".").last?.lowercased() ?? ""
+        let input = message.toolInput.flatMap(Self.object)
+        func detail(_ keys: [String]) -> String? {
+            keys.lazy.compactMap { input?[$0] as? String }.first { $0.nilIfBlank != nil }
+        }
+        func title(_ verb: String, _ detail: String?) -> String {
+            guard let detail else { return verb }
+            return verb + " " + Self.compact(detail)
+        }
+        switch name {
+        case "read", "read_file", "readfile":
+            return value(title("Read", detail(["file_path", "path", "filename"])), "doc.text", "Read")
+        case "grep", "search", "search_code", "search_files", "search_query", "ripgrep":
+            return value(title("Search", detail(["pattern", "query", "q", "search_term"])), "magnifyingglass", "Search")
+        case "glob", "find_files", "list_files", "list_directory", "ls":
+            return value(title("List files", detail(["pattern", "glob", "path", "directory"])), "folder", "Search")
+        case "bash", "shell", "shell_command", "exec_command", "run_command", "terminal":
+            return value(title("Run", detail(["command", "cmd"])), "terminal", "Command")
+        case "exec" where detail(["command", "cmd"]) != nil:
+            return value(title("Run", detail(["command", "cmd"])), "terminal", "Command")
+        case "exec" where message.toolName == "functions.exec":
+            return value("Run tool script", "terminal", "Command")
+        case "wait", "write_stdin":
+            return value("Wait for command", "terminal", "Command")
+        case "view_image", "open_image":
+            return value(title("View image", detail(["path", "image_path"])), "photo", "Image")
+        case "write", "write_file", "writefile", "create_file":
+            return value(title("Write", detail(["file_path", "path", "filename"])), "doc.badge.plus", "Write")
+        case "edit", "edit_file", "editfile", "multiedit", "multi_edit", "replace_in_file":
+            return value(title("Edit", detail(["file_path", "path", "filename"])), "pencil", "Edit")
+        case "apply_patch":
+            return value("Apply patch", "pencil", "Edit")
+        case "web_fetch", "webfetch", "fetch_url":
+            return value(title("Fetch", detail(["url"])), "globe", "Search")
+        default:
+            return value(message.activityTitle, "wrench.and.screwdriver")
+        }
+    }
+
+    private static func compact(_ text: String) -> String {
+        let line = text.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        return line.count > 88 ? String(line.prefix(87)) + "…" : line
+    }
+
+    private static func object(_ text: String) -> [String: Any]? {
+        guard let data = text.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func explicitFailure(_ text: String) -> Bool {
+        guard let output = object(text) else { return false }
+        // JSON booleans and numbers both bridge to NSNumber; distinguish them so
+        // malformed numeric error flags or boolean exit codes do not imply failure.
+        for key in ["isError", "is_error"] {
+            if let flag = output[key] as? NSNumber,
+               CFGetTypeID(flag) == CFBooleanGetTypeID(), flag.boolValue { return true }
+        }
+        if let code = output["exit_code"] as? NSNumber,
+           CFGetTypeID(code) != CFBooleanGetTypeID(), code.doubleValue != 0 { return true }
+        return false
+    }
+}

--- a/apps/macos/Sources/Memex/Client.swift
+++ b/apps/macos/Sources/Memex/Client.swift
@@ -228,6 +228,58 @@ struct MemexClient: Sendable {
             daemonRequest: sessionRequest(session, offset: offset, limit: limit)))
     }
 
+    /// A list count is a hint, not a snapshot: the page response supplies its
+    /// current total, so newly indexed or removed records can correct the offset.
+    func initialRecords(for session: Session, anchor: String?) async throws -> TranscriptPage {
+        let offset: Int
+        if anchor == nil, let count = session.messageCount, count >= 0 {
+            offset = max(0, count - Self.pageSize)
+        } else {
+            offset = try await initialRecordOffset(for: session, anchor: anchor).offset
+        }
+        var page = try await recordPage(for: session, offset: offset)
+        if anchor == nil {
+            let latestOffset = max(0, page.total - Self.pageSize)
+            if latestOffset != page.offset {
+                try Task.checkCancellation()
+                page = try await recordPage(for: session, offset: latestOffset)
+            }
+        }
+        return page
+    }
+
+    func recordPage(for session: Session, offset: Int, limit: Int = Self.pageSize) async throws -> TranscriptPage {
+        let args = ["session", "--machine", session.machineID, "--source-path", session.sourcePath,
+                    "--offset", String(offset), "--limit", String(limit), "--full", "--page-info", "--format", "json",
+                    "--", session.sessionID]
+        var request = DaemonRequest(op: "session_page")
+        request.machine = session.machineID
+        request.sessionID = session.sessionID
+        request.sourcePath = session.sourcePath
+        request.offset = offset
+        request.limit = limit
+        let data: Data
+        do {
+            data = try await run(args, daemonRequest: request)
+        } catch let error as ClientError where error.message.contains("--page-info") &&
+            (error.message.contains("unexpected argument") || error.message.contains("unrecognized option")) {
+            // Older local CLI overrides still work. Older remote peers already
+            // return page totals through the existing SessionPage RPC.
+            let records = try await records(for: session, offset: offset, limit: limit)
+            let metadata = try await recordMetadata(for: session, offset: offset, limit: 1)
+            return TranscriptPage(records: records, offset: offset, total: metadata.total)
+        }
+        let items = try JSONDecoder().decode([TranscriptPageItem].self, from: data)
+        let records = items.compactMap { if case .record(let record) = $0 { record } else { nil } }
+        if let total = items.compactMap({ if case .total(let total) = $0 { total } else { nil } }).last {
+            guard total >= 0 else { throw ClientError(message: "Memex returned an invalid transcript total.") }
+            return TranscriptPage(records: records, offset: offset, total: total)
+        }
+        // Tolerate an older CLI wrapper that accepts but does not emit page info.
+        let metadata = try await recordMetadata(for: session, offset: offset, limit: 1)
+        return TranscriptPage(records: records, offset: offset, total: metadata.total)
+    }
+
     /// The CLI has no ID-only session mode. Bound search scans to 256K characters
     /// and discard their bodies; a one-record total probe needs only one character.
     func recordMetadata(for session: Session, offset: Int, limit: Int) async throws -> RecordMetadataPage {
@@ -267,6 +319,26 @@ struct MemexClient: Sendable {
             }
             offset = next
             page = try await recordMetadata(for: session, offset: offset, limit: 500)
+        }
+    }
+}
+
+struct TranscriptPage: Sendable {
+    let records: [TranscriptRecord]
+    let offset: Int
+    let total: Int
+}
+
+private enum TranscriptPageItem: Decodable {
+    case record(TranscriptRecord)
+    case total(Int)
+    private enum CodingKeys: String, CodingKey { case type, total }
+    init(from decoder: Decoder) throws {
+        let fields = try decoder.container(keyedBy: CodingKeys.self)
+        if try fields.decodeIfPresent(String.self, forKey: .type) == "page" {
+            self = .total(try fields.decode(Int.self, forKey: .total))
+        } else {
+            self = .record(try TranscriptRecord(from: decoder))
         }
     }
 }

--- a/apps/macos/Sources/Memex/CodeSyntax.swift
+++ b/apps/macos/Sources/Memex/CodeSyntax.swift
@@ -1,0 +1,44 @@
+import AppKit
+
+/// Small, conservative lexical highlighter. Unknown languages remain literal.
+@MainActor enum CodeSyntax {
+    static func render(_ source: String, language: String, font: NSFont) -> NSAttributedString {
+        let result = NSMutableAttributedString(string: source, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: font.pointSize - 1, weight: .regular),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let language = language.lowercased().split(separator: " ").first.map(String.init) ?? "text"
+        let full = NSRange(location: 0, length: result.length)
+        if ["diff", "patch"].contains(language) {
+            for (pattern, color) in [("(?m)^\\+.*$", NSColor.systemGreen), ("(?m)^-.*$", NSColor.systemRed), ("(?m)^@@.*$", NSColor.systemPurple)] {
+                apply(pattern, color: color, to: result, range: full)
+            }
+            return result
+        }
+        guard ["swift", "rust", "rs", "javascript", "js", "typescript", "ts", "tsx", "jsx", "python", "py", "sql", "json", "bash", "sh", "zsh", "c", "cpp", "go", "java", "ruby", "rb", "yaml", "yml", "toml"].contains(language) else { return result }
+        // Consume quoted strings and comments as complete tokens so keywords
+        // inside them are never colored as executable code.
+        let hashComments = ["python", "py", "bash", "sh", "zsh", "ruby", "rb", "yaml", "yml", "toml"].contains(language)
+        let comment = language == "sql" ? "--[^\\n]*" : (hashComments ? "#[^\\n]*" : "//[^\\n]*|/\\*[\\s\\S]*?\\*/")
+        let pattern = "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|`(?:\\\\.|[^`\\\\])*`|" + comment + "|\\b[0-9]+(?:\\.[0-9]+)?\\b|\\b[A-Za-z_][A-Za-z_0-9]*\\b"
+        let keywords = Set("let var const func fn return if else for while switch case break continue class struct enum protocol extension import from as async await try catch throw throws public private static mut impl use pub def in is not and or None True False null true false select with recursive distinct from where group by order asc desc having limit offset join left right inner outer on union all insert into values update set delete create table alter drop begin end function export default new interface type guard defer do self super package match some nil void int string boolean bool final override actor nonisolated".lowercased().split(separator: " ").map(String.init))
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return result }
+        let ns = source as NSString
+        for match in regex.matches(in: source, range: full) {
+            let token = ns.substring(with: match.range)
+            let color: NSColor?
+            if token.hasPrefix("\"") || token.hasPrefix("'") || token.hasPrefix("`") { color = .systemRed }
+            else if token.hasPrefix("//") || token.hasPrefix("/*") || token.hasPrefix("#") || token.hasPrefix("--") { color = .secondaryLabelColor }
+            else if token.first?.isNumber == true { color = .systemOrange }
+            else if keywords.contains(token.lowercased()) { color = .systemPurple }
+            else { color = nil }
+            if let color { result.addAttribute(.foregroundColor, value: color, range: match.range) }
+        }
+        return result
+    }
+
+    private static func apply(_ pattern: String, color: NSColor, to result: NSMutableAttributedString, range: NSRange) {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+        for match in regex.matches(in: result.string, range: range) { result.addAttribute(.foregroundColor, value: color, range: match.range) }
+    }
+}

--- a/apps/macos/Sources/Memex/ConversationOutline.swift
+++ b/apps/macos/Sources/Memex/ConversationOutline.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Observation
+
+struct ConversationPrompt: Identifiable, Equatable {
+    let id: String
+    let offset: Int
+    let preview: String
+}
+
+/// Scans the same paged source as Find, without changing the reader's loaded window.
+@Observable @MainActor final class ConversationOutline {
+    private(set) var prompts: [ConversationPrompt] = []
+    private(set) var scanning = false
+    private(set) var error: String?
+    var selectedID: String?
+    private var token = UUID()
+    private var recordOffsets: [String: Int] = [:]
+
+    func load(session: Session?, client: MemexClient) async {
+        let token = UUID()
+        self.token = token
+        prompts = []; selectedID = nil; error = nil
+        recordOffsets = [:]
+        guard let session else { scanning = false; return }
+        scanning = true
+        defer { if self.token == token { scanning = false } }
+        do {
+            var offset = 0
+            while true {
+                try Task.checkCancellation()
+                let page = try await client.records(for: session, offset: offset)
+                try Task.checkCancellation()
+                guard self.token == token else { return }
+                for (index, record) in page.enumerated() { recordOffsets[record.id] = offset + index }
+                prompts += Self.entries(page, offset: offset)
+                if page.count < MemexClient.pageSize { break }
+                offset += page.count
+            }
+        } catch is CancellationError {
+        } catch { if self.token == token { self.error = error.localizedDescription } }
+    }
+
+    static func entries(_ records: [TranscriptRecord], offset: Int) -> [ConversationPrompt] {
+        records.enumerated().compactMap { index, record in
+            guard record.record.role == "user" else { return nil }
+            let visible = TranscriptPresentation.project([record]).filter { !$0.record.isInstruction }
+                .map { $0.record.text }.joined(separator: " ")
+            let preview = visible.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+            guard !preview.isEmpty else { return nil }
+            return ConversationPrompt(id: record.id, offset: offset + index, preview: String(preview.prefix(180)))
+        }
+    }
+
+    func move(_ direction: Int) -> ConversationPrompt? {
+        guard !prompts.isEmpty else { return nil }
+        let current = prompts.firstIndex { $0.id == selectedID }
+        let index = min(prompts.count - 1, max(0, (current ?? (direction > 0 ? -1 : prompts.count)) + direction))
+        selectedID = prompts[index].id
+        return prompts[index]
+    }
+
+    func follow(_ recordID: String?) {
+        guard let recordID, let offset = recordOffsets[recordID] else { return }
+        selectedID = prompts.last(where: { $0.offset <= offset })?.id
+    }
+}

--- a/apps/macos/Sources/Memex/Models.swift
+++ b/apps/macos/Sources/Memex/Models.swift
@@ -13,6 +13,7 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
     var repoProject: String?
     var machine: String?
     var searchRecordID: String?
+    var messageCount: Int?
 
     // A session ID alone is not unique across machines, providers or transcript files.
     var machineID: String { machine ?? "local" }
@@ -28,6 +29,7 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
         value.searchRecordID = searchRecordID
         if value.label == nil { value.label = label }
         if value.lastAt == nil { value.lastAt = lastAt }
+        if value.messageCount == nil { value.messageCount = messageCount }
         return value
     }
 
@@ -37,6 +39,7 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
         case lastAt = "last_at", resumeCommand = "resume_cmd"
         case repoProject = "repo_project"
         case searchRecordID = "search_record_id"
+        case messageCount = "message_count"
     }
 }
 
@@ -73,23 +76,64 @@ struct SearchHit: Decodable, Sendable {
 struct TranscriptRecord: Decodable, Identifiable, Equatable, Sendable {
     let recordID: String
     let record: Message
+    var sourceRecordID: String? = nil
+    var rawJSON: String? = nil
+    var sourceID: String { sourceRecordID ?? recordID }
     var id: String { recordID }
     enum CodingKeys: String, CodingKey { case recordID = "record_id", record }
+
+    init(recordID: String, record: Message, sourceRecordID: String? = nil, rawJSON: String? = nil) {
+        self.recordID = recordID
+        self.record = record
+        self.sourceRecordID = sourceRecordID
+        self.rawJSON = rawJSON
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        recordID = try container.decode(String.self, forKey: .recordID)
+        record = try container.decode(Message.self, forKey: .record)
+        rawJSON = try RawTranscriptJSON(from: decoder).prettyPrinted()
+    }
+
+    var rawTranscriptBody: String {
+        if let rawJSON { return rawJSON }
+        var fields: [String: RawTranscriptJSON] = ["role": .string(record.role), "text": .string(record.text)]
+        for (key, value) in [("tool_name", record.toolName), ("tool_input", record.toolInput),
+                             ("tool_output", record.toolOutput), ("event_id", record.eventID),
+                             ("parent_tool_use_id", record.parentToolUseID), ("source_turn_id", record.sourceTurnID),
+                             ("assistant_phase", record.assistantPhase), ("lifecycle_event", record.lifecycleEvent),
+                             ("source_record_type", record.sourceRecordType)] {
+            if let value { fields[key] = .string(value) }
+        }
+        if let content = record.sourceContent { fields["source_content"] = .string(content) }
+        return (try? RawTranscriptJSON.object(["record_id": .string(sourceID), "record": .object(fields)]).prettyPrinted()) ?? record.text
+    }
 }
 
 struct Message: Decodable, Equatable, Sendable {
     let role: String
-    let text: String
+    var text: String
     let toolName: String?
     let toolInput: String?
     let toolOutput: String?
     var eventID: String? = nil
     var parentToolUseID: String? = nil
+    var sourceTurnID: String? = nil
+    var assistantPhase: String? = nil
+    var lifecycleEvent: String? = nil
+    var sourceRecordType: String? = nil
+    var sourceContent: String? = nil
+    // Display-only classification; source records and serialized content stay intact.
+    var contextLabel: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case role, text
         case toolName = "tool_name", toolInput = "tool_input", toolOutput = "tool_output"
         case eventID = "event_id", parentToolUseID = "parent_tool_use_id"
+        case sourceTurnID = "source_turn_id", assistantPhase = "assistant_phase"
+        case lifecycleEvent = "lifecycle_event", sourceRecordType = "source_record_type"
+        case sourceContent = "source_content"
     }
 
     var isActivity: Bool { ["tool_use", "tool_result", "tool", "reasoning"].contains(role) }
@@ -98,7 +142,7 @@ struct Message: Decodable, Equatable, Sendable {
         let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.hasPrefix("<environment_context>") && value.hasSuffix("</environment_context>")
     }
-    var isInstruction: Bool { ["system", "developer"].contains(role) || isEnvironmentContext }
+    var isInstruction: Bool { contextLabel != nil || ["system", "developer"].contains(role) || isEnvironmentContext }
     var activityTitle: String {
         if role == "reasoning" { return "Reasoning" }
         guard let toolName = toolName?.nilIfBlank else {
@@ -114,6 +158,7 @@ struct TranscriptActivity: Identifiable, Sendable {
     var id: String { records.first(where: { $0.record.role == "tool_use" })?.id ?? records[0].id }
     var title: String {
         let message = records.first(where: { $0.record.role == "tool_use" })?.record ?? records[0].record
+        if let label = message.contextLabel { return label }
         if message.isEnvironmentContext { return "Environment context" }
         if message.isInstruction { return message.role.capitalized + " instructions" }
         return message.activityTitle
@@ -186,12 +231,34 @@ struct TranscriptActivity: Identifiable, Sendable {
 
 struct TranscriptItem: Identifiable, Sendable {
     let records: [TranscriptRecord]
-    var activities: [TranscriptActivity] { TranscriptActivity.pair(records) }
+    // Preserve pairing when routine spans are separated around explicit failures.
+    var groupedActivities: [TranscriptActivity]? = nil
+    var isCompletedWork = false
+    var activities: [TranscriptActivity] { groupedActivities ?? TranscriptActivity.pair(records) }
     var id: String { records[0].id }
-    var isActivity: Bool { records[0].record.isActivity }
+    var isActivity: Bool { isCompletedWork || records[0].record.isActivity }
     var isInstructions: Bool { records[0].record.isInstruction }
+    var activitySummary: String {
+        if isCompletedWork { return "Completed work" }
+        if isInstructions { return title }
+        let entries = activities
+        guard entries.count > 1 else { return entries.first?.presentation.title ?? title }
+        if entries.allSatisfy({ $0.presentation.category == nil && $0.records[0].record.role != "reasoning" }) {
+            return "\(entries.count) tool calls"
+        }
+        var categories: [(String, Int)] = []
+        for entry in entries {
+            let category = entry.presentation.category?.lowercased() ?? (entry.records[0].record.role == "reasoning" ? "reasoning" : "tool")
+            if let index = categories.firstIndex(where: { $0.0 == category }) { categories[index].1 += 1 }
+            else { categories.append((category, 1)) }
+        }
+        let details = categories.prefix(3).map { name, count in
+            name == "reasoning" ? "reasoning" : "\(count) \(name)\(count == 1 ? "" : name == "search" ? "es" : "s")"
+        }.joined(separator: ", ")
+        return "\(entries.count) activities · \(details)" + (categories.count > 3 ? ", …" : "")
+    }
     var title: String {
-        if isInstructions { return "Session instructions" }
+        if isInstructions { return "Session context" }
         var names: [String] = []
         // Use the same readable labels for group summaries and individual tools.
         for item in records where item.record.role != "tool_result" {
@@ -204,21 +271,48 @@ struct TranscriptItem: Identifiable, Sendable {
     }
 
     static func group(_ records: [TranscriptRecord]) -> [TranscriptItem] {
+        TranscriptPresentation.group(records)
+    }
+
+    static func groupConsecutive(_ records: [TranscriptRecord]) -> [TranscriptItem] {
         var result: [TranscriptItem] = []
         var pending: [TranscriptRecord] = []
+        func flush() {
+            guard !pending.isEmpty else { return }
+            let entries = TranscriptActivity.pair(pending)
+            guard pending[0].record.isActivity, entries.contains(where: { $0.presentation.needsAttention }) else {
+                result.append(TranscriptItem(records: pending))
+                pending = []
+                return
+            }
+            var routine: [TranscriptActivity] = []
+            func appendRoutine() {
+                if !routine.isEmpty {
+                    result.append(TranscriptItem(records: routine.flatMap(\.records), groupedActivities: routine))
+                    routine = []
+                }
+            }
+            for entry in entries {
+                if entry.presentation.needsAttention {
+                    appendRoutine()
+                    result.append(TranscriptItem(records: entry.records, groupedActivities: [entry]))
+                } else { routine.append(entry) }
+            }
+            appendRoutine()
+            pending = []
+        }
         for record in records {
             let canGroup = record.record.isActivity || record.record.isInstruction
             if let previous = pending.first,
                !canGroup || previous.record.isActivity != record.record.isActivity {
-                result.append(TranscriptItem(records: pending))
-                pending = []
+                flush()
             }
             if canGroup { pending.append(record) }
             else {
                 result.append(TranscriptItem(records: [record]))
             }
         }
-        if !pending.isEmpty { result.append(TranscriptItem(records: pending)) }
+        flush()
         return result
     }
 }

--- a/apps/macos/Sources/Memex/Models.swift
+++ b/apps/macos/Sources/Memex/Models.swift
@@ -107,6 +107,7 @@ struct TranscriptRecord: Decodable, Identifiable, Equatable, Sendable {
             if let value { fields[key] = .string(value) }
         }
         if let content = record.sourceContent { fields["source_content"] = .string(content) }
+        if let isError = record.toolResultIsError { fields["tool_result_is_error"] = .bool(isError) }
         return (try? RawTranscriptJSON.object(["record_id": .string(sourceID), "record": .object(fields)]).prettyPrinted()) ?? record.text
     }
 }
@@ -124,6 +125,7 @@ struct Message: Decodable, Equatable, Sendable {
     var lifecycleEvent: String? = nil
     var sourceRecordType: String? = nil
     var sourceContent: String? = nil
+    var toolResultIsError: Bool? = nil
     // Display-only classification; source records and serialized content stay intact.
     var contextLabel: String? = nil
 
@@ -134,6 +136,7 @@ struct Message: Decodable, Equatable, Sendable {
         case sourceTurnID = "source_turn_id", assistantPhase = "assistant_phase"
         case lifecycleEvent = "lifecycle_event", sourceRecordType = "source_record_type"
         case sourceContent = "source_content"
+        case toolResultIsError = "tool_result_is_error"
     }
 
     var isActivity: Bool { ["tool_use", "tool_result", "tool", "reasoning"].contains(role) }

--- a/apps/macos/Sources/Memex/RawTranscriptJSON.swift
+++ b/apps/macos/Sources/Memex/RawTranscriptJSON.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Retains unknown CLI fields for inspection without coupling the reader to the entire schema.
+indirect enum RawTranscriptJSON: Codable {
+    case object([String: RawTranscriptJSON])
+    case array([RawTranscriptJSON])
+    case string(String)
+    case number(Decimal)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer()
+        if value.decodeNil() { self = .null }
+        else if let boolean = try? value.decode(Bool.self) { self = .bool(boolean) }
+        else if let text = try? value.decode(String.self) { self = .string(text) }
+        else if let number = try? value.decode(Decimal.self) { self = .number(number) }
+        else if let array = try? value.decode([RawTranscriptJSON].self) { self = .array(array) }
+        else { self = .object(try value.decode([String: RawTranscriptJSON].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var value = encoder.singleValueContainer()
+        switch self {
+        case .object(let fields): try value.encode(fields)
+        case .array(let elements): try value.encode(elements)
+        case .string(let text): try value.encode(text)
+        case .number(let number): try value.encode(number)
+        case .bool(let boolean): try value.encode(boolean)
+        case .null: try value.encodeNil()
+        }
+    }
+
+    func prettyPrinted() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return String(decoding: try encoder.encode(self), as: UTF8.self)
+    }
+}

--- a/apps/macos/Sources/Memex/Reader.swift
+++ b/apps/macos/Sources/Memex/Reader.swift
@@ -5,6 +5,7 @@ struct ReaderView: View {
     @Bindable var store: Store
     @State private var navigation = TranscriptNavigationState()
     @State private var find: ConversationFindState?
+    @State private var rawTranscript = false
     @FocusState private var findFocused: Bool
 
     var body: some View {
@@ -12,6 +13,7 @@ struct ReaderView: View {
             if let session = store.selected {
                 VStack(spacing: 0) {
                     header(session)
+                        .contextMenu { Toggle("Raw transcript", isOn: $rawTranscript) }
                     Divider().opacity(0.5)
                     if let find, find.isOpen { findBar(find) }
                     NativeTranscript(sessionID: store.readerPositionKey,
@@ -23,7 +25,9 @@ struct ReaderView: View {
                                      anchorID: store.readerAnchorID, navigation: navigation,
                                      onLoadEarlier: { Task { await store.loadEarlierRecords() } },
                                      findQuery: find?.isOpen == true ? find?.query ?? "" : "",
-                                     findHit: find?.selectedHit, findGeneration: find?.generation ?? 0)
+                                     findHit: find?.selectedHit, findGeneration: find?.generation ?? 0,
+                                     rawTranscript: rawTranscript, isLocalHost: session.machineID == "local",
+                                     sourcePath: session.sourcePath)
                     if let error = store.readerError {
                         ErrorBanner(message: error) {
                             Task { await store.retryRecords() }

--- a/apps/macos/Sources/Memex/RichContentView.swift
+++ b/apps/macos/Sources/Memex/RichContentView.swift
@@ -48,6 +48,7 @@ enum RichContentBlock: Equatable {
     case markdown(String)
     case code(String, language: String)
     case attachment(label: String, source: String, image: Bool)
+    case attachmentNotice(label: String, detail: String)
     case embeddedImage(label: String, data: Data, mimeType: String)
 }
 
@@ -116,6 +117,8 @@ struct RichContentDocument {
             case .code(let source, let language): return CodeContentView(code: source, language: language, font: font)
             case .embeddedImage(let label, let data, let mimeType):
                 return AttachmentContentView(label: label, source: "Embedded image · \(mimeType)", isImage: true, context: context, embeddedData: data)
+            case .attachmentNotice(let label, let detail):
+                return AttachmentContentView(label: label, source: "", isImage: false, context: context, unavailableDetail: detail)
             case .attachment(let label, let source, let image):
                 let card = AttachmentContentView(label: label, source: source, isImage: image, context: context)
                 card.onOpenLocation = { [weak self] location in self?.open(location) }
@@ -309,14 +312,14 @@ struct RichContentDocument {
     let contentHeight: CGFloat
     override var isFlipped: Bool { true }
 
-    init(label: String, source: String, isImage: Bool, context: RichContentContext, embeddedData: Data? = nil) {
+    init(label: String, source: String, isImage: Bool, context: RichContentContext, embeddedData: Data? = nil, unavailableDetail: String? = nil) {
         let location = ContentLocation.parse(source)
         self.location = location
         self.context = context
         let embeddedData = embeddedData.flatMap { $0.count <= 20_000_000 ? $0 : nil }
         self.embeddedData = embeddedData
         title = NSTextField(labelWithString: label.isEmpty ? (location?.url.lastPathComponent ?? "Attachment") : label)
-        detail = NSTextField(wrappingLabelWithString: source + ((location?.url.isFileURL == true && !context.isLocalHost) ? " · Recorded on another host" : ""))
+        detail = NSTextField(wrappingLabelWithString: unavailableDetail ?? (source + ((location?.url.isFileURL == true && !context.isLocalHost) ? " · Recorded on another host" : "")))
         // Never interpret another machine's absolute path on this machine, and
         // never fetch remote media as a side effect of reading a transcript.
         var thumbnail: NSImage?
@@ -342,6 +345,7 @@ struct RichContentDocument {
         preview.image = thumbnail
         preview.imageScaling = .scaleProportionallyUpOrDown
         openButton.title = thumbnail == nil ? "Open" : "Enlarge"
+        openButton.isHidden = unavailableDetail != nil
         openButton.isEnabled = thumbnail != nil || location?.canOpen(in: context) == true
         openButton.target = self
         openButton.action = #selector(openAttachment)
@@ -353,7 +357,7 @@ struct RichContentDocument {
         effectiveAppearance.performAsCurrentDrawingAppearance {
             layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.035).cgColor
         }
-        title.frame = NSRect(x: 12, y: 8, width: max(1, bounds.width - 100), height: 20)
+        title.frame = NSRect(x: 12, y: 8, width: max(1, bounds.width - (openButton.isHidden ? 24 : 100)), height: 20)
         openButton.frame = NSRect(x: max(0, bounds.width - 80), y: 6, width: 70, height: 24)
         detail.frame = NSRect(x: 12, y: 31, width: max(1, bounds.width - 24), height: 32)
         preview.frame = NSRect(x: 12, y: 68, width: max(1, bounds.width - 24), height: max(0, bounds.height - 80))

--- a/apps/macos/Sources/Memex/RichContentView.swift
+++ b/apps/macos/Sources/Memex/RichContentView.swift
@@ -1,0 +1,379 @@
+import AppKit
+import ImageIO
+import Markdown
+
+/// Local paths are meaningful only when the session's exact host is this host.
+struct RichContentContext: Equatable {
+    var isLocalHost = false
+}
+
+struct ContentLocation: Equatable {
+    let url: URL
+    let line: Int?
+
+    static func parse(_ source: String) -> ContentLocation? {
+        if source.hasPrefix("/") {
+            var path = source
+            var line: Int?
+            if let colon = path.lastIndex(of: ":"), let number = Int(path[path.index(after: colon)...]), number > 0 {
+                line = number
+                path = String(path[..<colon])
+            }
+            return ContentLocation(url: URL(fileURLWithPath: path), line: line)
+        }
+        guard let url = URL(string: source), let scheme = url.scheme?.lowercased(),
+              ["https", "http", "mailto", "file"].contains(scheme) else { return nil }
+        if scheme == "file", let host = url.host, !host.isEmpty && host != "localhost" { return nil }
+        if scheme == "file" {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let fragment = components?.fragment ?? ""
+            let line = Int(fragment.hasPrefix("L") ? String(fragment.dropFirst()) : fragment)
+            components?.fragment = nil
+            return ContentLocation(url: components?.url ?? url, line: line.flatMap { $0 > 0 ? $0 : nil })
+        }
+        return ContentLocation(url: url, line: nil)
+    }
+
+    func canOpen(in context: RichContentContext) -> Bool { !url.isFileURL || context.isLocalHost }
+
+    @MainActor @discardableResult func open(in context: RichContentContext) -> Bool {
+        guard canOpen(in: context) else { return false }
+        if url.isFileURL, let line { return SourceFilePreview.show(url: url, line: line) }
+        return NSWorkspace.shared.open(url)
+    }
+}
+
+enum RichContentBlock: Equatable {
+    case attributed(NSAttributedString)
+    case markdown(String)
+    case code(String, language: String)
+    case attachment(label: String, source: String, image: Bool)
+    case embeddedImage(label: String, data: Data, mimeType: String)
+}
+
+struct RichContentDocument {
+    let blocks: [RichContentBlock]
+    var hasRichBlocks: Bool { blocks.contains { if case .markdown = $0 { false } else { true } } }
+
+    init(_ source: String) {
+        var result: [RichContentBlock] = []
+        for node in Document(parsing: source).children {
+            if let code = node as? CodeBlock {
+                result.append(.code(code.code, language: code.language ?? "text"))
+            } else if let paragraph = node as? Paragraph,
+                      paragraph.children.contains(where: { $0 is Markdown.Image }) {
+                var prose = ""
+                for child in paragraph.children {
+                    if let image = child as? Markdown.Image, let source = image.source {
+                        if !prose.isEmpty { result.append(.markdown(prose)); prose = "" }
+                        result.append(.attachment(label: image.plainText, source: source, image: true))
+                    } else { prose += child.detachedFromParent.format() }
+                }
+                if !prose.isEmpty { result.append(.markdown(prose)) }
+            } else if let paragraph = node as? Paragraph, paragraph.childCount == 1,
+                      let link = paragraph.child(at: 0) as? Markdown.Link,
+                      let source = link.destination, ContentLocation.parse(source)?.url.isFileURL == true {
+                result.append(.attachment(label: link.plainText, source: source, image: false))
+            } else {
+                result.append(.markdown(node.detachedFromParent.format()))
+            }
+        }
+        blocks = result
+    }
+}
+
+/// Measured with the same native layout used for display; no estimated row heights.
+@MainActor final class RichContentView: NSView, NSTextViewDelegate {
+    var onOpenLocation: ((ContentLocation) -> Void)?
+    private var context = RichContentContext()
+    private var items: [NSView] = []
+    override var isFlipped: Bool { true }
+
+    func configure(text: String, font: NSFont, context: RichContentContext) {
+        configure(blocks: RichContentDocument(text).blocks, font: font, context: context)
+    }
+
+    func configure(blocks: [RichContentBlock], font: NSFont, context: RichContentContext) {
+        self.context = context
+        items.forEach { $0.removeFromSuperview() }
+        items = blocks.map { block in
+            switch block {
+            case .markdown, .attributed:
+                let view = Self.textView()
+                let rendered: NSAttributedString
+                if case .markdown(let source) = block { rendered = RichTextRenderer.renderMarkdown(source, font: font) }
+                else if case .attributed(let content) = block { rendered = content }
+                else { rendered = NSAttributedString(string: "") }
+                let content = NSMutableAttributedString(attributedString: rendered)
+                content.enumerateAttribute(RichTextRenderer.sourceLocationAttribute, in: NSRange(location: 0, length: content.length)) { value, range, _ in
+                    guard let source = value as? String, let location = ContentLocation.parse(source), location.canOpen(in: context) else { return }
+                    content.addAttribute(.link, value: source, range: range)
+                    content.addAttribute(.foregroundColor, value: NSColor.linkColor, range: range)
+                }
+                view.textStorage?.setAttributedString(content)
+                view.delegate = self
+                return view
+            case .code(let source, let language): return CodeContentView(code: source, language: language, font: font)
+            case .embeddedImage(let label, let data, let mimeType):
+                return AttachmentContentView(label: label, source: "Embedded image · \(mimeType)", isImage: true, context: context, embeddedData: data)
+            case .attachment(let label, let source, let image):
+                let card = AttachmentContentView(label: label, source: source, isImage: image, context: context)
+                card.onOpenLocation = { [weak self] location in self?.open(location) }
+                return card
+            }
+        }
+        items.forEach { addSubview($0) }
+        needsLayout = true
+    }
+
+    func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+        let source = (link as? String) ?? (link as? URL)?.absoluteString
+        guard let source, let location = ContentLocation.parse(source) else { return true }
+        open(location)
+        return true
+    }
+
+    private func open(_ location: ContentLocation) {
+        guard location.canOpen(in: context) else { return }
+        if let onOpenLocation { onOpenLocation(location) }
+        else { location.open(in: context) }
+    }
+
+    @discardableResult func height(for width: CGFloat) -> CGFloat {
+        var y: CGFloat = 0
+        for item in items {
+            let height: CGFloat
+            if let text = item as? NSTextView { height = Self.textHeight(text, width: width) }
+            else if let code = item as? CodeContentView { height = code.height(for: width) }
+            else if let attachment = item as? AttachmentContentView { height = attachment.contentHeight }
+            else { height = 0 }
+            item.frame = NSRect(x: 0, y: y, width: max(1, width), height: height)
+            y += height + 8
+        }
+        return max(0, y - 8)
+    }
+
+    override func layout() { super.layout(); height(for: bounds.width) }
+
+    static func textView() -> NSTextView {
+        let view = NSTextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.drawsBackground = false
+        view.textContainerInset = .zero
+        view.textContainer?.lineFragmentPadding = 0
+        view.textContainer?.widthTracksTextView = false
+        return view
+    }
+
+    static func textHeight(_ view: NSTextView, width: CGFloat) -> CGFloat {
+        guard let container = view.textContainer, let manager = view.layoutManager else { return 0 }
+        container.containerSize = NSSize(width: max(1, width), height: .greatestFiniteMagnitude)
+        manager.ensureLayout(for: container)
+        return ceil(manager.usedRect(for: container).height)
+    }
+}
+
+/// A code card owns horizontal panning; vertical gestures belong to the transcript.
+@MainActor final class CodeHorizontalScrollView: NSScrollView {
+    override func scrollWheel(with event: NSEvent) {
+        if abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX), event.scrollingDeltaY != 0 {
+            var ancestor = superview
+            while let view = ancestor {
+                if let scroll = view as? NSScrollView {
+                    scroll.scrollWheel(with: event)
+                    return
+                }
+                ancestor = view.superview
+            }
+            return
+        }
+        super.scrollWheel(with: event)
+    }
+}
+
+@MainActor private final class CodeCopyButton: NSButton {
+    var isCardHovered = false { didSet { refreshVisibility() } }
+    override var acceptsFirstResponder: Bool { true }
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted { alphaValue = 1 }
+        return accepted
+    }
+    override func resignFirstResponder() -> Bool {
+        let accepted = super.resignFirstResponder()
+        if accepted { alphaValue = isCardHovered ? 1 : 0 }
+        return accepted
+    }
+    func refreshVisibility() { alphaValue = isCardHovered || window?.firstResponder === self ? 1 : 0 }
+}
+
+@MainActor final class CodeContentView: NSView {
+    let code: String
+    let language: String
+    private let label: NSTextField
+    private let copyButton = CodeCopyButton(title: "", target: nil, action: nil)
+    private var hoverTracking: NSTrackingArea?
+    let scrollView = CodeHorizontalScrollView()
+    let textView = RichContentView.textView()
+    override var isFlipped: Bool { true }
+
+    init(code: String, language: String, font: NSFont) {
+        self.code = code
+        self.language = language
+        label = NSTextField(labelWithString: language)
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        label.font = .systemFont(ofSize: 11, weight: .medium)
+        label.textColor = .secondaryLabelColor
+        copyButton.isBordered = false
+        copyButton.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy code")
+        copyButton.imagePosition = .imageOnly
+        copyButton.toolTip = "Copy code"
+        copyButton.setAccessibilityLabel("Copy code")
+        copyButton.alphaValue = 0
+        copyButton.target = self
+        copyButton.action = #selector(copyCode)
+        // A fence terminator contributes one final newline. Do not draw its
+        // empty line, but retain the exact original code for the Copy action.
+        let displayCode = code.hasSuffix("\r\n") || code.hasSuffix("\n") ? String(code.dropLast()) : code
+        textView.textStorage?.setAttributedString(CodeSyntax.render(displayCode, language: language, font: font))
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = []
+        textView.minSize = .zero
+        textView.maxSize = NSSize(width: 1_000_000, height: 1_000_000)
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.heightTracksTextView = false
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = true
+        scrollView.hasVerticalScroller = false
+        scrollView.verticalScrollElasticity = .none
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = textView
+        addSubview(label); addSubview(copyButton); addSubview(scrollView)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func metrics() -> (height: CGFloat, width: CGFloat) {
+        let height = RichContentView.textHeight(textView, width: 1_000_000)
+        let usedWidth = textView.layoutManager.flatMap { manager in textView.textContainer.map { manager.usedRect(for: $0).width } } ?? 0
+        return (height, ceil(usedWidth) + 4)
+    }
+
+    func height(for width: CGFloat) -> CGFloat {
+        let size = metrics()
+        let overflow = size.width > max(1, width - 24)
+        // Only overflowing code needs a scrollbar. Reserve legacy thickness
+        // there so either macOS scrollbar preference leaves every line visible.
+        let scrollbar = overflow ? NSScroller.scrollerWidth(for: .regular, scrollerStyle: .legacy) : 0
+        return size.height + 40 + scrollbar
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTracking { removeTrackingArea(hoverTracking) }
+        let tracking = NSTrackingArea(rect: .zero, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self)
+        addTrackingArea(tracking)
+        hoverTracking = tracking
+    }
+    override func mouseEntered(with event: NSEvent) { copyButton.isCardHovered = true }
+    override func mouseExited(with event: NSEvent) { copyButton.isCardHovered = false }
+
+    override func layout() {
+        super.layout()
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.035).cgColor
+        }
+        label.frame = NSRect(x: 12, y: 8, width: max(0, bounds.width - 90), height: 18)
+        copyButton.frame = NSRect(x: max(0, bounds.width - 36), y: 5, width: 24, height: 24)
+        let size = metrics()
+        scrollView.hasHorizontalScroller = size.width > max(1, bounds.width - 24)
+        scrollView.frame = NSRect(x: 12, y: 32, width: max(1, bounds.width - 24), height: max(1, bounds.height - 40))
+        textView.frame = NSRect(x: 0, y: 0, width: max(scrollView.contentSize.width, size.width), height: size.height)
+    }
+    @objc private func copyCode() { NSPasteboard.general.clearContents(); NSPasteboard.general.setString(code, forType: .string) }
+}
+
+@MainActor final class AttachmentContentView: NSView {
+    var onOpenLocation: ((ContentLocation) -> Void)?
+    private let title: NSTextField
+    private let detail: NSTextField
+    private let preview = NSImageView()
+    private let openButton = NSButton(title: "Open", target: nil, action: nil)
+    private let location: ContentLocation?
+    private let context: RichContentContext
+    private var imageWindow: NSWindow?
+    private let embeddedData: Data?
+    let contentHeight: CGFloat
+    override var isFlipped: Bool { true }
+
+    init(label: String, source: String, isImage: Bool, context: RichContentContext, embeddedData: Data? = nil) {
+        let location = ContentLocation.parse(source)
+        self.location = location
+        self.context = context
+        let embeddedData = embeddedData.flatMap { $0.count <= 20_000_000 ? $0 : nil }
+        self.embeddedData = embeddedData
+        title = NSTextField(labelWithString: label.isEmpty ? (location?.url.lastPathComponent ?? "Attachment") : label)
+        detail = NSTextField(wrappingLabelWithString: source + ((location?.url.isFileURL == true && !context.isLocalHost) ? " · Recorded on another host" : ""))
+        // Never interpret another machine's absolute path on this machine, and
+        // never fetch remote media as a side effect of reading a transcript.
+        var thumbnail: NSImage?
+        var imageSource: CGImageSource?
+        if isImage, let embeddedData { imageSource = CGImageSourceCreateWithData(embeddedData as CFData, nil) }
+        else if isImage, context.isLocalHost, let url = location?.url, url.isFileURL {
+            imageSource = CGImageSourceCreateWithURL(url as CFURL, nil)
+        }
+        if let imageSource, let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize: 600,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+           ] as CFDictionary) { thumbnail = NSImage(cgImage: cgImage, size: .zero) }
+        contentHeight = thumbnail == nil ? 70 : 260
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        title.font = .systemFont(ofSize: 13, weight: .medium)
+        title.isSelectable = true
+        detail.font = .systemFont(ofSize: 11)
+        detail.textColor = .secondaryLabelColor
+        detail.isSelectable = true
+        preview.image = thumbnail
+        preview.imageScaling = .scaleProportionallyUpOrDown
+        openButton.title = thumbnail == nil ? "Open" : "Enlarge"
+        openButton.isEnabled = thumbnail != nil || location?.canOpen(in: context) == true
+        openButton.target = self
+        openButton.action = #selector(openAttachment)
+        addSubview(title); addSubview(detail); addSubview(preview); addSubview(openButton)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    override func layout() {
+        super.layout()
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.035).cgColor
+        }
+        title.frame = NSRect(x: 12, y: 8, width: max(1, bounds.width - 100), height: 20)
+        openButton.frame = NSRect(x: max(0, bounds.width - 80), y: 6, width: 70, height: 24)
+        detail.frame = NSRect(x: 12, y: 31, width: max(1, bounds.width - 24), height: 32)
+        preview.frame = NSRect(x: 12, y: 68, width: max(1, bounds.width - 24), height: max(0, bounds.height - 80))
+    }
+    @objc private func openAttachment() {
+        if preview.image != nil {
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 650), styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
+            let view = NSImageView()
+            if let embeddedData { view.image = NSImage(data: embeddedData) ?? preview.image }
+            else if let location, location.canOpen(in: context) { view.image = NSImage(contentsOf: location.url) ?? preview.image }
+            else { view.image = preview.image }
+            view.imageScaling = .scaleProportionallyUpOrDown
+            window.contentView = view
+            window.title = title.stringValue
+            window.isReleasedWhenClosed = false
+            window.center(); window.makeKeyAndOrderFront(nil)
+            imageWindow = window
+        } else if let location, location.canOpen(in: context) {
+            if let onOpenLocation { onOpenLocation(location) }
+            else { location.open(in: context) }
+        }
+    }
+}

--- a/apps/macos/Sources/Memex/RichTextRenderer.swift
+++ b/apps/macos/Sources/Memex/RichTextRenderer.swift
@@ -4,6 +4,7 @@ import Markdown
 /// Render Markdown and prompt sections as selectable native text.
 @MainActor
 enum RichTextRenderer {
+    static let sourceLocationAttribute = NSAttributedString.Key("MemexSourceLocation")
     static func render(_ text: String, font: NSFont) -> NSAttributedString {
         PromptSections.render(text, font: font) ?? renderMarkdown(text, font: font)
     }
@@ -38,13 +39,13 @@ enum RichTextRenderer {
             output.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor,
                                 range: NSRange(location: start, length: output.length - start))
         } else if let code = node as? CodeBlock {
-            let value = codeText(code.code, font: font)
+            let value = CodeSyntax.render(code.code, language: code.language ?? "text", font: font)
             appendParagraph(value, to: output, style: paragraph(indent: indent + 10, spacing: 12))
         } else if let html = node as? HTMLBlock {
             appendParagraph(codeText(html.rawHTML, font: font), to: output,
                             style: paragraph(indent: indent, spacing: 10))
         } else if let heading = node as? Heading {
-            let headingFont = NSFont.systemFont(ofSize: font.pointSize + CGFloat(max(1, 5 - heading.level)) * 2, weight: .semibold)
+            let headingFont = NSFont.systemFont(ofSize: font.pointSize + CGFloat(max(1, 4 - heading.level)) * 1.5, weight: .semibold)
             let value = inlineChildren(node, attributes: [.font: headingFont, .foregroundColor: NSColor.labelColor])
             let style = paragraph(indent: indent, spacing: 9)
             style.paragraphSpacingBefore = 8
@@ -73,7 +74,7 @@ enum RichTextRenderer {
                 block.setWidth(6, type: .absoluteValueType, for: .padding)
                 block.setWidth(0.5, type: .absoluteValueType, for: .border)
                 block.setBorderColor(.separatorColor)
-                if rowIndex == 0 { block.backgroundColor = .quaternaryLabelColor }
+                if rowIndex == 0 { block.backgroundColor = NSColor.labelColor.withAlphaComponent(0.035) }
                 let style = paragraph(indent: indent, spacing: 0)
                 style.textBlocks = [block]
                 if columnIndex < node.columnAlignments.count {
@@ -148,6 +149,10 @@ enum RichTextRenderer {
             attributes[.link] = url
             attributes[.foregroundColor] = NSColor.linkColor
             attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
+        }
+        if let link = node as? Markdown.Link, let destination = link.destination,
+           ContentLocation.parse(destination)?.url.isFileURL == true {
+            attributes[sourceLocationAttribute] = destination
         }
         if let image = node as? Markdown.Image {
             let value = NSMutableAttributedString(string: "[Image: ", attributes: attributes)

--- a/apps/macos/Sources/Memex/SourceContent.swift
+++ b/apps/macos/Sources/Memex/SourceContent.swift
@@ -30,11 +30,17 @@ enum SourceContent {
                 if source?["type"] as? String == "text", let text = source?["data"] as? String {
                     return .code(text, language: "text")
                 }
+                if source?["type"] as? String == "base64" || value["file_data"] != nil {
+                    let mime = source?["media_type"] as? String
+                    return .attachmentNotice(label: label,
+                        detail: "Embedded document" + (mime.map { " · " + $0 } ?? "") + ". Preview unavailable; contents are retained in the raw transcript.")
+                }
                 // Unavailable provider file IDs remain inspectable without treating
                 // their identifier as a local path or guessing a download URL.
                 if let id = value["file_id"] as? String {
-                    return .markdown("\(label) · `\(id)`\n\nAttachment is stored with the provider.")
+                    return .attachmentNotice(label: label, detail: "\(id) · Attachment is stored with the provider.")
                 }
+                return .attachmentNotice(label: label, detail: "Preview unavailable; attachment details are retained in the raw transcript.")
             }
             return nil
         }

--- a/apps/macos/Sources/Memex/SourceContent.swift
+++ b/apps/macos/Sources/Memex/SourceContent.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Typed provider content retained by ingestion. Plain-text lookalikes never
+/// become attachments, and an image placeholder is hidden only with its image.
+enum SourceContent {
+    static func blocks(_ message: Message) -> [RichContentBlock] {
+        guard let source = message.sourceContent, let data = source.data(using: .utf8),
+              let values = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return values.compactMap { value in
+            let type = value["type"] as? String ?? ""
+            let label = value["title"] as? String ?? value["filename"] as? String ?? "Attachment"
+            let source = value["source"] as? [String: Any]
+            if ["input_image", "image", "image_url", "local_image", "localImage"].contains(type) {
+                let mime = source?["media_type"] as? String ?? value["mimeType"] as? String ?? "image/png"
+                if let encoded = source?["data"] as? String ?? value["data"] as? String,
+                   let image = imageData(encoded) { return .embeddedImage(label: label == "Attachment" ? "Image" : label, data: image, mimeType: mime) }
+                let url = value["image_url"] as? String ?? (value["image_url"] as? [String: Any])?["url"] as? String
+                    ?? value["url"] as? String ?? source?["url"] as? String ?? value["path"] as? String
+                if let url {
+                    if url.hasPrefix("data:image/"), let separator = url.range(of: ";base64,"),
+                       let image = imageData(String(url[separator.upperBound...])) {
+                        return .embeddedImage(label: "Image", data: image, mimeType: String(url.dropFirst(5).prefix(while: { $0 != ";" })))
+                    }
+                    if ContentLocation.parse(url) != nil { return .attachment(label: label == "Attachment" ? "Image" : label, source: url, image: true) }
+                }
+            }
+            if ["document", "input_file", "file", "attachment"].contains(type) {
+                if let path = value["path"] as? String ?? value["file_url"] as? String ?? source?["url"] as? String,
+                   ContentLocation.parse(path) != nil { return .attachment(label: label, source: path, image: false) }
+                if source?["type"] as? String == "text", let text = source?["data"] as? String {
+                    return .code(text, language: "text")
+                }
+                // Unavailable provider file IDs remain inspectable without treating
+                // their identifier as a local path or guessing a download URL.
+                if let id = value["file_id"] as? String {
+                    return .markdown("\(label) · `\(id)`\n\nAttachment is stored with the provider.")
+                }
+            }
+            return nil
+        }
+    }
+
+    static func displayText(_ message: Message) -> String {
+        guard message.text.contains("<<ImageDisplayed>>") else { return message.text }
+        let imageCount = blocks(message).filter {
+            switch $0 { case .embeddedImage, .attachment(_, _, true): true; default: false }
+        }.count
+        guard imageCount > 0 else { return message.text }
+        var remaining = imageCount
+        return message.text.components(separatedBy: "\n").filter { line in
+            let compact = line.trimmingCharacters(in: .whitespaces)
+            guard remaining > 0, compact == "<<ImageDisplayed>>" else { return true }
+            remaining -= 1
+            return false
+        }.joined(separator: "\n")
+    }
+
+    private static func imageData(_ encoded: String) -> Data? {
+        guard encoded.utf8.count <= 28_000_000, let data = Data(base64Encoded: encoded), data.count <= 20_000_000 else { return nil }
+        return data
+    }
+}

--- a/apps/macos/Sources/Memex/SourceFilePreview.swift
+++ b/apps/macos/Sources/Memex/SourceFilePreview.swift
@@ -1,0 +1,93 @@
+import AppKit
+
+/// Explicit local-file navigation, with a visible and selectable target line.
+/// Text is never interpreted as markup or executed.
+@MainActor final class SourceFilePreview: NSWindowController, NSWindowDelegate {
+    private static var openPreviews: [UUID: SourceFilePreview] = [:]
+    private let id = UUID()
+    private let url: URL
+
+    static func show(url: URL, line: Int) -> Bool {
+        let controller = SourceFilePreview(url: url, line: line)
+        openPreviews[controller.id] = controller
+        controller.window?.center()
+        controller.showWindow(nil)
+        return true
+    }
+
+    private init(url: URL, line: Int) {
+        self.url = url
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 650),
+                              styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
+        super.init(window: window)
+        window.title = "\(url.lastPathComponent):\(line)"
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        let root = NSView()
+        window.contentView = root
+        let controls = NSStackView()
+        controls.orientation = .horizontal
+        let path = NSTextField(labelWithString: "\(url.path):\(line)")
+        path.isSelectable = true
+        path.lineBreakMode = .byTruncatingMiddle
+        let open = NSButton(title: "Open file", target: self, action: #selector(openFile))
+        let reveal = NSButton(title: "Reveal in Finder", target: self, action: #selector(revealFile))
+        controls.addArrangedSubview(path); controls.addArrangedSubview(open); controls.addArrangedSubview(reveal)
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.autohidesScrollers = true
+        let text = RichContentView.textView()
+        text.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        text.textContainerInset = NSSize(width: 16, height: 16)
+        text.isHorizontallyResizable = true
+        text.isVerticallyResizable = true
+        scroll.documentView = text
+        for view in [controls, scroll] { view.translatesAutoresizingMaskIntoConstraints = false; root.addSubview(view) }
+        NSLayoutConstraint.activate([
+            controls.topAnchor.constraint(equalTo: root.topAnchor, constant: 10),
+            controls.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 12),
+            controls.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -12),
+            scroll.topAnchor.constraint(equalTo: controls.bottomAnchor, constant: 10),
+            scroll.leadingAnchor.constraint(equalTo: root.leadingAnchor), scroll.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            scroll.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+        ])
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? Int.max
+        if size <= 5_000_000, let source = try? String(contentsOf: url, encoding: .utf8) {
+            text.string = source
+            let height = RichContentView.textHeight(text, width: 1_000_000)
+            let width = text.layoutManager.flatMap { manager in text.textContainer.map { manager.usedRect(for: $0).width } } ?? 900
+            text.frame = NSRect(x: 0, y: 0, width: max(900, width + 32), height: max(650, height + 32))
+            if let range = Self.range(ofLine: line, in: source) {
+                text.setSelectedRange(range)
+                text.textStorage?.addAttribute(.backgroundColor, value: NSColor.findHighlightColor.withAlphaComponent(0.35), range: range)
+                root.layoutSubtreeIfNeeded()
+                text.scrollRangeToVisible(range)
+            } else { window.subtitle = "Line \(line) is beyond the end of this file" }
+        } else {
+            text.string = "Cannot preview line \(line). The file is unavailable, not UTF-8 text, or larger than 5 MB. Use Open file to view it in its default application."
+            text.textContainer?.containerSize = NSSize(width: 850, height: CGFloat.greatestFiniteMagnitude)
+            text.frame = NSRect(x: 0, y: 0, width: 900, height: 650)
+        }
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    static func range(ofLine line: Int, in source: String) -> NSRange? {
+        guard line > 0 else { return nil }
+        let text = source as NSString
+        var current = 1
+        var offset = 0
+        while offset < text.length {
+            let range = text.lineRange(for: NSRange(location: offset, length: 0))
+            if current == line { return range }
+            offset = NSMaxRange(range)
+            current += 1
+        }
+        return current == line && (source.isEmpty || source.last?.isNewline == true)
+            ? NSRange(location: text.length, length: 0) : nil
+    }
+
+    @objc private func openFile() { NSWorkspace.shared.open(url) }
+    @objc private func revealFile() { NSWorkspace.shared.activateFileViewerSelecting([url]) }
+    func windowWillClose(_ notification: Notification) { Self.openPreviews[id] = nil }
+}

--- a/apps/macos/Sources/Memex/Store.swift
+++ b/apps/macos/Sources/Memex/Store.swift
@@ -376,15 +376,12 @@ final class Store {
         defer { if readerGeneration == generation { loadingRecords = false } }
         let anchor = readerAnchorID
         do {
-            let start = try await client.initialRecordOffset(for: selected, anchor: anchor)
+            let page = try await client.initialRecords(for: selected, anchor: anchor)
             try Task.checkCancellation()
             guard readerGeneration == generation, readerRequestID == request else { return }
-            let page = try await client.records(for: selected, offset: start.offset)
-            try Task.checkCancellation()
-            guard readerGeneration == generation, readerRequestID == request else { return }
-            records = page
-            recordsOffset = start.offset
-            recordsTotal = start.total
+            records = page.records
+            recordsOffset = page.offset
+            recordsTotal = page.total
             loadedReaderKey = key
             updateRecordBounds()
             cacheReaderWindow()
@@ -405,23 +402,17 @@ final class Store {
         failedPageWasEarlier = nil
         defer { if readerGeneration == generation { loadingRecords = false } }
         do {
-            let start: (offset: Int, total: Int)
+            let page: TranscriptPage
             if let offset {
-                let total: Int
-                if loadedReaderKey == key { total = recordsTotal }
-                else { total = try await client.recordMetadata(for: selected, offset: 0, limit: 1).total }
-                start = (max(0, offset - MemexClient.pageSize / 2), total)
+                page = try await client.recordPage(for: selected, offset: max(0, offset - MemexClient.pageSize / 2))
             } else {
-                start = try await client.initialRecordOffset(for: selected, anchor: recordID)
+                page = try await client.initialRecords(for: selected, anchor: recordID)
             }
             try Task.checkCancellation()
             guard readerGeneration == generation, readerRequestID == request else { return }
-            let page = try await client.records(for: selected, offset: start.offset)
-            try Task.checkCancellation()
-            guard readerGeneration == generation, readerRequestID == request else { return }
-            records = page
-            recordsOffset = start.offset
-            recordsTotal = start.total
+            records = page.records
+            recordsOffset = page.offset
+            recordsTotal = page.total
             loadedReaderKey = key
             updateRecordBounds()
             cacheReaderWindow()

--- a/apps/macos/Sources/Memex/ToolContentRenderer.swift
+++ b/apps/macos/Sources/Memex/ToolContentRenderer.swift
@@ -3,6 +3,67 @@ import AppKit
 /// Structured presentation is separate from the original transcript used by find
 /// and the raw-content disclosure. No source text is discarded or rewritten.
 @MainActor enum ToolContentRenderer {
+    /// Only explicitly typed images or image-view tool arguments become previews.
+    /// Relative paths stay as transcript text because their host/workdir is unknown.
+    static func imageSources(_ records: [TranscriptRecord]) -> [String] {
+        var sources: [String] = []
+        func add(_ source: String?) {
+            guard let source, source.hasPrefix("/") || source.hasPrefix("https://") || source.hasPrefix("http://"), !sources.contains(source) else { return }
+            sources.append(source)
+        }
+        func inspect(_ value: Any) {
+            if let object = value as? [String: Any] {
+                if object["type"] as? String == "image" || object["type"] as? String == "image_url" {
+                    add(object["image_url"] as? String ?? object["url"] as? String ?? (object["image_url"] as? [String: Any])?["url"] as? String)
+                }
+                for key in ["content", "result"] { if let nested = object[key] { inspect(nested) } }
+            } else if let array = value as? [Any] { for item in array { inspect(item) } }
+        }
+        for record in records {
+            let message = record.record
+            let name = message.toolName?.components(separatedBy: "__").last?.components(separatedBy: ".").last
+            if ["view_image", "open_image"].contains(name ?? ""), let input = message.toolInput.flatMap(json) as? [String: Any] {
+                add(input["path"] as? String ?? input["image_path"] as? String)
+            }
+            for part in [message.toolOutput, message.role == "tool_use" ? nil : message.text] {
+                if let part, let value = json(part) { inspect(value) }
+            }
+        }
+        return sources
+    }
+
+    /// Split the same rendered field walk into native cards; metadata and generic
+    /// values keep their original attributed presentation and exact ordering.
+    static func richBlocks(_ records: [TranscriptRecord], rendered: NSAttributedString? = nil) -> [RichContentBlock] {
+        let rendered = rendered ?? render(records)
+        var blocks: [RichContentBlock] = []
+        rendered.enumerateAttribute(ToolPresentationSupport.codeLanguageAttribute, in: NSRange(location: 0, length: rendered.length)) { language, range, _ in
+            let part = rendered.attributedSubstring(from: range)
+            if let language = language as? String { blocks.append(.code(part.string, language: language)) }
+            else { blocks.append(.attributed(part)) }
+        }
+        var seenImages = Set<Data>()
+        func embeddedImages(_ value: Any) {
+            if let object = value as? [String: Any] {
+                if object["type"] as? String == "image", let encoded = object["data"] as? String,
+                   let mime = object["mimeType"] as? String ?? object["mime_type"] as? String,
+                   mime.hasPrefix("image/"), encoded.utf8.count <= 28_000_000,
+                   let data = Data(base64Encoded: encoded), data.count <= 20_000_000, seenImages.insert(data).inserted {
+                    blocks.append(.embeddedImage(label: "Image result", data: data, mimeType: mime))
+                }
+                for key in ["content", "result"] { if let nested = object[key] { embeddedImages(nested) } }
+            } else if let array = value as? [Any] { for item in array { embeddedImages(item) } }
+        }
+        for record in records {
+            let message = record.record
+            for part in [message.toolOutput, message.role == "tool_use" ? nil : message.text] {
+                if let part, let value = json(part) { embeddedImages(value) }
+            }
+        }
+        for source in imageSources(records) { blocks.append(.attachment(label: "", source: source, image: true)) }
+        return blocks
+    }
+
     static func render(_ records: [TranscriptRecord], raw: Bool = false) -> NSAttributedString {
         let result = NSMutableAttributedString(string: "")
         for record in records {
@@ -13,18 +74,22 @@ import AppKit
                 if let value, value.nilIfBlank != nil, !parts.contains(value) { parts.append(value) }
             }
             for (index, part) in parts.enumerated() {
-                if index > 0 { append("\n\n", to: result) }
+                if index > 0 { append(raw ? "\n\n" : "\n", to: result) }
                 if raw { append(part, to: result, code: true) }
-                else { content(part, to: result, code: message.role == "tool_use") }
+                else { content(part, to: result, code: message.role == "tool_use", toolName: message.toolName ?? records.first?.record.toolName ?? "") }
             }
-            if record.id != records.last?.id { append("\n\n", to: result) }
+            if record.id != records.last?.id {
+                if raw { append("\n\n", to: result) }
+                else if !result.string.hasSuffix("\n") { append("\n", to: result) }
+            }
         }
         return result
     }
 
-    private static func content(_ text: String, to result: NSMutableAttributedString, code: Bool) {
+    private static func content(_ text: String, to result: NSMutableAttributedString, code: Bool, toolName: String) {
+        let text = text.trimmingCharacters(in: .newlines)
         if let value = json(text) {
-            valueBlocks(value, to: result)
+            valueBlocks(value, to: result, toolName: toolName)
             return
         }
         // Execution wrappers prepend timing/status lines to a JSON result. Only
@@ -38,11 +103,12 @@ import AppKit
             let suffix = String(text[next...])
             if let value = json(suffix) {
                 append(String(text[...boundary]), to: result, code: code)
-                valueBlocks(value, to: result)
+                valueBlocks(value, to: result, toolName: toolName)
                 return
             }
         }
         if isOpaque(text) { opaque(text, to: result) }
+        else if let decorated = ToolPresentationSupport.decorate(text, path: "", toolName: toolName, code: code) { result.append(decorated) }
         else { append(text, to: result, code: code) }
     }
 
@@ -52,19 +118,20 @@ import AppKit
         return try? JSONSerialization.jsonObject(with: Data(trimmed.utf8))
     }
 
-    private static func valueBlocks(_ value: Any, to result: NSMutableAttributedString, path: String = "") {
+    private static func valueBlocks(_ value: Any, to result: NSMutableAttributedString, path: String = "", toolName: String) {
         if let object = value as? [String: Any], !object.isEmpty {
             for key in object.keys.sorted() {
-                valueBlocks(object[key]!, to: result, path: path.isEmpty ? key : "\(path).\(key)")
+                valueBlocks(object[key]!, to: result, path: path.isEmpty ? key : "\(path).\(key)", toolName: toolName)
             }
         } else if let array = value as? [Any], !array.isEmpty {
-            for (index, entry) in array.enumerated() { valueBlocks(entry, to: result, path: "\(path)[\(index)]") }
+            for (index, entry) in array.enumerated() { valueBlocks(entry, to: result, path: "\(path)[\(index)]", toolName: toolName) }
         } else {
             if result.length > 0, !result.string.hasSuffix("\n") { append("\n", to: result) }
             if !path.isEmpty { label(path, to: result) }
             if let text = value as? String {
                 if isOpaque(text) { opaque(text, to: result) }
-                else if let nested = json(text) { valueBlocks(nested, to: result) }
+                else if let nested = json(text) { valueBlocks(nested, to: result, toolName: toolName) }
+                else if let decorated = ToolPresentationSupport.decorate(text, path: path, toolName: toolName, code: false) { result.append(decorated) }
                 else if ["message", "description", "prompt", "instructions", "text"].contains(path.components(separatedBy: ".").last ?? "") {
                     result.append(RichTextRenderer.render(text, font: .systemFont(ofSize: 14)))
                 } else { append(text, to: result, code: ["cmd", "command", "code", "script", "output"].contains(path.components(separatedBy: ".").last ?? "")) }
@@ -88,8 +155,8 @@ import AppKit
 
     private static func label(_ text: String, to result: NSMutableAttributedString) {
         let style = NSMutableParagraphStyle()
-        style.paragraphSpacingBefore = 8
-        style.paragraphSpacing = 4
+        style.paragraphSpacingBefore = result.length == 0 ? 0 : 4
+        style.paragraphSpacing = 2
         result.append(NSAttributedString(string: text + "\n", attributes: [
             .font: NSFont.systemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.secondaryLabelColor, .paragraphStyle: style
@@ -98,8 +165,8 @@ import AppKit
 
     private static func append(_ text: String, to result: NSMutableAttributedString, code: Bool = false) {
         let style = NSMutableParagraphStyle()
-        style.lineSpacing = 3
-        style.paragraphSpacing = 5
+        style.lineSpacing = 2
+        style.paragraphSpacing = 0
         result.append(NSAttributedString(string: text, attributes: [
             .font: code ? NSFont.monospacedSystemFont(ofSize: 12, weight: .regular) : NSFont.systemFont(ofSize: 14),
             .foregroundColor: NSColor.labelColor, .paragraphStyle: style

--- a/apps/macos/Sources/Memex/ToolPresentationSupport.swift
+++ b/apps/macos/Sources/Memex/ToolPresentationSupport.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+/// Decorations never change the underlying text or interpret executable tool input.
+@MainActor enum ToolPresentationSupport {
+    static let codeLanguageAttribute = NSAttributedString.Key("MemexToolCodeLanguage")
+
+    static func decorate(_ text: String, path: String, toolName: String, code: Bool) -> NSAttributedString? {
+        let name = toolName.components(separatedBy: "__").last?.components(separatedBy: ".").last?.lowercased() ?? ""
+        let key = path.components(separatedBy: ".").last ?? ""
+        let fileTool = ["read", "read_file", "readfile", "write", "write_file", "edit", "edit_file"].contains(name)
+        let searchTool = ["grep", "search", "search_code", "search_files", "ripgrep"].contains(name)
+        let commandTool = ["bash", "shell", "shell_command", "exec_command", "run_command", "terminal", "exec", "write_stdin"].contains(name)
+        let commandField = ["cmd", "command", "code", "script", "output"].contains(key) || path.isEmpty
+        let patch = ["patch", "diff"].contains(key) || name == "apply_patch"
+        let pathValue = ["path", "file_path", "filename"].contains(key) && text.hasPrefix("/")
+        guard patch || fileTool || searchTool || pathValue || (commandTool && commandField) else { return nil }
+        let language = patch ? "diff" : (commandTool && code && path.isEmpty && toolName == "functions.exec" ? "javascript" : (["cmd", "command"].contains(key) ? "sh" : "text"))
+        let result = NSMutableAttributedString(attributedString: CodeSyntax.render(text, language: language, font: .systemFont(ofSize: 13)))
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 2
+        style.paragraphSpacing = 0
+        result.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: result.length))
+        let fileContent = fileTool && (path.isEmpty || ["content", "text", "output"].contains(key))
+        if result.length > 0, patch || fileContent || (commandTool && commandField) {
+            result.addAttribute(codeLanguageAttribute, value: language, range: NSRange(location: 0, length: result.length))
+        }
+        if pathValue { result.addAttributes([RichTextRenderer.sourceLocationAttribute: text, .foregroundColor: NSColor.linkColor], range: NSRange(location: 0, length: result.length)) }
+        if searchTool, let expression = try? NSRegularExpression(pattern: #"(?m)^(/[^\n:]+):(\d+)(?::(\d+))?:"#) {
+            let source = text as NSString
+            for match in expression.matches(in: text, range: NSRange(location: 0, length: source.length)) {
+                let file = source.substring(with: match.range(at: 1))
+                let destination = file + ":" + source.substring(with: match.range(at: 2))
+                result.addAttributes([RichTextRenderer.sourceLocationAttribute: destination, .foregroundColor: NSColor.linkColor], range: match.range)
+            }
+        }
+        return result
+    }
+}

--- a/apps/macos/Sources/Memex/TranscriptController.swift
+++ b/apps/macos/Sources/Memex/TranscriptController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Observation
 
 /// AppKit owns transcript scrolling and row reuse. SwiftUI never estimates the
 /// height of a lazy transcript row or feeds those estimates back into layout.
@@ -18,6 +19,11 @@ struct NativeTranscript: NSViewControllerRepresentable {
     var findQuery = ""
     var findHit: ConversationFindHit?
     var findGeneration = 0
+    var rawTranscript = false
+    var isLocalHost = false
+    var sourcePath = ""
+    var requestedRecordID: String?
+    var requestGeneration = 0
 
     func makeNSViewController(context: Context) -> TranscriptController { TranscriptController() }
     func updateNSViewController(_ controller: TranscriptController, context: Context) {
@@ -25,19 +31,25 @@ struct NativeTranscript: NSViewControllerRepresentable {
                           hasMore: hasMore, isLoading: isLoading, onLoadMore: onLoadMore,
                           hasEarlier: hasEarlier, startsAtEnd: startsAtEnd, anchorID: anchorID,
                           navigation: navigation, onLoadEarlier: onLoadEarlier,
-                          findQuery: findQuery, findHit: findHit, findGeneration: findGeneration)
+                          findQuery: findQuery, findHit: findHit, findGeneration: findGeneration,
+                          rawTranscript: rawTranscript, isLocalHost: isLocalHost, sourcePath: sourcePath,
+                          requestedRecordID: requestedRecordID, requestGeneration: requestGeneration)
     }
 }
 
 /// In-memory reading positions outlive the controller when the selection is empty.
-@MainActor final class TranscriptNavigationState {
+@Observable @MainActor final class TranscriptNavigationState {
     struct Position {
         let recordID: String
         let offset: CGFloat
         let expanded: Set<String>
+        var fullBodies: Set<String> = []
+        var rawRows: Set<String> = []
+        var rowID: String? = nil
     }
-    var positions: [String: Position] = [:]
-    private var order: [String] = []
+    @ObservationIgnored var positions: [String: Position] = [:]
+    var visibleRecordID: String?
+    @ObservationIgnored private var order: [String] = []
 
     func save(_ position: Position, for key: String) {
         positions[key] = position
@@ -54,13 +66,20 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     private(set) var rows: [Row] = []
     private var sessionID = ""
     private var records: [TranscriptRecord] = []
+    private var groupedItems: [TranscriptItem] = []
     private var provider = ""
     private var expanded = Set<String>()
     private var rawTools = Set<String>()
+    private var fullBodies = Set<String>()
+    private var rawTranscript = false
+    private var isLocalHost = false
+    private var sourcePath = ""
+    private var appliedRequestGeneration = -1
     private var measurements: [String: Measurement] = [:]
     private var measuredWidth: CGFloat = 0
     private var notifiedWidth: CGFloat = 0
     private var textLayouts: [String: TranscriptTextLayout] = [:]
+    private var richLayouts: [String: RichContentView] = [:]
     private var findRecordBodies: [String: String] = [:]
     private var hasMore = false
     private var isLoading = false
@@ -101,6 +120,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     }
 
     struct Measurement {
+        let rowID: String
         let title: String
         let body: String
         let attributedBody: NSAttributedString
@@ -115,6 +135,16 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         let showsRawControl: Bool
         let showsRaw: Bool
         let finding: Bool
+        let symbolName: String?
+        let hasFailure: Bool
+        var isLong = false
+        var showsFullBody = false
+        var fullTextHeight: CGFloat = 0
+        var originalRecords: [TranscriptRecord] = []
+        var originalBody: String { originalRecords.map { $0.rawTranscriptBody }.joined(separator: "\n\n") }
+        var richContent: RichContentView?
+        var isLocalHost = false
+        var hasBody: Bool { !body.isEmpty || richContent != nil }
     }
 
     override func loadView() {
@@ -141,6 +171,9 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         scrollView.contentView.postsBoundsChangedNotifications = true
         NotificationCenter.default.addObserver(self, selector: #selector(scrolled),
             name: NSView.boundsDidChangeNotification, object: scrollView.contentView)
+        for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
+            NotificationCenter.default.addObserver(self, selector: #selector(refreshVisibleActions), name: name, object: nil)
+        }
         view = scrollView
     }
 
@@ -148,9 +181,15 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
                 hasMore: Bool = false, isLoading: Bool = false, onLoadMore: (() -> Void)? = nil,
                 hasEarlier: Bool = false, startsAtEnd: Bool = false, anchorID: String? = nil,
                 navigation: TranscriptNavigationState? = nil, onLoadEarlier: (() -> Void)? = nil,
-                findQuery: String = "", findHit: ConversationFindHit? = nil, findGeneration: Int = 0) {
+                findQuery: String = "", findHit: ConversationFindHit? = nil, findGeneration: Int = 0,
+                rawTranscript: Bool = false, isLocalHost: Bool = false, sourcePath: String = "",
+                requestedRecordID: String? = nil, requestGeneration: Int = 0) {
         _ = view
         let changedSession = self.sessionID != sessionID
+        let changedMode = self.rawTranscript != rawTranscript
+        self.rawTranscript = rawTranscript
+        self.isLocalHost = isLocalHost
+        self.sourcePath = sourcePath
         let changedQuery = self.findQuery != findQuery
         let changedFind = self.findQuery != findQuery || self.findHit != findHit || self.findGeneration != findGeneration
         self.findQuery = findQuery
@@ -166,7 +205,16 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             measurements.removeAll(keepingCapacity: true)
             textLayouts.removeAll(keepingCapacity: true)
         }
-        defer { applyFindPosition() }
+        defer {
+            applyFindPosition()
+            if let requestedRecordID, appliedRequestGeneration != requestGeneration,
+               let row = rowIndex(for: requestedRecordID) {
+                table.scrollRowToVisible(row)
+                appliedRequestGeneration = requestGeneration
+                savePosition()
+            }
+            savePosition()
+        }
         if changedSession { savePosition() }
         if let navigation { self.navigation = navigation }
         self.hasEarlier = hasEarlier
@@ -179,7 +227,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         self.hasMore = hasMore
         self.isLoading = isLoading
         self.onLoadMore = onLoadMore
-        guard changedSession || self.records != records || self.provider != provider else {
+        guard changedSession || changedMode || changedFind || self.records != records || self.provider != provider else {
             if changedQuery { table.reloadData() }
             return
         }
@@ -192,6 +240,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             // The final tool/instruction group may gain records across pages.
             measurements.removeValue(forKey: last.id)
             textLayouts.removeValue(forKey: last.id)
+            richLayouts.removeValue(forKey: last.id)
         }
         findRecordBodies.removeAll(keepingCapacity: true)
         self.sessionID = sessionID
@@ -200,7 +249,9 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         if changedSession {
             table.minimumDocumentHeight = 0
             needsInitialPosition = true
-            rawTools.removeAll()
+            rawTools = self.navigation.positions[sessionID]?.rawRows ?? []
+            fullBodies = self.navigation.positions[sessionID]?.fullBodies ?? []
+            appliedRequestGeneration = -1
             expanded = self.navigation.positions[sessionID]?.expanded ?? []
         }
         if needsInitialPosition, self.navigation.positions[sessionID] == nil, let anchorID,
@@ -211,7 +262,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
                 expanded.insert("activity:\(activity.id)")
             }
         }
-        rebuildRows(resetMeasurements: !appendOnly)
+        rebuildRows(resetMeasurements: !appendOnly || changedMode || changedQuery)
         if needsInitialPosition {
             applyInitialPosition()
         } else if let visiblePosition {
@@ -304,6 +355,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             if case .group = row { return false }
             return row.records.contains { $0.id == recordID }
         } ?? rows.firstIndex { $0.records.contains { $0.id == recordID } }
+          ?? rows.firstIndex { $0.records.contains { $0.sourceID == recordID } }
     }
 
     private func currentPosition() -> TranscriptNavigationState.Position? {
@@ -311,16 +363,22 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         let y = scrollView.contentView.bounds.minY
         let row = table.row(at: NSPoint(x: 1, y: y + 1))
         guard rows.indices.contains(row) else { return nil }
-        return .init(recordID: recordID(at: row), offset: y - table.rect(ofRow: row).minY,
-                     expanded: expanded)
+        return .init(recordID: rows[row].records[0].sourceID, offset: y - table.rect(ofRow: row).minY,
+                     expanded: expanded, fullBodies: fullBodies, rawRows: rawTools, rowID: rows[row].id)
     }
 
     private func savePosition() {
-        if let position = currentPosition() { navigation.save(position, for: sessionID) }
+        if let position = currentPosition() {
+            navigation.save(position, for: sessionID)
+            let navigation = navigation
+            Task { @MainActor in
+                if navigation.visibleRecordID != position.recordID { navigation.visibleRecordID = position.recordID }
+            }
+        }
     }
 
     private func restore(_ position: TranscriptNavigationState.Position) {
-        guard let row = rowIndex(for: position.recordID) else { return }
+        guard let row = rows.firstIndex(where: { $0.id == position.rowID }) ?? rowIndex(for: position.recordID) else { return }
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: max(0, table.rect(ofRow: row).minY + position.offset)))
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
@@ -344,7 +402,14 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
-    private func rebuildRows(resetMeasurements: Bool = false) {
+    private func rebuildRows(resetMeasurements: Bool = false, regroup: Bool = true) {
+        if regroup {
+            groupedItems = rawTranscript ? [] : TranscriptItem.group(records).map { entry in
+                var item = entry
+                if item.isActivity || item.isInstructions { item.groupedActivities = item.activities }
+                return item
+            }
+        }
         let previous = Dictionary(rows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         let openedRecords = Set(rows.filter {
             if case .activity = $0 { return expanded.contains($0.id) }
@@ -354,31 +419,63 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             if case .activity(_, false) = $0 { return expanded.contains($0.id) }
             return false
         }.flatMap(\.records).map(\.id))
-        rows = TranscriptItem.group(records).flatMap { item -> [Row] in
+        let openedGroupRecords = Set(rows.filter {
+            if case .group = $0 { return expanded.contains($0.id) }
+            return false
+        }.flatMap(\.records).map(\.id))
+        rows = rawTranscript ? records.map { .message($0) } : groupedItems.flatMap { item -> [Row] in
             guard item.isActivity || item.isInstructions else { return [.message(item.records[0])] }
             let activities = item.activities
             for activity in activities where activity.records.contains(where: { openedRecords.contains($0.id) }) {
                 expanded.insert("activity:\(activity.id)")
             }
-            if activities.count == 1 { return [.activity(activities[0], nested: false)] }
+            if activities.count == 1 && !item.isCompletedWork { return [.activity(activities[0], nested: false)] }
             let group = Row.group(item)
-            if item.records.contains(where: { openedSingletons.contains($0.id) }) { expanded.insert(group.id) }
-            return expanded.contains(group.id)
-                ? [group] + activities.map { .activity($0, nested: true) } : [group]
+            if item.records.contains(where: { openedSingletons.contains($0.id) || openedGroupRecords.contains($0.id) }) {
+                expanded.insert(group.id)
+            }
+            return expanded.contains(group.id) && !rawTools.contains(group.id)
+                ? [group] + activities.map {
+                    item.isCompletedWork && $0.records.count == 1 && $0.records[0].record.role == "assistant"
+                        ? .message($0.records[0]) : .activity($0, nested: true)
+                } : [group]
+        }
+        // Searching injected text reveals the original mixed record once, so a
+        // source occurrence cannot be confused with a projected request segment.
+        if !rawTranscript, let hit = findHit, !findQuery.isEmpty,
+           let original = records.first(where: { $0.id == hit.recordID }),
+           TranscriptPresentation.project([original]) != [original] {
+            let insertion = rows.firstIndex { $0.records.contains { $0.sourceID == hit.recordID } } ?? rows.count
+            rows = rows.compactMap { row in
+                let remaining = row.records.filter { $0.sourceID != hit.recordID }
+                if remaining.count == row.records.count { return row }
+                if remaining.isEmpty { return nil }
+                switch row {
+                case .group: return .group(TranscriptItem(records: remaining))
+                case .activity(_, let nested): return .activity(TranscriptActivity(records: remaining), nested: nested)
+                case .message: return nil
+                }
+            }
+            rows.insert(.message(original), at: min(insertion, rows.count))
         }
         if resetMeasurements {
             measurements.removeAll(keepingCapacity: true)
             textLayouts.removeAll(keepingCapacity: true)
+            richLayouts.removeAll(keepingCapacity: true)
         } else {
             // A result can join an already visible call after paging, and a
             // singleton can become nested. Retain only unchanged row layouts.
             for row in rows {
-                if previous[row.id]?.records != row.records {
+                if (previous[row.id]?.records ?? measurements[row.id]?.originalRecords) != row.records {
                     measurements.removeValue(forKey: row.id)
                     textLayouts.removeValue(forKey: row.id)
-                } else if case .activity(_, let nested) = row,
-                          case .activity(_, let wasNested)? = previous[row.id], nested != wasNested {
-                    measurements.removeValue(forKey: row.id)
+                    richLayouts.removeValue(forKey: row.id)
+                } else if case .activity(_, let nested) = row {
+                    if case .activity(_, let wasNested)? = previous[row.id], nested != wasNested {
+                        measurements.removeValue(forKey: row.id)
+                    } else if let measurement = measurements[row.id], measurement.contentX != (nested ? 50 : 30) {
+                        measurements.removeValue(forKey: row.id)
+                    }
                 }
             }
         }
@@ -386,7 +483,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     }
 
     func toggle(_ id: String) {
-        updateDisclosure(id) {
+        updateDisclosure(id, resetText: false) {
             if expanded.contains(id) { expanded.remove(id) } else { expanded.insert(id) }
         }
     }
@@ -394,10 +491,17 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     func toggleRaw(_ id: String) {
         updateDisclosure(id) {
             if rawTools.contains(id) { rawTools.remove(id) } else { rawTools.insert(id) }
+            expanded.insert(id)
         }
     }
 
-    private func updateDisclosure(_ id: String, change: () -> Void) {
+    func toggleFullBody(_ id: String) {
+        updateDisclosure(id, resetText: false) {
+            if fullBodies.contains(id) { fullBodies.remove(id) } else { fullBodies.insert(id) }
+        }
+    }
+
+    private func updateDisclosure(_ id: String, resetText: Bool = true, change: () -> Void) {
         guard let row = rows.firstIndex(where: { $0.id == id }) else { return }
         view.layoutSubtreeIfNeeded()
         // Anchor the clicked header, not the first record in the viewport: a
@@ -415,8 +519,20 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         // releases it again without moving the reader's content.
         table.minimumDocumentHeight = scrollView.contentView.bounds.maxY
         measurements.removeValue(forKey: id)
-        textLayouts.removeValue(forKey: id)
-        rebuildRows()
+        if resetText { textLayouts.removeValue(forKey: id) }
+        // A tool's formatted contents do not change when hidden or shown. Keep
+        // its rich view, and refresh only this row unless a group changes membership.
+        if case .group = rows[row] {
+            rebuildRows(regroup: false)
+        } else {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                table.noteHeightOfRows(withIndexesChanged: IndexSet(integer: row))
+            }
+            if let cell = table.view(atColumn: 0, row: row, makeIfNecessary: false) as? TranscriptCell {
+                configure(cell, row: row)
+            }
+        }
         view.layoutSubtreeIfNeeded()
         guard let updatedRow = rows.firstIndex(where: { $0.id == id }) else { return }
         scrollView.contentView.scroll(to: NSPoint(x: 0, y: max(0, table.rect(ofRow: updatedRow).minY - offset)))
@@ -428,6 +544,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat { measurement(at: row).height }
 
     @objc private func scrolled(_ notification: Notification) {
+        refreshVisibleActions()
         if !updatingRows {
             if table.minimumDocumentHeight > scrollView.contentView.bounds.maxY {
                 table.minimumDocumentHeight = scrollView.contentView.bounds.maxY
@@ -437,6 +554,14 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             savePosition()
         }
         loadNextPageIfNeeded()
+    }
+
+    @objc private func refreshVisibleActions() {
+        let visible = table.rows(in: scrollView.documentVisibleRect)
+        guard visible.location != NSNotFound else { return }
+        for row in visible.location..<min(rows.count, NSMaxRange(visible)) {
+            (table.view(atColumn: 0, row: row, makeIfNecessary: false) as? TranscriptCell)?.refreshActions()
+        }
     }
 
     func loadNextPageIfNeeded() {
@@ -464,6 +589,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     private func resizeRowsIfNeeded() {
         let width = table.bounds.width
         guard abs(width - notifiedWidth) > 0.5 else { return }
+        let position = currentPosition()
         notifiedWidth = width
         measuredWidth = width
         measurements.removeAll(keepingCapacity: true)
@@ -476,6 +602,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
                 configure(cell, row: row)
             }
         }
+        if let position { restore(position) }
     }
 
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
@@ -489,7 +616,8 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
     private func configure(_ cell: TranscriptCell, row: Int) {
         let id = rows[row].id
         cell.configure(measurement(at: row), toggle: { [weak self] in self?.toggle(id) },
-                       toggleRaw: { [weak self] in self?.toggleRaw(id) })
+                       toggleRaw: { [weak self] in self?.toggleRaw(id) },
+                       toggleFull: { [weak self] in self?.toggleFullBody(id) })
     }
 
     func measurement(at index: Int) -> Measurement {
@@ -507,40 +635,94 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         let isDisclosure: Bool
         let isTool: Bool
         let indent: CGFloat
+        var symbolName: String?
+        var hasFailure = false
         switch row {
         case .group(let item):
-            title = item.title
+            title = item.activitySummary
+            symbolName = item.isInstructions ? "doc.text" : "list.bullet"
             isUser = false; isDisclosure = true; isTool = true; indent = 0
         case .activity(let entry, let nested):
-            title = entry.title
+            let presentation = entry.presentation
+            title = presentation.title
+            symbolName = presentation.symbolName
+            hasFailure = presentation.needsAttention
             isUser = false; isDisclosure = true
-            isTool = !entry.records[0].record.isInstruction && entry.records[0].record.role != "reasoning"
+            isTool = entry.records[0].record.isActivity && entry.records[0].record.role != "reasoning"
             indent = nested ? 20 : 0
             if isExpanded { fullText = entry.body }
         case .message(let entry):
-            isUser = entry.record.role == "user"
-            isDisclosure = !["user", "assistant"].contains(entry.record.role)
+            isUser = !rawTranscript && entry.record.role == "user"
+            isDisclosure = !rawTranscript && !["user", "assistant"].contains(entry.record.role)
             isTool = false; indent = 0
-            title = isUser ? "You" : (entry.record.role == "assistant" ? provider : entry.record.role.capitalized)
+            if let event = entry.record.lifecycleEvent {
+                switch event {
+                case "task_complete": title = "Completed"; symbolName = "checkmark.circle"
+                case "turn_aborted": title = "Interrupted"; symbolName = "pause.circle"; hasFailure = true
+                case "task_started": title = "Turn started"; symbolName = "clock"
+                default: title = entry.record.text; symbolName = "info.circle"
+                }
+            } else {
+                title = isUser ? "You" : (entry.record.role == "assistant" ? provider : entry.record.role.capitalized)
+                symbolName = isDisclosure ? "doc.text" : nil
+            }
             if !isDisclosure || isExpanded { fullText = entry.record.text }
         }
+        let rawMessage: Bool
+        if case .activity = row { rawMessage = rawTranscript || (rawTools.contains(row.id) && !isTool) }
+        else { rawMessage = rawTranscript || rawTools.contains(row.id) }
+        if rawMessage { fullText = row.records.map { $0.rawTranscriptBody }.joined(separator: "\n\n") }
         let body = fullText
         let font: NSFont = isTool ? .monospacedSystemFont(ofSize: 12, weight: .regular) : .systemFont(ofSize: 14)
         let available = max(120, min(800, width - 60) - indent)
-        let contentWidth = isUser ? min(620, available) : available
-        let contentX = isUser ? width - 30 - contentWidth : 30 + indent
-        let bodyWidth = contentWidth - (isUser ? 30 : 0)
-        let showsRaw = rawTools.contains(row.id) || !findQuery.isEmpty
+        let maximumContentWidth = isUser ? available * 0.77 : available
+        let showsRaw = rawMessage || rawTools.contains(row.id) || !findQuery.isEmpty
+        let attachments = !showsRaw && !isTool ? row.records.flatMap { SourceContent.blocks($0.record) } : []
         let textLayout: TranscriptTextLayout
-        if let cached = textLayouts[row.id] { textLayout = cached }
-        else if isTool && isExpanded && !body.isEmpty {
-            textLayout = TranscriptTextLayout(rendered: ToolContentRenderer.render(row.records, raw: showsRaw), trimEdges: false)
+        var renderedTool: NSAttributedString?
+        if body.isEmpty { textLayout = TranscriptTextLayout(text: "", font: font) }
+        else if let cached = textLayouts[row.id] { textLayout = cached }
+        else if rawMessage {
+            textLayout = TranscriptTextLayout(rendered: NSAttributedString(string: body, attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular), .foregroundColor: NSColor.labelColor]), trimEdges: false)
+        } else if isTool && isExpanded && !body.isEmpty {
+            let rendered = ToolContentRenderer.render(row.records, raw: showsRaw)
+            renderedTool = rendered
+            textLayout = TranscriptTextLayout(rendered: rendered, trimEdges: !showsRaw)
+        } else if !findQuery.isEmpty {
+            // Source-only matches (Markdown destinations and context wrappers)
+            // remain selectable at their exact occurrence in plain source text.
+            textLayout = TranscriptTextLayout(rendered: NSAttributedString(string: body, attributes: [.font: font, .foregroundColor: NSColor.labelColor]), trimEdges: false)
         } else { textLayout = TranscriptTextLayout(text: body, font: font) }
-        textLayouts[row.id] = textLayout
-        let textHeight = textLayout.height(for: bodyWidth)
-        let bodyHeight = textHeight + (isUser && !body.isEmpty ? 30 : 0)
-        let showsRawControl = isTool && isExpanded && !body.isEmpty
-        let height = 38 + bodyHeight + (body.isEmpty ? 0 : 20) + (showsRawControl ? 28 : 0)
+        if !body.isEmpty { textLayouts[row.id] = textLayout }
+        let contentWidth = isUser && attachments.isEmpty
+            ? min(maximumContentWidth, max(44, textLayout.width(for: maximumContentWidth - 24) + 24))
+            : maximumContentWidth
+        let contentX = isUser ? width - 30 - contentWidth : 30 + indent
+        let bodyWidth = contentWidth - (isUser || isDisclosure ? 24 : 0)
+        var richContent: RichContentView?
+        let mayHaveRichBlocks = body.contains("```") || body.contains("~~~") || body.contains("![") || body.contains("](/") || body.contains("](file:")
+        if !showsRaw && (!attachments.isEmpty || (!body.isEmpty && (isTool || (mayHaveRichBlocks && RichContentDocument(body).hasRichBlocks)))) {
+            if let cached = richLayouts[row.id] { richContent = cached }
+            else {
+                let view = RichContentView()
+                if isTool {
+                    view.configure(blocks: ToolContentRenderer.richBlocks(row.records, rendered: renderedTool), font: font, context: RichContentContext(isLocalHost: isLocalHost))
+                } else {
+                    view.configure(blocks: RichContentDocument(body).blocks + attachments, font: font, context: RichContentContext(isLocalHost: isLocalHost))
+                }
+                richLayouts[row.id] = view
+                richContent = view
+            }
+        }
+        let fullTextHeight = richContent?.height(for: bodyWidth) ?? textLayout.height(for: bodyWidth)
+        let isLong = fullTextHeight > 440
+        let showsFullBody = fullBodies.contains(row.id) || !findQuery.isEmpty
+        let textHeight = isLong && !showsFullBody ? 360 : fullTextHeight
+        let hasBody = !body.isEmpty || richContent != nil
+        let showsRawControl = isTool && isExpanded && !body.isEmpty && !findQuery.isEmpty
+        let bodyY: CGFloat = isDisclosure ? (showsRawControl ? 74 : 44) : 16
+        let bodyBottom = bodyY + textHeight + (isUser ? 16 : 0)
+        let height: CGFloat = hasBody ? bodyBottom + (isLong ? 26 : 0) + (isDisclosure ? 12 : 0) + 4 + 18 + 10 : 38
         let highlighted: NSAttributedString
         if findQuery.isEmpty {
             highlighted = textLayout.attributedText
@@ -551,9 +733,16 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
             }
             highlighted = value
         }
-        let result = Measurement(title: title, body: body, attributedBody: highlighted, font: font, textHeight: textHeight, height: height,
+        var result = Measurement(rowID: row.id, title: title, body: body, attributedBody: highlighted, font: font, textHeight: textHeight, height: height,
             contentX: contentX, contentWidth: contentWidth, isUser: isUser, isDisclosure: isDisclosure,
-            isExpanded: isExpanded, showsRawControl: showsRawControl, showsRaw: showsRaw, finding: !findQuery.isEmpty)
+            isExpanded: isExpanded, showsRawControl: showsRawControl, showsRaw: showsRaw, finding: !findQuery.isEmpty,
+            symbolName: symbolName, hasFailure: hasFailure)
+        result.isLong = isLong
+        result.showsFullBody = showsFullBody
+        result.fullTextHeight = fullTextHeight
+        result.originalRecords = row.records
+        result.richContent = richContent
+        result.isLocalHost = isLocalHost
         measurements[row.id] = result
         return result
     }
@@ -570,23 +759,27 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
 }
 
 @MainActor
-private final class TranscriptCell: NSTableCellView {
-    private let titleLabel = NSTextField(labelWithString: "")
-    private let disclosure = NSButton()
+private final class TranscriptCell: NSTableCellView, NSTextViewDelegate {
+    private let disclosure = TranscriptDisclosureButton()
     private let rawDisclosure = NSButton()
     private let message = NSTextView()
     private let bubble = NSView()
+    private let activityIcon = NSImageView()
+    private let detailPanel = NSView()
+    private let richClip = TranscriptContentClip()
+    private weak var installedRichContent: RichContentView?
+    private let showAll = NSButton()
+    private let copyButton = TranscriptActionButton()
+    private var tracking: NSTrackingArea?
     private var measurement: TranscriptController.Measurement?
     private var onToggle: (() -> Void)?
     private var onToggleRaw: (() -> Void)?
+    private var onToggleFull: (() -> Void)?
     private var displayedText: NSAttributedString?
     override var isFlipped: Bool { true }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        titleLabel.font = .systemFont(ofSize: 12, weight: .medium)
-        titleLabel.textColor = .secondaryLabelColor
-        titleLabel.lineBreakMode = .byTruncatingTail
         disclosure.cell = TranscriptDisclosureCell()
         disclosure.isBordered = false
         disclosure.alignment = .left
@@ -601,6 +794,8 @@ private final class TranscriptCell: NSTableCellView {
         rawDisclosure.contentTintColor = .secondaryLabelColor
         rawDisclosure.target = self
         rawDisclosure.action = #selector(toggleRaw)
+        message.wantsLayer = true
+        message.layer?.masksToBounds = true
         message.isEditable = false
         message.isSelectable = true
         message.drawsBackground = false
@@ -609,26 +804,62 @@ private final class TranscriptCell: NSTableCellView {
         message.isVerticallyResizable = false
         message.isHorizontallyResizable = false
         message.textContainer?.widthTracksTextView = true
+        message.delegate = self
         bubble.wantsLayer = true
         bubble.layer?.cornerRadius = 16
+        detailPanel.wantsLayer = true
+        detailPanel.layer?.cornerRadius = 8
+        activityIcon.imageScaling = .scaleProportionallyDown
+        addSubview(detailPanel)
         addSubview(bubble)
-        addSubview(titleLabel)
+        addSubview(activityIcon)
         addSubview(disclosure)
         addSubview(rawDisclosure)
         addSubview(message)
+        richClip.wantsLayer = true
+        richClip.layer?.masksToBounds = true
+        addSubview(richClip)
+        copyButton.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy message")
+        copyButton.imagePosition = .imageOnly
+        copyButton.title = ""
+        copyButton.setAccessibilityLabel("Copy message")
+        copyButton.toolTip = "Copy message"
+        copyButton.isBordered = false
+        copyButton.contentTintColor = .secondaryLabelColor
+        copyButton.target = self
+        copyButton.action = #selector(copyBody)
+        copyButton.wantsLayer = true
+        copyButton.onFocus = { [weak self] in self?.refreshActions() }
+        addSubview(copyButton)
+        showAll.isBordered = false
+        showAll.alignment = .left
+        showAll.font = .systemFont(ofSize: 12)
+        showAll.target = self
+        showAll.action = #selector(toggleFull)
+        addSubview(showAll)
     }
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func configure(_ value: TranscriptController.Measurement, toggle: @escaping () -> Void, toggleRaw: @escaping () -> Void) {
+    func configure(_ value: TranscriptController.Measurement, toggle: @escaping () -> Void, toggleRaw: @escaping () -> Void,
+                   toggleFull: @escaping () -> Void) {
         measurement = value
         onToggle = toggle
         onToggleRaw = toggleRaw
+        onToggleFull = toggleFull
+        showAll.isHidden = !value.isLong
+        showAll.title = value.showsFullBody ? "Show less" : "Show all"
+        showAll.isEnabled = !value.finding
+        refreshActions()
         rawDisclosure.isHidden = !value.showsRawControl
         rawDisclosure.title = value.finding ? "Raw content shown for Find" : (value.showsRaw ? "Show formatted content" : "Show raw content")
         rawDisclosure.isEnabled = !value.finding
-        titleLabel.stringValue = value.title
-        titleLabel.alignment = value.isUser ? .right : .left
-        titleLabel.isHidden = value.isDisclosure
+        message.setAccessibilityLabel(value.title)
+        activityIcon.isHidden = value.symbolName == nil
+        activityIcon.image = value.symbolName.flatMap { NSImage(systemSymbolName: $0, accessibilityDescription: nil) }
+        activityIcon.contentTintColor = value.hasFailure ? .systemOrange : .tertiaryLabelColor
+        disclosure.restingTint = value.hasFailure ? .systemOrange : .secondaryLabelColor
+        disclosure.toolTip = value.title
+        detailPanel.isHidden = !value.isDisclosure || !value.hasBody
         disclosure.isHidden = !value.isDisclosure
         disclosure.title = value.title
         disclosure.image = NSImage(systemSymbolName: value.isExpanded ? "chevron.down" : "chevron.right",
@@ -637,14 +868,39 @@ private final class TranscriptCell: NSTableCellView {
         disclosure.setAccessibilityLabel(value.title)
         disclosure.setAccessibilityValue(value.isExpanded ? "Expanded" : "Collapsed")
         if displayedText !== value.attributedBody {
-            message.textStorage?.setAttributedString(value.attributedBody)
+            let rendered = NSMutableAttributedString(attributedString: value.attributedBody)
+            rendered.enumerateAttribute(RichTextRenderer.sourceLocationAttribute, in: NSRange(location: 0, length: rendered.length)) { source, range, _ in
+                if value.isLocalHost, let source = source as? String {
+                    rendered.addAttributes([.link: source, .foregroundColor: NSColor.linkColor], range: range)
+                }
+            }
+            message.textStorage?.setAttributedString(rendered)
             message.setSelectedRange(NSRange(location: 0, length: 0))
             displayedText = value.attributedBody
         }
-        message.isHidden = value.body.isEmpty
-        bubble.isHidden = !value.isUser || value.body.isEmpty
-        bubble.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.10).cgColor
+        if installedRichContent !== value.richContent {
+            installedRichContent?.removeFromSuperview()
+            if let rich = value.richContent { richClip.addSubview(rich) }
+            installedRichContent = value.richContent
+        }
+        richClip.isHidden = value.richContent == nil
+        message.isHidden = !value.hasBody || value.richContent != nil
+        bubble.isHidden = !value.isUser || !value.hasBody
+        updateBubbleColor()
         needsLayout = true
+        message.alphaValue = 1
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBubbleColor()
+    }
+
+    private func updateBubbleColor() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            bubble.layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.05).cgColor
+            detailPanel.layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.035).cgColor
+        }
     }
 
     override func layout() {
@@ -652,13 +908,25 @@ private final class TranscriptCell: NSTableCellView {
         guard let value = measurement else { return }
         let x = value.contentX
         let width = value.contentWidth
-        titleLabel.frame = NSRect(x: x, y: 10, width: width, height: 18)
-        disclosure.frame = NSRect(x: x, y: 8, width: width, height: 22)
-        rawDisclosure.frame = NSRect(x: x, y: 32, width: width, height: 22)
-        let bodyY: CGFloat = value.showsRawControl ? 62 : 34
-        let inset: CGFloat = value.isUser ? 15 : 0
-        message.frame = NSRect(x: x + inset, y: bodyY + inset, width: width - 2 * inset, height: value.textHeight)
-        bubble.frame = NSRect(x: x, y: 34, width: width, height: value.textHeight + 2 * inset)
+        activityIcon.frame = NSRect(x: x, y: 12, width: 14, height: 14)
+        // Reserve the action gutter before hover so the title and chevron never move.
+        let actionGutter: CGFloat = value.isDisclosure ? 32 : 0
+        disclosure.frame = NSRect(x: x + 22, y: 8, width: max(0, width - 22 - actionGutter), height: 22)
+        rawDisclosure.frame = NSRect(x: x + 12, y: 44, width: width - 24, height: 22)
+        let bodyY: CGFloat = value.isDisclosure ? (value.showsRawControl ? 74 : 44) : 16
+        let inset: CGFloat = value.isUser || value.isDisclosure ? 12 : 0
+        let verticalInset: CGFloat = value.isUser ? 8 : 0
+        message.frame = NSRect(x: x + inset, y: bodyY + verticalInset, width: width - 2 * inset, height: value.textHeight)
+        richClip.frame = message.frame
+        installedRichContent?.frame = NSRect(x: 0, y: 0, width: message.frame.width, height: value.fullTextHeight)
+        bubble.frame = NSRect(x: x, y: bodyY, width: width, height: value.textHeight + 2 * verticalInset)
+        let bodyBottom = message.frame.maxY + verticalInset
+        let footerY = bodyBottom + (value.isLong ? 26 : 0) + (value.isDisclosure ? 12 : 0) + 4
+        detailPanel.frame = NSRect(x: x, y: 32, width: width, height: max(0, footerY - 4 - 32))
+        showAll.frame = NSRect(x: x + inset, y: bodyBottom + 4, width: 100, height: 22)
+        let actionY = value.hasBody ? footerY : 10
+        copyButton.frame = NSRect(x: x + width - 24, y: actionY - 3, width: 24, height: 24)
+        refreshActions()
     }
 
     func clearFindSelection() { message.setSelectedRange(NSRange(location: 0, length: 0)) }
@@ -675,6 +943,83 @@ private final class TranscriptCell: NSTableCellView {
 
     @objc private func toggle() { onToggle?() }
     @objc private func toggleRaw() { onToggleRaw?() }
+    @objc private func toggleFull() { onToggleFull?() }
+    @objc private func copyBody() {
+        guard let measurement else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(measurement.body.isEmpty ? measurement.originalBody : measurement.body, forType: .string)
+    }
+    func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+        let source = (link as? String) ?? (link as? URL)?.absoluteString
+        guard let source, let location = ContentLocation.parse(source),
+              location.canOpen(in: RichContentContext(isLocalHost: measurement?.isLocalHost == true)) else { return true }
+        location.open(in: RichContentContext(isLocalHost: measurement?.isLocalHost == true))
+        return true
+    }
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let tracking { removeTrackingArea(tracking) }
+        let area = NSTrackingArea(rect: .zero, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self)
+        tracking = area
+        addTrackingArea(area)
+        refreshActions()
+    }
+    override func mouseEntered(with event: NSEvent) { refreshActions() }
+    override func mouseExited(with event: NSEvent) { refreshActions() }
+    func refreshActions() {
+        let hovered = window.map { $0.isKeyWindow && visibleRect.contains(convert($0.mouseLocationOutsideOfEventStream, from: nil)) } ?? false
+        let focused = window?.firstResponder === copyButton
+        copyButton.alphaValue = hovered || focused ? 1 : 0
+    }
+}
+
+@MainActor private final class TranscriptContentClip: NSView {
+    override var isFlipped: Bool { true }
+}
+
+@MainActor private final class TranscriptActionButton: NSButton {
+    var onFocus: (() -> Void)?
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        onFocus?()
+        return result
+    }
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        onFocus?()
+        return result
+    }
+}
+
+@MainActor private final class TranscriptDisclosureButton: NSButton {
+    var restingTint: NSColor = .secondaryLabelColor { didSet { refreshTint() } }
+    private var hovering = false
+    private var tracking: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let tracking { removeTrackingArea(tracking) }
+        let area = NSTrackingArea(rect: .zero, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+                                  owner: self, userInfo: nil)
+        tracking = area
+        addTrackingArea(area)
+    }
+
+    override func mouseEntered(with event: NSEvent) { hovering = true; refreshTint() }
+    override func mouseExited(with event: NSEvent) { hovering = false; refreshTint() }
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        refreshTint()
+        return accepted
+    }
+    override func resignFirstResponder() -> Bool {
+        let accepted = super.resignFirstResponder()
+        contentTintColor = restingTint
+        return accepted
+    }
+    private func refreshTint() {
+        contentTintColor = hovering || window?.firstResponder === self ? .labelColor : restingTint
+    }
 }
 
 /// Reserve identical text and symbol geometry in both disclosure states. The
@@ -728,6 +1073,11 @@ private final class TranscriptCell: NSTableCellView {
         container.containerSize = NSSize(width: width, height: .greatestFiniteMagnitude)
         manager.ensureLayout(for: container)
         return ceil(manager.usedRect(for: container).height)
+    }
+
+    func width(for width: CGFloat) -> CGFloat {
+        _ = height(for: width)
+        return ceil(manager.usedRect(for: container).width)
     }
 }
 

--- a/apps/macos/Sources/Memex/TranscriptPresentation.swift
+++ b/apps/macos/Sources/Memex/TranscriptPresentation.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+/// Lossless display projection. Synthetic context IDs always point back to the source record.
+/// Only leading, complete harness envelopes are recognized; quoted/fenced examples and
+/// wrappers appearing after user prose remain normal message content.
+enum TranscriptPresentation {
+    static func project(_ records: [TranscriptRecord]) -> [TranscriptRecord] {
+        records.flatMap { sourceEntry in
+            if let reply = questionReply(sourceEntry) { return reply }
+            var displayMessage = sourceEntry.record
+            displayMessage.text = SourceContent.displayText(displayMessage)
+            if displayMessage.role == "assistant" {
+                displayMessage.text = assistantDisplayText(displayMessage.text)
+            }
+            let entry = TranscriptRecord(recordID: sourceEntry.id, record: displayMessage,
+                                         sourceRecordID: sourceEntry.sourceRecordID,
+                                         rawJSON: sourceEntry.rawJSON ?? (displayMessage.text != sourceEntry.record.text ? sourceEntry.rawTranscriptBody : nil))
+            guard entry.record.role == "user", entry.record.contextLabel == nil else { return [entry] }
+            var remaining = entry.record.text[...]
+            var pieces: [(String, String)] = []
+            while let envelope = leadingEnvelope(remaining) {
+                pieces.append((String(remaining[..<envelope.end]), envelope.label))
+                remaining = remaining[envelope.end...]
+            }
+            guard !pieces.isEmpty else { return [entry] }
+            let hasRequest = !remaining.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if !hasRequest, !remaining.isEmpty {
+                pieces[pieces.count - 1].0 += remaining
+            }
+            return pieces.enumerated().map { index, piece in
+                var message = entry.record
+                message.text = piece.0
+                message.contextLabel = piece.1
+                return TranscriptRecord(recordID: !hasRequest && pieces.count == 1 ? entry.id : "\(entry.id):context:\(index)",
+                                        record: message, sourceRecordID: entry.sourceID, rawJSON: entry.rawJSON ?? sourceEntry.rawTranscriptBody)
+            } + (hasRequest ? [requestRecord(entry, text: String(remaining), original: sourceEntry.rawTranscriptBody)] : [])
+        }
+    }
+
+    /// These are transport markers, not arbitrary XML or Markdown directives. Keep
+    /// examples in Markdown code/quotes intact and retain the complete source in rawJSON.
+    private static func assistantDisplayText(_ text: String) -> String {
+        let source = text as NSString
+        let protected = protectedMarkdownRanges(text)
+        func isProtected(_ range: NSRange) -> Bool {
+            protected.contains { NSIntersectionRange($0, range).length > 0 }
+        }
+        var removals: [NSRange] = []
+        let citationPattern = #"(?m)^[ \t]*<oai-mem-citation>\s*<citation_entries>[^<>]*</citation_entries>\s*<rollout_ids>[^<>]*</rollout_ids>\s*</oai-mem-citation>\s*\z"#
+        if let regex = try? NSRegularExpression(pattern: citationPattern),
+           let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: source.length)),
+           !isProtected(match.range) {
+            removals.append(match.range)
+        }
+        let annotationPattern = #"(?<!:)::?codex-annotation\{index="[0-9]+"\}(?!\})"#
+        if let regex = try? NSRegularExpression(pattern: annotationPattern) {
+            for match in regex.matches(in: text, range: NSRange(location: 0, length: source.length)) {
+                let range = match.range
+                guard !isProtected(range), !removals.contains(where: { NSIntersectionRange($0, range).length > 0 }) else { continue }
+                // Also retain explicitly quoted literal examples outside Markdown code.
+                let before = range.location > 0 ? source.substring(with: NSRange(location: range.location - 1, length: 1)) : ""
+                let after = NSMaxRange(range) < source.length ? source.substring(with: NSRange(location: NSMaxRange(range), length: 1)) : ""
+                guard !["\"", "'", "“", "‘"].contains(before), !["\"", "'", "”", "’"].contains(after) else { continue }
+                removals.append(range)
+            }
+        }
+        guard !removals.isEmpty else { return text }
+        let result = NSMutableString(string: text)
+        for range in removals.sorted(by: { $0.location > $1.location }) { result.deleteCharacters(in: range) }
+        return (result as String).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func protectedMarkdownRanges(_ text: String) -> [NSRange] {
+        let source = text as NSString
+        var protected: [NSRange] = []
+        var offset = 0
+        var fence: (character: Character, count: Int)?
+        var inlineTicks: Int? = nil
+        for line in text.components(separatedBy: "\n") {
+            let length = (line as NSString).length
+            let range = NSRange(location: offset, length: length)
+            let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+            let first = trimmed.first
+            let run = first.map { character in trimmed.prefix(while: { $0 == character }).count } ?? 0
+            if let active = fence {
+                protected.append(range)
+                if first == active.character && run >= active.count,
+                   trimmed.dropFirst(run).allSatisfy({ $0.isWhitespace }) { fence = nil }
+            } else if (first == "`" || first == "~") && run >= 3 {
+                fence = (first!, run)
+                protected.append(range)
+            } else if trimmed.hasPrefix(">") || line.hasPrefix("    ") || line.hasPrefix("\t") {
+                protected.append(range)
+            } else {
+                var cursor = offset
+                let end = offset + length
+                var start = inlineTicks == nil ? nil : offset
+                while cursor < end {
+                    if source.character(at: cursor) == 96 {
+                        var next = cursor + 1
+                        while next < end && source.character(at: next) == 96 { next += 1 }
+                        let count = next - cursor
+                        if inlineTicks == count {
+                            protected.append(NSRange(location: start ?? offset, length: next - (start ?? offset)))
+                            inlineTicks = nil
+                            start = nil
+                        } else if inlineTicks == nil {
+                            inlineTicks = count
+                            start = cursor
+                        }
+                        cursor = next
+                    } else { cursor += 1 }
+                }
+                if let start { protected.append(NSRange(location: start, length: end - start)) }
+            }
+            offset += length + 1
+        }
+        return protected
+    }
+
+    private static func questionReply(_ entry: TranscriptRecord) -> [TranscriptRecord]? {
+        guard entry.record.role == "user", entry.record.contextLabel == nil else { return nil }
+        let text = entry.record.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let opening = "<send_user_message_question_reply>"
+        let closing = "</send_user_message_question_reply>"
+        guard text.hasPrefix(opening), text.hasSuffix(closing) else { return nil }
+        let payload = String(text.dropFirst(opening.count).dropLast(closing.count))
+        guard let data = payload.data(using: .utf8),
+              let replies = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]], !replies.isEmpty,
+              replies.allSatisfy({ $0["question"] is String && $0["answer"] is String && $0["questionItemId"] is String }) else { return nil }
+        let raw = entry.rawJSON ?? entry.rawTranscriptBody
+        return replies.enumerated().flatMap { index, reply -> [TranscriptRecord] in
+            var context = entry.record
+            context.text = reply["question"] as? String ?? ""
+            context.contextLabel = "Question"
+            var answer = entry.record
+            answer.text = reply["answer"] as? String ?? ""
+            return [TranscriptRecord(recordID: "\(entry.id):question:\(index)", record: context, sourceRecordID: entry.sourceID, rawJSON: raw),
+                    TranscriptRecord(recordID: index == 0 ? entry.id : "\(entry.id):answer:\(index)", record: answer, sourceRecordID: entry.sourceID, rawJSON: raw)]
+        }
+    }
+
+    private static func requestRecord(_ entry: TranscriptRecord, text: String, original: String) -> TranscriptRecord {
+        var message = entry.record
+        message.text = text
+        return TranscriptRecord(recordID: entry.id, record: message, sourceRecordID: entry.sourceID, rawJSON: entry.rawJSON ?? original)
+    }
+
+    private static func leadingEnvelope(_ input: Substring) -> (end: String.Index, label: String)? {
+        let value = input.drop(while: { $0.isWhitespace })
+        // Match precise harness opening tags, never arbitrary HTML or XML names.
+        let tags: [(String, String)] = [
+            ("recommended_plugins", "Available plugins"),
+            ("environment_context", "Environment context"),
+            ("permissions instructions", "Permissions"),
+            ("skills_instructions", "Skills"),
+            ("app-context", "Application context"),
+            ("collaboration_mode", "Collaboration mode"),
+            ("context_window", "Context window")
+        ]
+        for (tag, label) in tags where value.hasPrefix("<\(tag)>") {
+            guard let close = value.range(of: "</\(tag)>") else { return nil }
+            return (close.upperBound, label)
+        }
+        if (value.hasPrefix("# AGENTS.md instructions for ") || value.hasPrefix("# AGENTS.md instructions\n")),
+           let newline = value.firstIndex(of: "\n") {
+            let afterHeading = value[value.index(after: newline)...].drop(while: { $0.isWhitespace })
+            guard afterHeading.hasPrefix("<INSTRUCTIONS>"),
+                  let close = afterHeading.range(of: "</INSTRUCTIONS>") else { return nil }
+            return (close.upperBound, "Project instructions")
+        }
+        return nil
+    }
+
+    static func group(_ source: [TranscriptRecord]) -> [TranscriptItem] {
+        let records = project(source)
+        // Require both a recorded final answer and task completion for this exact source
+        // turn. Partial pages, aborted turns, and old records keep their original hierarchy.
+        let byTurn = Dictionary(grouping: records.filter { $0.record.sourceTurnID?.nilIfBlank != nil }) {
+            $0.record.sourceTurnID!
+        }
+        let completed = Set(byTurn.compactMap { turn, entries -> String? in
+            guard entries.contains(where: { $0.record.lifecycleEvent == "task_complete" }),
+                  entries.contains(where: { $0.record.role == "assistant" && $0.record.assistantPhase == "final_answer" }),
+                  !entries.contains(where: { $0.record.lifecycleEvent == "turn_aborted" }) else { return nil }
+            return turn
+        })
+        func isWork(_ entry: TranscriptRecord) -> Bool {
+            guard let turn = entry.record.sourceTurnID, completed.contains(turn), !entry.record.isInstruction else { return false }
+            return entry.record.isActivity || (entry.record.role == "assistant" && entry.record.assistantPhase == "commentary")
+        }
+        var output: [TranscriptItem] = []
+        var ordinary: [TranscriptRecord] = []
+        var work: [TranscriptRecord] = []
+        func flushOrdinary() {
+            output += TranscriptItem.groupConsecutive(ordinary)
+            ordinary = []
+        }
+        func flushWork() {
+            guard !work.isEmpty else { return }
+            // Failures stay individually visible even in an otherwise completed turn.
+            let groups = TranscriptItem.groupConsecutive(work)
+            var routine: [TranscriptRecord] = []
+            func flushRoutine() {
+                if !routine.isEmpty { output.append(TranscriptItem(records: routine, isCompletedWork: true)); routine = [] }
+            }
+            for group in groups {
+                if group.activities.contains(where: { $0.presentation.needsAttention }) {
+                    flushRoutine()
+                    output.append(group)
+                } else { routine += group.records }
+            }
+            flushRoutine()
+            work = []
+        }
+        for entry in records {
+            if isWork(entry) {
+                flushOrdinary()
+                if work.first?.record.sourceTurnID != entry.record.sourceTurnID { flushWork() }
+                work.append(entry)
+            } else {
+                flushWork()
+                ordinary.append(entry)
+            }
+        }
+        flushWork()
+        flushOrdinary()
+        return output
+    }
+}

--- a/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
+++ b/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Memex
 
@@ -65,6 +66,19 @@ struct ActivityPresentationTests {
         #expect(original.presentation.title.hasSuffix("…"))
         #expect(original.records[0].record.toolInput == input)
         #expect(original.body == body)
+    }
+
+    @MainActor @Test func decodedClaudeEnvelopeFailuresStayVisibleWithPlainTextOutput() throws {
+        let data = Data(#"[{"record_id":"a","record":{"role":"tool_result","text":"ok","tool_output":"ok","tool_result_is_error":false}},{"record_id":"b","record":{"role":"tool_result","text":"permission denied","tool_output":"permission denied","tool_result_is_error":true}},{"record_id":"c","record":{"role":"tool_result","text":"ordinary"}}]"#.utf8)
+        let records = try JSONDecoder().decode([TranscriptRecord].self, from: data)
+        #expect(!TranscriptActivity(records: [records[0]]).presentation.hasFailure)
+        #expect(TranscriptActivity(records: [records[1]]).presentation.hasFailure)
+        #expect(!TranscriptActivity(records: [records[2]]).presentation.hasFailure)
+        let reader = TranscriptController()
+        reader.update(sessionID: "claude-errors", records: records, provider: "claude")
+        #expect(reader.rows.count == 3)
+        #expect(reader.measurement(at: 1).title.hasPrefix("Failed"))
+        #expect(records[1].rawTranscriptBody.contains("tool_result_is_error"))
     }
 
     private func activity(_ name: String?, input: String? = nil, output: String? = nil) -> TranscriptActivity {

--- a/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
+++ b/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
@@ -1,0 +1,74 @@
+import Testing
+@testable import Memex
+
+struct ActivityPresentationTests {
+    @Test func knownProviderToolsUseStructuredArguments() {
+        let examples = [
+            ("Read", #"{"file_path":"/project/settings.swift"}"#, "Read /project/settings.swift", "doc.text"),
+            ("mcp__filesystem__read_file", #"{"path":"README.md"}"#, "Read README.md", "doc.text"),
+            ("Grep", #"{"pattern":"TranscriptActivity"}"#, "Search TranscriptActivity", "magnifyingglass"),
+            ("functions.exec_command", #"{"cmd":"git status --short"}"#, "Run git status --short", "terminal"),
+            ("Bash", #"{"command":"swift test"}"#, "Run swift test", "terminal"),
+            ("exec", #"{"cmd":"swift test"}"#, "Run swift test", "terminal"),
+            ("Write", #"{"file_path":"new.swift","content":"ignored"}"#, "Write new.swift", "doc.badge.plus"),
+            ("MultiEdit", #"{"file_path":"Models.swift"}"#, "Edit Models.swift", "pencil"),
+            ("Glob", #"{"pattern":"**/*.swift"}"#, "List files **/*.swift", "folder")
+        ]
+        for (name, input, title, symbol) in examples {
+            let presentation = activity(name, input: input).presentation
+            #expect(presentation.title == title)
+            #expect(presentation.symbolName == symbol)
+            #expect(!presentation.hasFailure)
+        }
+    }
+
+    @Test func unknownAndExecutableInputsAreNeverInterpreted() {
+        let unknown = activity("custom_magic", input: #"{"command":"delete everything","path":"secret"}"#)
+        #expect(unknown.presentation.title == "Custom Magic")
+        #expect(unknown.presentation.category == nil)
+        let executable = activity("functions.exec", input: "await tools.exec_command({cmd: 'swift test'})")
+        #expect(executable.presentation.title == "Run tool script")
+    }
+
+    @Test func malformedOrMissingArgumentsHaveSafeFallbacks() {
+        for input in ["not json", "[1, 2]", #"{"cmd":42}"#, #"{"cmd":"  "}"#, "null"] {
+            #expect(activity("exec_command", input: input).presentation.title == "Run")
+        }
+        #expect(activity("Read").presentation.title == "Read")
+        #expect(activity(nil).presentation.title == "Tool activity")
+        #expect(activity("exec", input: #"{"cmd":42}"#).presentation.title == "Exec")
+    }
+
+    @Test func failureRequiresAnExplicitStructuredOutputStatus() {
+        for output in [#"{"isError":true}"#, #"{"is_error":true}"#, #"{"exit_code":1}"#, #"{"exit_code":-9}"#] {
+            #expect(activity("Bash", output: output).presentation.hasFailure)
+            #expect(activity("Bash", output: output).presentation.title == "Failed · Run")
+        }
+        for output in ["error: something failed", #"{"error":"failed"}"#, #"{"isError":false,"exit_code":0}"#,
+                       #"{"is_error":1}"#, #"{"exit_code":true}"#, #"{"exit_code":"1"}"#,
+                       #"{"data":{"isError":true}}"#] {
+            #expect(!activity("Bash", output: output).presentation.hasFailure)
+        }
+        #expect(!activity("Bash", input: #"{"isError":true,"exit_code":2}"#).presentation.hasFailure)
+        let result = TranscriptRecord(recordID: "result", record: Message(role: "tool_result", text: #"{"exit_code":2}"#,
+            toolName: "Bash", toolInput: nil, toolOutput: nil))
+        #expect(TranscriptActivity(records: [result]).presentation.hasFailure)
+        #expect(activity("custom_magic", output: #"{"isError":true}"#).presentation.title == "Failed · Custom Magic")
+    }
+
+    @Test func summariesPreserveSourceAndBoundDetails() {
+        let input = "{\"cmd\":\"echo hello\\n" + String(repeating: "x", count: 160) + "\"}"
+        let original = activity("Bash", input: input)
+        let body = original.body
+        #expect(original.presentation.title.hasPrefix("Run echo hello "))
+        #expect(original.presentation.title.count <= 92)
+        #expect(original.presentation.title.hasSuffix("…"))
+        #expect(original.records[0].record.toolInput == input)
+        #expect(original.body == body)
+    }
+
+    private func activity(_ name: String?, input: String? = nil, output: String? = nil) -> TranscriptActivity {
+        TranscriptActivity(records: [TranscriptRecord(recordID: "call", record: Message(role: "tool_use", text: "",
+            toolName: name, toolInput: input, toolOutput: output))])
+    }
+}

--- a/apps/macos/Tests/MemexTests/ActivityReaderTests.swift
+++ b/apps/macos/Tests/MemexTests/ActivityReaderTests.swift
@@ -1,0 +1,101 @@
+import AppKit
+import Testing
+@testable import Memex
+
+@Suite(.serialized) @MainActor
+struct ActivityReaderTests {
+    @Test func summaryCountsOperationsRatherThanCallAndResultRecords() {
+        let records = [entry("a", "Read", input: #"{"path":"a.swift"}"#),
+                       result("a-result", "a", #"{"text":"contents"}"#),
+                       entry("b", "Read", input: #"{"path":"b.swift"}"#),
+                       entry("c", "Grep", input: #"{"pattern":"Reader"}"#)]
+        let controller = reader(records)
+        #expect(controller.rows.count == 1)
+        #expect(controller.measurement(at: 0).title == "3 activities · 2 reads, 1 search")
+        controller.toggle(controller.rows[0].id)
+        #expect(controller.rows.count == 4)
+        #expect(controller.measurement(at: 1).title == "Read a.swift")
+        #expect(controller.measurement(at: 1).symbolName == "doc.text")
+        #expect(controller.rows[1].records.map(\.id) == ["a", "a-result"])
+    }
+
+    @Test func explicitFailureStaysVisibleAndFindStillRevealsItsOutput() throws {
+        let records = [entry("a", "Read", input: #"{"path":"a.swift"}"#),
+                       entry("b", "Bash", input: #"{"command":"swift test"}"#),
+                       result("b-result", "b", #"{"exit_code":1,"output":"specific failure"}"#)]
+        let controller = reader(records)
+        #expect(controller.rows.count == 2)
+        let failed = controller.measurement(at: 1)
+        #expect(failed.title == "Failed · Run swift test")
+        #expect(failed.hasFailure)
+        #expect(failed.body.isEmpty)
+        let hit = try #require(ConversationMatcher.matches(records, query: "specific failure").first)
+        controller.update(sessionID: "activity", records: records, provider: "claude",
+                          findQuery: "specific failure", findHit: hit, findGeneration: 1)
+        #expect(controller.measurement(at: 1).body.contains("specific failure"))
+        #expect(controller.selectedFindRange != nil)
+    }
+
+    @Test func aPagedFailurePromotesItsOperationWithoutLosingExpandedContents() {
+        let calls = [entry("a", "Read", input: #"{"path":"a.swift"}"#),
+                     entry("b", "Bash", input: #"{"command":"swift test"}"#)]
+        let controller = reader(calls)
+        controller.toggle(controller.rows[0].id)
+        controller.toggle("activity:b")
+        controller.update(sessionID: "activity", records: calls + [result("r", "b", #"{"is_error":true}"#)], provider: "claude")
+        #expect(controller.rows.count == 2)
+        #expect(controller.measurement(at: 0).contentX == 30)
+        #expect(controller.measurement(at: 1).isExpanded)
+        #expect(controller.measurement(at: 1).hasFailure)
+        #expect(controller.rows[1].records.map(\.id) == ["b", "r"])
+    }
+
+    @Test func failureLeavesSurroundingRoutineSpansCompactAndPreservesPairing() throws {
+        let calls = (0..<5).map { entry("call-\($0)", "Bash", input: "{\"command\":\"step \($0)\"}") }
+        let records = calls + [result("failed-output", "call-2", #"{"exit_code":2,"output":"failed middle"}"#)]
+        let controller = reader(records)
+        #expect(controller.rows.count == 3)
+        #expect(controller.measurement(at: 0).title == "2 activities · 2 commands")
+        #expect(controller.measurement(at: 1).hasFailure)
+        #expect(controller.measurement(at: 2).title == "2 activities · 2 commands")
+        #expect(controller.rows[1].records.map(\.id) == ["call-2", "failed-output"])
+        #expect(Set(controller.rows.flatMap(\.records).map(\.id)) == Set(records.map(\.id)))
+        let hit = try #require(ConversationMatcher.matches(records, query: "step 4").first)
+        controller.update(sessionID: "activity", records: records, provider: "claude",
+                          findQuery: "step 4", findHit: hit, findGeneration: 1)
+        let row = try #require(controller.rows.firstIndex { $0.id == "activity:call-4" })
+        #expect(controller.measurement(at: row).isExpanded)
+        #expect(controller.selectedFindRange != nil)
+    }
+
+    @Test func assistantMessagesAndUnknownStatesRemainVisible() {
+        let records = [entry("a", "custom_operation", input: "unstructured"),
+                       TranscriptRecord(recordID: "commentary", record: Message(role: "assistant", text: "Checking the result",
+                            toolName: nil, toolInput: nil, toolOutput: nil)),
+                       entry("b", "Bash", input: #"{"command":"swift test"}"#)]
+        let controller = reader(records)
+        #expect(controller.rows.count == 3)
+        #expect(controller.measurement(at: 0).title == "Custom Operation")
+        #expect(!controller.measurement(at: 0).hasFailure)
+        #expect(controller.measurement(at: 1).body == "Checking the result")
+        #expect(controller.measurement(at: 2).title == "Run swift test")
+        #expect(!controller.measurement(at: 2).isExpanded)
+    }
+
+    private func reader(_ records: [TranscriptRecord]) -> TranscriptController {
+        let controller = TranscriptController()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 600)
+        controller.update(sessionID: "activity", records: records, provider: "claude")
+        return controller
+    }
+
+    private func entry(_ id: String, _ tool: String, input: String) -> TranscriptRecord {
+        TranscriptRecord(recordID: id, record: Message(role: "tool_use", text: "", toolName: tool,
+            toolInput: input, toolOutput: nil, eventID: id))
+    }
+
+    private func result(_ id: String, _ call: String, _ output: String) -> TranscriptRecord {
+        TranscriptRecord(recordID: id, record: Message(role: "tool_result", text: "", toolName: nil,
+            toolInput: nil, toolOutput: output, parentToolUseID: call))
+    }
+}

--- a/apps/macos/Tests/MemexTests/DaemonClientTests.swift
+++ b/apps/macos/Tests/MemexTests/DaemonClientTests.swift
@@ -259,7 +259,8 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
     try FileManager.default.createDirectory(at: inputs, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: root) }
     let transcript = #"{"type":"user","uuid":"native-fixture-message","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:00Z","message":{"role":"user","content":"hello persistent native connection"}}"#
-    try (transcript + "\n").write(to: inputs.appendingPathComponent("native-fixture.jsonl"), atomically: true, encoding: .utf8)
+    let image = #"{"type":"user","uuid":"native-fixture-image","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"<<ImageDisplayed>>\nInspect this image"},{"type":"image","source":{"type":"url","url":"https://example.com/native-fixture.png"}}]}}"#
+    try (transcript + "\n" + image + "\n").write(to: inputs.appendingPathComponent("native-fixture.jsonl"), atomically: true, encoding: .utf8)
     let logURL = root.appendingPathComponent("daemon.log")
     FileManager.default.createFile(atPath: logURL.path, contents: nil)
     let log = try FileHandle(forWritingTo: logURL)
@@ -282,16 +283,36 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
         daemonSocket: root.appendingPathComponent("state/native/app.sock"))
     func waitForSession() async throws -> Session {
         let deadline = ContinuousClock.now.advanced(by: .seconds(20))
+        var lastObservation = "No client request completed"
         while child.isRunning, ContinuousClock.now < deadline {
-            if let rows = try? await client.sessions(limit: 5), let session = rows.first,
-               let hits = try? await client.search("persistent", project: nil, source: nil, limit: 5),
-               !hits.isEmpty { return session }
+            do {
+                let rows = try await client.sessions(limit: 5)
+                if let session = rows.first {
+                    let hits = try await client.search("persistent", project: nil, source: nil, limit: 5)
+                    if !hits.isEmpty { return session }
+                    lastObservation = "Sessions returned \(rows.count) rows, but fixture search returned no matches"
+                } else {
+                    lastObservation = "Sessions returned no rows"
+                }
+            } catch {
+                lastObservation = "Client request failed: \(error)"
+            }
             try await Task.sleep(for: .milliseconds(50))
         }
-        throw ClientError(message: "Isolated daemon did not publish fixture: \((try? String(contentsOf: logURL, encoding: .utf8)) ?? "")")
+        let socket = root.appendingPathComponent("state/native/app.sock")
+        let socketExists = FileManager.default.fileExists(atPath: socket.path)
+        let processStatus = child.isRunning ? "running" : "exited with status \(child.terminationStatus)"
+        let daemonLog = (try? String(contentsOf: logURL, encoding: .utf8)) ?? "Log unavailable"
+        throw ClientError(message: "Isolated daemon did not publish fixture. Process: \(processStatus). Socket: \(socket.path) (exists: \(socketExists)). \(lastObservation). Daemon log:\n\(daemonLog)")
     }
     let session = try await waitForSession()
     #expect(session.sessionID == "native-fixture")
+    #expect(session.messageCount == 2)
+    let initial = try await client.initialRecords(for: session, anchor: nil)
+    #expect(initial.total == 2)
+    #expect(initial.offset == 0)
+    #expect(initial.records.count == 2)
+    #expect(initial.records.last?.record.sourceContent != nil)
     #expect(try await client.machines() == [.local])
     #expect(try await client.projects().reduce(0) { $0 + $1.sessionCount } == 1)
     #expect(try await client.sessionCount() == 1)
@@ -299,7 +320,13 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
     #expect(try await client.search("persistent", project: nil, source: nil, limit: 1000).first?.sessionID == session.sessionID)
     #expect(try await client.sessionDetails(for: session).id == session.id)
     #expect(try await client.records(for: session, offset: 0).first?.record.text == "hello persistent native connection")
-    #expect(try await client.recordMetadata(for: session, offset: 0, limit: 1).total == 1)
+    #expect(try await client.recordMetadata(for: session, offset: 0, limit: 1).total == 2)
+    let records = try await client.records(for: session, offset: 0)
+    let imageMessage = try #require(records.last?.record)
+    #expect(imageMessage.sourceContent != nil)
+    #expect(SourceContent.blocks(imageMessage).contains(.attachment(label: "Image", source: "https://example.com/native-fixture.png", image: true)))
+    #expect(SourceContent.displayText(imageMessage) == "Inspect this image")
+    #expect(records.last?.rawTranscriptBody.contains("ImageDisplayed") == true)
     child.terminate()
     child.waitUntilExit()
     child = try start()

--- a/apps/macos/Tests/MemexTests/DaemonClientTests.swift
+++ b/apps/macos/Tests/MemexTests/DaemonClientTests.swift
@@ -260,7 +260,9 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
     defer { try? FileManager.default.removeItem(at: root) }
     let transcript = #"{"type":"user","uuid":"native-fixture-message","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:00Z","message":{"role":"user","content":"hello persistent native connection"}}"#
     let image = #"{"type":"user","uuid":"native-fixture-image","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"<<ImageDisplayed>>\nInspect this image"},{"type":"image","source":{"type":"url","url":"https://example.com/native-fixture.png"}}]}}"#
-    try (transcript + "\n" + image + "\n").write(to: inputs.appendingPathComponent("native-fixture.jsonl"), atomically: true, encoding: .utf8)
+    let failedTool = #"{"type":"user","uuid":"native-fixture-error","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:02Z","message":{"content":[{"type":"tool_result","tool_use_id":"failed-call","is_error":true,"content":"permission denied"}]}}"#
+    let document = #"{"type":"user","uuid":"native-fixture-document","sessionId":"native-fixture","timestamp":"2026-09-07T12:00:03Z","message":{"content":[{"type":"document","title":"Report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQ="}}]}}"#
+    try ([transcript, image, failedTool, document].joined(separator: "\n") + "\n").write(to: inputs.appendingPathComponent("native-fixture.jsonl"), atomically: true, encoding: .utf8)
     let logURL = root.appendingPathComponent("daemon.log")
     FileManager.default.createFile(atPath: logURL.path, contents: nil)
     let log = try FileHandle(forWritingTo: logURL)
@@ -307,11 +309,11 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
     }
     let session = try await waitForSession()
     #expect(session.sessionID == "native-fixture")
-    #expect(session.messageCount == 2)
+    #expect(session.messageCount == 4)
     let initial = try await client.initialRecords(for: session, anchor: nil)
-    #expect(initial.total == 2)
+    #expect(initial.total == 4)
     #expect(initial.offset == 0)
-    #expect(initial.records.count == 2)
+    #expect(initial.records.count == 4)
     #expect(initial.records.last?.record.sourceContent != nil)
     #expect(try await client.machines() == [.local])
     #expect(try await client.projects().reduce(0) { $0 + $1.sessionCount } == 1)
@@ -320,13 +322,28 @@ func isolatedRustDaemonServesSwiftClientAndReconnects() async throws {
     #expect(try await client.search("persistent", project: nil, source: nil, limit: 1000).first?.sessionID == session.sessionID)
     #expect(try await client.sessionDetails(for: session).id == session.id)
     #expect(try await client.records(for: session, offset: 0).first?.record.text == "hello persistent native connection")
-    #expect(try await client.recordMetadata(for: session, offset: 0, limit: 1).total == 2)
+    #expect(try await client.recordMetadata(for: session, offset: 0, limit: 1).total == 4)
     let records = try await client.records(for: session, offset: 0)
-    let imageMessage = try #require(records.last?.record)
+    let imageRecord = try #require(records.first { $0.record.eventID == "native-fixture-image" })
+    let imageMessage = imageRecord.record
     #expect(imageMessage.sourceContent != nil)
     #expect(SourceContent.blocks(imageMessage).contains(.attachment(label: "Image", source: "https://example.com/native-fixture.png", image: true)))
     #expect(SourceContent.displayText(imageMessage) == "Inspect this image")
-    #expect(records.last?.rawTranscriptBody.contains("ImageDisplayed") == true)
+    #expect(imageRecord.rawTranscriptBody.contains("ImageDisplayed"))
+    let failure = try #require(records.first { $0.record.role == "tool_result" })
+    #expect(failure.record.toolResultIsError == true)
+    #expect(failure.record.toolOutput == "permission denied")
+    #expect(TranscriptActivity(records: [failure]).presentation.hasFailure)
+    let documentRecord = try #require(records.first { $0.record.eventID == "native-fixture-document" })
+    let documentBlocks = SourceContent.blocks(documentRecord.record)
+    #expect(documentBlocks.count == 1)
+    if case .attachmentNotice(let label, let detail) = documentBlocks.first {
+        #expect(label == "Report.pdf")
+        #expect(detail.contains("application/pdf"))
+    } else {
+        Issue.record("Expected a visible embedded document card")
+    }
+    #expect(documentRecord.rawTranscriptBody.contains("JVBERi0xLjQ="))
     child.terminate()
     child.waitUntilExit()
     child = try start()

--- a/apps/macos/Tests/MemexTests/FindTests.swift
+++ b/apps/macos/Tests/MemexTests/FindTests.swift
@@ -51,15 +51,15 @@ struct FindTests {
         #expect(controller.selectedFindRange?.location == 13)
     }
 
-    @Test func hiddenMarkdownSourceMatchDoesNotSelectAnotherVisibleOccurrence() {
+    @Test func hiddenMarkdownSourceMatchRevealsAndSelectsItsOriginalOccurrence() {
         let controller = TranscriptController()
         controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 400)
         let record = entry("link", "[label](https://example.com/needle) needle")
         let hit = ConversationMatcher.matches([record], query: "needle")[0]
         controller.update(sessionID: "link", records: [record], provider: "codex",
                           findQuery: "needle", findHit: hit, findGeneration: 1)
-        #expect(controller.measurement(at: 0).attributedBody.string == "label needle")
-        #expect(controller.selectedFindRange == nil)
+        #expect(controller.measurement(at: 0).attributedBody.string == record.record.text)
+        #expect(controller.selectedFindRange == NSRange(location: 28, length: 6))
     }
 
     @Test func scansBeyondFirstPageAndIsolatesCancelledQueryAndSession() async throws {

--- a/apps/macos/Tests/MemexTests/ModelTests.swift
+++ b/apps/macos/Tests/MemexTests/ModelTests.swift
@@ -77,7 +77,7 @@ private func record(_ id: String, _ role: String, _ tool: String? = nil) -> Tran
                  record("7", "developer"), record("8", "assistant")]
     let items = TranscriptItem.group(input)
     #expect(items.count == 5)
-    #expect(items[0].title == "Session instructions")
+    #expect(items[0].title == "Session context")
     #expect(items[0].records.count == 3)
     #expect(items[1].records[0].record.role == "user")
     #expect(items[2].isActivity)

--- a/apps/macos/Tests/MemexTests/ReaderEnhancementTests.swift
+++ b/apps/macos/Tests/MemexTests/ReaderEnhancementTests.swift
@@ -1,0 +1,230 @@
+import AppKit
+import Testing
+@testable import Memex
+
+@Suite(.serialized) @MainActor struct ReaderEnhancementTests {
+    @Test func expandedToolPanelHasEqualInsetsAroundItsContent() throws {
+        let tool = TranscriptRecord(recordID: "tool", record: Message(role: "tool_use", text: "", toolName: "exec_command", toolInput: #"{"cmd":"printf hello"}"#, toolOutput: nil))
+        let reader = controller([tool])
+        reader.toggle(reader.rows[0].id)
+        let value = reader.measurement(at: 0)
+        let cell = try #require(reader.tableView(reader.table, viewFor: reader.table.tableColumns.first, row: 0))
+        cell.frame = NSRect(x: 0, y: 0, width: 700, height: value.height)
+        cell.layoutSubtreeIfNeeded()
+        let clip = try #require(value.richContent?.superview)
+        let panel = try #require(cell.subviews.first { !$0.isHidden && $0.layer?.cornerRadius == 8 })
+        #expect(clip.frame.minX - panel.frame.minX == 12)
+        #expect(panel.frame.maxX - clip.frame.maxX == 12)
+        #expect(clip.frame.minY - panel.frame.minY == 12)
+        #expect(panel.frame.maxY - clip.frame.maxY == 12)
+    }
+
+    @Test func showingActionsDoesNotMoveDisclosureTitleOrChevron() throws {
+        let reader = controller([record("tool", "tool_use", String(repeating: "Long command ", count: 20))])
+        let value = reader.measurement(at: 0)
+        let cell = try #require(reader.tableView(reader.table, viewFor: reader.table.tableColumns.first, row: 0))
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: value.height), styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView = cell
+        cell.layoutSubtreeIfNeeded()
+        let buttons = cell.subviews.compactMap { $0 as? NSButton }
+        let disclosure = try #require(buttons.first { $0.title == value.title })
+        let copy = try #require(buttons.first { $0.accessibilityLabel() == "Copy message" })
+        let frame = disclosure.frame
+        let titleRect = disclosure.cell?.titleRect(forBounds: disclosure.bounds)
+        let imageRect = disclosure.cell?.imageRect(forBounds: disclosure.bounds)
+        #expect(window.makeFirstResponder(copy))
+        cell.updateTrackingAreas()
+        #expect(copy.alphaValue == 1)
+        #expect(copy.title.isEmpty)
+        #expect(copy.image != nil)
+        #expect(!buttons.contains { ["Raw", "Source"].contains($0.title) })
+        #expect(disclosure.frame == frame)
+        #expect(disclosure.cell?.titleRect(forBounds: disclosure.bounds) == titleRect)
+        #expect(disclosure.cell?.imageRect(forBounds: disclosure.bounds) == imageRect)
+        #expect(disclosure.frame.maxX <= copy.frame.minX)
+        window.makeFirstResponder(nil)
+        cell.updateTrackingAreas()
+        #expect(disclosure.frame == frame)
+    }
+
+    @Test func toolReopenReusesRenderedContentAndKeepsCollapsedBodyEmpty() throws {
+        let tool = TranscriptRecord(recordID: "tool", record: Message(role: "tool_use", text: "", toolName: "exec_command", toolInput: #"{"cmd":"printf hello"}"#, toolOutput: nil))
+        let reader = controller([tool])
+        let id = reader.rows[0].id
+        reader.toggle(id)
+        let opened = reader.measurement(at: 0)
+        let rich = try #require(opened.richContent)
+        reader.toggle(id)
+        #expect(!reader.measurement(at: 0).hasBody)
+        reader.toggle(id)
+        #expect(reader.measurement(at: 0).richContent === rich)
+        #expect(reader.measurement(at: 0).attributedBody === opened.attributedBody)
+        #expect(reader.measurement(at: 0).height == opened.height)
+        reader.toggleRaw(id)
+        #expect(reader.measurement(at: 0).richContent == nil)
+        reader.toggleRaw(id)
+        #expect(reader.measurement(at: 0).richContent === rich)
+    }
+
+    @Test func longRichBodyStartsAtTopAndFooterDoesNotOverlap() throws {
+        let reader = controller([record("code", "assistant", "```swift\n" + String(repeating: "let value = 42\n", count: 100) + "```")])
+        let value = reader.measurement(at: 0)
+        let cell = try #require(reader.tableView(reader.table, viewFor: reader.table.tableColumns.first, row: 0))
+        cell.frame = NSRect(x: 0, y: 0, width: 700, height: value.height)
+        cell.layoutSubtreeIfNeeded()
+        let show = try #require(cell.subviews.compactMap { $0 as? NSButton }.first { $0.title == "Show all" })
+        let copy = try #require(cell.subviews.compactMap { $0 as? NSButton }.first { $0.accessibilityLabel() == "Copy message" })
+        let rich = try #require(value.richContent)
+        let clip = try #require(rich.superview)
+        #expect(clip.isFlipped)
+        #expect(rich.frame.minY == 0)
+        #expect(show.frame.minY >= clip.frame.maxY)
+        #expect(copy.frame.minY >= show.frame.maxY)
+        #expect(copy.frame.maxY <= cell.bounds.maxY)
+        #expect(copy.alphaValue == 0)
+    }
+
+    @Test func longMessagesExpandWithoutDiscardingCopyText() {
+        let source = String(repeating: "A complete line of source content.\n\n", count: 120)
+        let records = [record("long", "user", source)]
+        let reader = controller(records)
+        let collapsed = reader.measurement(at: 0)
+        #expect(collapsed.isLong)
+        #expect(collapsed.textHeight == 360)
+        #expect(collapsed.body == source)
+        #expect(collapsed.attributedBody.string.contains("source content."))
+        reader.toggleFullBody(reader.rows[0].id)
+        let expanded = reader.measurement(at: 0)
+        #expect(expanded.showsFullBody)
+        #expect(expanded.textHeight == expanded.fullTextHeight)
+        #expect(expanded.height > collapsed.height)
+        reader.toggleFullBody(reader.rows[0].id)
+        #expect(reader.measurement(at: 0).textHeight == collapsed.textHeight)
+    }
+
+    @Test func findShowsExactOccurrenceInsideSuppressedMixedContext() throws {
+        let source = "<recommended_plugins>\nHidden needle\n</recommended_plugins>\nActual request"
+        let records = [record("mixed", "user", source)]
+        let reader = controller(records)
+        #expect(reader.rows.count == 2)
+        #expect(reader.measurement(at: 1).body.trimmingCharacters(in: .whitespacesAndNewlines) == "Actual request")
+        let hit = try #require(ConversationMatcher.matches(records, query: "needle").first)
+        reader.update(sessionID: "reader", records: records, provider: "codex", findQuery: "needle", findHit: hit, findGeneration: 1)
+        #expect(reader.rows.count == 1)
+        let selected = try #require(reader.selectedFindRange)
+        #expect((reader.measurement(at: 0).attributedBody.string as NSString).substring(with: selected) == "needle")
+        reader.update(sessionID: "reader", records: records, provider: "codex")
+        #expect(reader.rows.count == 2)
+    }
+
+    @Test func rawTranscriptContainsUnknownFieldsAndUnpairedRecords() throws {
+        let data = Data(#"{"record_id":"raw","unknown_envelope":42,"record":{"role":"user","text":"<environment_context>hidden</environment_context>","new_provider_field":{"original":true}}}"#.utf8)
+        let source = try JSONDecoder().decode(TranscriptRecord.self, from: data)
+        let reader = controller([source])
+        reader.update(sessionID: "reader", records: [source], provider: "codex", rawTranscript: true)
+        let value = reader.measurement(at: 0)
+        #expect(!value.isDisclosure)
+        #expect(value.body.contains("unknown_envelope"))
+        #expect(value.body.contains("new_provider_field"))
+        #expect(value.body.contains("hidden"))
+        #expect(value.attributedBody.string == source.rawTranscriptBody)
+    }
+
+    @Test func promptOutlineOmitsInjectedContextAndRetainsSourceOffsets() {
+        let records = [record("context", "user", "<environment_context>\nprivate setup\n</environment_context>"),
+                       record("a", "user", "<recommended_plugins>\ncatalog\n</recommended_plugins>\nFix the reader"),
+                       record("b", "assistant", "Working"), record("c", "user", "Then test it")]
+        let entries = ConversationOutline.entries(records, offset: 20)
+        #expect(entries.map(\.id) == ["a", "c"])
+        #expect(entries.map(\.offset) == [21, 23])
+        #expect(entries.first?.preview == "Fix the reader")
+    }
+
+    @Test func sourceOnlyMarkdownMatchIsSelectedPrecisely() throws {
+        let records = [record("link", "assistant", "See [the result](https://example.com/hidden-target).")]
+        let reader = controller(records)
+        let hit = try #require(ConversationMatcher.matches(records, query: "hidden-target").first)
+        reader.update(sessionID: "reader", records: records, provider: "codex", findQuery: "hidden-target", findHit: hit, findGeneration: 1)
+        let selected = try #require(reader.selectedFindRange)
+        #expect((reader.measurement(at: 0).attributedBody.string as NSString).substring(with: selected) == "hidden-target")
+    }
+
+    @Test func richCodeUsesNativeContentAndFindReturnsToExactText() throws {
+        let records = [record("code", "assistant", "```swift\nlet target = 42\n```\n")]
+        let reader = controller(records)
+        #expect(reader.measurement(at: 0).richContent != nil)
+        let hit = try #require(ConversationMatcher.matches(records, query: "target").first)
+        reader.update(sessionID: "reader", records: records, provider: "codex", findQuery: "target", findHit: hit, findGeneration: 1)
+        #expect(reader.measurement(at: 0).richContent == nil)
+        #expect(reader.selectedFindRange != nil)
+    }
+
+    @Test func lifecycleLabelsRequireRecordedEvents() {
+        var completed = record("complete", "lifecycle", "Turn completed").record
+        completed.lifecycleEvent = "task_complete"
+        var aborted = record("abort", "lifecycle", "Turn interrupted").record
+        aborted.lifecycleEvent = "turn_aborted"
+        let reader = controller([TranscriptRecord(recordID: "complete", record: completed), TranscriptRecord(recordID: "abort", record: aborted)])
+        #expect(reader.measurement(at: 0).title == "Completed")
+        #expect(reader.measurement(at: 1).title == "Interrupted")
+        #expect(reader.measurement(at: 1).hasFailure)
+    }
+
+    @Test func returningToLongExpandedRawMessageRestoresDisplayStateAndOffset() {
+        let navigation = TranscriptNavigationState()
+        let records = [record("long", "assistant", String(repeating: "A line of retained content.\n", count: 180))]
+        let reader = controller(records)
+        reader.update(sessionID: "reader", records: records, provider: "codex", navigation: navigation)
+        reader.toggleRaw("message:long")
+        reader.toggleFullBody("message:long")
+        reader.scrollView.contentView.scroll(to: NSPoint(x: 0, y: 500))
+        reader.update(sessionID: "other", records: [record("other", "user", "Other")], provider: "codex", navigation: navigation)
+        reader.update(sessionID: "reader", records: records, provider: "codex", navigation: navigation)
+        #expect(reader.measurement(at: 0).showsFullBody)
+        #expect(reader.measurement(at: 0).showsRaw)
+        #expect(abs(reader.scrollView.contentView.bounds.minY - 500) < 1)
+    }
+
+    @Test func pagedToolResultsRefreshTheNativeRichView() {
+        let call = TranscriptRecord(recordID: "call", record: Message(role: "tool_use", text: "", toolName: "bash", toolInput: #"{"command":"echo result"}"#, toolOutput: nil, eventID: "call"))
+        let result = TranscriptRecord(recordID: "output", record: Message(role: "tool_result", text: "fresh output", toolName: "bash", toolInput: nil, toolOutput: nil, parentToolUseID: "call"))
+        let reader = controller([call])
+        reader.toggle("activity:call")
+        let before = reader.measurement(at: 0).richContent
+        #expect(before != nil)
+        reader.update(sessionID: "reader", records: [call, result], provider: "codex")
+        #expect(reader.measurement(at: 0).richContent !== before)
+        #expect(reader.measurement(at: 0).body.contains("fresh output"))
+    }
+
+    @Test func groupReopenReusesToolViewButPagingWhileHiddenRefreshesIt() throws {
+        let call = TranscriptRecord(recordID: "call", record: Message(role: "tool_use", text: "", toolName: "bash", toolInput: #"{"command":"echo result"}"#, toolOutput: nil, eventID: "call"))
+        let other = TranscriptRecord(recordID: "other", record: Message(role: "tool_use", text: "", toolName: "bash", toolInput: #"{"command":"pwd"}"#, toolOutput: nil, eventID: "other"))
+        let result = TranscriptRecord(recordID: "output", record: Message(role: "tool_result", text: "fresh output", toolName: "bash", toolInput: nil, toolOutput: nil, parentToolUseID: "call"))
+        let reader = controller([call, other])
+        let group = reader.rows[0].id
+        reader.toggle(group)
+        reader.toggle("activity:call")
+        let before = try #require(reader.measurement(at: 1).richContent)
+        reader.toggle(group)
+        reader.toggle(group)
+        #expect(reader.measurement(at: 1).richContent === before)
+        reader.toggle(group)
+        reader.update(sessionID: "reader", records: [call, other, result], provider: "codex")
+        reader.toggle(group)
+        #expect(reader.measurement(at: 1).richContent !== before)
+        #expect(reader.measurement(at: 1).body.contains("fresh output"))
+    }
+
+    private func controller(_ records: [TranscriptRecord]) -> TranscriptController {
+        let reader = TranscriptController()
+        reader.view.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+        reader.update(sessionID: "reader", records: records, provider: "codex")
+        return reader
+    }
+    private func record(_ id: String, _ role: String, _ text: String) -> TranscriptRecord {
+        TranscriptRecord(recordID: id, record: Message(role: role, text: text, toolName: nil, toolInput: nil, toolOutput: nil))
+    }
+}

--- a/apps/macos/Tests/MemexTests/ReaderLoadingTests.swift
+++ b/apps/macos/Tests/MemexTests/ReaderLoadingTests.swift
@@ -11,12 +11,16 @@ private struct ReaderFixture {
         let executable = directory.appendingPathComponent("cli")
         let script = #"""
         #!/bin/sh
-        offset=0; limit=60; full=0; budget=0; session=''
+        offset=0; limit=60; full=0; budget=0; page_info=0; session=''
+        printf '%s\n' "$*" >> "$(dirname "$0")/requests"
         while [ "$#" -gt 0 ]; do
           case "$1" in
             --offset) shift; offset="$1";;
             --limit) shift; limit="$1";;
             --full) full=1;;
+            --page-info)
+              if [ -f "$(dirname "$0")/legacy" ]; then echo "unexpected argument '--page-info'" >&2; exit 2; fi
+              page_info=1;;
             --max-chars) shift; budget="$1";;
             --) shift; session="$1"; break;;
           esac
@@ -37,14 +41,14 @@ private struct ReaderFixture {
           else [ "$budget" = 262144 ] || exit 3; limit=300
           fi
         fi
-        awk -v offset="$offset" -v limit="$limit" -v full="$full" -v session="$session" 'BEGIN {
+        awk -v offset="$offset" -v limit="$limit" -v full="$full" -v page_info="$page_info" -v session="$session" 'BEGIN {
           total=620; end=offset+limit; if(end>total)end=total;
           printf "[";
           for(i=offset;i<end;i++) {
             if(i>offset)printf ",";
             printf "{\"record_id\":\"%s-r%d\",\"record\":{\"role\":\"assistant\",\"text\":\"%s\"}}",session,i,full ? "complete text" : "";
           }
-          if(!full) {
+          if(!full || page_info) {
             if(end>offset)printf ",";
             printf "{\"type\":\"page\",\"total\":620,\"next_offset\":%s}",(end<total ? end : "null");
           }
@@ -56,9 +60,52 @@ private struct ReaderFixture {
         client = MemexClient(executable: executable)
     }
     func cleanUp() { try? FileManager.default.removeItem(at: directory) }
-    func session(_ id: String, anchor: String? = nil) -> Session {
-        Session(source: "codex", sessionID: id, sourcePath: "/\(id)", project: "memex", searchRecordID: anchor)
+    func session(_ id: String, anchor: String? = nil, count: Int? = nil) -> Session {
+        Session(source: "codex", sessionID: id, sourcePath: "/\(id)", project: "memex", searchRecordID: anchor, messageCount: count)
     }
+}
+
+@MainActor @Test func readerUsesListCountToLoadCompleteLatestPageInOneRequest() async throws {
+    let fixture = try ReaderFixture()
+    defer { fixture.cleanUp() }
+    let session = try JSONDecoder().decode(Session.self, from: Data(#"{"source":"codex","session_id":"one","source_path":"/one","project":"memex","message_count":620}"#.utf8))
+    let store = Store(client: fixture.client)
+    store.sessions = [session]
+    store.selectedID = session.id
+    await store.loadRecords()
+    #expect(store.readerError == nil)
+    #expect(store.recordsOffset == 560)
+    #expect(store.records.count == 60)
+    #expect(store.records.last?.id == "one-r619")
+    #expect(store.records.allSatisfy { $0.record.text == "complete text" })
+    #expect(!store.hasMoreRecords)
+    let requests = try String(contentsOf: fixture.directory.appendingPathComponent("requests"), encoding: .utf8).split(separator: "\n")
+    #expect(requests.count == 1)
+    #expect(requests[0].contains("--page-info"))
+    #expect(!requests[0].contains("--max-chars"))
+}
+
+@Test(arguments: [0, 100, 1000]) func initialPageCorrectsStaleListCount(count: Int) async throws {
+    let fixture = try ReaderFixture()
+    defer { fixture.cleanUp() }
+    let page = try await fixture.client.initialRecords(for: fixture.session("one", count: count), anchor: nil)
+    #expect(page.offset == 560)
+    #expect(page.total == 620)
+    #expect(page.records.last?.id == "one-r619")
+    let requests = try String(contentsOf: fixture.directory.appendingPathComponent("requests"), encoding: .utf8).split(separator: "\n")
+    #expect(requests.count == 2)
+    #expect(requests.allSatisfy { $0.contains("--page-info") })
+}
+
+@Test func initialPageSupportsOlderCLIWithoutPageInfo() async throws {
+    let fixture = try ReaderFixture()
+    defer { fixture.cleanUp() }
+    try Data().write(to: fixture.directory.appendingPathComponent("legacy"))
+    let page = try await fixture.client.initialRecords(for: fixture.session("one", count: 620), anchor: nil)
+    #expect(page.offset == 560)
+    #expect(page.total == 620)
+    #expect(page.records.count == 60)
+    #expect(page.records.first?.record.text == "complete text")
 }
 
 @MainActor @Test func readerStartsAtNewestAndPrependsWithoutOverlapThenRestoresWindow() async throws {
@@ -205,4 +252,20 @@ private struct ReaderFixture {
     #expect(store.hasEarlierRecords && store.hasMoreRecords)
     await store.revealRecord("one-r110", offset: 110)
     #expect(store.recordsOffset == 70)
+}
+
+@MainActor @Test func findRevealWithKnownOffsetLoadsInOneRequest() async throws {
+    let fixture = try ReaderFixture()
+    defer { fixture.cleanUp() }
+    let store = Store(client: fixture.client)
+    let session = fixture.session("one")
+    store.sessions = [session]
+    store.selectedID = session.id
+    await store.revealRecord("one-r100", offset: 100)
+    #expect(store.readerError == nil)
+    #expect(store.recordsOffset == 70)
+    #expect(store.records.contains { $0.id == "one-r100" })
+    #expect(store.hasEarlierRecords && store.hasMoreRecords)
+    let requests = try String(contentsOf: fixture.directory.appendingPathComponent("requests"), encoding: .utf8).split(separator: "\n")
+    #expect(requests.count == 1)
 }

--- a/apps/macos/Tests/MemexTests/ReaderPerformanceTests.swift
+++ b/apps/macos/Tests/MemexTests/ReaderPerformanceTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Testing
+@testable import Memex
+
+/// Opt-in profiling of a captured `memex session --full --format json` page. Reports
+/// counts and timings only; source content and record identifiers never enter logs.
+@Suite(.serialized) @MainActor struct ReaderPerformanceTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"] != nil))
+    func capturedPageDecodeAndNativeLayout() throws {
+        let path = try #require(ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"])
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        _ = NSApplication.shared
+        for iteration in 0..<3 {
+            let decodeStart = ContinuousClock.now
+            let records = try JSONDecoder().decode([TranscriptRecord].self, from: data)
+            let decodeMS = milliseconds(since: decodeStart)
+            #expect(!records.isEmpty)
+
+            let reader = TranscriptController()
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 700),
+                                  styleMask: [.titled, .resizable], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            window.contentViewController = reader
+            window.contentView?.layoutSubtreeIfNeeded()
+            defer { window.close() }
+
+            let updateStart = ContinuousClock.now
+            reader.update(sessionID: "performance", records: records, provider: "codex", startsAtEnd: true)
+            let updateMS = milliseconds(since: updateStart)
+            let layoutStart = ContinuousClock.now
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            let layoutMS = milliseconds(since: layoutStart)
+            #expect(!reader.rows.isEmpty)
+
+            let warmStart = ContinuousClock.now
+            reader.update(sessionID: "performance", records: records, provider: "codex", startsAtEnd: true)
+            window.contentView?.layoutSubtreeIfNeeded()
+            let warmMS = milliseconds(since: warmStart)
+
+            print(String(format: "reader_perf iteration=%d bytes=%d records=%d rows=%d decode_ms=%.2f update_ms=%.2f layout_ms=%.2f render_total_ms=%.2f warm_update_ms=%.2f",
+                         iteration, data.count, records.count, reader.rows.count, decodeMS, updateMS, layoutMS, updateMS + layoutMS, warmMS))
+        }
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"] != nil))
+    func capturedPageLargestToolDisclosure() throws {
+        let path = try #require(ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"])
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let records = try JSONDecoder().decode([TranscriptRecord].self, from: data)
+        let activities = TranscriptItem.group(records).flatMap(\.activities).filter {
+            $0.records.contains { ["tool_use", "tool_result", "tool"].contains($0.record.role) }
+        }
+        func bytes(_ activity: TranscriptActivity) -> Int {
+            activity.records.reduce(0) { count, entry in
+                count + entry.record.text.utf8.count + (entry.record.toolInput?.utf8.count ?? 0)
+                    + (entry.record.toolOutput?.utf8.count ?? 0)
+            }
+        }
+        let largest = try #require(activities.max { bytes($0) < bytes($1) })
+        _ = NSApplication.shared
+        let reader = TranscriptController()
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 700),
+                              styleMask: [.titled, .resizable], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentViewController = reader
+        defer { window.close() }
+        window.contentView?.layoutSubtreeIfNeeded()
+        reader.update(sessionID: "disclosure-performance", records: records, provider: "codex", startsAtEnd: true)
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        func timedToggle(_ id: String, phase: String) {
+            let start = ContinuousClock.now
+            reader.toggle(id)
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            let elapsed = milliseconds(since: start)
+            print(String(format: "reader_disclosure_perf phase=%@ bytes=%d records=%d rows=%d elapsed_ms=%.2f",
+                         phase, bytes(largest), largest.records.count, reader.rows.count, elapsed))
+        }
+        if let groupIndex = reader.rows.firstIndex(where: { row in
+            guard case .group = row else { return false }
+            return row.records.contains { $0.id == largest.records[0].id }
+        }) {
+            let groupID = reader.rows[groupIndex].id
+            reader.table.scrollRowToVisible(groupIndex)
+            window.contentView?.layoutSubtreeIfNeeded()
+            timedToggle(groupID, phase: "group_open")
+            timedToggle(groupID, phase: "group_close")
+            timedToggle(groupID, phase: "group_reopen")
+        }
+        let toolID = "activity:\(largest.id)"
+        let toolIndex = try #require(reader.rows.firstIndex { $0.id == toolID })
+        reader.table.scrollRowToVisible(toolIndex)
+        window.contentView?.layoutSubtreeIfNeeded()
+        timedToggle(toolID, phase: "tool_first_open")
+        #expect(reader.measurement(at: toolIndex).isExpanded)
+        timedToggle(toolID, phase: "tool_close")
+        #expect(!reader.measurement(at: toolIndex).isExpanded)
+        timedToggle(toolID, phase: "tool_reopen")
+        #expect(reader.measurement(at: toolIndex).isExpanded)
+    }
+
+    private func milliseconds(since start: ContinuousClock.Instant) -> Double {
+        let duration = start.duration(to: .now).components
+        return Double(duration.seconds) * 1_000 + Double(duration.attoseconds) / 1_000_000_000_000_000
+    }
+}

--- a/apps/macos/Tests/MemexTests/RenderingTests.swift
+++ b/apps/macos/Tests/MemexTests/RenderingTests.swift
@@ -5,6 +5,55 @@ import Testing
 
 @Suite(.serialized) @MainActor
 struct RenderingTests {
+    @Test func messagesUseUnlabelledContentSizedBubblesAndKeepAccessibleSpeakers() throws {
+        let controller = TranscriptController()
+        let window = readerWindow(controller)
+        defer { window.close() }
+        let records = ["user", "assistant"].enumerated().map { index, role in
+            TranscriptRecord(recordID: "clean-\(index)", record: Message(role: role, text: "Short reply",
+                toolName: nil, toolInput: nil, toolOutput: nil))
+        }
+        controller.update(sessionID: "clean", records: records, provider: "codex")
+        pump(window)
+        #expect(controller.measurement(at: 0).contentWidth < 150)
+        for row in 0..<2 {
+            let cell = try #require(controller.table.view(atColumn: 0, row: row, makeIfNecessary: true))
+            cell.layoutSubtreeIfNeeded()
+            #expect(descendants(of: cell, as: NSTextField.self).allSatisfy {
+                $0.isHiddenOrHasHiddenAncestor || !["You", "codex"].contains($0.stringValue)
+            })
+            let text = try #require(descendants(of: cell, as: NSTextView.self).first)
+            #expect(text.accessibilityLabel() == (row == 0 ? "You" : "codex"))
+            #expect(text.isSelectable)
+            #expect(text.frame.maxY <= controller.measurement(at: row).height)
+        }
+    }
+
+    @Test func userBubblesWrapWithinReaderAtNarrowAndWideSizes() throws {
+        let controller = TranscriptController()
+        let window = readerWindow(controller)
+        defer { window.close() }
+        let record = TranscriptRecord(recordID: "wrapped", record: Message(role: "user",
+            text: String(repeating: "A longer message that needs room to wrap. ", count: 30),
+            toolName: nil, toolInput: nil, toolOutput: nil))
+        controller.update(sessionID: "wrapped", records: [record], provider: "codex")
+        for width in [350.0, 700.0, 1200.0] {
+            window.setContentSize(NSSize(width: width, height: 600))
+            pump(window)
+            let readerWidth = controller.table.bounds.width
+            let value = controller.measurement(at: 0)
+            #expect(value.contentWidth <= min(800, readerWidth - 60) * 0.77)
+            #expect(abs(value.contentX + value.contentWidth - (readerWidth - 30)) < 1)
+            let cell = try #require(controller.table.view(atColumn: 0, row: 0, makeIfNecessary: true))
+            cell.layoutSubtreeIfNeeded()
+            let text = try #require(descendants(of: cell, as: NSTextView.self).first)
+            let manager = try #require(text.layoutManager)
+            let container = try #require(text.textContainer)
+            manager.ensureLayout(for: container)
+            #expect(manager.usedRect(for: container).height <= value.fullTextHeight + 1)
+        }
+    }
+
     @Test func wideReaderKeepsAssistantAndToolsAtLeftGutter() {
         let controller = TranscriptController()
         controller.view.frame = NSRect(x: 0, y: 0, width: 1600, height: 700)
@@ -59,7 +108,11 @@ struct RenderingTests {
             let manager = try #require(text.layoutManager)
             let container = try #require(text.textContainer)
             manager.ensureLayout(for: container)
-            #expect(manager.usedRect(for: container).height <= measured.textHeight + 1)
+            if let rich = measured.richContent {
+                #expect(rich.height(for: measured.contentWidth) == measured.fullTextHeight)
+            } else {
+                #expect(manager.usedRect(for: container).height <= measured.fullTextHeight + 1)
+            }
             if width == 500, let path = ProcessInfo.processInfo.environment["MEMEX_RENDER_SNAPSHOT"],
                let bitmap = cell.bitmapImageRepForCachingDisplay(in: cell.bounds) {
                 cell.wantsLayer = true
@@ -149,7 +202,7 @@ struct RenderingTests {
         #expect(controller.measurement(at: 0).body == "Complete instructions")
     }
 
-    @Test func messagesShowFullTextWithoutCharacterCounterControls() throws {
+    @Test func longMessagesRetainFullSelectableTextBehindShowAll() throws {
         let controller = TranscriptController()
         controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 600)
         let text = String(repeating: "Complete message content. ", count: 400) + "END OF MESSAGE"
@@ -161,7 +214,10 @@ struct RenderingTests {
             #expect(controller.measurement(at: row).body == text)
             let cell = try #require(controller.table.view(atColumn: 0, row: row, makeIfNecessary: true))
             #expect(descendants(of: cell, as: NSTextView.self).contains { $0.string.hasSuffix("END OF MESSAGE") })
-            #expect(descendants(of: cell, as: NSButton.self).allSatisfy { $0.isHidden })
+            #expect(descendants(of: cell, as: NSButton.self).contains { !$0.isHidden && $0.title == "Show all" })
+            #expect(controller.measurement(at: row).textHeight < controller.measurement(at: row).fullTextHeight)
+            controller.toggleFullBody(controller.rows[row].id)
+            #expect(controller.measurement(at: row).textHeight == controller.measurement(at: row).fullTextHeight)
         }
     }
 
@@ -308,6 +364,15 @@ struct RenderingTests {
         let index = try #require(controller.rows.firstIndex { $0.id == "activity:tool" })
         #expect(controller.measurement(at: index).body == "matching tool content")
         #expect(abs(controller.scrollView.contentView.bounds.minY - controller.table.rect(ofRow: index).minY) < 1)
+    }
+
+    private func readerWindow(_ controller: TranscriptController) -> NSWindow {
+        _ = NSApplication.shared
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 700, height: 600),
+                              styleMask: [.titled, .resizable], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentViewController = controller
+        return window
     }
 
     private func simpleRecords(_ range: Range<Int>) -> [TranscriptRecord] {

--- a/apps/macos/Tests/MemexTests/RichContentTests.swift
+++ b/apps/macos/Tests/MemexTests/RichContentTests.swift
@@ -1,0 +1,199 @@
+import AppKit
+import Testing
+@testable import Memex
+
+@Test func richDocumentPreservesCodeAndSurroundingProse() {
+    let source = "Before.\n\n```swift\nlet x = \"**literal**\"\n```\n\nAfter."
+    let document = RichContentDocument(source)
+    #expect(document.hasRichBlocks)
+    #expect(document.blocks.count == 3)
+    #expect(document.blocks[1] == .code("let x = \"**literal**\"\n", language: "swift"))
+    if case .markdown(let text) = document.blocks[2] { #expect(text == "After.") }
+    else { Issue.record("Missing trailing prose") }
+}
+
+@Test func attachmentsRetainSourceAndHostBoundary() throws {
+    let document = RichContentDocument("Before ![Screenshot](/tmp/screenshot.png) after.\n\n[Source](/tmp/source.swift:42)")
+    #expect(document.blocks.contains(.attachment(label: "Screenshot", source: "/tmp/screenshot.png", image: true)))
+    #expect(document.blocks.contains(.attachment(label: "Source", source: "/tmp/source.swift:42", image: false)))
+    let source = try #require(ContentLocation.parse("/tmp/source file.swift:42"))
+    #expect(source.url.path == "/tmp/source file.swift")
+    #expect(source.line == 42)
+    #expect(!source.canOpen(in: RichContentContext()))
+    #expect(source.canOpen(in: RichContentContext(isLocalHost: true)))
+    #expect(ContentLocation.parse("javascript:alert(1)") == nil)
+    #expect(ContentLocation.parse("file://another-host/tmp/image.png") == nil)
+    #expect(ContentLocation.parse("relative/path.png") == nil)
+}
+
+@MainActor @Test func syntaxColorsTokensWithoutChangingCopyText() throws {
+    let source = "let x = \"return 42\" // let y = 2\n"
+    let rendered = CodeSyntax.render(source, language: "swift", font: .systemFont(ofSize: 14))
+    #expect(rendered.string == source)
+    let ns = source as NSString
+    #expect(rendered.attribute(.foregroundColor, at: ns.range(of: "let").location, effectiveRange: nil) as? NSColor == .systemPurple)
+    #expect(rendered.attribute(.foregroundColor, at: ns.range(of: "return").location, effectiveRange: nil) as? NSColor == .systemRed)
+    #expect(rendered.attribute(.foregroundColor, at: ns.range(of: "let y").location, effectiveRange: nil) as? NSColor == .secondaryLabelColor)
+    #expect(CodeSyntax.render(source, language: "unknown", font: .systemFont(ofSize: 14)).string == source)
+}
+
+@MainActor @Test func codeCardKeepsLongLinesHorizontallyScrollable() {
+    let code = "let value = \"" + String(repeating: "long ", count: 100) + "\"\n"
+    let card = CodeContentView(code: code, language: "swift", font: .systemFont(ofSize: 14))
+    card.frame = NSRect(x: 0, y: 0, width: 300, height: card.height(for: 300))
+    card.layoutSubtreeIfNeeded()
+    #expect(card.scrollView.hasHorizontalScroller)
+    #expect(card.textView.frame.width > 300)
+    #expect(card.textView.string == String(code.dropLast()))
+    #expect(card.height(for: 200) == card.height(for: 600))
+}
+
+@MainActor @Test func remoteImageDoesNotLoadLocalFileAndKeepsStableHeight() {
+    let card = AttachmentContentView(label: "Image", source: "/System/Library/CoreServices/DefaultDesktop.heic", isImage: true, context: RichContentContext())
+    #expect(card.contentHeight == 70)
+    let view = RichContentView()
+    view.configure(text: "Text\n\n```json\n{\"value\": 42}\n```\n\n![Image](https://example.com/image.png)", font: .systemFont(ofSize: 14), context: RichContentContext())
+    let first = view.height(for: 400)
+    #expect(first > 70)
+    #expect(view.height(for: 400) == first)
+}
+
+@MainActor @Test func localLinksRetainLineMetadataWithoutOpeningByDefault() throws {
+    let rendered = RichTextRenderer.renderMarkdown("See [file](/tmp/source.swift:24).", font: .systemFont(ofSize: 14))
+    let index = (rendered.string as NSString).range(of: "file").location
+    #expect(rendered.attribute(RichTextRenderer.sourceLocationAttribute, at: index, effectiveRange: nil) as? String == "/tmp/source.swift:24")
+    #expect(rendered.attribute(.link, at: index, effectiveRange: nil) == nil)
+}
+
+@MainActor @Test func sourceLineNavigationHandlesUnicodeAndRejectsRemoteOpen() throws {
+    let source = "First\nUnicode 🙂 here\nThird\n"
+    let range = try #require(SourceFilePreview.range(ofLine: 2, in: source))
+    #expect((source as NSString).substring(with: range) == "Unicode 🙂 here\n")
+    #expect(SourceFilePreview.range(ofLine: 9, in: source) == nil)
+    #expect(SourceFilePreview.range(ofLine: 2, in: "Only line") == nil)
+    let location = try #require(ContentLocation.parse("file:///tmp/source.swift#L24"))
+    #expect(location.line == 24)
+    #expect(location.url.fragment == nil)
+    #expect(!location.open(in: RichContentContext()))
+}
+
+@MainActor @Test func richContentSupportsAttributedFieldsAndEmbeddedImages() throws {
+    let bitmap = try #require(NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: 2, pixelsHigh: 2, bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB, bytesPerRow: 8, bitsPerPixel: 32))
+    let data = try #require(bitmap.representation(using: .png, properties: [:]))
+    let card = AttachmentContentView(label: "Result", source: "Embedded image", isImage: true, context: RichContentContext(), embeddedData: data)
+    #expect(card.contentHeight == 260)
+    let view = RichContentView()
+    view.configure(blocks: [.attributed(NSAttributedString(string: "Retained metadata")), .embeddedImage(label: "Result", data: data, mimeType: "image/png")], font: .systemFont(ofSize: 14), context: RichContentContext())
+    #expect(view.height(for: 400) > 260)
+    #expect(view.subviews.compactMap { $0 as? NSTextView }.contains { $0.string == "Retained metadata" })
+}
+
+@Test func ordinaryRepliesStayPlainAndInlineFilesKeepProse() {
+    let plain = RichContentDocument("Short reply.")
+    #expect(!plain.hasRichBlocks)
+    #expect(plain.blocks == [.markdown("Short reply.")])
+    let inline = RichContentDocument("See [source](/tmp/source.swift:42) for details.")
+    #expect(!inline.hasRichBlocks)
+    #expect(inline.blocks.count == 1)
+}
+
+@MainActor private final class WheelRecordingScrollView: NSScrollView {
+    var receivedEvents: [NSEvent] = []
+    override func scrollWheel(with event: NSEvent) { receivedEvents.append(event) }
+}
+
+@MainActor @Test func codeWheelRoutesVerticalGesturesToTranscriptAndKeepsHorizontalPanning() async throws {
+    _ = NSApplication.shared
+    let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 400), styleMask: [.titled], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    defer { window.close() }
+    let outer = WheelRecordingScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
+    window.contentView = outer
+    let document = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 1000))
+    outer.documentView = document
+    let code = CodeContentView(code: String(repeating: "long ", count: 100) + "\nsecond line\n", language: "text", font: .systemFont(ofSize: 14))
+    code.frame = NSRect(x: 0, y: 0, width: 300, height: code.height(for: 300))
+    document.addSubview(code)
+    code.scrollView.scrollerStyle = .legacy
+    window.orderFront(nil)
+    window.contentView?.layoutSubtreeIfNeeded()
+    code.layoutSubtreeIfNeeded()
+    let verticalCG = try #require(CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: -100, wheel2: -4, wheel3: 0))
+    let vertical = try #require(NSEvent(cgEvent: verticalCG))
+    code.scrollView.scrollWheel(with: vertical)
+    #expect(outer.receivedEvents.count == 1)
+    #expect(outer.receivedEvents.first === vertical)
+    #expect(code.scrollView.contentView.bounds.origin.y == 0)
+    #expect(code.textView.frame.height <= code.scrollView.contentSize.height)
+    let horizontalCG = try #require(CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: 0, wheel2: -80, wheel3: 0))
+    let horizontal = try #require(NSEvent(cgEvent: horizontalCG))
+    #expect(horizontal.scrollingDeltaX < 0)
+    #expect(code.textView.frame.width > code.scrollView.contentSize.width)
+    code.scrollView.scrollWheel(with: horizontal)
+    // AppKit can animate wheel scrolling; exercise a window-backed scroll view
+    // and allow the animation to advance before inspecting its final bounds.
+    for _ in 0..<25 where code.scrollView.contentView.bounds.origin.x == 0 {
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    #expect(outer.receivedEvents.count == 1)
+    #expect(code.scrollView.contentView.bounds.origin.x > 0)
+    #expect(code.scrollView.contentView.bounds.origin.y == 0)
+}
+
+@MainActor @Test func shortCodeCardHasTightGeometryAndCopiesExactOriginal() throws {
+    _ = NSApplication.shared
+    let original = "const answer = {\n  value: 42\n}\n"
+    let card = CodeContentView(code: original, language: "ts", font: .systemFont(ofSize: 14))
+    card.scrollView.scrollerStyle = .legacy
+    card.frame = NSRect(x: 0, y: 0, width: 400, height: card.height(for: 400))
+    let window = NSWindow(contentRect: card.frame, styleMask: [.titled], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    window.contentView = card
+    defer { window.close() }
+    card.layoutSubtreeIfNeeded()
+    #expect(card.textView.string == "const answer = {\n  value: 42\n}")
+    #expect(!card.scrollView.hasHorizontalScroller)
+    #expect(abs(card.scrollView.contentSize.height - card.textView.frame.height) <= 1)
+    #expect(card.bounds.height - card.scrollView.frame.maxY == 8)
+    let button = try #require(card.subviews.compactMap { $0 as? NSButton }.first)
+    #expect(button.title.isEmpty)
+    #expect(button.image != nil)
+    #expect(button.alphaValue == 0)
+    let buttonFrame = button.frame
+    let hover = try #require(NSEvent.enterExitEvent(with: .mouseEntered, location: .zero, modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber, context: nil, eventNumber: 0, trackingNumber: 0, userData: nil))
+    card.mouseEntered(with: hover)
+    #expect(button.alphaValue == 1)
+    #expect(button.frame == buttonFrame)
+    card.mouseExited(with: hover)
+    #expect(button.alphaValue == 0)
+    #expect(window.makeFirstResponder(button))
+    #expect(button.alphaValue == 1)
+    #expect(button.frame == buttonFrame)
+    _ = window.makeFirstResponder(nil)
+    #expect(button.alphaValue == 0)
+    let pasteboard = NSPasteboard.general
+    let previous = (pasteboard.pasteboardItems ?? []).map { item in
+        item.types.compactMap { type in item.data(forType: type).map { (type, $0) } }
+    }
+    defer {
+        pasteboard.clearContents()
+        let items = previous.map { representations in
+            let item = NSPasteboardItem()
+            for (type, data) in representations { item.setData(data, forType: type) }
+            return item
+        }
+        pasteboard.writeObjects(items)
+    }
+    let copyAction = try #require(button.action)
+    #expect(NSApplication.shared.sendAction(copyAction, to: button.target, from: button))
+    #expect(pasteboard.string(forType: .string) == original)
+}
+
+@MainActor @Test func codeDisplayRemovesOnlyOneTerminalNewline() {
+    let card = CodeContentView(code: "value\n\n", language: "text", font: .systemFont(ofSize: 14))
+    #expect(card.textView.string == "value\n")
+    #expect(card.code == "value\n\n")
+    let windows = CodeContentView(code: "value\r\n", language: "text", font: .systemFont(ofSize: 14))
+    #expect(windows.textView.string == "value")
+    #expect(windows.code == "value\r\n")
+}

--- a/apps/macos/Tests/MemexTests/SourceContentTests.swift
+++ b/apps/macos/Tests/MemexTests/SourceContentTests.swift
@@ -64,3 +64,33 @@ import Testing
     #expect(reader.rows.count == 3)
     #expect(reader.measurement(at: 1).title.hasPrefix("Cancelled"))
 }
+
+@MainActor @Test func embeddedAndUnavailableDocumentsHaveVisibleCardsAndPreserveRawPayload() throws {
+    let sources = [
+        #"[{"type":"document","title":"Report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQ="}}]"#,
+        #"[{"type":"input_file","filename":"Report.pdf","file_data":"data:application/pdf;base64,JVBERi0xLjQ="}]"#,
+        #"[{"type":"input_file","filename":"Report.pdf","file_id":"file-123"}]"#,
+        #"[{"type":"document","title":"Report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"invalid"}}]"#,
+        #"[{"type":"document","title":"Report.pdf","source":{"type":"unknown"}}]"#
+    ]
+    for source in sources {
+        let record = TranscriptRecord(recordID: "document", record: Message(role: "user", text: "", toolName: nil,
+            toolInput: nil, toolOutput: nil, sourceContent: source))
+        let reader = TranscriptController()
+        reader.view.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+        reader.update(sessionID: source, records: [record], provider: "claude")
+        let measurement = reader.measurement(at: 0)
+        let rich = try #require(measurement.richContent)
+        #expect(measurement.hasBody)
+        #expect(measurement.textHeight >= 70)
+        let card = try #require(rich.subviews.first as? AttachmentContentView)
+        let labels = card.subviews.compactMap { ($0 as? NSTextField)?.stringValue }
+        #expect(labels.contains("Report.pdf"))
+        #expect(labels.contains { $0.contains("raw transcript") || $0.contains("provider") })
+        #expect(card.subviews.compactMap { $0 as? NSButton }.allSatisfy { $0.isHidden })
+        #expect(record.record.sourceContent == source)
+        reader.update(sessionID: source, records: [record], provider: "claude", rawTranscript: true)
+        #expect(reader.measurement(at: 0).body.contains("source_content"))
+        #expect(reader.measurement(at: 0).body.contains("Report.pdf"))
+    }
+}

--- a/apps/macos/Tests/MemexTests/SourceContentTests.swift
+++ b/apps/macos/Tests/MemexTests/SourceContentTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Testing
+@testable import Memex
+
+@Test func onlyTypedRepresentedImagesSuppressStandalonePlaceholders() {
+    let text = "<<ImageDisplayed>>\nWhat changed?\n<<ImageDisplayed>>"
+    var message = Message(role: "user", text: text, toolName: nil, toolInput: nil, toolOutput: nil)
+    #expect(SourceContent.displayText(message) == text)
+    message.sourceContent = #"[{"type":"input_image","image_url":"https://example.com/image.png"}]"#
+    #expect(SourceContent.displayText(message) == "What changed?\n<<ImageDisplayed>>")
+    #expect(message.text == text)
+    message.text = "Explain the <<ImageDisplayed>> marker"
+    #expect(SourceContent.displayText(message) == message.text)
+    message.sourceContent = #"[{"type":"text","text":"image_url: https://example.com/image.png"}]"#
+    message.text = text
+    #expect(SourceContent.displayText(message) == text)
+}
+
+@Test func typedDocumentsAndImagePathsRetainTheirIdentity() {
+    let message = Message(role: "user", text: "Look at these", toolName: nil, toolInput: nil, toolOutput: nil,
+        sourceContent: #"[{"type":"localImage","path":"/tmp/photo.png"},{"type":"input_file","file_url":"/tmp/report.pdf","filename":"Report"} ,{"type":"document","source":{"type":"text","data":"literal **source**"}}]"#)
+    let blocks = SourceContent.blocks(message)
+    #expect(blocks.count == 3)
+    #expect(blocks[0] == .attachment(label: "Image", source: "/tmp/photo.png", image: true))
+    #expect(blocks[1] == .attachment(label: "Report", source: "/tmp/report.pdf", image: false))
+    #expect(blocks[2] == .code("literal **source**", language: "text"))
+}
+
+@Test func placeholderProjectionKeepsOriginalRawRecordAndStableID() {
+    let message = Message(role: "user", text: "<<ImageDisplayed>>\nQuestion", toolName: nil, toolInput: nil, toolOutput: nil,
+        sourceContent: #"[{"type":"input_image","image_url":"/tmp/image.png"}]"#)
+    let original = TranscriptRecord(recordID: "image", record: message)
+    let projected = TranscriptPresentation.project([original])
+    #expect(projected.first?.id == "image")
+    #expect(projected.first?.record.text == "Question")
+    #expect(projected.first?.rawTranscriptBody == original.rawTranscriptBody)
+    #expect(TranscriptPresentation.project(projected) == projected)
+}
+
+@MainActor @Test func imageOnlyMessageGetsVisibleNativeContentAndRawFallback() {
+    let source = #"[{"type":"input_image","image_url":"https://example.com/image.png"}]"#
+    let record = TranscriptRecord(recordID: "image", record: Message(role: "user", text: "", toolName: nil,
+        toolInput: nil, toolOutput: nil, sourceContent: source))
+    let reader = TranscriptController()
+    reader.view.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+    reader.update(sessionID: "image", records: [record], provider: "codex")
+    let value = reader.measurement(at: 0)
+    #expect(value.richContent != nil)
+    #expect(value.hasBody)
+    #expect(value.textHeight >= 70)
+    #expect(value.contentWidth > 200)
+    reader.update(sessionID: "image", records: [record], provider: "codex", rawTranscript: true)
+    #expect(reader.measurement(at: 0).richContent == nil)
+    #expect(reader.measurement(at: 0).body.contains("source_content"))
+}
+
+@MainActor @Test func interruptedToolRemainsVisibleAmongRoutineOperations() {
+    let records = ["a", "b", "c"].map { id in
+        TranscriptRecord(recordID: id, record: Message(role: "tool_result", text: "", toolName: "bash", toolInput: nil,
+            toolOutput: id == "b" ? #"{"status":"cancelled","output":"Interrupted by request"}"# : #"{"output":"routine"}"#))
+    }
+    let reader = TranscriptController()
+    reader.update(sessionID: "statuses", records: records, provider: "codex")
+    #expect(reader.rows.count == 3)
+    #expect(reader.measurement(at: 1).title.hasPrefix("Cancelled"))
+}

--- a/apps/macos/Tests/MemexTests/ToolContentTests.swift
+++ b/apps/macos/Tests/MemexTests/ToolContentTests.swift
@@ -29,6 +29,45 @@ struct ToolContentTests {
         #expect(ToolContentRenderer.render(records, raw: true).string.contains(output))
     }
 
+    @Test func tighterSpacingKeepsAllExecutionFieldsVisible() {
+        let source = #"{"chunk_id":"4c7793","exit_code":0,"original_token_count":0,"output":"","wall_time_seconds":0.32208491700000003}"#
+        let record = entry("result", output: source)
+        let rendered = ToolContentRenderer.render([record]).string
+        for key in ["chunk_id", "exit_code", "original_token_count", "output", "wall_time_seconds"] {
+            #expect(rendered.contains(key + "\n"))
+        }
+        #expect(rendered.contains("4c7793"))
+        #expect(rendered.contains("0.322084917"))
+        #expect(ToolContentRenderer.render([record], raw: true).string == source)
+    }
+
+    @Test func formattedToolLayoutTrimsTrailingSpaceWhileRawRetainsSource() {
+        let source = "{\"chunk_id\":\"sample\",\"exit_code\":0,\"output\":\"done\\n\\n\"}\n\n"
+        let controller = TranscriptController()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+        controller.update(sessionID: "spacing", records: [entry("result", output: source)], provider: "codex")
+        controller.toggle(controller.rows[0].id)
+        let formatted = controller.measurement(at: 0).attributedBody
+        #expect(formatted.string.hasSuffix("done"))
+        #expect(formatted.string.contains("chunk_id\nsample"))
+        let key = (formatted.string as NSString).range(of: "exit_code")
+        let style = formatted.attribute(.paragraphStyle, at: key.location, effectiveRange: nil) as? NSParagraphStyle
+        #expect(style?.paragraphSpacingBefore == 4)
+        controller.toggleRaw(controller.rows[0].id)
+        #expect(controller.measurement(at: 0).attributedBody.string == source)
+    }
+
+    @Test func formattedSectionSpacingDoesNotAccumulateBlankParagraphs() throws {
+        let records = [entry("call", input: "echo hello\n\n\n"), entry("result", output: #"{"exit_code":0,"output":"hello"}"#)]
+        let rendered = ToolContentRenderer.render(records)
+        #expect(rendered.string == "Input\necho hello\nOutput\nexit_code\n0\noutput\nhello\n")
+        let source = rendered.string as NSString
+        let range = source.range(of: "echo hello")
+        let style = try #require(rendered.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle)
+        #expect(style.paragraphSpacing == 0)
+        #expect(ToolContentRenderer.render(records, raw: true).string.contains("echo hello\n\n\n"))
+    }
+
     @Test func proseFieldsRenderMarkdownAndOrdinaryLongTextIsNeverCollapsed() throws {
         let text = "A **readable** message.\n\n" + String(repeating: "ordinary words ", count: 100)
         let data = try JSONSerialization.data(withJSONObject: ["message": text, "options": ["count": 2], "empty": []])
@@ -51,12 +90,11 @@ struct ToolContentTests {
         controller.toggle(controller.rows[0].id)
         #expect(!controller.measurement(at: 0).attributedBody.string.contains(payload))
         let cell = try #require(controller.table.view(atColumn: 0, row: 0, makeIfNecessary: true))
-        let reveal = try #require(cell.subviews.compactMap { $0 as? NSButton }.first { $0.title == "Show raw content" })
+        #expect(!cell.subviews.compactMap { $0 as? NSButton }.contains { $0.title == "Raw" || $0.title == "Source" })
         cell.layoutSubtreeIfNeeded()
         let bodyView = try #require(cell.subviews.compactMap { $0 as? NSTextView }.first)
-        #expect(bodyView.frame.minY == 62)
-        #expect(reveal.frame.maxY < bodyView.frame.minY)
-        reveal.performClick(nil)
+        #expect(bodyView.frame.minY == 44)
+        controller.toggleRaw(controller.rows[0].id)
         #expect(controller.measurement(at: 0).attributedBody.string == source)
         controller.toggleRaw(controller.rows[0].id)
         let hit = try #require(ConversationMatcher.matches([record], query: payload).first)

--- a/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
+++ b/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
@@ -47,7 +47,7 @@ struct ToolPresentationSupportTests {
             switch block {
             case .attributed(let text): return text.string
             case .code(let source, _), .markdown(let source): return source
-            case .attachment, .embeddedImage: return ""
+            case .attachment, .attachmentNotice, .embeddedImage: return ""
             }
         }.joined()
         #expect(combined == ToolContentRenderer.render([entry]).string)

--- a/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
+++ b/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
@@ -1,0 +1,79 @@
+import AppKit
+import Testing
+@testable import Memex
+
+@Suite(.serialized) @MainActor
+struct ToolPresentationSupportTests {
+    @Test func patchHasDiffColorsAndKeepsEveryLine() throws {
+        let patch = "*** Begin Patch\n@@ section\n-old\n+new\n unchanged\n*** End Patch"
+        let result = try #require(ToolPresentationSupport.decorate(patch, path: "", toolName: "apply_patch", code: true))
+        #expect(result.string == patch)
+        let addition = (patch as NSString).range(of: "+new")
+        #expect(result.attribute(.foregroundColor, at: addition.location, effectiveRange: nil) as? NSColor == .systemGreen)
+    }
+
+    @Test func searchResultsLinkFilesWithoutHidingMatchText() throws {
+        let text = "/tmp/source.swift:42:8: matched text\nrelative.swift:1: another match"
+        let result = try #require(ToolPresentationSupport.decorate(text, path: "output", toolName: "Grep", code: false))
+        #expect(result.string == text)
+        let destination = try #require(result.attribute(RichTextRenderer.sourceLocationAttribute, at: 0, effectiveRange: nil) as? String)
+        #expect(destination == "/tmp/source.swift:42")
+        #expect(result.attribute(.link, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test func fileReadIsLiteralAndUnknownToolsKeepFallback() throws {
+        let content = "# literal code\nlet value = **notMarkdown**"
+        let result = try #require(ToolPresentationSupport.decorate(content, path: "text", toolName: "read_file", code: false))
+        #expect(result.string == content)
+        #expect(ToolPresentationSupport.decorate(content, path: "text", toolName: "custom", code: false) == nil)
+    }
+
+    @Test func toolRenderingRetainsAllFieldsAlongsideSpecializedContent() {
+        let source = ##"{"path":"/tmp/file.swift","content":"# literal\nlet value = **literal**","metadata":{"count":2}}"##
+        let entry = TranscriptRecord(recordID: "read", record: Message(role: "tool_result", text: "", toolName: "read_file", toolInput: nil, toolOutput: source))
+        let result = ToolContentRenderer.render([entry])
+        #expect(result.string.contains("content\n# literal\nlet value = **literal**"))
+        #expect(result.string.contains("metadata.count\n2"))
+        #expect(result.string.contains("path\n/tmp/file.swift"))
+        #expect(ToolContentRenderer.render([entry], raw: true).string == source)
+    }
+
+    @Test func richToolCardsPreserveFieldsAndUseLiteralCode() {
+        let source = #"{"cmd":"printf '**literal**'","workdir":"/tmp","timeout_ms":5000}"#
+        let entry = TranscriptRecord(recordID: "command", record: Message(role: "tool_use", text: "", toolName: "exec_command", toolInput: source, toolOutput: nil))
+        let blocks = ToolContentRenderer.richBlocks([entry])
+        #expect(blocks.contains(.code("printf '**literal**'", language: "sh")))
+        let combined = blocks.map { block -> String in
+            switch block {
+            case .attributed(let text): return text.string
+            case .code(let source, _), .markdown(let source): return source
+            case .attachment, .embeddedImage: return ""
+            }
+        }.joined()
+        #expect(combined == ToolContentRenderer.render([entry]).string)
+        #expect(combined.contains("timeout_ms\n5000"))
+        #expect(combined.contains("workdir\n/tmp"))
+    }
+
+    @Test func imagesRequireExplicitToolOrPayloadEvidence() {
+        let call = TranscriptRecord(recordID: "image", record: Message(role: "tool_use", text: "", toolName: "view_image", toolInput: #"{"path":"/tmp/image.png"}"#, toolOutput: nil))
+        let result = TranscriptRecord(recordID: "result", record: Message(role: "tool_result", text: #"{"content":[{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}],"path":"/tmp/not-an-image"}"#, toolName: "custom", toolInput: nil, toolOutput: nil))
+        #expect(ToolContentRenderer.imageSources([call, result]) == ["/tmp/image.png", "https://example.com/image.png"])
+    }
+
+    @Test func embeddedImagesKeepOriginalPayloadInRawContent() {
+        let source = #"{"content":[{"type":"image","data":"aGVsbG8=","mimeType":"image/png"}]}"#
+        let entry = TranscriptRecord(recordID: "image", record: Message(role: "tool_result", text: source, toolName: "custom", toolInput: nil, toolOutput: nil))
+        #expect(ToolContentRenderer.richBlocks([entry]).contains(.embeddedImage(label: "Image result", data: Data("hello".utf8), mimeType: "image/png")))
+        #expect(ToolContentRenderer.render([entry], raw: true).string == source)
+    }
+
+    @Test func explicitInterruptionsAreDistinctFromFailure() {
+        for status in ["cancelled", "interrupted", "incomplete"] {
+            let entry = TranscriptRecord(recordID: "result", record: Message(role: "tool_result", text: "", toolName: "Bash", toolInput: nil, toolOutput: "{\"status\":\"\(status)\"}"))
+            let presentation = TranscriptActivity(records: [entry]).presentation
+            #expect(presentation.title == status.capitalized + " · Run")
+            #expect(!presentation.hasFailure)
+        }
+    }
+}

--- a/apps/macos/Tests/MemexTests/TranscriptPresentationTests.swift
+++ b/apps/macos/Tests/MemexTests/TranscriptPresentationTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import Memex
+
+@Test func olderAgentsHeadingWithoutPathStillCollapsesAndPreservesRequest() {
+    let source = presentationRecord("older", "user", "# AGENTS.md instructions\n\n<INSTRUCTIONS>\nLong setup\n</INSTRUCTIONS>\nActual request")
+    let projected = TranscriptPresentation.project([source])
+    #expect(projected.count == 2)
+    #expect(projected[0].record.contextLabel == "Project instructions")
+    #expect(projected[1].record.text.trimmingCharacters(in: .whitespacesAndNewlines) == "Actual request")
+    #expect(projected[0].rawTranscriptBody == source.rawTranscriptBody)
+}
+
+private func presentationRecord(_ id: String, _ role: String, _ text: String, turn: String? = nil,
+                                phase: String? = nil, lifecycle: String? = nil) -> TranscriptRecord {
+    TranscriptRecord(recordID: id, record: Message(role: role, text: text, toolName: nil,
+        toolInput: nil, toolOutput: nil, sourceTurnID: turn, assistantPhase: phase, lifecycleEvent: lifecycle))
+}
+
+@Test func mixedInjectedContextPreservesRequestAndSourceMapping() {
+    let text = "<recommended_plugins>plugins</recommended_plugins>\n# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>rules</INSTRUCTIONS><environment_context>env</environment_context>\nFix the toolbar"
+    let original = presentationRecord("source", "user", text)
+    let projected = TranscriptPresentation.project([original])
+    #expect(projected.count == 4)
+    #expect(projected.dropLast().allSatisfy { $0.record.isInstruction })
+    #expect(projected.last?.record.text == "\nFix the toolbar")
+    #expect(projected.last?.id == "source")
+    #expect(projected.allSatisfy { $0.sourceID == "source" })
+    #expect(projected.map(\.record.text).joined() == text)
+    #expect(original.record.text == text)
+    #expect(Set(projected.map(\.id)).count == 4)
+    #expect(TranscriptPresentation.project(projected) == projected)
+}
+
+@Test func contextRecognitionDoesNotEatQuotesExamplesOrUnknownHTML() {
+    for text in ["Explain <environment_context>x</environment_context>",
+                 "```xml\n<environment_context>x</environment_context>\n```",
+                 "> <recommended_plugins>x</recommended_plugins>",
+                 "<div>hello</div>", "<environment_context>unfinished",
+                 "# AGENTS.md instructions for /repo\nDiscuss this example"] {
+        let original = presentationRecord("a", "user", text)
+        #expect(TranscriptPresentation.project([original]) == [original])
+    }
+}
+
+@Test func completedWorkRequiresExplicitCompletionAndFinalForSameTurn() {
+    let commentary = presentationRecord("c", "assistant", "Working", turn: "t", phase: "commentary")
+    let tool = presentationRecord("tool", "tool_use", "read", turn: "t")
+    let final = presentationRecord("f", "assistant", "Done", turn: "t", phase: "final_answer")
+    let completion = presentationRecord("done", "lifecycle", "", turn: "t", lifecycle: "task_complete")
+    let items = TranscriptItem.group([commentary, tool, final, completion])
+    #expect(items[0].isCompletedWork)
+    #expect(items[0].records.map(\.id) == ["c", "tool"])
+    #expect(!items[1].isCompletedWork)
+    #expect(items[1].records[0].id == "f")
+    #expect(items.flatMap(\.records).map(\.id) == ["c", "tool", "f", "done"])
+    for incomplete in [[commentary, tool, final], [commentary, tool, completion],
+                       [commentary, tool, final, presentationRecord("x", "lifecycle", "", turn: "other", lifecycle: "task_complete")],
+                       [commentary, tool, final, completion, presentationRecord("a", "lifecycle", "", turn: "t", lifecycle: "turn_aborted")]] {
+        #expect(!TranscriptItem.group(incomplete).contains { $0.isCompletedWork })
+    }
+}
+
+@Test func completedWorkDoesNotCrossUnclassifiedMessagesOrTurns() {
+    let records = [presentationRecord("a", "assistant", "work", turn: "t", phase: "commentary"),
+                   presentationRecord("u", "user", "another request"),
+                   presentationRecord("b", "assistant", "work", turn: "t", phase: "commentary"),
+                   presentationRecord("f", "assistant", "done", turn: "t", phase: "final_answer"),
+                   presentationRecord("e", "lifecycle", "", turn: "t", lifecycle: "task_complete")]
+    let items = TranscriptItem.group(records)
+    #expect(items[0].isCompletedWork)
+    #expect(!items[1].isCompletedWork)
+    #expect(items[2].isCompletedWork)
+    #expect(items.flatMap(\.records).map(\.id) == records.map(\.id))
+}
+
+@Test func rawTranscriptRetainsUnknownFieldsAndOriginalMixedRecord() throws {
+    let json = #"{"record_id":"r","record":{"role":"user","text":"<environment_context>env</environment_context>request","future":{"answer":42,"flag":true}},"extra":[null,"retained"]}"#
+    let record = try JSONDecoder().decode(TranscriptRecord.self, from: Data(json.utf8))
+    let original = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? NSDictionary
+    let decoded = try JSONSerialization.jsonObject(with: Data(record.rawTranscriptBody.utf8)) as? NSDictionary
+    #expect(original == decoded)
+    #expect(TranscriptPresentation.project([record]).allSatisfy { $0.rawTranscriptBody == record.rawTranscriptBody })
+}
+
+@Test func recordedQuestionRepliesShowTheActualAnswerAndKeepQuestionAndRawPayload() {
+    let source = #"<send_user_message_question_reply>[{"questionItemId":"q1","question":"Which environment?","answer":"Use staging"}]</send_user_message_question_reply>"#
+    let original = presentationRecord("reply", "user", source)
+    let projected = TranscriptPresentation.project([original])
+    #expect(projected.count == 2)
+    #expect(projected[0].record.isInstruction)
+    #expect(projected[0].record.contextLabel == "Question")
+    #expect(projected[1].record.text == "Use staging")
+    #expect(projected[1].id == "reply")
+    #expect(projected.allSatisfy { $0.rawTranscriptBody == original.rawTranscriptBody })
+    #expect(TranscriptPresentation.project(projected) == projected)
+    let quoted = presentationRecord("quoted", "user", "Explain this: " + source)
+    #expect(TranscriptPresentation.project([quoted]) == [quoted])
+}
+
+private let memoryCitationFixture = """
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:1-2|note=[prior context]
+</citation_entries>
+<rollout_ids>
+019c6e27-e55b-73d1-87d8-4e01f1f75043
+</rollout_ids>
+</oai-mem-citation>
+"""
+
+@Test func assistantTransportMarkersDisappearWithoutChangingSourceOrAnswer() {
+    let text = "The answer :codex-annotation{index=\"1\"} is here.\n\n" + memoryCitationFixture
+    let original = presentationRecord("answer", "assistant", text)
+    let projected = TranscriptPresentation.project([original])
+    #expect(projected.count == 1)
+    #expect(projected[0].record.text == "The answer  is here.")
+    #expect(projected[0].id == original.id)
+    #expect(projected[0].sourceID == original.sourceID)
+    #expect(projected[0].rawTranscriptBody == original.rawTranscriptBody)
+    #expect(TranscriptPresentation.project(projected) == projected)
+    #expect(original.record.text == text)
+}
+
+@Test func assistantTransportProjectionPreservesLiteralCodeQuotesAndUnknownTags() {
+    let annotation = ":codex-annotation{index=\"1\"}"
+    for text in ["`" + annotation + "`", "```text\n" + annotation + "\n```",
+                 "~~~xml\n" + memoryCitationFixture + "\n~~~",
+                 "> " + annotation, "    " + annotation,
+                 "\"" + annotation + "\"", "'" + annotation + "'",
+                 "<div>ordinary HTML</div>", "<oai-mem-citation>unfinished",
+                 memoryCitationFixture + "\nThis is an explanation of that format.",
+                 ":codex-annotation{other=\"1\"}", ":codex-annotation{index=\"one\"}",
+                 "<oai-mem-citation><unexpected>content</unexpected></oai-mem-citation>"] {
+        let original = presentationRecord("example", "assistant", text)
+        #expect(TranscriptPresentation.project([original])[0].record.text == text)
+    }
+    let user = presentationRecord("user", "user", "Inspect " + annotation + "\n" + memoryCitationFixture)
+    #expect(TranscriptPresentation.project([user]) == [user])
+}
+
+@Test func assistantTransportProjectionHandlesMultipleAnnotationsAndMultilineCode() {
+    let annotation = "::codex-annotation{index=\"12\"}"
+    let text = "First" + annotation + ". Second" + annotation + "."
+    #expect(TranscriptPresentation.project([presentationRecord("a", "assistant", text)])[0].record.text == "First. Second.")
+    let code = "`multiline\n:codex-annotation{index=\"1\"}\nexample`"
+    #expect(TranscriptPresentation.project([presentationRecord("a", "assistant", code)])[0].record.text == code)
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -427,6 +427,9 @@ EXAMPLES:
         /// Return at most this many records (default 50, maximum 500; --full defaults to all)
         #[arg(long)]
         limit: Option<usize>,
+        /// Include total and next_offset with a bounded full-content page
+        #[arg(long, requires_all = ["full", "limit"])]
+        page_info: bool,
         /// Show human-readable output with timestamps and role labels
         #[arg(short, long, hide = true)]
         verbose: bool,
@@ -1546,6 +1549,7 @@ pub fn run() -> Result<()> {
             source_path,
             offset,
             limit,
+            page_info,
             verbose,
             output,
             read,
@@ -1557,6 +1561,7 @@ pub fn run() -> Result<()> {
                 source_path,
                 offset,
                 limit,
+                page_info,
                 output: output.resolve(
                     OutputFormat::Jsonl,
                     verbose.then_some(OutputFormat::Text),
@@ -1907,6 +1912,16 @@ fn run_index_loop(
     web_listen: Option<String>,
     mcp: Option<crate::mcp::HttpOptions>,
 ) -> Result<()> {
+    // Keep the native listener alive for every daemon watch mode, including
+    // the default event loop, and release it when that loop exits or fails.
+    #[cfg(unix)]
+    let _native_server = match crate::native::spawn(index.root.clone()) {
+        Ok(server) => Some(server),
+        Err(error) => {
+            eprintln!("native app socket unavailable: {error:#}");
+            None
+        }
+    };
     if mode == WatchMode::Poll {
         run_poll_loop(index, interval_secs, web_listen, mcp)
     } else {
@@ -1920,14 +1935,6 @@ fn run_poll_loop(
     web_listen: Option<String>,
     mcp: Option<crate::mcp::HttpOptions>,
 ) -> Result<()> {
-    #[cfg(unix)]
-    let _native_server = match crate::native::spawn(index.root.clone()) {
-        Ok(server) => Some(server),
-        Err(error) => {
-            eprintln!("native app socket unavailable: {error:#}");
-            None
-        }
-    };
     let mcp_server = mcp
         .map(|options| crate::mcp::spawn_http(index.root.clone(), options))
         .transpose()?;
@@ -3053,6 +3060,36 @@ pub(crate) fn native_request(paths: &Paths, operation: crate::native::Operation)
                 &collected.render,
             )?))
         }
+        Operation::SessionPage {
+            machine,
+            session_id,
+            source_path,
+            offset,
+            limit,
+        } => {
+            check_index(&machine)?;
+            let (records, page) = collect_session_page(
+                paths,
+                &config,
+                &machine,
+                &session_id,
+                &source_path,
+                offset,
+                Some(limit),
+                &ReadArgs {
+                    full: true,
+                    max_chars: None,
+                },
+                true,
+            )?;
+            let mut items = records
+                .into_iter()
+                .map(serde_json::to_value)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let (total, next_offset) = page.expect("full page requested with metadata");
+            items.push(serde_json::json!({"type":"page", "machine":machine, "session_id":session_id, "source_path":source_path, "offset":offset, "total":total, "next_offset":next_offset}));
+            Ok(tag(items, machine))
+        }
         Operation::Session {
             machine,
             session_id,
@@ -3074,6 +3111,7 @@ pub(crate) fn native_request(paths: &Paths, operation: crate::native::Operation)
                     full: max_chars.is_none(),
                     max_chars,
                 },
+                false,
             )?;
             let mut items = records
                 .into_iter()
@@ -4039,6 +4077,7 @@ struct SessionRunArgs {
     source_path: Option<String>,
     offset: usize,
     limit: Option<usize>,
+    page_info: bool,
     output: OutputOptions,
     read: ReadArgs,
     root: Option<PathBuf>,
@@ -4056,33 +4095,58 @@ fn collect_session_page(
     offset: usize,
     limit: Option<usize>,
     read: &ReadArgs,
+    page_info: bool,
 ) -> Result<CollectedSessionPage> {
     let mut budget = read.budget()?;
     if session_id.is_empty() {
         return Err(anyhow!("session_id must not be empty"));
     }
+    if page_info && (!read.full || limit.is_none()) {
+        return Err(anyhow!(
+            "--page-info requires --full and an explicit --limit"
+        ));
+    }
     if read.full {
-        let records = hydrate_session_records(
-            paths,
-            config,
-            machine,
-            session_id,
-            source_path,
-            offset,
-            limit,
-        )?
-        .into_iter()
-        .map(|mut record| {
-            let record_id = canonical_record_id(&record);
-            let content = budget.apply(&mut record, None, 0)?;
-            Ok(BoundedRecord {
-                record_id,
-                record,
-                content,
+        let (records, page) = if page_info {
+            let context = session_page_context(
+                paths,
+                config,
+                machine,
+                &SessionPageRequest {
+                    session_id: session_id.to_owned(),
+                    source_path: source_path.to_owned(),
+                    offset,
+                    limit: limit.expect("validated above"),
+                },
+            )?;
+            (context.records, Some((context.total, context.next_offset)))
+        } else {
+            (
+                hydrate_session_records(
+                    paths,
+                    config,
+                    machine,
+                    session_id,
+                    source_path,
+                    offset,
+                    limit,
+                )?,
+                None,
+            )
+        };
+        let records = records
+            .into_iter()
+            .map(|mut record| {
+                let record_id = canonical_record_id(&record);
+                let content = budget.apply(&mut record, None, 0)?;
+                Ok(BoundedRecord {
+                    record_id,
+                    record,
+                    content,
+                })
             })
-        })
-        .collect::<Result<Vec<_>>>()?;
-        Ok((records, None))
+            .collect::<Result<Vec<_>>>()?;
+        Ok((records, page))
     } else {
         let request = SessionPageRequest {
             session_id: session_id.to_owned(),
@@ -4105,6 +4169,7 @@ fn run_session(args: SessionRunArgs) -> Result<()> {
         source_path,
         offset,
         limit,
+        page_info,
         output,
         read,
         root,
@@ -4121,6 +4186,7 @@ fn run_session(args: SessionRunArgs) -> Result<()> {
         offset,
         limit,
         &read,
+        page_info,
     )?;
     let text = output.format == OutputFormat::Text;
     let mut writer = output.writer();
@@ -9172,6 +9238,52 @@ arguments = {
             panic!("expected hydrate command");
         };
         assert_eq!(input, Some(PathBuf::from("requests.jsonl")));
+    }
+
+    #[test]
+    fn session_page_info_requires_an_explicit_full_page() {
+        let parsed = Cli::try_parse_from([
+            "memex",
+            "session",
+            "fixture",
+            "--full",
+            "--limit",
+            "60",
+            "--page-info",
+        ])
+        .unwrap();
+        assert!(matches!(
+            parsed.command,
+            Some(Commands::Session {
+                page_info: true,
+                read: ReadArgs { full: true, .. },
+                limit: Some(60),
+                ..
+            })
+        ));
+        for arguments in [
+            vec![
+                "memex",
+                "session",
+                "fixture",
+                "--page-info",
+                "--limit",
+                "60",
+            ],
+            vec!["memex", "session", "fixture", "--page-info", "--full"],
+            vec!["memex", "show", "1", "--page-info"],
+        ] {
+            assert!(Cli::try_parse_from(arguments).is_err());
+        }
+        let legacy = Cli::try_parse_from(["memex", "session", "fixture", "--full"]).unwrap();
+        assert!(matches!(
+            legacy.command,
+            Some(Commands::Session {
+                page_info: false,
+                limit: None,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2581,8 +2581,8 @@ struct MemorySurfaceSearchArgs {
 }
 
 enum UnifiedSearchResult {
-    Conversation(LocatedRecord),
-    Memory(LocatedMemoryHit),
+    Conversation(Box<LocatedRecord>),
+    Memory(Box<LocatedMemoryHit>),
 }
 
 impl UnifiedSearchResult {
@@ -2761,19 +2761,19 @@ fn collect_search_with_memories(
     let mut results = if content == SearchContent::Memories {
         memory_results
             .into_iter()
-            .map(UnifiedSearchResult::Memory)
+            .map(|result| UnifiedSearchResult::Memory(Box::new(result)))
             .collect::<Vec<_>>()
     } else {
         // Scores from independent conversation and memory indexes are not comparable. Rank each
         // corpus with reciprocal-rank fusion before merging them.
         let mut merged = Vec::with_capacity(conversation_results.len() + memory_results.len());
         for (rank, result) in conversation_results.into_iter().enumerate() {
-            let mut result = UnifiedSearchResult::Conversation(result);
+            let mut result = UnifiedSearchResult::Conversation(Box::new(result));
             result.set_score(1.0 / (60.0 + rank as f32 + 1.0));
             merged.push(result);
         }
         for (rank, result) in memory_results.into_iter().enumerate() {
-            let mut result = UnifiedSearchResult::Memory(result);
+            let mut result = UnifiedSearchResult::Memory(Box::new(result));
             result.set_score(1.0 / (60.0 + rank as f32 + 1.0));
             merged.push(result);
         }
@@ -2794,7 +2794,7 @@ fn collect_search_with_memories(
         match result {
             UnifiedSearchResult::Conversation(result) => {
                 let mut projected = project_located_results(
-                    vec![result],
+                    vec![*result],
                     &RenderOptions {
                         verbose: false,
                         pretty,
@@ -2816,7 +2816,7 @@ fn collect_search_with_memories(
                 values.extend(projected);
             }
             UnifiedSearchResult::Memory(result) => {
-                let mut projected = project_memory_result(result, &fields)?;
+                let mut projected = project_memory_result(*result, &fields)?;
                 if content == SearchContent::All
                     && fields.as_ref().is_none_or(|set| set.contains("kind"))
                 {

--- a/src/index.rs
+++ b/src/index.rs
@@ -33,6 +33,8 @@ use tantivy::{
 
 #[derive(Clone)]
 pub struct IndexFields {
+    /// Optional for reading generations built before transcript presentation metadata.
+    pub reader_metadata: Option<Field>,
     /// Present in indexes created after canonical record lookup was introduced. Older indexes
     /// remain readable and use a scoped stored-record fallback until they are rebuilt.
     pub canonical_record_id: Option<Field>,
@@ -551,7 +553,10 @@ impl SearchIndex {
         let meta_path = dir.join("meta.json");
         if meta_path.exists() {
             let index = Index::open_in_dir(dir)?;
-            if !schema_is_current(&index.schema()) {
+            if !schema_is_current(&index.schema())
+                || (matches!(stale_schema_policy, StaleSchemaPolicy::Recreate)
+                    && index.schema().get_field("reader_metadata").is_err())
+            {
                 return match stale_schema_policy {
                     StaleSchemaPolicy::Error => Err(stale_schema_error(dir)),
                     StaleSchemaPolicy::Recreate => {
@@ -803,6 +808,9 @@ impl SearchIndex {
             self.fields.source_tool_assistant_uuid,
             &record.links.source_tool_assistant_uuid,
         );
+        if let Some(field) = self.fields.reader_metadata {
+            doc.add_text(field, serde_json::to_string(&record.links)?);
+        }
         doc.add_text(self.fields.source_path, &record.source_path);
         writer.add_document(doc)?;
         Ok(())
@@ -2266,6 +2274,7 @@ fn build_schema_with_options(
     builder.add_text_field("parent_tool_use_id", STRING | STORED);
     builder.add_text_field("source_tool_use_id", STRING | STORED);
     builder.add_text_field("source_tool_assistant_uuid", STRING | STORED);
+    builder.add_text_field("reader_metadata", STORED);
     builder.add_text_field("source_path", session_identity_options);
 
     Ok(builder.build())
@@ -2306,6 +2315,7 @@ fn load_fields(schema: Schema) -> Result<IndexFields> {
             .map_err(|_| anyhow!(format!("missing field {name}")))
     };
     Ok(IndexFields {
+        reader_metadata: schema.get_field("reader_metadata").ok(),
         canonical_record_id: schema.get_field("canonical_record_id").ok(),
         doc_id: get("doc_id")?,
         ts: get("ts")?,
@@ -2491,6 +2501,11 @@ fn record_from_doc(fields: &IndexFields, doc: &TantivyDocument) -> Record {
             parent_tool_use_id: get_str(fields.parent_tool_use_id),
             source_tool_use_id: get_str(fields.source_tool_use_id),
             source_tool_assistant_uuid: get_str(fields.source_tool_assistant_uuid),
+            ..fields
+                .reader_metadata
+                .and_then(&get_str)
+                .and_then(|json| serde_json::from_str(&json).ok())
+                .unwrap_or_default()
         },
         source_path,
     }
@@ -2557,6 +2572,80 @@ mod tests {
         assert!(err.to_string().contains("index schema"));
         assert!(tmp.path().join("meta.json").exists());
         assert!(tmp.path().join("sentinel").exists());
+    }
+
+    #[test]
+    fn reader_metadata_round_trips_without_changing_record_sequence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let index = SearchIndex::open_or_create(tmp.path()).unwrap();
+        let mut writer = index.writer().unwrap();
+        let mut record = test_record(1, "Turn completed");
+        record.links.source_turn_id = Some("provider-turn".to_string());
+        record.links.assistant_phase = Some("final_answer".to_string());
+        record.links.lifecycle_event = Some("task_complete".to_string());
+        record.links.source_record_type = Some("event_msg/task_complete".to_string());
+        record.links.source_content =
+            Some(r#"[{"type":"input_image","image_url":"/tmp/photo.png"}]"#.to_string());
+        index.add_record(&mut writer, &record).unwrap();
+        writer.commit().unwrap();
+        let rows = index
+            .records_by_context_scope(Some("session"), Some(crate::types::SourceKind::Codex))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].turn_id, record.turn_id);
+        assert_eq!(
+            serde_json::to_value(&rows[0].links).unwrap(),
+            serde_json::to_value(&record.links).unwrap()
+        );
+    }
+
+    #[test]
+    fn reader_metadata_upgrade_keeps_old_generation_readable_until_publish() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut schema =
+            serde_json::to_value(build_schema_with_canonical_record_id(true).unwrap()).unwrap();
+        schema
+            .as_array_mut()
+            .unwrap()
+            .retain(|field| field["name"] != "reader_metadata");
+        let schema: Schema = serde_json::from_value(schema).unwrap();
+        drop(Index::create_in_dir(tmp.path(), schema).unwrap());
+        let legacy = SearchIndex::open_or_create(tmp.path()).unwrap();
+        assert!(legacy.fields.reader_metadata.is_none());
+        let mut writer = legacy.writer().unwrap();
+        legacy
+            .add_record(&mut writer, &test_record(1, "legacy record"))
+            .unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+        let fresh = SearchIndex::open_or_create_for_ingest(tmp.path()).unwrap();
+        assert!(fresh.fields.reader_metadata.is_some());
+        assert_eq!(fresh.doc_count().unwrap(), 0);
+        // Ingest detects the empty private generation and reparses all source files;
+        // the published generation remains intact throughout that rebuild.
+        assert_eq!(
+            SearchIndex::open_or_create(tmp.path())
+                .unwrap()
+                .doc_count()
+                .unwrap(),
+            1
+        );
+        let mut reparsed = test_record(1, "legacy record");
+        reparsed.links.source_turn_id = Some("recovered-turn".to_string());
+        let mut writer = fresh.writer().unwrap();
+        fresh.add_record(&mut writer, &reparsed).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+        fresh.publish_generation().unwrap();
+        let reopened = SearchIndex::open_or_create(tmp.path()).unwrap();
+        let rows = reopened
+            .records_by_context_scope(Some("session"), Some(crate::types::SourceKind::Codex))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].links.source_turn_id.as_deref(),
+            Some("recovered-turn")
+        );
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -2581,6 +2581,9 @@ mod tests {
         let mut writer = index.writer().unwrap();
         let mut record = test_record(1, "Turn completed");
         record.links.source_turn_id = Some("provider-turn".to_string());
+        record.links.legacy_turn_id = Some(0);
+        record.links.source_record_offset = Some(123);
+        record.links.tool_result_is_error = Some(true);
         record.links.assistant_phase = Some("final_answer".to_string());
         record.links.lifecycle_event = Some("task_complete".to_string());
         record.links.source_record_type = Some("event_msg/task_complete".to_string());

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -75,6 +75,7 @@ struct FileTask {
     source: SourceKind,
     offset: u64,
     turn_id: u32,
+    legacy_turn_id: Option<u32>,
     size: u64,
     mtime: i64,
     delete_first: bool,
@@ -223,14 +224,17 @@ fn prepare_file_task(
         .min(size) as usize;
     let identity = file_identity(&path, metadata, prefix_bytes);
     let parser_version = crate::sources::index_state_version_for(source, include_reasoning);
-    let parser_version_invalidated =
-        previous.is_some_and(|previous| previous.parser_version != parser_version);
+    let tracks_legacy_ordinal = matches!(source, SourceKind::Claude | SourceKind::Codex);
+    let parser_version_invalidated = previous.is_some_and(|previous| {
+        previous.parser_version != parser_version
+            || (tracks_legacy_ordinal && previous.offset > 0 && previous.legacy_turn_id.is_none())
+    });
     let (offset, turn_id, delete_first, pending_tool_calls, skip) = match previous {
         None => (0, 0, false, HashMap::new(), false),
         Some(previous)
             if size < previous.size
                 || mtime < previous.mtime
-                || previous.parser_version != parser_version
+                || parser_version_invalidated
                 || file_was_replaced(&previous.identity, &identity)
                 || (size == previous.size
                     && previous
@@ -269,6 +273,11 @@ fn prepare_file_task(
             source,
             offset,
             turn_id,
+            legacy_turn_id: if tracks_legacy_ordinal && offset == 0 {
+                Some(0)
+            } else {
+                previous.and_then(|previous| previous.legacy_turn_id)
+            },
             size,
             mtime,
             delete_first,
@@ -326,6 +335,7 @@ fn completed_file_state(
     task: &FileTask,
     offset: u64,
     turn_id: u32,
+    legacy_turn_id: Option<u32>,
     pending_tool_calls: HashMap<String, PendingToolCall>,
 ) -> FileState {
     FileState {
@@ -333,6 +343,7 @@ fn completed_file_state(
         mtime: task.mtime,
         offset,
         turn_id,
+        legacy_turn_id,
         parser_version: task.parser_version,
         pending_tool_calls,
         identity: task.identity.clone(),
@@ -2222,6 +2233,7 @@ fn parse_claude_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2255,6 +2267,7 @@ fn parse_codex_session(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2288,6 +2301,7 @@ fn parse_codex_history(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         session_ids,
@@ -2321,6 +2335,7 @@ fn finish_source_parse(
         task,
         parsed.offset,
         parsed.turn_id,
+        parsed.legacy_turn_id,
         parsed.pending_tool_calls,
     );
     tx_update.send(FileUpdate {
@@ -2345,6 +2360,7 @@ fn parse_opencode_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         opencode_session_links,
@@ -2378,6 +2394,7 @@ fn parse_jcode_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2411,6 +2428,7 @@ fn parse_muse_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2444,6 +2462,7 @@ fn parse_cursor_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         next_doc_id,
@@ -2475,6 +2494,7 @@ fn parse_pi_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2507,6 +2527,7 @@ fn parse_omp_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2539,6 +2560,7 @@ fn parse_openclaw_file(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -2570,6 +2592,7 @@ fn parse_copilot_session(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         next_doc_id,
@@ -2602,6 +2625,7 @@ fn parse_grok_session(
         crate::sources::IndexParseState {
             offset: task.offset,
             turn_id: task.turn_id,
+            legacy_turn_id: task.legacy_turn_id,
             pending_tool_calls: task.pending_tool_calls.clone(),
         },
         include_reasoning,
@@ -3761,6 +3785,7 @@ mod tests {
             source,
             offset,
             turn_id,
+            legacy_turn_id: Some(turn_id),
             size: metadata.len(),
             mtime: metadata
                 .modified()
@@ -4823,6 +4848,7 @@ mod tests {
             &original,
             metadata.len(),
             1,
+            Some(1),
             original.pending_tool_calls.clone(),
         );
 
@@ -4919,8 +4945,13 @@ mod tests {
                 ..PendingToolCall::default()
             },
         );
-        let previous =
-            completed_file_state(&first, metadata.len(), 1, first.pending_tool_calls.clone());
+        let previous = completed_file_state(
+            &first,
+            metadata.len(),
+            1,
+            Some(1),
+            first.pending_tool_calls.clone(),
+        );
 
         fs::OpenOptions::new()
             .append(true)
@@ -4958,8 +4989,13 @@ mod tests {
         fs::write(&path, r#"{"id":"s1","messages":[]}"#).expect("write session");
         let metadata = path.metadata().expect("session metadata");
         let (first, _) = prepare_file_task(path.clone(), SourceKind::Jcode, false, &metadata, None);
-        let previous =
-            completed_file_state(&first, metadata.len(), 1, first.pending_tool_calls.clone());
+        let previous = completed_file_state(
+            &first,
+            metadata.len(),
+            1,
+            Some(1),
+            first.pending_tool_calls.clone(),
+        );
 
         fs::OpenOptions::new()
             .append(true)
@@ -5003,6 +5039,7 @@ mod tests {
                 .unwrap_or(0),
             offset: metadata.len(),
             turn_id: 1,
+            legacy_turn_id: Some(1),
             parser_version: crate::sources::index_state_version(SourceKind::Claude)
                 .saturating_sub(1),
             pending_tool_calls: HashMap::from([(
@@ -5021,6 +5058,105 @@ mod tests {
         assert!(task.parser_version_invalidated);
         assert_eq!(task.offset, 0);
         assert!(task.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn reader_identity_counter_survives_ingest_state_and_missing_counter_reparses() {
+        use crate::retrieval::canonical_record_id;
+        use serde_json::json;
+        use std::io::Write;
+        for source in [SourceKind::Codex, SourceKind::Claude] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("session.jsonl");
+            let (added, question, answer) = if source == SourceKind::Codex {
+                (
+                    json!({"type":"event_msg", "payload":{"type":"task_started", "turn_id":"turn"}}),
+                    json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":"Question"}}),
+                    json!({"type":"response_item", "payload":{"type":"message", "role":"assistant", "content":"Answer"}}),
+                )
+            } else {
+                (
+                    json!({"type":"user", "message":{"content":[{"type":"image", "source":{"type":"url", "url":"https://example.com/image.png"}}]}}),
+                    json!({"type":"user", "message":{"content":"Question"}}),
+                    json!({"type":"assistant", "message":{"content":"Answer"}}),
+                )
+            };
+            fs::write(&path, format!("{added}\n{question}\n")).unwrap();
+            let progress = Arc::new(Progress::new([0; SOURCE_COUNT], [0; SOURCE_COUNT], false));
+            let next_doc_id = AtomicU64::new(1);
+            let (tx_record, rx_record, tx_update, rx_update) = parser_channels();
+            let parse = |task: &FileTask| match source {
+                SourceKind::Codex => parse_codex_session(
+                    task,
+                    false,
+                    &tx_record,
+                    &tx_update,
+                    &next_doc_id,
+                    &progress,
+                ),
+                SourceKind::Claude => {
+                    parse_claude_file(task, false, &tx_record, &tx_update, &next_doc_id, &progress)
+                }
+                _ => unreachable!(),
+            };
+            let metadata = path.metadata().unwrap();
+            let (first, _) = prepare_file_task(path.clone(), source, false, &metadata, None);
+            parse(&first).unwrap();
+            let mut incremental = rx_record.try_iter().collect::<Vec<_>>();
+            let state = rx_update.try_recv().unwrap().state;
+            assert_eq!(state.turn_id, 2);
+            assert_eq!(state.legacy_turn_id, Some(1));
+            let serialized = serde_json::to_value(state).unwrap();
+            let persisted: FileState = serde_json::from_value(serialized.clone()).unwrap();
+            let mut missing_counter = serialized;
+            missing_counter
+                .as_object_mut()
+                .unwrap()
+                .remove("legacy_turn_id");
+            let missing_counter: FileState = serde_json::from_value(missing_counter).unwrap();
+            let (rebuild, skip) = prepare_file_task(
+                path.clone(),
+                source,
+                false,
+                &metadata,
+                Some(&missing_counter),
+            );
+            assert!(!skip);
+            assert!(rebuild.delete_first && rebuild.parser_version_invalidated);
+            assert_eq!(rebuild.offset, 0);
+            assert_eq!(rebuild.legacy_turn_id, Some(0));
+
+            writeln!(
+                fs::OpenOptions::new().append(true).open(&path).unwrap(),
+                "{answer}"
+            )
+            .unwrap();
+            let (resumed, _) = prepare_file_task(
+                path.clone(),
+                source,
+                false,
+                &path.metadata().unwrap(),
+                Some(&persisted),
+            );
+            assert!(!resumed.delete_first);
+            assert_eq!(resumed.legacy_turn_id, Some(1));
+            parse(&resumed).unwrap();
+            incremental.extend(rx_record.try_iter());
+            let state = rx_update.try_recv().unwrap().state;
+            assert_eq!(state.legacy_turn_id, Some(2));
+            assert_eq!(incremental.last().unwrap().links.legacy_turn_id, Some(1));
+            let (full, _) =
+                prepare_file_task(path.clone(), source, false, &path.metadata().unwrap(), None);
+            parse(&full).unwrap();
+            let full = rx_record.try_iter().collect::<Vec<_>>();
+            assert_eq!(
+                incremental
+                    .iter()
+                    .map(canonical_record_id)
+                    .collect::<Vec<_>>(),
+                full.iter().map(canonical_record_id).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]
@@ -5049,6 +5185,7 @@ mod tests {
             mtime,
             offset: metadata.len() - 100,
             turn_id: 3,
+            legacy_turn_id: Some(3),
             parser_version: version,
             pending_tool_calls: HashMap::new(),
             identity,
@@ -5840,6 +5977,7 @@ mod tests {
             source: SourceKind::Pi,
             offset: existing.len() as u64,
             turn_id: 1,
+            legacy_turn_id: Some(1),
             size: (existing.len() + appended.len()) as u64,
             mtime: 0,
             delete_first: false,
@@ -5919,6 +6057,7 @@ mod tests {
             source: SourceKind::Copilot,
             offset: 0,
             turn_id: 0,
+            legacy_turn_id: Some(0),
             size: meta.len(),
             mtime: 0,
             delete_first: false,

--- a/src/ingest/selection.rs
+++ b/src/ingest/selection.rs
@@ -623,6 +623,7 @@ mod tests {
                 mtime: 0,
                 offset: 3,
                 turn_id: 0,
+                legacy_turn_id: None,
                 parser_version: 0,
                 pending_tool_calls: Default::default(),
                 identity: Default::default(),

--- a/src/native.rs
+++ b/src/native.rs
@@ -22,7 +22,13 @@ const MAX_RESPONSE: usize = 64 * 1024 * 1024;
 const MAX_CONNECTIONS: usize = 16;
 const IO_TIMEOUT: Duration = Duration::from_secs(120);
 const CAPABILITIES: &[&str] = &[
-    "machines", "projects", "sessions", "count", "search", "session",
+    "machines",
+    "projects",
+    "sessions",
+    "count",
+    "search",
+    "session",
+    "session_page",
 ];
 
 #[derive(Deserialize)]
@@ -49,6 +55,13 @@ pub(crate) enum Operation {
         source: Option<String>,
         since: Option<String>,
         origin: SessionOrigin,
+        limit: usize,
+    },
+    SessionPage {
+        machine: String,
+        session_id: String,
+        source_path: String,
+        offset: usize,
         limit: usize,
     },
     Session {
@@ -535,6 +548,81 @@ mod tests {
         writer.wait_merging_threads().unwrap();
         index.publish_generation().unwrap();
         analytics.flush().unwrap();
+    }
+
+    #[test]
+    fn session_page_returns_full_content_and_metadata_from_the_same_scope() {
+        let root = root();
+        let paths = Paths::new(Some(root.path().to_path_buf())).unwrap();
+        paths.ensure_dirs().unwrap();
+        let records = (1..=4)
+            .map(|id| Record {
+                source: SourceKind::Codex,
+                doc_id: id,
+                ts: id,
+                project: "fixture".into(),
+                session_id: "session-page".into(),
+                turn_id: id as u32,
+                role: "user".into(),
+                text: format!("{id}:{}", "λ".repeat(6000)),
+                tool_name: None,
+                tool_input: Some("argument".repeat(1000)),
+                tool_output: Some("output".repeat(2000)),
+                links: RecordLinks::default(),
+                source_path: if id == 4 {
+                    "/other-source.jsonl"
+                } else {
+                    "/page-source.jsonl"
+                }
+                .into(),
+            })
+            .collect::<Vec<_>>();
+        publish(&paths, &records);
+        let server = spawn(Some(root.path().to_path_buf())).unwrap();
+        let mut stream = connect(&server);
+        let hello = request(&mut stream, json!({"op":"hello"}));
+        assert!(
+            hello["result"]["capabilities"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("session_page"))
+        );
+        let operation = json!({"op":"session_page", "machine":"local", "session_id":"session-page", "source_path":"/page-source.jsonl", "offset":0, "limit":2});
+        for (offset, expected, next) in [(0, 2, Some(2)), (2, 1, None), (5, 0, None)] {
+            let mut page_operation = operation.clone();
+            page_operation["offset"] = json!(offset);
+            let response = request(&mut stream, page_operation);
+            let items = response["result"].as_array().unwrap();
+            assert_eq!(items.len(), expected + 1);
+            for (item, original) in items[..expected].iter().zip(records.iter().skip(offset)) {
+                assert_eq!(item["record"]["text"], original.text);
+                assert_eq!(
+                    item["record"]["tool_input"],
+                    original.tool_input.as_deref().unwrap()
+                );
+                assert_eq!(
+                    item["record"]["tool_output"],
+                    original.tool_output.as_deref().unwrap()
+                );
+                assert_eq!(item["content"]["truncated"], false);
+                assert!(item["record_id"].is_string());
+            }
+            assert_eq!(
+                items.last().unwrap(),
+                &json!({"type":"page", "machine":"local", "session_id":"session-page", "source_path":"/page-source.jsonl", "offset":offset, "total":3, "next_offset":next})
+            );
+        }
+        let mut legacy = operation.clone();
+        legacy["op"] = json!("session");
+        let response = request(&mut stream, legacy);
+        assert_eq!(response["result"].as_array().unwrap().len(), 2);
+        assert_eq!(response["result"][0]["record"]["text"], records[0].text);
+        let mut invalid = operation;
+        invalid["limit"] = json!(0);
+        assert_eq!(
+            request(&mut stream, invalid)["error"]["code"],
+            "request_failed"
+        );
     }
 
     #[test]

--- a/src/read_budget.rs
+++ b/src/read_budget.rs
@@ -100,6 +100,9 @@ impl ReadBudget {
         record.text.clear();
         record.tool_input = None;
         record.tool_output = None;
+        // Typed source blocks can duplicate every field and include binary data.
+        // A field projection must not return those unselected contents.
+        record.links.source_content = None;
         match field {
             ReadField::Text => record.text = selected.unwrap_or_default(),
             ReadField::ToolInput => record.tool_input = selected,
@@ -126,6 +129,11 @@ impl ReadBudget {
     }
 
     fn apply_all(&mut self, record: &mut Record) -> ContentPage {
+        // Source blocks have no character-continuation contract. Keep them only
+        // for full-record reads so they cannot bypass a bounded content budget.
+        if self.remaining.is_some() {
+            record.links.source_content = None;
+        }
         let text = std::mem::take(&mut record.text);
         let tool_input = record.tool_input.take();
         let tool_output = record.tool_output.take();
@@ -238,6 +246,40 @@ mod tests {
             }]
         );
         assert_eq!(budget.remaining(), Some(0));
+    }
+
+    #[test]
+    fn source_blocks_are_exclusive_to_unbounded_full_record_reads() {
+        let mut original = record("message", Some("input"), Some("output"));
+        original.links.source_content = Some(
+            serde_json::json!([
+                {"type": "text", "text": "message"},
+                {"type": "image", "source": {"type": "base64", "data": "a".repeat(100_000)}}
+            ])
+            .to_string(),
+        );
+        for limit in [Some(0), Some(1), Some(100), None] {
+            for field in [
+                None,
+                Some(ReadField::Text),
+                Some(ReadField::ToolInput),
+                Some(ReadField::ToolOutput),
+            ] {
+                let mut value = original.clone();
+                let mut budget = ReadBudget::from_remaining(limit);
+                let page = budget.apply(&mut value, field, 0).unwrap();
+                if limit.is_none() && field.is_none() {
+                    assert_eq!(value.links.source_content, original.links.source_content);
+                } else {
+                    assert!(value.links.source_content.is_none());
+                    let serialized = serde_json::to_string(&value).unwrap();
+                    assert!(!serialized.contains("base64"));
+                }
+                if let Some(limit) = limit {
+                    assert!(page.returned_chars <= limit);
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -166,7 +166,13 @@ pub fn canonical_record_id(record: &Record) -> String {
     hash_field(&mut hasher, "source", record.source.storage_label());
     let has_native_event = record.links.event_id.is_some();
     let has_native_tool = record.role == "tool_use" && record.links.source_tool_use_id.is_some();
-    if has_native_event || has_native_tool {
+    if let Some(offset) = record.links.source_record_offset {
+        // Newly retained display records never occupied a legacy ordinal. Keep
+        // their physical source identity separate from both legacy and native IDs.
+        hash_field(&mut hasher, "session", &record.session_id);
+        hash_field(&mut hasher, "source-path", &record.source_path);
+        hash_field(&mut hasher, "source-record-offset", &offset.to_string());
+    } else if has_native_event || has_native_tool {
         // Event/tool IDs are source-native identities.  Do not include optional parent/thread
         // metadata here: parsers may learn to populate those fields later without changing the
         // identity of an already-indexed source event.
@@ -191,7 +197,15 @@ pub fn canonical_record_id(record: &Record) -> String {
         // remain distinct and deterministic across local index rebuilds.
         hash_field(&mut hasher, "session", &record.session_id);
         hash_field(&mut hasher, "source-path", &record.source_path);
-        hash_field(&mut hasher, "turn", &record.turn_id.to_string());
+        hash_field(
+            &mut hasher,
+            "turn",
+            &record
+                .links
+                .legacy_turn_id
+                .unwrap_or(record.turn_id)
+                .to_string(),
+        );
     }
     hash_field(&mut hasher, "role", &record.role);
     hash_field(

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -18,8 +18,8 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    // Preserve image/document content, including attachment-only messages.
-    index: 5,
+    // Preserve pre-reader fallback IDs independently of attachment-only messages.
+    index: 6,
     usage: 4,
 };
 
@@ -270,6 +270,14 @@ pub(crate) fn parse_index_records(
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
+    let mut legacy_turn_id = state.legacy_ordinal()?;
+    let mut emit = |mut record: Record| {
+        if record.links.source_record_offset.is_none() {
+            record.links.legacy_turn_id = Some(legacy_turn_id);
+            legacy_turn_id += 1;
+        }
+        emit(record)
+    };
     use memchr::memchr;
     use memmap2::Mmap;
     use simd_json::prelude::*;
@@ -287,6 +295,7 @@ pub(crate) fn parse_index_records(
     let mut diagnostics = ParseDiagnostics::default();
 
     while start < mmap.len() {
+        let source_record_offset = start as u64;
         let slice = &mmap[start..];
         let relative = memchr(b'\n', slice).unwrap_or(slice.len());
         let line = &slice[..relative];
@@ -523,6 +532,7 @@ pub(crate) fn parse_index_records(
                 }
                 let tool_name = pending.and_then(|call| call.tool_name);
                 let mut links = entry_links.clone();
+                links.tool_result_is_error = block_object.get("is_error").and_then(|v| v.as_bool());
                 if let Some(tool_use_id) = &tool_use_id {
                     links.event_id = entry_uuid
                         .as_ref()
@@ -573,6 +583,9 @@ pub(crate) fn parse_index_records(
             entry_links.source_content = Some(serde_json::to_string(&display_blocks)?);
         }
         if !text.is_empty() || entry_links.source_content.is_some() {
+            if text.is_empty() {
+                entry_links.source_record_offset = Some(source_record_offset);
+            }
             emit(Record {
                 source: SourceKind::Claude,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -595,6 +608,7 @@ pub(crate) fn parse_index_records(
     Ok(IndexParseOutput {
         offset: mmap.len() as u64,
         turn_id,
+        legacy_turn_id: Some(legacy_turn_id),
         pending_tool_calls,
         session_id: Some(session_id),
         diagnostics,
@@ -938,6 +952,191 @@ mod tests {
                     output
                 );
             }
+        }
+    }
+
+    #[test]
+    fn attachment_records_preserve_legacy_ids_across_full_and_incremental_parsing() {
+        use crate::retrieval::canonical_record_id;
+        use serde_json::json;
+        use std::io::Write;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let entry = |role, content| json!({"type":role, "sessionId":"session", "message":{"content":content}});
+        let legacy = vec![
+            entry("user", json!("Question")),
+            entry(
+                "assistant",
+                json!([
+                    {"type":"tool_use", "id":"call", "name":"Read", "input":{}},
+                    {"type":"thinking", "thinking":"Reasoning"},
+                    {"type":"text", "text":"Working"}
+                ]),
+            ),
+            entry(
+                "user",
+                json!([{"type":"tool_result", "tool_use_id":"call", "content":"read result"}]),
+            ),
+            entry("assistant", json!("Answer A")),
+            entry(
+                "assistant",
+                json!([{"type":"tool_use", "name":"Other", "input":"other input"}]),
+            ),
+            json!({"type":"assistant", "uuid":"native-answer", "message":{"content":"Answer B"}}),
+        ];
+        let image =
+            json!({"type":"image", "source":{"type":"url", "url":"https://example.com/image.png"}});
+        let document = json!({"type":"document", "source":{"type":"base64", "media_type":"application/pdf", "data":"AAAA"}});
+        let mut mixed = legacy.clone();
+        // A tool-only source line gains an attachment-only aggregate message;
+        // the tool's existing identity and the next legacy ordinal both survive.
+        mixed[4]["message"]["content"]
+            .as_array_mut()
+            .unwrap()
+            .push(image.clone());
+        mixed.insert(2, entry("user", json!([document])));
+        mixed.insert(0, entry("user", json!([image])));
+        let encoded = |values: &[serde_json::Value]| {
+            values.iter().map(|v| format!("{v}\n")).collect::<String>()
+        };
+        for include_reasoning in [false, true] {
+            let parse = |state| {
+                let mut records = Vec::new();
+                let output = parse_index_records(
+                    &path,
+                    state,
+                    include_reasoning,
+                    &AtomicU64::new(1),
+                    |record| {
+                        records.push(record);
+                        Ok(())
+                    },
+                )
+                .unwrap();
+                (records, output)
+            };
+            fs::write(&path, encoded(&legacy)).unwrap();
+            let (baseline, _) = parse(IndexParseState::default());
+            assert_eq!(baseline.len(), 7 + usize::from(include_reasoning));
+            let baseline_ids = baseline
+                .iter()
+                .enumerate()
+                .map(|(ordinal, record)| {
+                    let mut original = record.clone();
+                    original.turn_id = ordinal as u32;
+                    original.links.legacy_turn_id = None;
+                    original.links.source_record_offset = None;
+                    canonical_record_id(&original)
+                })
+                .collect::<Vec<_>>();
+            fs::write(&path, encoded(&mixed)).unwrap();
+            let (full, output) = parse(IndexParseState::default());
+            let old_records = full
+                .iter()
+                .filter(|record| record.links.source_record_offset.is_none())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                old_records
+                    .iter()
+                    .map(|record| canonical_record_id(record))
+                    .collect::<Vec<_>>(),
+                baseline_ids
+            );
+            assert_eq!(
+                old_records
+                    .iter()
+                    .map(|record| &record.text)
+                    .collect::<Vec<_>>(),
+                baseline
+                    .iter()
+                    .map(|record| &record.text)
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(full.len(), baseline.len() + 3);
+            assert_eq!(output.legacy_turn_id, Some(baseline.len() as u32));
+            let full_ids = full.iter().map(canonical_record_id).collect::<Vec<_>>();
+            assert_eq!(
+                full_ids
+                    .iter()
+                    .collect::<std::collections::HashSet<_>>()
+                    .len(),
+                full.len()
+            );
+
+            fs::write(&path, "").unwrap();
+            let mut state = IndexParseState::default();
+            let mut incremental = Vec::new();
+            for value in &mixed {
+                writeln!(
+                    fs::OpenOptions::new().append(true).open(&path).unwrap(),
+                    "{value}"
+                )
+                .unwrap();
+                let (records, output) = parse(state);
+                incremental.extend(records);
+                state = IndexParseState {
+                    offset: output.offset,
+                    turn_id: output.turn_id,
+                    legacy_turn_id: output.legacy_turn_id,
+                    pending_tool_calls: output.pending_tool_calls,
+                };
+            }
+            assert_eq!(
+                incremental
+                    .iter()
+                    .map(canonical_record_id)
+                    .collect::<Vec<_>>(),
+                full_ids
+            );
+            assert_eq!(state.legacy_turn_id, Some(baseline.len() as u32));
+            assert!(
+                parse_index_records(
+                    &path,
+                    IndexParseState {
+                        offset: state.offset,
+                        turn_id: state.turn_id,
+                        ..IndexParseState::default()
+                    },
+                    include_reasoning,
+                    &AtomicU64::new(1),
+                    |_| Ok(())
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn tool_result_envelope_failure_survives_plain_text_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        for flag in [
+            serde_json::json!(true),
+            serde_json::json!(false),
+            serde_json::json!(1),
+            serde_json::Value::Null,
+        ] {
+            fs::write(&path, format!("{}\n", serde_json::json!({"type":"user", "sessionId":"session", "message":{"content":[{"type":"tool_result", "tool_use_id":"call", "is_error":flag, "content":"permission denied"}]}}))).unwrap();
+            let mut records = Vec::new();
+            parse_index_records(
+                &path,
+                IndexParseState::default(),
+                false,
+                &AtomicU64::new(1),
+                |record| {
+                    records.push(record);
+                    Ok(())
+                },
+            )
+            .unwrap();
+            let result = &records[0];
+            assert_eq!(result.tool_output.as_deref(), Some("permission denied"));
+            assert_eq!(result.links.tool_result_is_error, flag.as_bool());
+            let json = serde_json::to_value(result).unwrap();
+            assert_eq!(
+                json.get("tool_result_is_error").and_then(|v| v.as_bool()),
+                flag.as_bool()
+            );
         }
     }
 

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -18,9 +18,8 @@ use walkdir::WalkDir;
 
 pub const VERSIONS: ParserVersions = ParserVersions {
     identity: 2,
-    // Bumped for the agent-file backfill mirror: forces a full re-parse
-    // so unlabeled agent-*.jsonl transcripts reclassify on next index.
-    index: 4,
+    // Preserve image/document content, including attachment-only messages.
+    index: 5,
     usage: 4,
 };
 
@@ -360,6 +359,7 @@ pub(crate) fn parse_index_records(
                 object,
                 "sourceToolAssistantUUID",
             ),
+            ..RecordLinks::default()
         };
         let timestamp = object
             .get("timestamp")
@@ -397,8 +397,9 @@ pub(crate) fn parse_index_records(
                                 .get("name")
                                 .and_then(|value| value.as_str())
                                 .map(str::to_string);
-                            let tool_input =
-                                block_object.get("input").map(|value| value.to_string());
+                            let tool_input = block_object
+                                .get("input")
+                                .and_then(super::common::tool_value_text);
                             let text = tool_input.clone().unwrap_or_default();
                             let tool_id = block_object
                                 .get("id")
@@ -482,7 +483,7 @@ pub(crate) fn parse_index_records(
                         "redacted_thinking" => {
                             diagnostics.encrypted_reasoning_dropped += 1;
                         }
-                        "tool_result" | "image" => {}
+                        "tool_result" | "image" | "document" => {}
                         unknown => diagnostics.increment_unknown_semantic(unknown),
                     }
                     content_index += 1;
@@ -501,12 +502,14 @@ pub(crate) fn parse_index_records(
                 {
                     continue;
                 }
-                let tool_output = block_object.get("content").map(|value| value.to_string());
+                let tool_output = block_object
+                    .get("content")
+                    .and_then(super::common::tool_value_text);
                 let mut text = super::common::tool_result_text(block).unwrap_or_default();
                 if text.is_empty()
                     && let Some(content) = block_object.get("content")
                 {
-                    text = content.to_string();
+                    text = super::common::tool_value_text(content).unwrap_or_default();
                 }
                 let tool_use_id = block_object
                     .get("tool_use_id")
@@ -547,7 +550,29 @@ pub(crate) fn parse_index_records(
         }
 
         let text = text_parts.join(" ").trim().to_string();
-        if !text.is_empty() {
+        let mut entry_links = entry_links;
+        if let Some(array) = content.and_then(|v| v.as_array())
+            && array.iter().any(|block| {
+                matches!(
+                    block.get("type").and_then(|v| v.as_str()),
+                    Some("image" | "document")
+                )
+            })
+        {
+            // Tool and reasoning blocks have their own governed projections. Do not
+            // duplicate them or expose hidden thinking through attachment metadata.
+            let display_blocks = array
+                .iter()
+                .filter(|block| {
+                    matches!(
+                        block.get("type").and_then(|v| v.as_str()),
+                        Some("text" | "image" | "document")
+                    )
+                })
+                .collect::<Vec<_>>();
+            entry_links.source_content = Some(serde_json::to_string(&display_blocks)?);
+        }
+        if !text.is_empty() || entry_links.source_content.is_some() {
             emit(Record {
                 source: SourceKind::Claude,
                 doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -880,6 +905,95 @@ mod tests {
         let events = parse_usage_file(&path).unwrap();
         assert_eq!(events[0].timestamp_ms, 1_776_386_452_000);
         assert_eq!(events[1].timestamp_ms, 1_776_386_452_437);
+    }
+
+    #[test]
+    fn structured_tool_values_preserve_json_and_verbatim_strings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        for output in [
+            serde_json::json!({"ok":true,"rows":[1,2]}),
+            serde_json::json!([{"type":"text","text":"hello", "extra":42}]),
+            serde_json::json!("plain\noutput"),
+        ] {
+            fs::write(&path, format!("{}\n", serde_json::json!({"type":"user", "sessionId":"session", "message":{"content":[{"type":"tool_result", "tool_use_id":"call", "content":output}]}}))).unwrap();
+            let mut records = Vec::new();
+            parse_index_records(
+                &path,
+                IndexParseState::default(),
+                false,
+                &AtomicU64::new(1),
+                |record| {
+                    records.push(record);
+                    Ok(())
+                },
+            )
+            .unwrap();
+            let actual = records[0].tool_output.as_ref().unwrap();
+            if let Some(text) = output.as_str() {
+                assert_eq!(actual, text);
+            } else {
+                assert_eq!(
+                    serde_json::from_str::<serde_json::Value>(actual).unwrap(),
+                    output
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn source_content_preserves_images_documents_without_exposing_reasoning() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let image = serde_json::json!({"type":"image", "source":{"type":"base64", "media_type":"image/png", "data":"AAAA"}});
+        let document = serde_json::json!({"type":"document", "source":{"type":"url", "url":"https://example.com/notes.pdf"}, "title":"Notes"});
+        let contents = [
+            serde_json::json!([image]),
+            serde_json::json!([{"type":"text", "text":"<<ImageDisplayed>>"}, document, {"type":"thinking", "thinking":"private reasoning"}]),
+            serde_json::json!([{"type":"text", "text":"plain text"}]),
+        ];
+        fs::write(&path, contents.iter().map(|content| format!("{}\n", serde_json::json!({"type":"user", "sessionId":"session", "message":{"role":"user", "content":content}}))).collect::<String>()).unwrap();
+        let mut records = Vec::new();
+        let parsed = parse_index_records(
+            &path,
+            IndexParseState::default(),
+            false,
+            &AtomicU64::new(1),
+            |record| {
+                records.push(record);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(
+            !parsed
+                .diagnostics
+                .unknown_semantic_types
+                .contains_key("document")
+        );
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].text, "");
+        assert_eq!(records[1].text, "<<ImageDisplayed>>");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                records[0].links.source_content.as_ref().unwrap()
+            )
+            .unwrap(),
+            contents[0]
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                records[1].links.source_content.as_ref().unwrap()
+            )
+            .unwrap(),
+            serde_json::json!([contents[1][0], document])
+        );
+        assert!(
+            !serde_json::to_string(&records)
+                .unwrap()
+                .contains("private reasoning")
+        );
+        assert!(records[2].links.source_content.is_none());
     }
 
     #[test]

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -22,8 +22,8 @@ use std::sync::{Arc, Mutex};
 pub const VERSIONS: ParserVersions = ParserVersions {
     // Recompute persisted identities and usage parents for guardian reviews.
     identity: 3,
-    // Reparse turn identity, assistant phase, and explicit lifecycle events.
-    index: 7,
+    // Preserve pre-reader fallback IDs independently of added display records.
+    index: 8,
     usage: 5,
 };
 
@@ -364,6 +364,14 @@ pub(crate) fn parse_index_records(
     next_doc_id: &AtomicU64,
     mut emit: impl FnMut(Record) -> Result<()>,
 ) -> Result<IndexParseOutput> {
+    let mut legacy_turn_id = state.legacy_ordinal()?;
+    let mut emit = |mut record: Record| {
+        if record.links.source_record_offset.is_none() {
+            record.links.legacy_turn_id = Some(legacy_turn_id);
+            legacy_turn_id += 1;
+        }
+        emit(record)
+    };
     let file = File::open(path)?;
     let mmap = unsafe { Mmap::map(&file)? };
     let mut start = state.offset as usize;
@@ -375,6 +383,7 @@ pub(crate) fn parse_index_records(
     let mut diagnostics = ParseDiagnostics::default();
 
     while start < mmap.len() {
+        let source_record_offset = start as u64;
         let slice = &mmap[start..];
         let relative = memchr(b'\n', slice).unwrap_or(slice.len());
         let line = &slice[..relative];
@@ -438,6 +447,7 @@ pub(crate) fn parse_index_records(
                 links.event_id = super::common::borrowed_string(payload, "id");
                 links.lifecycle_event = Some(event_type.to_string());
                 links.source_record_type = Some(format!("event_msg/{event_type}"));
+                links.source_record_offset = Some(source_record_offset);
                 emit(Record {
                     source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -578,6 +588,15 @@ pub(crate) fn parse_index_records(
                 let text = text_parts.join("\n").trim().to_string();
                 if text.is_empty() && links.source_content.is_none() {
                     continue;
+                }
+                // The old parser skipped every message with either prefix,
+                // including bundled requests and non-user roles. These records
+                // must not consume another source record's legacy identity.
+                if text.is_empty()
+                    || text.starts_with("<system_instruction>")
+                    || text.starts_with("<system-instruction>")
+                {
+                    links.source_record_offset = Some(source_record_offset);
                 }
                 // Keep injected instructions inspectable in raw transcripts. Only a
                 // standalone wrapper changes role; a bundled user request stays a user record.
@@ -852,6 +871,7 @@ pub(crate) fn parse_index_records(
     Ok(IndexParseOutput {
         offset: mmap.len() as u64,
         turn_id,
+        legacy_turn_id: Some(legacy_turn_id),
         pending_tool_calls,
         session_id: Some(metadata.session_id),
         diagnostics,
@@ -929,6 +949,7 @@ pub(crate) fn parse_history_records(
         turn_id += 1;
     }
     Ok(IndexParseOutput {
+        legacy_turn_id: Some(turn_id),
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls: state.pending_tool_calls,
@@ -1574,6 +1595,179 @@ mod tests {
     }
 
     #[test]
+    fn reader_records_preserve_legacy_ids_across_full_and_incremental_parsing() {
+        use crate::retrieval::canonical_record_id;
+        use serde_json::json;
+        use std::io::Write;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let response = |payload| json!({"type":"response_item", "payload":payload});
+        // Every pre-reader emitting branch, including native IDs that still
+        // advance the ordinal used by subsequent id-less records.
+        let legacy = vec![
+            response(json!({"type":"message", "role":"user", "content":"Question"})),
+            response(json!({"type":"message", "role":"assistant", "content":"Commentary A"})),
+            response(
+                json!({"type":"message", "role":"assistant", "content":"Commentary B", "id":"native-answer"}),
+            ),
+            response(
+                json!({"type":"function_call", "name":"read", "call_id":"call", "arguments":"{}"}),
+            ),
+            response(
+                json!({"type":"function_call_output", "call_id":"call", "output":"read result"}),
+            ),
+            response(json!({"type":"custom_tool_call", "name":"custom", "input":"custom input"})),
+            response(json!({"type":"custom_tool_call_output", "output":"custom result"})),
+            response(json!({"type":"web_search_call", "query":"web input"})),
+            response(json!({"type":"tool_search_call", "arguments":"tool input"})),
+            response(json!({"type":"tool_search_output", "tools":[{"name":"found"}]})),
+            json!({"type":"event_msg", "payload":{"type":"agent_reasoning", "text":"Reasoning"}}),
+            response(json!({"type":"message", "role":"assistant", "content":""})),
+            response(json!({"type":"function_call_output", "output":""})),
+        ];
+        let added = vec![
+            json!({"type":"event_msg", "payload":{"type":"task_started", "turn_id":"turn"}}),
+            json!({"type":"event_msg", "payload":{"type":"task_complete", "turn_id":"turn"}}),
+            json!({"type":"event_msg", "payload":{"type":"turn_aborted", "turn_id":"turn"}}),
+            response(
+                json!({"type":"message", "role":"user", "content":[{"type":"input_image", "image_url":"/tmp/image.png"}]}),
+            ),
+            response(
+                json!({"type":"message", "role":"user", "content":[{"type":"input_file", "file_id":"file"}]}),
+            ),
+            response(
+                json!({"type":"message", "role":"user", "content":"  <system_instruction>context</system_instruction>"}),
+            ),
+            response(
+                json!({"type":"message", "role":"user", "content":"<system-instruction>context</system-instruction> Actual request"}),
+            ),
+            response(
+                json!({"type":"message", "role":"assistant", "content":"<system_instruction>unclosed prefix"}),
+            ),
+            response(
+                json!({"type":"message", "role":"developer", "content":"<system-instruction>context</system-instruction>"}),
+            ),
+        ];
+        let mut mixed = Vec::new();
+        for index in 0..legacy.len().max(added.len()) {
+            if let Some(value) = added.get(index) {
+                mixed.push(value.clone());
+            }
+            if let Some(value) = legacy.get(index) {
+                mixed.push(value.clone());
+            }
+        }
+        let encoded = |values: &[serde_json::Value]| {
+            values.iter().map(|v| format!("{v}\n")).collect::<String>()
+        };
+        for include_reasoning in [false, true] {
+            let parse = |state| {
+                let mut records = Vec::new();
+                let output = parse_index_records(
+                    &path,
+                    state,
+                    include_reasoning,
+                    &AtomicU64::new(1),
+                    |record| {
+                        records.push(record);
+                        Ok(())
+                    },
+                )
+                .unwrap();
+                (records, output)
+            };
+            fs::write(&path, encoded(&legacy)).unwrap();
+            let (baseline, _) = parse(IndexParseState::default());
+            assert_eq!(baseline.len(), 10 + usize::from(include_reasoning));
+            // Strip the added identity fields to calculate precisely the old
+            // canonical hash from each pre-reader ordinal and source identity.
+            let baseline_ids = baseline
+                .iter()
+                .enumerate()
+                .map(|(ordinal, record)| {
+                    let mut original = record.clone();
+                    original.turn_id = ordinal as u32;
+                    original.links.legacy_turn_id = None;
+                    original.links.source_record_offset = None;
+                    canonical_record_id(&original)
+                })
+                .collect::<Vec<_>>();
+            fs::write(&path, encoded(&mixed)).unwrap();
+            let (full, output) = parse(IndexParseState::default());
+            let old_records = full
+                .iter()
+                .filter(|record| record.links.source_record_offset.is_none())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                old_records
+                    .iter()
+                    .map(|record| canonical_record_id(record))
+                    .collect::<Vec<_>>(),
+                baseline_ids
+            );
+            assert_eq!(
+                old_records
+                    .iter()
+                    .map(|record| &record.text)
+                    .collect::<Vec<_>>(),
+                baseline
+                    .iter()
+                    .map(|record| &record.text)
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(output.legacy_turn_id, Some(baseline.len() as u32));
+            assert_eq!(full.len(), baseline.len() + added.len());
+            let full_ids = full.iter().map(canonical_record_id).collect::<Vec<_>>();
+            assert_eq!(full_ids.iter().collect::<HashSet<_>>().len(), full.len());
+
+            fs::write(&path, "").unwrap();
+            let mut state = IndexParseState::default();
+            let mut incremental = Vec::new();
+            for value in &mixed {
+                writeln!(
+                    fs::OpenOptions::new().append(true).open(&path).unwrap(),
+                    "{value}"
+                )
+                .unwrap();
+                let (records, output) = parse(state);
+                incremental.extend(records);
+                state = IndexParseState {
+                    offset: output.offset,
+                    turn_id: output.turn_id,
+                    legacy_turn_id: output.legacy_turn_id,
+                    pending_tool_calls: output.pending_tool_calls,
+                };
+            }
+            assert_eq!(
+                incremental
+                    .iter()
+                    .map(canonical_record_id)
+                    .collect::<Vec<_>>(),
+                full_ids
+            );
+            assert_eq!(
+                incremental.iter().map(|r| r.turn_id).collect::<Vec<_>>(),
+                full.iter().map(|r| r.turn_id).collect::<Vec<_>>()
+            );
+            assert_eq!(state.legacy_turn_id, Some(baseline.len() as u32));
+            assert!(
+                parse_index_records(
+                    &path,
+                    IndexParseState {
+                        offset: state.offset,
+                        turn_id: state.turn_id,
+                        ..IndexParseState::default()
+                    },
+                    include_reasoning,
+                    &AtomicU64::new(1),
+                    |_| Ok(())
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
     fn structured_tool_values_preserve_json_and_verbatim_strings() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("session.jsonl");
@@ -1758,6 +1952,7 @@ mod tests {
             IndexParseState {
                 offset: first.offset,
                 turn_id: first.turn_id,
+                legacy_turn_id: first.legacy_turn_id,
                 ..IndexParseState::default()
             },
         );
@@ -1770,6 +1965,7 @@ mod tests {
             IndexParseState {
                 offset: second.offset,
                 turn_id: second.turn_id,
+                legacy_turn_id: second.legacy_turn_id,
                 ..IndexParseState::default()
             },
         );

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -1,3 +1,4 @@
+use super::common::tool_value_text as value_text;
 use super::{
     ConversationKind, IndexParseOutput, IndexParseState, ParseDiagnostics, ParserVersions,
     SessionIdentity, SourceFile, SourceMetadata, UsageDependency, UsageParseOutput,
@@ -21,9 +22,8 @@ use std::sync::{Arc, Mutex};
 pub const VERSIONS: ParserVersions = ParserVersions {
     // Recompute persisted identities and usage parents for guardian reviews.
     identity: 3,
-    // Bumped for role-string subagent source detection: forces a full
-    // re-parse so stored kinds are recomputed on next index.
-    index: 5,
+    // Reparse turn identity, assistant phase, and explicit lifecycle events.
+    index: 7,
     usage: 5,
 };
 
@@ -195,6 +195,7 @@ struct SessionMeta {
     project: String,
     cwd: Option<PathBuf>,
     links: SessionLinks,
+    source_turn_id: Option<String>,
 }
 
 fn fallback_meta(path: &Path) -> SessionMeta {
@@ -202,6 +203,7 @@ fn fallback_meta(path: &Path) -> SessionMeta {
         session_id: session_id_from_path(path).unwrap_or_else(|| "unknown".to_string()),
         project: SourceKind::Codex.label().to_string(),
         cwd: None,
+        source_turn_id: None,
         links: SessionLinks {
             conversation_kind: Some(ConversationKind::Main.as_str().to_string()),
             ..SessionLinks::default()
@@ -305,10 +307,28 @@ fn read_meta_until(path: &Path, limit: u64) -> Result<SessionMeta> {
         buffer.clear();
         buffer.extend_from_slice(line);
         if let Ok(value) = simd_json::to_borrowed_value(&mut buffer)
-            && value.get("type").and_then(|value| value.as_str()) == Some("session_meta")
             && let Some(payload) = value.get("payload").and_then(|value| value.as_object())
         {
-            apply_meta(payload, &mut metadata);
+            match value.get("type").and_then(|value| value.as_str()) {
+                Some("session_meta") => apply_meta(payload, &mut metadata),
+                Some("turn_context") => {
+                    metadata.source_turn_id = super::common::borrowed_string(payload, "turn_id");
+                }
+                Some("event_msg")
+                    if payload.get("type").and_then(|v| v.as_str()) == Some("task_started") =>
+                {
+                    metadata.source_turn_id = super::common::borrowed_string(payload, "turn_id");
+                }
+                Some("event_msg")
+                    if matches!(
+                        payload.get("type").and_then(|v| v.as_str()),
+                        Some("task_complete" | "turn_aborted")
+                    ) =>
+                {
+                    metadata.source_turn_id = None;
+                }
+                _ => {}
+            }
         }
     }
     Ok(metadata)
@@ -391,12 +411,60 @@ pub(crate) fn parse_index_records(
             continue;
         }
         if entry_type == "turn_context" {
+            metadata.source_turn_id = object
+                .get("payload")
+                .and_then(|v| v.as_object())
+                .and_then(|payload| super::common::borrowed_string(payload, "turn_id"));
             continue;
         }
         if entry_type == "event_msg" {
             let Some(payload) = object.get("payload").and_then(|value| value.as_object()) else {
                 continue;
             };
+            let event_type = payload
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            if matches!(
+                event_type,
+                "task_started" | "task_complete" | "turn_aborted"
+            ) {
+                if event_type == "task_started" {
+                    metadata.source_turn_id = super::common::borrowed_string(payload, "turn_id");
+                }
+                let mut links = metadata.links.record_links();
+                links.source_turn_id = super::common::borrowed_string(payload, "turn_id")
+                    .or_else(|| metadata.source_turn_id.clone());
+                links.event_id = super::common::borrowed_string(payload, "id");
+                links.lifecycle_event = Some(event_type.to_string());
+                links.source_record_type = Some(format!("event_msg/{event_type}"));
+                emit(Record {
+                    source: SourceKind::Codex,
+                    doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
+                    ts: timestamp,
+                    project: metadata.project.clone(),
+                    session_id: metadata.session_id.clone(),
+                    turn_id,
+                    role: "lifecycle".to_string(),
+                    text: match event_type {
+                        "task_started" => "Turn started",
+                        "task_complete" => "Turn completed",
+                        _ => "Turn interrupted",
+                    }
+                    .to_string(),
+                    tool_name: None,
+                    tool_input: None,
+                    // Keep the complete original event available without repeating its answer.
+                    tool_output: Some(serde_json::to_string(payload)?),
+                    links,
+                    source_path: source_path.clone(),
+                })?;
+                turn_id += 1;
+                if event_type != "task_started" {
+                    metadata.source_turn_id = None;
+                }
+                continue;
+            }
             if payload.get("type").and_then(|value| value.as_str()) == Some("agent_reasoning")
                 && include_reasoning
                 && let Some(text) = payload
@@ -407,6 +475,8 @@ pub(crate) fn parse_index_records(
             {
                 let mut links = metadata.links.record_links();
                 links.event_id = super::common::borrowed_string(payload, "id");
+                links.source_turn_id = metadata.source_turn_id.clone();
+                links.source_record_type = Some("event_msg/agent_reasoning".to_string());
                 emit(Record {
                     source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -441,6 +511,10 @@ pub(crate) fn parse_index_records(
             .unwrap_or("");
         let mut links = metadata.links.record_links();
         links.event_id = super::common::borrowed_string(payload, "id");
+        links.source_turn_id = super::common::borrowed_string(payload, "turn_id")
+            .or_else(|| metadata.source_turn_id.clone());
+        links.assistant_phase = super::common::borrowed_string(payload, "phase");
+        links.source_record_type = Some(format!("response_item/{payload_type}"));
         match payload_type {
             "message" => {
                 let role = payload
@@ -452,6 +526,44 @@ pub(crate) fn parse_index_records(
                     if let Some(text) = content.as_str() {
                         text_parts.push(text);
                     } else if let Some(array) = content.as_array() {
+                        if array.iter().any(|block| {
+                            matches!(
+                                block.get("type").and_then(|v| v.as_str()),
+                                Some(
+                                    "image"
+                                        | "input_image"
+                                        | "local_image"
+                                        | "localImage"
+                                        | "file"
+                                        | "input_file"
+                                        | "document"
+                                        | "attachment"
+                                )
+                            )
+                        }) {
+                            let display_blocks = array
+                                .iter()
+                                .filter(|block| {
+                                    matches!(
+                                        block.get("type").and_then(|v| v.as_str()),
+                                        Some(
+                                            "text"
+                                                | "input_text"
+                                                | "output_text"
+                                                | "image"
+                                                | "input_image"
+                                                | "local_image"
+                                                | "localImage"
+                                                | "file"
+                                                | "input_file"
+                                                | "document"
+                                                | "attachment"
+                                        )
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            links.source_content = Some(serde_json::to_string(&display_blocks)?);
+                        }
                         for block in array {
                             if let Some(text) = block
                                 .as_object()
@@ -464,9 +576,16 @@ pub(crate) fn parse_index_records(
                     }
                 }
                 let text = text_parts.join("\n").trim().to_string();
-                if text.is_empty() || is_system_instruction(&text) {
+                if text.is_empty() && links.source_content.is_none() {
                     continue;
                 }
+                // Keep injected instructions inspectable in raw transcripts. Only a
+                // standalone wrapper changes role; a bundled user request stays a user record.
+                let role = if role == "user" && is_standalone_system_instruction(&text) {
+                    "system"
+                } else {
+                    role
+                };
                 emit(Record {
                     source: SourceKind::Codex,
                     doc_id: next_doc_id.fetch_add(1, Ordering::SeqCst),
@@ -737,27 +856,6 @@ pub(crate) fn parse_index_records(
         session_id: Some(metadata.session_id),
         diagnostics,
     })
-}
-
-fn value_text(value: &BorrowedValue<'_>) -> Option<String> {
-    if let Some(text) = value.as_str() {
-        return Some(text.to_string());
-    }
-    if let Some(array) = value.as_array() {
-        let text = array
-            .iter()
-            .filter_map(|item| {
-                item.as_object()
-                    .and_then(|object| object.get("text").or_else(|| object.get("content")))
-                    .and_then(|value| value.as_str())
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        if !text.is_empty() {
-            return Some(text);
-        }
-    }
-    Some(value.to_string())
 }
 
 pub(crate) fn parse_history_records(
@@ -1437,9 +1535,18 @@ pub(crate) fn reconcile_usage(events: &mut Vec<UsageEvent>) {
     });
 }
 
-fn is_system_instruction(text: &str) -> bool {
-    let text = text.trim_start();
-    text.starts_with("<system_instruction>") || text.starts_with("<system-instruction>")
+fn is_standalone_system_instruction(text: &str) -> bool {
+    let text = text.trim();
+    ["system_instruction", "system-instruction"]
+        .iter()
+        .any(|tag| {
+            let open = format!("<{tag}>");
+            let close = format!("</{tag}>");
+            text.strip_prefix(&open).is_some_and(|rest| {
+                rest.find(&close)
+                    .is_some_and(|end| rest[end + close.len()..].trim().is_empty())
+            })
+        })
 }
 
 #[cfg(test)]
@@ -1454,6 +1561,224 @@ mod tests {
             output,
             reasoning: 0,
         }
+    }
+
+    fn parse_transcript(path: &Path, state: IndexParseState) -> (Vec<Record>, IndexParseOutput) {
+        let mut records = Vec::new();
+        let output = parse_index_records(path, state, false, &AtomicU64::new(1), |record| {
+            records.push(record);
+            Ok(())
+        })
+        .unwrap();
+        (records, output)
+    }
+
+    #[test]
+    fn structured_tool_values_preserve_json_and_verbatim_strings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        for output in [
+            serde_json::json!({"ok":true,"rows":[1,2]}),
+            serde_json::json!([{"type":"text","text":"hello", "extra":42}]),
+            serde_json::json!("plain\noutput"),
+        ] {
+            fs::write(&path, format!("{}\n", serde_json::json!({"type":"response_item", "payload":{"type":"function_call_output", "call_id":"call", "output":output}}))).unwrap();
+            let (records, _) = parse_transcript(&path, IndexParseState::default());
+            let actual = records[0].tool_output.as_ref().unwrap();
+            if let Some(text) = output.as_str() {
+                assert_eq!(actual, text);
+            } else {
+                assert_eq!(
+                    serde_json::from_str::<serde_json::Value>(actual).unwrap(),
+                    output
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn source_content_excludes_non_display_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let image = serde_json::json!({"type":"input_image", "image_url":"/tmp/photo.png"});
+        fs::write(&path, format!("{}\n", serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":[image, {"type":"reasoning", "encrypted_content":"private-ciphertext"}, {"type":"tool_use","input":"private-tool"}]}}))).unwrap();
+        let (records, _) = parse_transcript(&path, IndexParseState::default());
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                records[0].links.source_content.as_ref().unwrap()
+            )
+            .unwrap(),
+            serde_json::json!([image])
+        );
+        let serialized = serde_json::to_string(&records).unwrap();
+        assert!(!serialized.contains("private-ciphertext"));
+        assert!(!serialized.contains("private-tool"));
+    }
+
+    #[test]
+    fn source_content_preserves_typed_attachments_and_image_only_messages() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let contents = [
+            serde_json::json!([{"type":"input_image", "image_url":"data:image/png;base64,AAAA", "detail":"original"}]),
+            serde_json::json!([{"type":"input_text", "text":"<<ImageDisplayed>> What is this?"}, {"type":"localImage", "path":"/tmp/photo.png"}]),
+            serde_json::json!([{"type":"input_file", "file_id":"file-123", "filename":"notes.pdf"}]),
+            serde_json::json!([{"type":"input_text", "text":"ordinary message"}]),
+        ];
+        fs::write(&path, contents.iter().map(|content| format!("{}\n", serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":content}}))).collect::<String>()).unwrap();
+        let (records, _) = parse_transcript(&path, IndexParseState::default());
+        assert_eq!(records.len(), 4);
+        assert_eq!(records[0].text, "");
+        assert_eq!(records[1].text, "<<ImageDisplayed>> What is this?");
+        assert_eq!(records[2].text, "");
+        for (record, content) in records[..3].iter().zip(&contents[..3]) {
+            assert_eq!(
+                &serde_json::from_str::<serde_json::Value>(
+                    record.links.source_content.as_ref().unwrap()
+                )
+                .unwrap(),
+                content
+            );
+            assert!(serde_json::to_value(record).unwrap()["source_content"].is_string());
+        }
+        assert!(records[3].links.source_content.is_none());
+    }
+
+    #[test]
+    fn transcript_preserves_turn_phase_and_explicit_lifecycle_without_echoes() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let lines = [
+            serde_json::json!({"type":"event_msg", "payload":{"type":"task_started", "turn_id":"turn-a"}}),
+            serde_json::json!({"type":"event_msg", "payload":{"type":"user_message", "message":"Question"}}),
+            serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":"Question", "id":"user-a"}}),
+            serde_json::json!({"type":"turn_context", "payload":{"turn_id":"turn-a"}}),
+            serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"assistant", "phase":"commentary", "content":"Working"}}),
+            serde_json::json!({"type":"event_msg", "payload":{"type":"agent_message", "message":"Answer"}}),
+            serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"assistant", "phase":"final_answer", "content":"Answer"}}),
+            serde_json::json!({"type":"event_msg", "payload":{"type":"task_complete", "turn_id":"turn-a", "last_agent_message":"Answer"}}),
+            serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":"Question", "id":"user-b"}}),
+        ];
+        fs::write(
+            &path,
+            lines.iter().map(|v| format!("{v}\n")).collect::<String>(),
+        )
+        .unwrap();
+        let (records, _) = parse_transcript(&path, IndexParseState::default());
+        assert_eq!(records.len(), 6);
+        assert!(
+            records[..5]
+                .iter()
+                .all(|r| r.links.source_turn_id.as_deref() == Some("turn-a"))
+        );
+        assert_eq!(
+            records[2].links.assistant_phase.as_deref(),
+            Some("commentary")
+        );
+        assert_eq!(
+            records[3].links.assistant_phase.as_deref(),
+            Some("final_answer")
+        );
+        assert_eq!(
+            records[4].links.lifecycle_event.as_deref(),
+            Some("task_complete")
+        );
+        assert_eq!(records[4].role, "lifecycle");
+        assert!(
+            records[4]
+                .tool_output
+                .as_ref()
+                .unwrap()
+                .contains("last_agent_message")
+        );
+        let lifecycle: serde_json::Value =
+            serde_json::from_str(records[4].tool_output.as_ref().unwrap()).unwrap();
+        assert_eq!(lifecycle["type"], "task_complete");
+        assert_eq!(lifecycle["last_agent_message"], "Answer");
+        assert_eq!(records[5].links.source_turn_id, None);
+        // Equal user text with distinct source records is not discarded.
+        assert_eq!(records.iter().filter(|r| r.text == "Question").count(), 2);
+        assert_eq!(
+            records.iter().map(|r| r.turn_id).collect::<Vec<_>>(),
+            [0, 1, 2, 3, 4, 5]
+        );
+        let json = serde_json::to_value(&records[3]).unwrap();
+        assert_eq!(json["assistant_phase"], "final_answer");
+        assert_eq!(json["source_turn_id"], "turn-a");
+        assert!(json.get("lifecycle_event").is_none());
+    }
+
+    #[test]
+    fn standalone_injected_instructions_are_preserved_without_hiding_bundled_requests() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let texts = [
+            "<system_instruction>Injected context</system_instruction>",
+            "<system-instruction>Other context</system-instruction>",
+            "<system_instruction>Context</system_instruction>\nActual request",
+            "Please explain <system_instruction> literally",
+        ];
+        fs::write(&path, texts.iter().map(|text| format!("{}\n", serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"user", "content":text}}))).collect::<String>()).unwrap();
+        let (records, _) = parse_transcript(&path, IndexParseState::default());
+        assert_eq!(
+            records.iter().map(|r| r.text.as_str()).collect::<Vec<_>>(),
+            texts
+        );
+        assert_eq!(
+            records.iter().map(|r| r.role.as_str()).collect::<Vec<_>>(),
+            ["system", "system", "user", "user"]
+        );
+        assert!(
+            records
+                .iter()
+                .all(|r| r.links.source_record_type.as_deref() == Some("response_item/message"))
+        );
+        fs::write(&path, format!("{}\n", serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"assistant", "content":texts[0]}}))).unwrap();
+        let (records, _) = parse_transcript(&path, IndexParseState::default());
+        assert_eq!(records[0].role, "assistant");
+        assert_eq!(records[0].text, texts[0]);
+    }
+
+    #[test]
+    fn incremental_transcript_recovers_turn_identity_and_does_not_infer_completion() {
+        use std::io::Write;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(
+            &path,
+            "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"turn-a\"}}\n",
+        )
+        .unwrap();
+        let (_, first) = parse_transcript(&path, IndexParseState::default());
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(file, "{}", serde_json::json!({"type":"response_item", "payload":{"type":"message", "role":"assistant", "phase":"final_answer", "content":"Partial answer"}})).unwrap();
+        let (records, second) = parse_transcript(
+            &path,
+            IndexParseState {
+                offset: first.offset,
+                turn_id: first.turn_id,
+                ..IndexParseState::default()
+            },
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].links.source_turn_id.as_deref(), Some("turn-a"));
+        assert_eq!(records[0].links.lifecycle_event, None);
+        writeln!(file, "{}", serde_json::json!({"type":"event_msg", "payload":{"type":"turn_aborted", "turn_id":"turn-a", "reason":"interrupted"}})).unwrap();
+        let (records, _) = parse_transcript(
+            &path,
+            IndexParseState {
+                offset: second.offset,
+                turn_id: second.turn_id,
+                ..IndexParseState::default()
+            },
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].links.source_turn_id.as_deref(), Some("turn-a"));
+        assert_eq!(
+            records[0].links.lifecycle_event.as_deref(),
+            Some("turn_aborted")
+        );
     }
 
     #[test]

--- a/src/sources/common.rs
+++ b/src/sources/common.rs
@@ -91,6 +91,15 @@ pub(crate) fn borrowed_string(
         .map(str::to_string)
 }
 
+/// Preserve string tool payloads verbatim and structured payloads as valid JSON.
+pub(crate) fn tool_value_text(value: &simd_json::BorrowedValue<'_>) -> Option<String> {
+    use simd_json::prelude::*;
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| serde_json::to_string(value).ok())
+}
+
 pub(crate) fn tool_result_text(block: &simd_json::BorrowedValue<'_>) -> Option<String> {
     use simd_json::prelude::*;
     let object = block.as_object()?;

--- a/src/sources/copilot.rs
+++ b/src/sources/copilot.rs
@@ -337,6 +337,7 @@ pub(crate) fn parse_index_records(
     }
 
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls,

--- a/src/sources/cursor.rs
+++ b/src/sources/cursor.rs
@@ -292,6 +292,7 @@ pub(crate) fn parse_index_records(
         }
     }
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls,

--- a/src/sources/grok.rs
+++ b/src/sources/grok.rs
@@ -378,6 +378,7 @@ pub(crate) fn parse_index_records(
     }
 
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls,

--- a/src/sources/jcode.rs
+++ b/src/sources/jcode.rs
@@ -157,6 +157,7 @@ pub(crate) fn parse_index_records(
     let Ok(value) = simd_json::to_borrowed_value(&mut bytes) else {
         diagnostics.malformed_json_lines += 1;
         return Ok(IndexParseOutput {
+            legacy_turn_id: None,
             offset: JCODE_PARSE_ORIGIN,
             turn_id: state.turn_id,
             pending_tool_calls: state.pending_tool_calls,
@@ -506,6 +507,7 @@ pub(crate) fn parse_index_records(
     }
 
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         // Change marker only: resume always restarts at JCODE_PARSE_ORIGIN.
         offset: bytes_len,
         turn_id,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -93,6 +93,7 @@ pub struct ParserVersions {
 pub(crate) struct IndexParseState {
     pub offset: u64,
     pub turn_id: u32,
+    pub legacy_turn_id: Option<u32>,
     pub pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
 }
 
@@ -100,9 +101,21 @@ pub(crate) struct IndexParseState {
 pub(crate) struct IndexParseOutput {
     pub offset: u64,
     pub turn_id: u32,
+    pub legacy_turn_id: Option<u32>,
     pub pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
     pub session_id: Option<String>,
     pub diagnostics: ParseDiagnostics,
+}
+
+impl IndexParseState {
+    fn legacy_ordinal(&self) -> anyhow::Result<u32> {
+        if self.offset == 0 {
+            return Ok(0);
+        }
+        self.legacy_turn_id.ok_or_else(|| {
+            anyhow::anyhow!("missing legacy record ordinal; reparse the source from offset zero")
+        })
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]

--- a/src/sources/muse.rs
+++ b/src/sources/muse.rs
@@ -507,6 +507,7 @@ pub(crate) fn parse_index_records(
     }
 
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls,

--- a/src/sources/opencode.rs
+++ b/src/sources/opencode.rs
@@ -690,6 +690,7 @@ pub(crate) fn parse_index_records(
         turn_id += 1;
     }
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: 0,
         turn_id,
         pending_tool_calls: state.pending_tool_calls,
@@ -719,6 +720,7 @@ pub(crate) fn parse_database_records(
     require_modern_schema(&connection, path)?;
     let Some(session) = enumerate_session_from_connection(&connection, path, session_id)? else {
         return Ok(IndexParseOutput {
+            legacy_turn_id: None,
             offset: 0,
             turn_id: state.turn_id,
             pending_tool_calls: state.pending_tool_calls,
@@ -844,6 +846,7 @@ pub(crate) fn parse_database_records(
         )?;
     }
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: 0,
         turn_id,
         pending_tool_calls: state.pending_tool_calls,

--- a/src/sources/pi.rs
+++ b/src/sources/pi.rs
@@ -684,6 +684,7 @@ pub(crate) fn parse_index_records_for(
     }
 
     Ok(IndexParseOutput {
+        legacy_turn_id: None,
         offset: mmap.len() as u64,
         turn_id,
         pending_tool_calls,

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,8 @@ pub struct FileState {
     pub mtime: i64,
     pub offset: u64,
     pub turn_id: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_turn_id: Option<u32>,
     #[serde(default)]
     pub parser_version: u32,
     #[serde(default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -202,6 +202,12 @@ impl SourceFilter {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecordLinks {
+    /// Original parser ordinal for fallback IDs, independent of added display records.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy_turn_id: Option<u32>,
+    /// Disjoint identity for newly retained records that had no legacy ordinal.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_record_offset: Option<u64>,
     /// Provider turn identity; `Record::turn_id` remains the ordered record sequence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_turn_id: Option<String>,
@@ -215,6 +221,9 @@ pub struct RecordLinks {
     /// Typed display content when a message includes attachments, serialized as JSON.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_content: Option<String>,
+    /// Provider tool-result envelope status; distinct from the result body.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_result_is_error: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -202,6 +202,19 @@ impl SourceFilter {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecordLinks {
+    /// Provider turn identity; `Record::turn_id` remains the ordered record sequence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assistant_phase: Option<String>,
+    /// Explicit provider event, never inferred from an answer or missing output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_record_type: Option<String>,
+    /// Typed display content when a message includes attachments, serialized as JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1284,6 +1284,7 @@ mod tests {
             mtime,
             offset: metadata.len(),
             turn_id: 1,
+            legacy_turn_id: None,
             parser_version: 1,
             pending_tool_calls: HashMap::new(),
             identity: FileIdentity {


### PR DESCRIPTION
Make the macOS conversation reader easier to scan: collapse injected session context and completed activity, render tool results, code and attachments, and preserve access to the complete raw transcript. Retain source and turn metadata so grouping, deduplication and precise search reveal follow the recorded conversation.

Speed up conversation loading with a single full-page request carrying pagination metadata, and make disclosure changes update in place with cached rendering and stable scroll position. Includes the reviewed spacing, overflow and hover-copy refinements.
