### PR TITLE
Fix session identities, titles, and transcript rendering

### DIFF
--- a/apps/macos/Sources/Memex/ActivityPresentation.swift
+++ b/apps/macos/Sources/Memex/ActivityPresentation.swift
@@ -91,6 +91,10 @@ extension TranscriptActivity {
     }
 
     private static func object(_ text: String) -> [String: Any]? {
+        // Status and arguments must be objects. Most tool output is plain text;
+        // do not allocate and invoke a failing JSON parser for each group pass.
+        let first = text.first(where: { !$0.isWhitespace })
+        guard first == "{" || first == "\u{FEFF}" else { return nil }
         guard let data = text.data(using: .utf8) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
     }

--- a/apps/macos/Sources/Memex/Models.swift
+++ b/apps/macos/Sources/Memex/Models.swift
@@ -19,6 +19,23 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
     var machineID: String { machine ?? "local" }
     var id: String { [machineID, source, sessionID, sourcePath].joined(separator: "\u{1f}") }
     var title: String { label?.nilIfBlank ?? "Untitled conversation" }
+    static func openingTitle(_ records: [TranscriptRecord]) -> String? {
+        if let request = TranscriptPresentation.project(records).first(where: {
+            $0.record.role == "user" && !$0.record.isInstruction && $0.record.text.nilIfBlank != nil
+        }) {
+            let text = request.record.text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+            return String(text.prefix(160)) + (text.count > 160 ? "…" : "")
+        }
+        for entry in records where entry.record.role == "developer" && entry.record.text.hasPrefix("<context_window>") {
+            if let line = entry.record.text.components(separatedBy: "\n").first(where: { $0.hasPrefix("Agent name: /root/") }) {
+                let name = line.dropFirst("Agent name: /root/".count).replacingOccurrences(of: "_", with: " ")
+                let title = String(name.prefix(160))
+                return title.prefix(1).uppercased() + title.dropFirst()
+            }
+        }
+        return nil
+    }
+
     var projectName: String { repoProject?.nilIfBlank ?? project.nilIfBlank ?? "No project" }
     var date: Date? { lastAt.flatMap { try? Date.ISO8601FormatStyle().parse($0) } }
 
@@ -65,7 +82,6 @@ struct SearchHit: Decodable, Sendable {
         if let existing = known[value.id] { value = existing }
         value.snippet = snippet
         value.searchRecordID = recordID
-        if value.label == nil { value.label = snippet?.nilIfBlank }
         if value.lastAt == nil, let ts {
             value.lastAt = ts
         }

--- a/apps/macos/Sources/Memex/PromptSections.swift
+++ b/apps/macos/Sources/Memex/PromptSections.swift
@@ -13,6 +13,10 @@ import AppKit
     private static let tag = try! NSRegularExpression(pattern: #"^\s*<(/?)([A-Za-z_][\w:.-]*)([^<>]*?)(/?)>\s*$"#)
     private static let inlinePair = try! NSRegularExpression(pattern: #"^\s*<([A-Za-z_][\w:.-]*)([^<>]*)>(.+)</\1>\s*$"#)
 
+    static func hasOpeningSection(_ text: String) -> Bool {
+        text.range(of: #"^\s*<[A-Za-z_][\w:.-]*(?:\s[^<>]*)?>"#, options: .regularExpression) != nil
+    }
+
     static func render(_ text: String, font: NSFont) -> NSAttributedString? {
         let root = Section()
         var stack = [root]
@@ -22,7 +26,29 @@ import AppKit
         func flush() {
             if !buffer.isEmpty { stack.last!.parts.append(.text(buffer)); buffer = "" }
         }
-        for original in text.components(separatedBy: "\n") {
+        // Put boundary tags on their own lines, except inside literal code fences.
+        var lines: [String] = []
+        var literalFence: Character?
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                if literalFence == nil { literalFence = trimmed.first }
+                else if literalFence == trimmed.first { literalFence = nil }
+                lines.append(line)
+            } else if literalFence != nil { lines.append(line) }
+            else {
+                let separated: String
+                if trimmed.hasPrefix("<") {
+                    separated = line.replacingOccurrences(of: #"</?[A-Za-z_][\w:.-]*(?:\s[^<>]*?)?/?>"#,
+                        with: "\n$0\n", options: .regularExpression)
+                } else {
+                    separated = line.replacingOccurrences(of: #"(?<=\S)(</[A-Za-z_][\w:.-]*>\s*)$"#,
+                        with: "\n$1", options: .regularExpression)
+                }
+                lines += separated.components(separatedBy: "\n")
+            }
+        }
+        for original in lines {
             let trimmed = original.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
                 if fence == nil { fence = trimmed.first }

--- a/apps/macos/Sources/Memex/SourceContent.swift
+++ b/apps/macos/Sources/Memex/SourceContent.swift
@@ -47,7 +47,9 @@ enum SourceContent {
     }
 
     static func displayText(_ message: Message) -> String {
-        guard message.text.contains("<<ImageDisplayed>>") else { return message.text }
+        // Without typed source content there cannot be an image to replace a
+        // placeholder. Avoid scanning large tool transcripts during every page update.
+        guard message.sourceContent != nil, message.text.contains("<<ImageDisplayed>>") else { return message.text }
         let imageCount = blocks(message).filter {
             switch $0 { case .embeddedImage, .attachment(_, _, true): true; default: false }
         }.count

--- a/apps/macos/Sources/Memex/Store.swift
+++ b/apps/macos/Sources/Memex/Store.swift
@@ -315,13 +315,18 @@ final class Store {
         sessionMetadataGeneration = generation
         loadingSessionMetadata = false
         sessionMetadataError = nil
-        guard let session = selected, session.machineID == "local",
-              session.searchRecordID != nil, session.resumeCommand == nil else { return }
+        guard let session = selected,
+              session.label?.nilIfBlank == nil || (session.searchRecordID != nil && session.machineID == "local" && session.resumeCommand == nil) else { return }
         let request = readerRequestID
         loadingSessionMetadata = true
         defer { if sessionMetadataGeneration == generation { loadingSessionMetadata = false } }
         do {
-            let detail = try await client.sessionDetails(for: session)
+            var detail = try await client.sessionDetails(for: session)
+            if detail.label?.nilIfBlank == nil { detail.label = session.label?.nilIfBlank }
+            if detail.label?.nilIfBlank == nil {
+                let opening = try await client.records(for: session, offset: 0, limit: 16)
+                detail.label = Session.openingTitle(opening)
+            }
             try Task.checkCancellation()
             guard sessionMetadataGeneration == generation, readerRequestID == request,
                   let index = sessions.firstIndex(where: { $0.id == session.id }) else { return }

--- a/apps/macos/Sources/Memex/ToolContentRenderer.swift
+++ b/apps/macos/Sources/Memex/ToolContentRenderer.swift
@@ -98,18 +98,42 @@ import AppKit
             valueBlocks(value, to: result, toolName: toolName)
             return
         }
-        // Execution wrappers prepend timing/status lines to a JSON result. Only
-        // split at a line boundary when the entire remaining suffix parses.
-        for boundary in text.indices where text[boundary] == "\n" {
-            var next = text.index(after: boundary)
-            while next < text.endIndex, text[next] == " " || text[next] == "\t" {
-                next = text.index(after: next)
+        // Scan once for complete JSON containers, including adjacent exec results.
+        // Bound presentation work; raw content and Find retain the original bytes.
+        if !code, text.utf8.count <= 256_000 {
+            var cursor = text.startIndex
+            var plainStart = cursor
+            while cursor < text.endIndex {
+                let character = text[cursor]
+                let atBoundary = cursor == text.startIndex || text[text.index(before: cursor)].isWhitespace
+                    || text[text.index(before: cursor)] == "}" || text[text.index(before: cursor)] == "]"
+                guard atBoundary, character == "{" || character == "[" else {
+                    cursor = text.index(after: cursor)
+                    continue
+                }
+                let start = cursor
+                var depth = 0
+                var quoted = false
+                var escaped = false
+                repeat {
+                    let c = text[cursor]
+                    if quoted {
+                        if escaped { escaped = false }
+                        else if c == "\\" { escaped = true }
+                        else if c == "\"" { quoted = false }
+                    } else if c == "\"" { quoted = true }
+                    else if c == "{" || c == "[" { depth += 1 }
+                    else if c == "}" || c == "]" { depth -= 1 }
+                    cursor = text.index(after: cursor)
+                } while cursor < text.endIndex && depth > 0
+                if depth == 0, let value = json(String(text[start..<cursor])) {
+                    append(String(text[plainStart..<start]), to: result, code: code)
+                    valueBlocks(value, to: result, toolName: toolName)
+                    plainStart = cursor
+                }
             }
-            guard next < text.endIndex, text[next] == "{" || text[next] == "[" else { continue }
-            let suffix = String(text[next...])
-            if let value = json(suffix) {
-                append(String(text[...boundary]), to: result, code: code)
-                valueBlocks(value, to: result, toolName: toolName)
+            if plainStart != text.startIndex {
+                append(String(text[plainStart...]), to: result, code: code)
                 return
             }
         }
@@ -120,7 +144,7 @@ import AppKit
 
     private static func json(_ text: String) -> Any? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return nil }
+        guard trimmed.utf8.count <= 256_000, trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return nil }
         return try? JSONSerialization.jsonObject(with: Data(trimmed.utf8))
     }
 

--- a/apps/macos/Sources/Memex/ToolContentRenderer.swift
+++ b/apps/macos/Sources/Memex/ToolContentRenderer.swift
@@ -144,7 +144,10 @@ import AppKit
 
     private static func json(_ text: String) -> Any? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.utf8.count <= 256_000, trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return nil }
+        // The size budget belongs to the adjacent-container scan, not complete
+        // JSON: typed image payloads can exceed it and still need previews and
+        // opaque-data suppression. Image decoding has its own limits above.
+        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return nil }
         return try? JSONSerialization.jsonObject(with: Data(trimmed.utf8))
     }
 

--- a/apps/macos/Sources/Memex/TranscriptController.swift
+++ b/apps/macos/Sources/Memex/TranscriptController.swift
@@ -234,6 +234,8 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         updatingRows = true
         defer { updatingRows = false }
         let appendOnly = !changedSession && self.provider == provider && records.starts(with: self.records)
+        let prependOnly = !changedSession && self.provider == provider
+            && records.suffix(self.records.count).elementsEqual(self.records)
         let oldOrigin = scrollView.contentView.bounds.origin
         let visiblePosition = changedSession ? nil : currentPosition()
         if appendOnly, self.records != records, let last = rows.last {
@@ -262,7 +264,9 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
                 expanded.insert("activity:\(activity.id)")
             }
         }
-        rebuildRows(resetMeasurements: !appendOnly || changedMode || changedQuery)
+        // Both paging directions retain unchanged layouts; rebuildRows invalidates
+        // boundary groups whose records or nesting changed.
+        rebuildRows(resetMeasurements: !(appendOnly || prependOnly) || changedMode || changedQuery)
         if needsInitialPosition {
             applyInitialPosition()
         } else if let visiblePosition {
@@ -360,7 +364,10 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
 
     private func currentPosition() -> TranscriptNavigationState.Position? {
         guard !needsInitialPosition, !rows.isEmpty else { return nil }
-        let y = scrollView.contentView.bounds.minY
+        // Rubber-banding can put the clip origin above the first row while
+        // an earlier page arrives. Anchor to that row, not an invalid hit-test
+        // that would restore the old pixel origin into the newly prepended page.
+        let y = max(0, scrollView.contentView.bounds.minY)
         let row = table.row(at: NSPoint(x: 1, y: y + 1))
         guard rows.indices.contains(row) else { return nil }
         return .init(recordID: rows[row].records[0].sourceID, offset: y - table.rect(ofRow: row).minY,
@@ -700,7 +707,7 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         let contentX = isUser ? width - 30 - contentWidth : 30 + indent
         let bodyWidth = contentWidth - (isUser || isDisclosure ? 24 : 0)
         var richContent: RichContentView?
-        let mayHaveRichBlocks = body.contains("```") || body.contains("~~~") || body.contains("![") || body.contains("](/") || body.contains("](file:")
+        let mayHaveRichBlocks = !PromptSections.hasOpeningSection(body) && (body.contains("```") || body.contains("~~~") || body.contains("![") || body.contains("](/") || body.contains("](file:"))
         if !showsRaw && (!attachments.isEmpty || (!body.isEmpty && (isTool || (mayHaveRichBlocks && RichContentDocument(body).hasRichBlocks)))) {
             if let cached = richLayouts[row.id] { richContent = cached }
             else {
@@ -854,7 +861,7 @@ private final class TranscriptCell: NSTableCellView, NSTextViewDelegate {
         rawDisclosure.title = value.finding ? "Raw content shown for Find" : (value.showsRaw ? "Show formatted content" : "Show raw content")
         rawDisclosure.isEnabled = !value.finding
         message.setAccessibilityLabel(value.title)
-        activityIcon.isHidden = value.symbolName == nil
+        activityIcon.isHidden = value.isDisclosure || value.symbolName == nil
         activityIcon.image = value.symbolName.flatMap { NSImage(systemSymbolName: $0, accessibilityDescription: nil) }
         activityIcon.contentTintColor = value.hasFailure ? .systemOrange : .tertiaryLabelColor
         disclosure.restingTint = value.hasFailure ? .systemOrange : .secondaryLabelColor
@@ -911,7 +918,7 @@ private final class TranscriptCell: NSTableCellView, NSTextViewDelegate {
         activityIcon.frame = NSRect(x: x, y: 12, width: 14, height: 14)
         // Reserve the action gutter before hover so the title and chevron never move.
         let actionGutter: CGFloat = value.isDisclosure ? 32 : 0
-        disclosure.frame = NSRect(x: x + 22, y: 8, width: max(0, width - 22 - actionGutter), height: 22)
+        disclosure.frame = NSRect(x: x, y: 8, width: max(0, width - actionGutter), height: 22)
         rawDisclosure.frame = NSRect(x: x + 12, y: 44, width: width - 24, height: 22)
         let bodyY: CGFloat = value.isDisclosure ? (value.showsRawControl ? 74 : 44) : 16
         let inset: CGFloat = value.isUser || value.isDisclosure ? 12 : 0

--- a/apps/macos/Sources/Memex/TranscriptPresentation.swift
+++ b/apps/macos/Sources/Memex/TranscriptPresentation.swift
@@ -40,6 +40,9 @@ enum TranscriptPresentation {
     /// These are transport markers, not arbitrary XML or Markdown directives. Keep
     /// examples in Markdown code/quotes intact and retain the complete source in rawJSON.
     private static func assistantDisplayText(_ text: String) -> String {
+        // Most messages contain no transport markers. Avoid scanning every
+        // Markdown code span again whenever an earlier page is inserted.
+        guard text.contains(":codex-annotation") || text.contains("<oai-mem-citation>") else { return text }
         let source = text as NSString
         let protected = protectedMarkdownRanges(text)
         func isProtected(_ range: NSRange) -> Bool {

--- a/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
+++ b/apps/macos/Tests/MemexTests/ActivityPresentationTests.swift
@@ -41,7 +41,7 @@ struct ActivityPresentationTests {
     }
 
     @Test func failureRequiresAnExplicitStructuredOutputStatus() {
-        for output in [#"{"isError":true}"#, #"{"is_error":true}"#, #"{"exit_code":1}"#, #"{"exit_code":-9}"#] {
+        for output in [" \n\t{\"exit_code\":2}", "\u{FEFF}{\"exit_code\":2}", #"{"isError":true}"#, #"{"is_error":true}"#, #"{"exit_code":1}"#, #"{"exit_code":-9}"#] {
             #expect(activity("Bash", output: output).presentation.hasFailure)
             #expect(activity("Bash", output: output).presentation.title == "Failed · Run")
         }

--- a/apps/macos/Tests/MemexTests/MachineTests.swift
+++ b/apps/macos/Tests/MemexTests/MachineTests.swift
@@ -20,7 +20,9 @@ import Testing
     let local = Session(source: "codex", sessionID: "same", sourcePath: "/same", project: "memex", label: "Local title")
     let unmatched = hit.session(known: [local.id: local])
     #expect(unmatched.machineID == "fixture-remote")
-    #expect(unmatched.title == "match")
+    #expect(unmatched.label == nil)
+    #expect(unmatched.title == "Untitled conversation")
+    #expect(unmatched.snippet == "match")
     var remote = local
     remote.machine = "fixture-remote"
     remote.label = "Remote title"

--- a/apps/macos/Tests/MemexTests/ModelTests.swift
+++ b/apps/macos/Tests/MemexTests/ModelTests.swift
@@ -198,3 +198,27 @@ private func linkedRecord(_ id: String, _ role: String, _ invocation: String?,
     #expect(instruction.body == "instructions")
     #expect(instruction.title == "Developer instructions")
 }
+
+@Test func searchExcerptNeverBecomesConversationTitle() {
+    let hit = SearchHit(source: "claude", sessionID: "s", sourcePath: "/a", project: "p",
+                        snippet: "old_string: String(large tool payload)", ts: nil)
+    let unknown = hit.session(known: [:])
+    #expect(unknown.label == nil)
+    #expect(unknown.title == "Untitled conversation")
+    #expect(unknown.snippet == hit.snippet)
+    var known = unknown
+    known.label = "Investigate equality deletes"
+    #expect(hit.session(known: [known.id: known]).title == "Investigate equality deletes")
+}
+
+@Test func openingTitleSkipsInjectedContextAndUsesRequestOrSubagentName() {
+    func entry(_ role: String, _ text: String) -> TranscriptRecord {
+        TranscriptRecord(recordID: text, record: Message(role: role, text: text, toolName: nil, toolInput: nil, toolOutput: nil))
+    }
+    let context = entry("user", "<recommended_plugins>plugins</recommended_plugins>\n<environment_context>environment</environment_context>")
+    let agent = entry("developer", "<context_window>\nAgent name: /root/activity_backfill\n</context_window>")
+    #expect(Session.openingTitle([agent, context]) == "Activity backfill")
+    #expect(Session.openingTitle([context, entry("user", "Please fix\n the backfill")]) == "Please fix the backfill")
+    #expect(Session.openingTitle([agent, context, entry("user", "Actual assignment")]) == "Actual assignment")
+    #expect(Session.openingTitle([context]) == nil)
+}

--- a/apps/macos/Tests/MemexTests/ReaderPerformanceTests.swift
+++ b/apps/macos/Tests/MemexTests/ReaderPerformanceTests.swift
@@ -101,6 +101,53 @@ import Testing
         #expect(reader.measurement(at: toolIndex).isExpanded)
     }
 
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"] != nil))
+    func capturedPagePrependLatency() throws {
+        let path = try #require(ProcessInfo.processInfo.environment["MEMEX_READER_PERF_INPUT"])
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let decodeStart = ContinuousClock.now
+        let records = try JSONDecoder().decode([TranscriptRecord].self, from: data)
+        print(String(format: "pagination_decode bytes=%d records=%d ms=%.2f", data.count, records.count, milliseconds(since: decodeStart)))
+        #expect(records.count > 60)
+        let projectionCosts = records.map { record in
+            let start = ContinuousClock.now
+            _ = TranscriptPresentation.project([record])
+            return (record.record.role, record.record.text.utf8.count, milliseconds(since: start))
+        }
+        for (role, bytes, ms) in projectionCosts.sorted(by: { $0.2 > $1.2 }).prefix(5) {
+            print(String(format: "pagination_projection role=%@ bytes=%d ms=%.2f", role, bytes, ms))
+        }
+        _ = NSApplication.shared
+        for iteration in 0..<3 {
+            let reader = TranscriptController()
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 700),
+                styleMask: [.titled, .resizable], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            window.contentViewController = reader
+            defer { window.close() }
+            window.contentView?.layoutSubtreeIfNeeded()
+            reader.update(sessionID: "pagination", records: Array(records.suffix(60)), provider: "codex", hasEarlier: true)
+            window.contentView?.layoutSubtreeIfNeeded()
+            reader.scrollView.contentView.scroll(to: .zero)
+            let projectStart = ContinuousClock.now
+            let projected = TranscriptPresentation.project(records)
+            let projectMS = milliseconds(since: projectStart)
+            let consecutiveStart = ContinuousClock.now
+            _ = TranscriptItem.groupConsecutive(projected)
+            let consecutiveMS = milliseconds(since: consecutiveStart)
+            let groupStart = ContinuousClock.now
+            _ = TranscriptItem.group(records)
+            let groupingMS = milliseconds(since: groupStart)
+            let start = ContinuousClock.now
+            reader.update(sessionID: "pagination", records: records, provider: "codex")
+            let updateMS = milliseconds(since: start)
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            print(String(format: "pagination_prepend iteration=%d project_ms=%.2f consecutive_ms=%.2f group_ms=%.2f update_ms=%.2f total_ms=%.2f rows=%d",
+                iteration, projectMS, consecutiveMS, groupingMS, updateMS, milliseconds(since: start), reader.rows.count))
+        }
+    }
+
     private func milliseconds(since start: ContinuousClock.Instant) -> Double {
         let duration = start.duration(to: .now).components
         return Double(duration.seconds) * 1_000 + Double(duration.attoseconds) / 1_000_000_000_000_000

--- a/apps/macos/Tests/MemexTests/RenderingTests.swift
+++ b/apps/macos/Tests/MemexTests/RenderingTests.swift
@@ -336,6 +336,36 @@ struct RenderingTests {
         #expect(abs(controller.scrollView.contentView.bounds.minY - savedY) < 1)
     }
 
+    @Test func prependingPageReusesUnchangedLayoutsAndInvalidatesChangedText() {
+        let controller = TranscriptController()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 450)
+        controller.update(sessionID: "cache", records: simpleRecords(60..<120), provider: "codex")
+        let cached = controller.measurement(at: 10).attributedBody
+        controller.update(sessionID: "cache", records: simpleRecords(0..<120), provider: "codex")
+        #expect(controller.measurement(at: 70).attributedBody === cached)
+        var edited = simpleRecords(0..<120)
+        var message = edited[70].record
+        message.text = "Updated message"
+        edited[70] = TranscriptRecord(recordID: edited[70].id, record: message)
+        controller.update(sessionID: "cache", records: edited, provider: "codex")
+        #expect(controller.measurement(at: 70).attributedBody !== cached)
+        #expect(controller.measurement(at: 70).attributedBody.string.contains("Updated message"))
+    }
+
+    @Test func prependingDuringTopOverscrollKeepsOldFirstMessageVisible() {
+        let controller = TranscriptController()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 450)
+        controller.scrollView.contentView = OverscrollClipView(frame: controller.scrollView.bounds)
+        controller.scrollView.documentView = controller.table
+        controller.update(sessionID: "overscroll", records: simpleRecords(60..<120), provider: "codex", hasEarlier: true)
+        // Trackpad rubber-banding allows a negative clip origin while the
+        // asynchronous earlier-page request completes.
+        controller.scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: -32))
+        #expect(controller.scrollView.contentView.bounds.minY < 0)
+        controller.update(sessionID: "overscroll", records: simpleRecords(0..<120), provider: "codex")
+        #expect(abs(controller.scrollView.contentView.bounds.minY - controller.table.rect(ofRow: 60).minY) < 1)
+    }
+
     @Test func prependingEarlierMessagesKeepsVisibleMessageAtSameOffset() {
         let controller = TranscriptController()
         controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 450)
@@ -403,4 +433,9 @@ struct RenderingTests {
 
 @MainActor private func descendants<T: NSView>(of view: NSView, as type: T.Type) -> [T] {
     ((view as? T).map { [$0] } ?? []) + view.subviews.flatMap { descendants(of: $0, as: type) }
+}
+
+/// Model the unconstrained clip bounds AppKit permits during rubber-banding.
+@MainActor private final class OverscrollClipView: NSClipView {
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect { proposedBounds }
 }

--- a/apps/macos/Tests/MemexTests/RichTextTests.swift
+++ b/apps/macos/Tests/MemexTests/RichTextTests.swift
@@ -88,3 +88,28 @@ import Testing
     #expect(title.minY <= 16) // Six-point outer margin plus ten-point card padding.
     #expect(text.string.contains("Context Window Reminder\nBody text."))
 }
+
+@MainActor @Test func inlineAndCompactPromptSectionsRenderWithoutRawTags() {
+    let source = "<multi_agent_role>You are an agent.\nMore **rules**.</multi_agent_role>\n<filesystem><workspace_roots><root>/tmp/project</root><root>/tmp/other</root></workspace_roots><entry access=\"read\"><path>/tmp/project</path></entry></filesystem>"
+    let rendered = RichTextRenderer.render(source, font: .systemFont(ofSize: 14)).string
+    #expect(rendered.contains("Multi Agent Role"))
+    #expect(rendered.contains("You are an agent."))
+    #expect(rendered.contains("Workspace Roots"))
+    #expect(rendered.contains("/tmp/other"))
+    #expect(rendered.contains("access=\"read\""))
+    #expect(!rendered.contains("<"))
+}
+
+@MainActor @Test func promptWithFencedCodeKeepsSectionRenderingInReader() {
+    let source = "<app-context>\n# Desktop context\n```swift\nlet x = 1\n```\n</app-context>"
+    let record = TranscriptRecord(recordID: "context", record: Message(role: "developer", text: source, toolName: nil, toolInput: nil, toolOutput: nil))
+    let controller = TranscriptController()
+    controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+    controller.update(sessionID: "prompt", records: [record], provider: "codex")
+    controller.toggle(controller.rows[0].id)
+    let measurement = controller.measurement(at: 0)
+    #expect(measurement.richContent == nil)
+    #expect(measurement.attributedBody.string.contains("App Context"))
+    #expect(!measurement.attributedBody.string.contains("<app-context>"))
+    #expect(measurement.attributedBody.string.contains("let x = 1"))
+}

--- a/apps/macos/Tests/MemexTests/SessionMetadataTests.swift
+++ b/apps/macos/Tests/MemexTests/SessionMetadataTests.swift
@@ -15,7 +15,7 @@ private struct MetadataFixture {
         printf '%s\n' "$@" > "$base/arguments"
         touch "$base/started"
         while [ -e "$base/hold" ]; do sleep 0.01; done
-        cat "$base/result"
+        if [ "$3" = session ] && [ -f "$base/opening" ]; then cat "$base/opening"; else cat "$base/result"; fi
         """#.write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
         try #"[{"source":"codex","session_id":"old","source_path":"/old file","project":"p","resume_cmd":"custom-resume old","cwd":"/tmp/p"}]"#
@@ -49,16 +49,11 @@ private struct MetadataFixture {
     #expect(args.contains("--session-id=old\n--source-path=/old file\n--origin\nall\n--limit\n1"))
 }
 
-@MainActor @Test func metadataRejectsWrongIdentityAndSkipsRemoteSessions() async throws {
+@MainActor @Test func metadataRejectsWrongIdentity() async throws {
     let fixture = try MetadataFixture()
     defer { fixture.cleanup() }
     let store = Store(client: fixture.client)
     var hit = fixture.hit
-    hit.machine = "nicbook-atm"
-    store.sessions = [hit]
-    store.selectedID = hit.id
-    await store.loadSelectedSessionMetadata()
-    #expect(!FileManager.default.fileExists(atPath: fixture.directory.appendingPathComponent("started").path))
     hit.machine = nil
     store.sessions = [hit]
     store.selectedID = hit.id
@@ -91,4 +86,52 @@ private struct MetadataFixture {
     #expect(store.sessions.first?.resumeCommand == nil)
     #expect(!store.loadingSessionMetadata)
     #expect(store.sessionMetadataError == nil)
+}
+
+@MainActor @Test func remoteSearchLoadsOpeningMessageTitleWithoutReplacingMatch() async throws {
+    let fixture = try MetadataFixture()
+    defer { fixture.cleanup() }
+    var hit = fixture.hit
+    hit.machine = "nicbook-atm"
+    hit.label = nil
+    try #"[{"source":"codex","session_id":"old","source_path":"/old file","project":"p","machine":"nicbook-atm","label":"Investigate equality deletes"}]"#
+        .write(to: fixture.directory.appendingPathComponent("result"), atomically: true, encoding: .utf8)
+    let store = Store(client: fixture.client)
+    store.sessions = [hit]
+    store.selectedID = hit.id
+    let readerID = store.readerRequestID
+    await store.loadSelectedSessionMetadata()
+    #expect(store.selected?.title == "Investigate equality deletes")
+    #expect(store.selected?.snippet == "matched text")
+    #expect(store.selected?.searchRecordID == "anchor")
+    #expect(store.readerRequestID == readerID)
+    #expect(store.sessionMetadataError == nil)
+    let args = try String(contentsOf: fixture.directory.appendingPathComponent("arguments"), encoding: .utf8)
+    #expect(args.contains("--machine\nnicbook-atm\n"))
+    try FileManager.default.removeItem(at: fixture.directory.appendingPathComponent("started"))
+    await store.loadSelectedSessionMetadata()
+    #expect(!FileManager.default.fileExists(atPath: fixture.directory.appendingPathComponent("started").path))
+}
+
+@MainActor @Test func untitledRecentSubagentUsesOpeningContextName() async throws {
+    let fixture = try MetadataFixture()
+    defer { fixture.cleanup() }
+    var hit = fixture.hit
+    hit.machine = "nicbook-atm"
+    hit.label = nil
+    hit.searchRecordID = nil
+    try #"[{"source":"codex","session_id":"old","source_path":"/old file","project":"p","machine":"nicbook-atm"}]"#
+        .write(to: fixture.directory.appendingPathComponent("result"), atomically: true, encoding: .utf8)
+    try #"[{"record_id":"context","record":{"role":"developer","text":"<context_window>\nAgent name: /root/activity_backfill\n</context_window>"}},{"record_id":"user","record":{"role":"user","text":"<recommended_plugins>plugins</recommended_plugins><environment_context>env</environment_context>"}}]"#
+        .write(to: fixture.directory.appendingPathComponent("opening"), atomically: true, encoding: .utf8)
+    let store = Store(client: fixture.client)
+    store.sessions = [hit]
+    store.selectedID = hit.id
+    let readerID = store.readerRequestID
+    await store.loadSelectedSessionMetadata()
+    #expect(store.selected?.title == "Activity backfill")
+    #expect(store.readerRequestID == readerID)
+    #expect(store.sessionMetadataError == nil)
+    let args = try String(contentsOf: fixture.directory.appendingPathComponent("arguments"), encoding: .utf8)
+    #expect(args.contains("--offset\n0\n--limit\n16\n"))
 }

--- a/apps/macos/Tests/MemexTests/ToolContentTests.swift
+++ b/apps/macos/Tests/MemexTests/ToolContentTests.swift
@@ -105,6 +105,24 @@ struct ToolContentTests {
         #expect(!controller.measurement(at: 0).attributedBody.string.contains(payload))
     }
 
+    @Test func adjacentExecutionResultsDecodeNestedJSONAndPreserveRaw() {
+        let first = #"{"chunk_id":"one","output":"{\"conditions\":[{\"message\":\"failed } [\"}]}"}"#
+        let second = #"{"chunk_id":"two","output":"log\nnext"}"#
+        let source = "Script completed\nOutput:\n" + first + second
+        let record = entry("result", output: source)
+        let rendered = ToolContentRenderer.render([record]).string
+        #expect(rendered.contains("conditions[0].message\nfailed } ["))
+        #expect(rendered.contains("chunk_id\ntwo"))
+        #expect(rendered.contains("output\nlog\nnext"))
+        #expect(ToolContentRenderer.render([record], raw: true).string == source)
+    }
+
+    @Test func malformedAndOversizedResultsRemainLiteral() {
+        for source in ["Output:\n{broken}", "Output:\n{\"output\":\"" + String(repeating: "x", count: 256_000) + "\"}"] {
+            #expect(ToolContentRenderer.render([entry("result", output: source)]).string == source)
+        }
+    }
+
     private func entry(_ id: String, input: String? = nil, output: String? = nil) -> TranscriptRecord {
         TranscriptRecord(recordID: id, record: Message(role: input == nil ? "tool_result" : "tool_use", text: "",
             toolName: "exec", toolInput: input, toolOutput: output))

--- a/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
+++ b/apps/macos/Tests/MemexTests/ToolPresentationSupportTests.swift
@@ -68,6 +68,24 @@ struct ToolPresentationSupportTests {
         #expect(ToolContentRenderer.render([entry], raw: true).string == source)
     }
 
+    @Test(arguments: ["mimeType", "mime_type"]) func largeImageResultsKeepPreviewsAndHideEncodedData(mimeKey: String) throws {
+        let data = Data(repeating: 42, count: 200_000)
+        let payload = data.base64EncodedString()
+        let source = String(decoding: try JSONSerialization.data(withJSONObject: ["content": [
+            ["type": "image", "data": payload, mimeKey: "image/png"],
+            ["type": "image_url", "url": "https://example.com/image.png"],
+        ]]), as: UTF8.self)
+        let entry = TranscriptRecord(recordID: "large-image", record: Message(role: "tool_result", text: "", toolName: "custom", toolInput: nil, toolOutput: source))
+        #expect(source.utf8.count > 256_000)
+        #expect(ToolContentRenderer.richBlocks([entry]).contains(.embeddedImage(label: "Image result", data: data, mimeType: "image/png")))
+        #expect(ToolContentRenderer.imageSources([entry]) == ["https://example.com/image.png"])
+        let rendered = ToolContentRenderer.render([entry]).string
+        #expect(rendered.contains("Encoded payload"))
+        #expect(!rendered.contains(payload))
+        #expect(ToolContentRenderer.render([entry], raw: true).string == source)
+        #expect(ConversationMatcher.matches([entry], query: payload).count == 1)
+    }
+
     @Test func imageURLFieldsPreservePrecedenceAndFallbacks() {
         let source = #"{"content":[{"type":"image","image_url":"/tmp/first.png","url":"/tmp/ignored.png"},{"type":"image_url","url":"/tmp/second.png"},{"type":"image_url","image_url":{"url":"/tmp/third.png"}}]}"#
         let entry = TranscriptRecord(recordID: "images", record: Message(role: "tool_result", text: source, toolName: "custom", toolInput: nil, toolOutput: nil))

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
-const SCHEMA_VERSION: i64 = 6;
+// Reconcile legacy catalogs that survived a rebuilt search index.
+const SCHEMA_VERSION: i64 = 7;
 const GIT_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_LABEL_CHARS: usize = 150;
 pub const UNFILED_PROJECT: &str = "Unfiled";
@@ -121,6 +122,7 @@ struct SessionAccumulator {
     last_at: u64,
     message_count: u64,
     first_user_text: Option<String>,
+    first_user_order: Option<(u32, u64, u64)>,
     conversation_kind: Option<String>,
 }
 
@@ -264,15 +266,14 @@ impl AnalyticsStore {
     }
 
     pub fn complete(&self) -> Result<bool> {
-        let value: Option<String> = self
-            .conn
+        self.conn
             .query_row(
-                "SELECT value FROM meta WHERE key = 'analytics_complete'",
-                [],
+                "SELECT EXISTS(SELECT 1 FROM meta WHERE key = 'analytics_complete' AND value = '1')
+                 AND EXISTS(SELECT 1 FROM meta WHERE key = 'schema_version' AND value = ?1)",
+                [SCHEMA_VERSION.to_string()],
                 |row| row.get(0),
             )
-            .optional()?;
-        Ok(value.as_deref() == Some("1"))
+            .map_err(Into::into)
     }
 
     pub fn mark_complete(&self) -> Result<()> {
@@ -284,7 +285,14 @@ impl AnalyticsStore {
         Ok(())
     }
 
+    pub fn mark_incomplete(&self) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM meta WHERE key = 'analytics_complete'", [])?;
+        Ok(())
+    }
+
     pub fn clear(&self) -> Result<()> {
+        self.mark_incomplete()?;
         self.conn.execute("DELETE FROM sessions", [])?;
         Ok(())
     }
@@ -422,6 +430,15 @@ impl AnalyticsStore {
         for row in rows {
             out.push(row?);
         }
+        let titles = SessionTitleLookup::new(out.iter().map(|row| (row.source, &row.session_id)));
+        for row in &mut out {
+            row.label = titles.resolve(
+                row.source,
+                &row.session_id,
+                &row.source_path,
+                row.label.as_deref(),
+            );
+        }
         Ok(out)
     }
 
@@ -512,6 +529,15 @@ impl AnalyticsStore {
         let mut out = Vec::new();
         for row in rows {
             out.push(row?);
+        }
+        let titles = SessionTitleLookup::new(out.iter().map(|row| (row.source, &row.session_id)));
+        for row in &mut out {
+            row.label = titles.resolve(
+                row.source,
+                &row.session_id,
+                &row.source_path,
+                row.label.as_deref(),
+            );
         }
         Ok(out)
     }
@@ -977,6 +1003,7 @@ impl AnalyticsWriter {
                 last_at: record.ts,
                 message_count: 0,
                 first_user_text: None,
+                first_user_order: None,
                 conversation_kind: None,
             });
         if record.ts < entry.started_at {
@@ -989,12 +1016,16 @@ impl AnalyticsWriter {
             }
         }
         entry.message_count = entry.message_count.saturating_add(1);
-        if entry.first_user_text.is_none()
+        let order = (record.turn_id, record.ts, record.doc_id);
+        if entry
+            .first_user_order
+            .is_none_or(|previous| order < previous)
             && record.role == "user"
             && !record.text.trim().is_empty()
             && !sanitize_label(&record.text).is_empty()
         {
             entry.first_user_text = Some(record.text.clone());
+            entry.first_user_order = Some(order);
         }
         // Prefer an explicit "main" over per-record non-main kinds: Pi and
         // OpenClaw stamp compaction/branch on entries inside otherwise-main
@@ -1487,6 +1518,20 @@ fn parse_copilot_workspace_cwd(contents: &str) -> CopilotWorkspaceCwd {
 
 #[allow(clippy::while_let_loop)]
 pub fn sanitize_label(raw: &str) -> String {
+    // Reference previews are context; only the explicit request following them
+    // belongs in a prompt-derived title. Preserve it before collapsing lines.
+    let trimmed = raw.trim_start();
+    let raw = if starts_ascii_ci(trimmed, "## Referenced ChatGPT conversation:")
+        || starts_ascii_ci(trimmed, "## Referenced chats with Codex:")
+    {
+        let mut lines = trimmed.split_inclusive('\n');
+        if !lines.any(|line| line.trim().eq_ignore_ascii_case("## My request:")) {
+            return String::new();
+        }
+        &trimmed[trimmed.len() - lines.clone().map(str::len).sum::<usize>()..]
+    } else {
+        raw
+    };
     // Comprehensive stripping of system wrappers (case-insensitive).
     // Fast path: neither the tag stripper nor the generic unwrap can match
     // without a '<', so ordinary prose skips the owned buffer entirely and
@@ -1502,6 +1547,8 @@ pub fn sanitize_label(raw: &str) -> String {
             "local-command-caveat",
             "local-command-output",
             "instructions",
+            "system_instruction",
+            "system_instructions",
             "environment_context",
             "cwd",
             "approval_policy",
@@ -1612,6 +1659,7 @@ fn finish_label(text: &str) -> String {
         return String::new();
     }
     if starts_ascii_ci(&collapsed, "# agents.md")
+        || starts_ascii_ci(&collapsed, "## referenced chatgpt conversation:")
         || find_ascii_ci(&collapsed, "global agent preferences").is_some()
         || starts_ascii_ci(&collapsed, "you are a reminder observer")
     {
@@ -1889,6 +1937,109 @@ impl OpencodeLookupCache {
             .entry((db_path.to_string(), session_id.to_string()))
             .or_insert_with(|| opencode_session_has_parent(db_path, session_id))
     }
+}
+
+/// Resolve provider-owned names on the machine that owns the transcripts.
+/// Keeping this in the catalog read path also handles renames and old indexes,
+/// without replaying messages or changing session counts.
+pub(crate) struct SessionTitleLookup {
+    codex: HashMap<String, crate::sources::codex::SessionTitleMetadata>,
+}
+
+impl SessionTitleLookup {
+    pub(crate) fn new<'a>(sessions: impl Iterator<Item = (SourceKind, &'a String)>) -> Self {
+        let ids = sessions
+            .filter(|(source, _)| *source == SourceKind::Codex)
+            .map(|(_, id)| id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        Self {
+            codex: crate::sources::codex::session_title_metadata(&ids),
+        }
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        source: SourceKind,
+        session_id: &str,
+        source_path: &str,
+        opening: Option<&str>,
+    ) -> Option<String> {
+        let codex = self
+            .codex
+            .get(session_id)
+            .filter(|_| source == SourceKind::Codex);
+        let explicit = match source {
+            SourceKind::Codex => codex.and_then(|metadata| metadata.title.clone()),
+            SourceKind::Claude => {
+                crate::sources::claude::session_title(Path::new(source_path), session_id)
+            }
+            _ => None,
+        };
+        explicit
+            .as_deref()
+            .and_then(nonempty_label)
+            .or_else(|| opening.and_then(nonempty_label))
+            .or_else(|| codex.and_then(|metadata| metadata.first_user_message.clone()))
+            .or_else(|| {
+                codex
+                    .and_then(|metadata| metadata.agent_path.as_deref())
+                    .and_then(human_agent_title)
+            })
+            .or_else(|| {
+                (source == SourceKind::Codex)
+                    .then(|| codex_assignment_title(source_path))
+                    .flatten()
+            })
+    }
+}
+
+fn nonempty_label(text: &str) -> Option<String> {
+    let title = sanitize_label(text);
+    (!title.is_empty()).then_some(title)
+}
+
+fn human_agent_title(path: &str) -> Option<String> {
+    let path = path.trim().strip_prefix("/root/")?;
+    let words = path
+        .split('/')
+        .map(|part| part.replace('_', " "))
+        .collect::<Vec<_>>()
+        .join(" / ");
+    let words = words.trim();
+    let mut chars = words.chars();
+    let first = chars.next()?;
+    nonempty_label(&format!("{}{}", first.to_uppercase(), chars.as_str()))
+}
+
+fn codex_assignment_title(source_path: &str) -> Option<String> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(source_path).ok()?;
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        // The task body may be encrypted; only read its public routing metadata.
+        if !line.contains("agent_message") || !line.contains("NEW_TASK") {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if value["type"] != "response_item" || value["payload"]["type"] != "agent_message" {
+            continue;
+        }
+        let payload = &value["payload"];
+        if payload["content"].as_array().is_some_and(|blocks| {
+            blocks.iter().any(|block| {
+                block["text"]
+                    .as_str()
+                    .is_some_and(|text| text.starts_with("Message Type: NEW_TASK\n"))
+            })
+        }) && let Some(title) = payload["recipient"].as_str().and_then(human_agent_title)
+        {
+            return Some(title);
+        }
+    }
+    None
 }
 
 fn extract_session_label(
@@ -2667,6 +2818,23 @@ mod tests {
     }
 
     #[test]
+    fn cleared_catalog_is_incomplete_until_rebuilt() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("analytics.sqlite");
+        let store = AnalyticsStore::open(&path).unwrap();
+        store.mark_complete().unwrap();
+        assert!(AnalyticsStore::is_complete(&path));
+        store.clear().unwrap();
+        assert!(!AnalyticsStore::is_complete(&path));
+        backfill_from_index(
+            &path,
+            &crate::index::SearchIndex::open_or_create(&temp.path().join("index")).unwrap(),
+        )
+        .unwrap();
+        assert!(AnalyticsStore::is_complete(&path));
+    }
+
+    #[test]
     fn analytics_schema_version_change_marks_incomplete() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let db = tmp.path().join("analytics.sqlite");
@@ -2682,9 +2850,13 @@ mod tests {
             .expect("seed meta");
         }
 
+        // Ingestion checks readiness read-only before opening its writer.
+        assert!(!AnalyticsStore::is_complete(&db));
         let store = AnalyticsStore::open(&db).expect("open store");
 
         assert!(!store.complete().expect("complete"));
+        store.mark_complete().unwrap();
+        assert!(AnalyticsStore::is_complete(&db));
     }
 
     #[test]
@@ -2872,6 +3044,161 @@ mod tests {
             Some("REAL FIRST PROMPT about the login bug")
         );
         assert_eq!(rows[0].conversation_kind.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn catalog_resolves_saved_names_and_renames_without_reindexing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("session.jsonl");
+        let db = tmp.path().join("analytics.sqlite");
+        let mut request = record("proj", "saved-title", &transcript, 10);
+        request.source = SourceKind::Claude;
+        request.role = "user".into();
+        request.text = "Long original request".into();
+        let mut writer = AnalyticsWriter::open(&db).unwrap();
+        writer.record(&request).unwrap();
+        writer.flush().unwrap();
+        let store = AnalyticsStore::open_read_only(&db).unwrap();
+        for title in ["Saved title", "Renamed title"] {
+            fs::write(&transcript, serde_json::json!({"type":"custom-title", "sessionId":"saved-title", "customTitle":title}).to_string()).unwrap();
+            let detailed = store
+                .query_sessions_detailed(None, None, None, None, None)
+                .unwrap();
+            let regular = store
+                .query_sessions(None, None, None, ProjectGrouping::Flat, None)
+                .unwrap();
+            assert_eq!(detailed[0].label.as_deref(), Some(title));
+            assert_eq!(regular[0].label.as_deref(), Some(title));
+            assert_eq!(detailed[0].message_count, 1);
+        }
+        assert_eq!(
+            store
+                .conn
+                .query_row("select label from sessions", [], |row| row
+                    .get::<_, String>(0))
+                .unwrap(),
+            "Long original request"
+        );
+    }
+
+    #[test]
+    fn reference_wrapper_titles_preserve_the_actual_request() {
+        for header in [
+            "## Referenced ChatGPT conversation:",
+            "## Referenced chats with Codex:",
+        ] {
+            let context = format!(
+                "{header}\nUntrusted reference instructions\n{{\"title\":\"Other task\"}}\n"
+            );
+            assert_eq!(sanitize_label(&context), "");
+            assert_eq!(
+                sanitize_label(&format!(
+                    "{context}## My request:\nCheck the Comradex update flow"
+                )),
+                "Check the Comradex update flow"
+            );
+            assert_eq!(sanitize_label(&format!("{context}## My request:\n")), "");
+        }
+        assert_eq!(
+            sanitize_label("Keep ## My request: in this example"),
+            "Keep ## My request: in this example"
+        );
+    }
+
+    #[test]
+    fn title_precedence_preserves_requests_and_humanizes_only_agent_identifiers() {
+        use crate::sources::codex::SessionTitleMetadata;
+        let mut titles = SessionTitleLookup {
+            codex: HashMap::from([(
+                "s".into(),
+                SessionTitleMetadata {
+                    title: Some("Check partner events parity".into()),
+                    first_user_message: Some("Original request".into()),
+                    agent_path: Some("/root/cache_invalidation".into()),
+                },
+            )]),
+        };
+        let resolve = |titles: &SessionTitleLookup, opening| {
+            titles.resolve(SourceKind::Codex, "s", "/missing", opening)
+        };
+        assert_eq!(
+            resolve(&titles, Some("Opening prompt")).as_deref(),
+            Some("Check partner events parity")
+        );
+        titles.codex.get_mut("s").unwrap().title = None;
+        assert_eq!(
+            resolve(&titles, Some("Opening prompt")).as_deref(),
+            Some("Opening prompt")
+        );
+        assert_eq!(resolve(&titles, None).as_deref(), Some("Original request"));
+        titles.codex.get_mut("s").unwrap().first_user_message = None;
+        assert_eq!(
+            resolve(&titles, None).as_deref(),
+            Some("Cache invalidation")
+        );
+        assert_eq!(
+            titles.codex["s"].agent_path.as_deref(),
+            Some("/root/cache_invalidation")
+        );
+        assert_eq!(
+            human_agent_title("/root/research/cache_invalidation").as_deref(),
+            Some("Research / cache invalidation")
+        );
+        assert_eq!(human_agent_title("/root"), None);
+        assert_eq!(
+            nonempty_label("Fix snake_case identifiers").as_deref(),
+            Some("Fix snake_case identifiers")
+        );
+    }
+
+    #[test]
+    fn encrypted_assignment_uses_public_task_name_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("agent.jsonl");
+        fs::write(&path, serde_json::json!({"type":"response_item", "payload": {
+            "type":"agent_message", "recipient":"/root/cache_invalidation", "content":[
+                {"type":"input_text", "text":"Message Type: NEW_TASK\nTask name: /root/cache_invalidation\nSender: /root\nPayload:\n"},
+                {"type":"encrypted_content", "encrypted_content":"private-ciphertext"}
+            ]
+        }}).to_string()).unwrap();
+        let titles = SessionTitleLookup {
+            codex: HashMap::new(),
+        };
+        assert_eq!(
+            titles
+                .resolve(
+                    SourceKind::Codex,
+                    "unavailable",
+                    path.to_str().unwrap(),
+                    None
+                )
+                .as_deref(),
+            Some("Cache invalidation")
+        );
+    }
+
+    #[test]
+    fn first_request_follows_logical_order_even_when_index_iteration_does_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("analytics.sqlite");
+        let transcript = tmp.path().join("session.jsonl");
+        let mut first = record("proj", "ordered", &transcript, 10);
+        first.role = "user".into();
+        first.text = "First request".into();
+        first.turn_id = 1;
+        let mut later = first.clone();
+        later.turn_id = 2;
+        later.text = "Later followup".into();
+        let mut writer = AnalyticsWriter::open(&db).unwrap();
+        writer.record(&later).unwrap();
+        writer.record(&first).unwrap();
+        writer.flush().unwrap();
+        let rows = writer
+            .store
+            .query_sessions_detailed(None, None, None, None, None)
+            .unwrap();
+        assert_eq!(rows[0].label.as_deref(), Some("First request"));
+        assert_eq!(rows[0].message_count, 2);
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1539,8 +1539,20 @@ fn ingest_selected(
     let totals = compute_totals(&tasks);
     let file_totals = compute_file_totals(&tasks);
     let analytics_db = analytics_path(&paths.state);
-    let analytics_needs_backfill =
-        !AnalyticsStore::is_complete(&analytics_db) && index.doc_count()? > 0;
+    // A replacement/empty index cannot inherit a complete catalog from its
+    // predecessor: otherwise moved paths remain as rows with no indexed records
+    // and reparsed messages get added to the old counts.
+    let analytics_needs_backfill = empty_index_rebuild
+        || if index.doc_count()? == 0 {
+            AnalyticsStore::is_ready(&analytics_db)
+        } else {
+            !AnalyticsStore::is_complete(&analytics_db)
+        };
+    if analytics_needs_backfill {
+        // Persist this before publishing any new index records. Recovery must
+        // retry reconciliation even if interrupted before the backfill starts.
+        AnalyticsStore::open(&analytics_db)?.mark_incomplete()?;
+    }
     if !recover_vectors
         && tasks.is_empty()
         && delete_paths.is_empty()
@@ -4385,6 +4397,49 @@ mod tests {
         .unwrap();
         assert!(!stale.exists());
         assert_eq!(fs::read(unrelated).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn rebuilding_empty_index_replaces_stale_catalog_rows() {
+        for has_transcript in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+            paths.ensure_dirs().unwrap();
+            let source_dir = temp.path().join("transcripts");
+            fs::create_dir_all(&source_dir).unwrap();
+            let transcript = source_dir.join("archived.jsonl");
+            if has_transcript {
+                fs::write(&transcript, br#"{"type":"user","sessionId":"session","message":{"role":"user","content":[{"type":"text","text":"Actual request"}]},"uuid":"u1","timestamp":"2024-01-01T00:00:00Z"}
+"#).unwrap();
+            }
+            let db = analytics_path(&paths.state);
+            let mut old = AnalyticsWriter::open(&db).unwrap();
+            for path in [temp.path().join("old-active.jsonl"), transcript.clone()] {
+                let mut stale = record(1, "user", "Previous request");
+                stale.source = SourceKind::Claude;
+                stale.session_id = "session".into();
+                stale.source_path = path.to_string_lossy().into_owned();
+                old.record(&stale).unwrap();
+            }
+            old.flush().unwrap();
+            AnalyticsStore::open(&db).unwrap().mark_complete().unwrap();
+            // The old catalog remains even if ingest state was lost as well.
+            let index = open_search_index(&paths);
+            let mut options = ingest_options(false, ModelChoice::default());
+            options.claude_sources = vec![source_dir];
+            ingest_all(&paths, &index, &options, &ingest_lease(&paths)).unwrap();
+            let store = AnalyticsStore::open_read_only(&db).unwrap();
+            let rows = store
+                .query_sessions_detailed(None, None, None, None, None)
+                .unwrap();
+            assert_eq!(rows.len(), usize::from(has_transcript));
+            if has_transcript {
+                assert_eq!(rows[0].source_path, transcript.to_string_lossy());
+                assert_eq!(rows[0].message_count, 1);
+                assert_eq!(rows[0].label.as_deref(), Some("Actual request"));
+            }
+            assert!(store.complete().unwrap());
+        }
     }
 
     #[test]

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -26,16 +26,38 @@ pub const VERSIONS: ParserVersions = ParserVersions {
 /// Return the human-facing title Claude stores alongside a conversation.
 ///
 /// Title records are metadata rather than transcript messages, so the search
-/// index intentionally does not contain them. The TUI uses this lightweight
-/// reader when it builds the recent-session list.
+/// index intentionally does not contain them. The shared session catalog reads
+/// this metadata so every client sees saved names and subsequent renames.
 pub fn session_title(path: &Path, session_id: &str) -> Option<String> {
-    let reader = BufReader::new(File::open(path).ok()?);
+    use memchr::memchr;
+    use memmap2::Mmap;
+    let file = File::open(path).ok()?;
+    let bytes = unsafe { Mmap::map(&file).ok()? };
     let mut custom_title = None;
     let mut ai_title = None;
     let mut agent_name = None;
 
-    for line in reader.lines().map_while(Result::ok) {
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let remaining = &bytes[offset..];
+        let length = memchr(b'\n', remaining).unwrap_or(remaining.len());
+        let line = &remaining[..length];
+        offset += length + usize::from(length < remaining.len());
+        // Most lines contain large transcript/tool bodies. Only metadata
+        // candidates need JSON decoding; still inspect every line for renames.
+        // Escaped JSON strings may encode the type using Unicode escapes.
+        if ![
+            b"custom-title".as_slice(),
+            b"ai-title",
+            b"agent-name",
+            b"\\u",
+        ]
+        .iter()
+        .any(|needle| memmem::find(line, needle).is_some())
+        {
+            continue;
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         if value
@@ -60,9 +82,8 @@ pub fn session_title(path: &Path, session_id: &str) -> Option<String> {
                 .and_then(Value::as_str),
             _ => None,
         }
-        .map(str::trim)
-        .filter(|title| !title.is_empty())
-        .map(str::to_string);
+        .map(crate::analytics::sanitize_label)
+        .filter(|title| !title.is_empty());
 
         match entry_type {
             "custom-title" if title.is_some() => custom_title = title,
@@ -879,6 +900,52 @@ mod tests {
             Some("My title")
         );
         assert_eq!(session_title(&path, "another-session"), None);
+    }
+
+    #[test]
+    fn session_title_scans_past_large_messages_and_keeps_last_matching_rename() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        let lines = [
+            serde_json::json!({"type":"custom-title", "sessionId":"s", "customTitle":"Original"}),
+            serde_json::json!({"type":"assistant", "message":{"content":"x".repeat(262144)}}),
+            serde_json::json!({"type":"assistant", "customTitle":"False match", "message":{"content":"custom-title"}}),
+            serde_json::json!({"type":"custom-title", "sessionId":"other", "customTitle":"Other session"}),
+            serde_json::json!({"type":"agent-name", "sessionId":"s", "agentName":"Agent name"}),
+            serde_json::json!({"type":"custom-title", "sessionId":"s", "customTitle":"Renamed"}),
+            serde_json::json!({"type":"ai-title", "sessionId":"s", "aiTitle":"Later generated title"}),
+        ];
+        // The final event intentionally has no trailing newline.
+        fs::write(
+            &path,
+            lines
+                .iter()
+                .map(Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+        .unwrap();
+        assert_eq!(session_title(&path, "s").as_deref(), Some("Renamed"));
+        assert_eq!(
+            session_title(&path, "other").as_deref(),
+            Some("Other session")
+        );
+    }
+
+    #[test]
+    fn session_title_keeps_agent_fallback_and_empty_file_behavior() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(&path, "").unwrap();
+        assert_eq!(session_title(&path, "s"), None);
+        fs::write(&path, "malformed custom-title\n{\"type\":\"agent-name\",\"sessionId\":\"s\",\"name\":\"Task name\"}").unwrap();
+        assert_eq!(session_title(&path, "s").as_deref(), Some("Task name"));
+        fs::write(
+            &path,
+            r#"{"type":"ai\u002dtitle","sessionId":"s","aiTitle":"Escaped type"}"#,
+        )
+        .unwrap();
+        assert_eq!(session_title(&path, "s").as_deref(), Some("Escaped type"));
     }
 
     #[test]

--- a/src/sources/codex.rs
+++ b/src/sources/codex.rs
@@ -20,11 +20,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub const VERSIONS: ParserVersions = ParserVersions {
-    // Recompute persisted identities and usage parents for guardian reviews.
-    identity: 3,
-    // Preserve pre-reader fallback IDs independently of added display records.
-    index: 8,
-    usage: 5,
+    // Recompute ownership after excluding copied parent session metadata.
+    identity: 4,
+    index: 9,
+    usage: 6,
 };
 
 pub fn classify_path(path: &str) -> Option<SourceKind> {
@@ -90,10 +89,33 @@ pub fn history_paths() -> Vec<PathBuf> {
         .collect()
 }
 
-/// Load the human-facing titles maintained by Codex's local thread database.
-/// The rollout JSONL files do not carry this value themselves.
+/// Provider metadata stays separate from transcript-derived title fallbacks.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SessionTitleMetadata {
+    pub title: Option<String>,
+    pub first_user_message: Option<String>,
+    pub agent_path: Option<String>,
+}
+
+/// Load titles without treating an agent identifier as a conversation title.
 pub fn session_titles(session_ids: &[String]) -> HashMap<String, String> {
+    session_title_metadata(session_ids)
+        .into_iter()
+        .filter_map(|(id, metadata)| {
+            metadata
+                .title
+                .or(metadata.first_user_message)
+                .map(|title| (id, title))
+        })
+        .collect()
+}
+
+/// Read each database's schema and prepare its lookup once for the whole batch.
+pub fn session_title_metadata(session_ids: &[String]) -> HashMap<String, SessionTitleMetadata> {
     let mut titles = HashMap::new();
+    if session_ids.is_empty() {
+        return titles;
+    }
     for home in homes() {
         for path in state_database_paths(&home) {
             let Ok(connection) = Connection::open_with_flags(
@@ -102,12 +124,18 @@ pub fn session_titles(session_ids: &[String]) -> HashMap<String, String> {
             ) else {
                 continue;
             };
+            let Some(query) = title_metadata_query(&connection) else {
+                continue;
+            };
+            let Ok(mut statement) = connection.prepare(&query) else {
+                continue;
+            };
             for session_id in session_ids {
                 if titles.contains_key(session_id) {
                     continue;
                 }
-                if let Some(title) = codex_thread_title(&connection, session_id) {
-                    titles.insert(session_id.clone(), title);
+                if let Some(metadata) = codex_thread_title_metadata(&mut statement, session_id) {
+                    titles.insert(session_id.clone(), metadata);
                 }
             }
         }
@@ -136,28 +164,63 @@ fn state_database_paths(home: &Path) -> Vec<PathBuf> {
     versioned_paths.into_iter().map(|(_, path)| path).collect()
 }
 
-fn codex_thread_title(connection: &Connection, session_id: &str) -> Option<String> {
-    // Current Codex builds have all three columns. The second query keeps the
-    // reader useful with older databases that only stored `title`.
-    for sql in [
-        "SELECT COALESCE(NULLIF(name, ''), NULLIF(title, ''), NULLIF(first_user_message, '')) FROM threads WHERE id = ?1",
-        "SELECT NULLIF(title, '') FROM threads WHERE id = ?1",
-    ] {
-        let title = connection
-            .query_row(sql, params![session_id], |row| {
-                row.get::<_, Option<String>>(0)
-            })
-            .optional()
-            .ok()
-            .flatten()
-            .flatten()
-            .map(|title| title.trim().to_string())
-            .filter(|title| !title.is_empty());
-        if title.is_some() {
-            return title;
-        }
+fn title_metadata_query(connection: &Connection) -> Option<String> {
+    let mut statement = connection.prepare("PRAGMA table_info(threads)").ok()?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .ok()?
+        .collect::<rusqlite::Result<HashSet<_>>>()
+        .ok()?;
+    if !columns.contains("id") {
+        return None;
     }
-    None
+    // Only these fixed identifiers enter SQL; unavailable older columns are NULL.
+    let fields = ["name", "title", "first_user_message", "agent_path"].map(|field| {
+        if columns.contains(field) {
+            field
+        } else {
+            "NULL"
+        }
+    });
+    Some(format!(
+        "SELECT {} FROM threads WHERE id = ?1",
+        fields.join(", ")
+    ))
+}
+
+fn codex_thread_title_metadata(
+    statement: &mut rusqlite::Statement<'_>,
+    session_id: &str,
+) -> Option<SessionTitleMetadata> {
+    let (name, title, first_user_message, agent_path) = statement
+        .query_row(params![session_id], |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .optional()
+        .ok()
+        .flatten()?;
+    let normalize = |value: Option<String>| {
+        value
+            .map(|text| crate::analytics::sanitize_label(&text))
+            .filter(|text| !text.is_empty())
+    };
+    let metadata = SessionTitleMetadata {
+        title: normalize(name).or_else(|| normalize(title)),
+        first_user_message: normalize(first_user_message),
+        agent_path: agent_path.filter(|path| {
+            path.strip_prefix("/root/")
+                .is_some_and(|name| !name.trim().is_empty())
+        }),
+    };
+    (metadata.title.is_some()
+        || metadata.first_user_message.is_some()
+        || metadata.agent_path.is_some())
+    .then_some(metadata)
 }
 
 pub fn session_id_from_path(path: &Path) -> Option<String> {
@@ -192,6 +255,7 @@ impl SessionLinks {
 #[derive(Clone)]
 struct SessionMeta {
     session_id: String,
+    owner_id: Option<String>,
     project: String,
     cwd: Option<PathBuf>,
     links: SessionLinks,
@@ -201,6 +265,7 @@ struct SessionMeta {
 fn fallback_meta(path: &Path) -> SessionMeta {
     SessionMeta {
         session_id: session_id_from_path(path).unwrap_or_else(|| "unknown".to_string()),
+        owner_id: session_id_from_path(path),
         project: SourceKind::Codex.label().to_string(),
         cwd: None,
         source_turn_id: None,
@@ -224,9 +289,31 @@ fn is_guardian_review(payload: &simd_json::borrowed::Object<'_>) -> bool {
             == Some("guardian")
 }
 
+// A rollout filename identifies its owner even when copied history precedes its
+// metadata. For nonstandard filenames, the first declared ID establishes ownership.
+fn accepts_meta(owner: &mut Option<String>, id: Option<&str>) -> bool {
+    let Some(id) = id.filter(|id| !id.is_empty()) else {
+        return true;
+    };
+    match owner {
+        Some(owner) => owner == id,
+        None => {
+            *owner = Some(id.to_string());
+            true
+        }
+    }
+}
+
 fn apply_meta(payload: &simd_json::borrowed::Object<'_>, metadata: &mut SessionMeta) {
-    if let Some(id) = payload.get("id").and_then(|value| value.as_str()) {
-        metadata.session_id = id.to_string();
+    let id = payload
+        .get("id")
+        .or_else(|| payload.get("session_id"))
+        .and_then(|value| value.as_str());
+    if !accepts_meta(&mut metadata.owner_id, id) {
+        return;
+    }
+    if let Some(id) = &metadata.owner_id {
+        metadata.session_id = id.clone();
     }
     if let Some(cwd) = payload.get("cwd").and_then(|value| value.as_str()) {
         metadata.project = super::common::project_from_path(cwd);
@@ -1389,7 +1476,10 @@ pub(crate) fn parse_usage_file(
         let payload = value.get("payload");
         match (kind, payload) {
             ("session_meta", Some(payload)) => {
-                session = borrowed_string(payload, &["id", "session_id"]).or(session);
+                let id = borrowed_string(payload, &["id", "session_id"]);
+                if !accepts_meta(&mut session, id.as_deref()) {
+                    continue;
+                }
                 permission_review = payload.as_object().is_some_and(is_guardian_review);
                 // Review sessions do not inherit the parent task's token counters.
                 parent = if permission_review {
@@ -1592,6 +1682,98 @@ mod tests {
         })
         .unwrap();
         (records, output)
+    }
+
+    #[test]
+    fn copied_parent_metadata_cannot_replace_rollout_ownership() {
+        use serde_json::json;
+        let owner = "01a08752-673e-7032-bfac-faf9eb95ae40";
+        let parent = "01a08749-9316-72b0-a489-1ae139f6789f";
+        for filename in [format!("rollout-{owner}.jsonl"), "session.jsonl".into()] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join(&filename);
+            let own_meta = |cwd| {
+                json!({"type":"session_meta", "timestamp": 1, "payload": {
+                    "id": owner, "cwd": cwd, "forked_from_id": parent,
+                    "source": {"subagent": {"thread_spawn": {
+                        "parent_thread_id": parent, "agent_path": "/root/review_placeholder_fix"
+                    }}}
+                }})
+            };
+            let foreign = json!({"type":"session_meta", "timestamp": 2, "payload": {
+                "id": parent, "cwd": "/repo/parent", "source": "vscode"
+            }});
+            let message = json!({"type":"response_item", "payload": {
+                "type":"message", "role":"assistant", "content":"Review result"
+            }});
+            let mut lines = Vec::new();
+            if filename.starts_with("rollout-") {
+                // The filename also protects against foreign metadata before our header.
+                lines.push(foreign.clone());
+            }
+            lines.extend([own_meta("/repo/initial"), foreign.clone(), message.clone()]);
+            let prefix = lines.iter().map(|v| format!("{v}\n")).collect::<String>();
+            let suffix = [own_meta("/repo/updated"), foreign, message,
+                json!({"type":"response", "timestamp":3, "usage":{"input_tokens":20,"output_tokens":3}})]
+                .iter().map(|v| format!("{v}\n")).collect::<String>();
+            fs::write(&path, &prefix).unwrap();
+            let (_, checkpoint) = parse_transcript(&path, IndexParseState::default());
+            use std::io::Write;
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap()
+                .write_all(suffix.as_bytes())
+                .unwrap();
+            let metadata = probe(&path).unwrap();
+            assert_eq!(metadata.session.session_id, owner);
+            assert_eq!(
+                metadata.session.conversation_kind,
+                ConversationKind::Subagent
+            );
+            assert_eq!(metadata.session.parent_session_id.as_deref(), Some(parent));
+            assert_eq!(metadata.cwd, Some(PathBuf::from("/repo/updated")));
+            let (records, output) = parse_transcript(&path, IndexParseState::default());
+            assert_eq!(output.session_id.as_deref(), Some(owner));
+            assert_eq!(records.len(), 2);
+            for record in &records {
+                assert_eq!(record.session_id, owner);
+                assert_eq!(record.links.conversation_kind.as_deref(), Some("subagent"));
+                assert_eq!(record.links.parent_session_id.as_deref(), Some(parent));
+            }
+            assert_eq!(records[0].project, "initial");
+            assert_eq!(records[1].project, "updated");
+            let (incremental, _) = parse_transcript(
+                &path,
+                IndexParseState {
+                    offset: checkpoint.offset,
+                    turn_id: checkpoint.turn_id,
+                    legacy_turn_id: checkpoint.legacy_turn_id,
+                    pending_tool_calls: checkpoint.pending_tool_calls,
+                },
+            );
+            assert_eq!(incremental.len(), 1);
+            assert_eq!(incremental[0].session_id, owner);
+            assert_eq!(
+                incremental[0].links.conversation_kind.as_deref(),
+                Some("subagent")
+            );
+            let usage = parse_usage_file(&path, &UsageParentIndex::new(&[])).unwrap();
+            assert_eq!(usage.events.len(), 1);
+            assert_eq!(usage.events[0].session_id.as_deref(), Some(owner));
+            assert_eq!(usage.events[0].project.as_deref(), Some("/repo/updated"));
+        }
+    }
+
+    #[test]
+    fn metadata_without_an_id_preserves_filename_fallback() {
+        let owner = "01a08752-673e-7032-bfac-faf9eb95ae40";
+        let mut metadata = fallback_meta(Path::new(&format!("rollout-{owner}.jsonl")));
+        let mut bytes = br#"{"cwd":"/repo/fallback","source":"vscode"}"#.to_vec();
+        let value = simd_json::to_borrowed_value(&mut bytes).unwrap();
+        apply_meta(value.as_object().unwrap(), &mut metadata);
+        assert_eq!(metadata.session_id, owner);
+        assert_eq!(metadata.project, "fallback");
     }
 
     #[test]
@@ -2034,10 +2216,104 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            codex_thread_title(&connection, "session-1").as_deref(),
+            codex_thread_title_metadata(
+                &mut connection
+                    .prepare(&title_metadata_query(&connection).unwrap())
+                    .unwrap(),
+                "session-1"
+            )
+            .unwrap()
+            .title
+            .as_deref(),
             Some("Pinned name")
         );
-        assert_eq!(codex_thread_title(&connection, "missing"), None);
+        assert_eq!(
+            codex_thread_title_metadata(
+                &mut connection
+                    .prepare(&title_metadata_query(&connection).unwrap())
+                    .unwrap(),
+                "missing"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_title_metadata_filters_each_candidate_before_falling_back() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection.execute_batch(
+            "CREATE TABLE threads (id TEXT, name TEXT, title TEXT, first_user_message TEXT, agent_path TEXT);
+             INSERT INTO threads VALUES ('title', '<environment_context>injected</environment_context>', 'Useful title', 'Actual request', '/root/cache_invalidation');
+             INSERT INTO threads VALUES ('first', '  ', '<recommended_plugins>injected</recommended_plugins>', 'Actual request', '/root');
+             INSERT INTO threads VALUES ('empty', NULL, '', '<INSTRUCTIONS>injected</INSTRUCTIONS>', '/root/');"
+        ).unwrap();
+        let mut statement = connection
+            .prepare(&title_metadata_query(&connection).unwrap())
+            .unwrap();
+        assert_eq!(
+            codex_thread_title_metadata(&mut statement, "title"),
+            Some(SessionTitleMetadata {
+                title: Some("Useful title".into()),
+                first_user_message: Some("Actual request".into()),
+                agent_path: Some("/root/cache_invalidation".into()),
+            })
+        );
+        assert_eq!(
+            codex_thread_title_metadata(&mut statement, "first"),
+            Some(SessionTitleMetadata {
+                title: None,
+                first_user_message: Some("Actual request".into()),
+                agent_path: None,
+            })
+        );
+        assert_eq!(codex_thread_title_metadata(&mut statement, "empty"), None);
+    }
+
+    #[test]
+    fn codex_title_metadata_reads_older_optional_column_sets() {
+        for schema in [
+            "CREATE TABLE threads (id TEXT, title TEXT); INSERT INTO threads VALUES ('s', 'Older title');",
+            "CREATE TABLE threads (id TEXT, title TEXT, first_user_message TEXT); INSERT INTO threads VALUES ('s', 'Older title', 'First prompt');",
+        ] {
+            let connection = Connection::open_in_memory().unwrap();
+            connection.execute_batch(schema).unwrap();
+            let mut statement = connection
+                .prepare(&title_metadata_query(&connection).unwrap())
+                .unwrap();
+            let metadata = codex_thread_title_metadata(&mut statement, "s").unwrap();
+            assert_eq!(metadata.title.as_deref(), Some("Older title"));
+            assert_eq!(metadata.agent_path, None);
+            if schema.contains("first_user_message") {
+                assert_eq!(metadata.first_user_message.as_deref(), Some("First prompt"));
+            } else {
+                assert_eq!(metadata.first_user_message, None);
+            }
+        }
+    }
+
+    #[test]
+    fn codex_title_metadata_preserves_only_rooted_agent_paths() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE threads (id TEXT, agent_path TEXT);
+            INSERT INTO threads VALUES ('valid', '/root/research/cache_invalidation'),
+                ('root', '/root'), ('blank', '/root/  '), ('relative', 'cache_invalidation');",
+            )
+            .unwrap();
+        let mut statement = connection
+            .prepare(&title_metadata_query(&connection).unwrap())
+            .unwrap();
+        assert_eq!(
+            codex_thread_title_metadata(&mut statement, "valid"),
+            Some(SessionTitleMetadata {
+                agent_path: Some("/root/research/cache_invalidation".into()),
+                ..Default::default()
+            })
+        );
+        for id in ["root", "blank", "relative"] {
+            assert_eq!(codex_thread_title_metadata(&mut statement, id), None);
+        }
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5341,7 +5341,7 @@ fn session_summary_from_row(row: SessionRow) -> SessionSummary {
         last_ts: row.last_at,
         hit_count: row.message_count.max(1) as usize,
         top_score: 0.0,
-        title: String::new(),
+        title: row.label.clone().unwrap_or_default(),
         snippet: String::new(),
         source_dir: row
             .cwd
@@ -5354,24 +5354,23 @@ fn session_summary_from_row(row: SessionRow) -> SessionSummary {
 }
 
 fn enrich_session_titles(index: &SearchIndex, sessions: &mut [SessionSummary]) {
-    let codex_ids = sessions
-        .iter()
-        .filter(|session| session.source == SourceKind::Codex)
-        .map(|session| session.session_id.clone())
-        .collect::<Vec<_>>();
-    let codex_titles = crate::sources::codex::session_titles(&codex_ids);
-
+    let titles = crate::analytics::SessionTitleLookup::new(
+        sessions
+            .iter()
+            .map(|session| (session.source, &session.session_id)),
+    );
     for session in sessions {
-        let source_title = match session.source {
-            SourceKind::Codex => codex_titles.get(&session.session_id).cloned(),
-            SourceKind::Claude => crate::sources::claude::session_title(
-                std::path::Path::new(&session.source_path),
+        let opening = session
+            .label
+            .clone()
+            .or_else(|| first_user_prompt(index, session));
+        session.title = titles
+            .resolve(
+                session.source,
                 &session.session_id,
-            ),
-            _ => None,
-        };
-        session.title = source_title
-            .or_else(|| first_user_prompt(index, session))
+                &session.source_path,
+                opening.as_deref(),
+            )
             .map(|title| summarize(&title, 120))
             .unwrap_or_default();
     }
@@ -5390,7 +5389,10 @@ fn first_user_prompt(index: &SearchIndex, session: &SessionSummary) -> Option<St
             .then_with(|| left.ts.cmp(&right.ts))
             .then_with(|| left.doc_id.cmp(&right.doc_id))
     });
-    records.into_iter().next().map(|record| record.text)
+    records
+        .into_iter()
+        .map(|record| crate::analytics::sanitize_label(&record.text))
+        .find(|text| !text.is_empty())
 }
 
 fn enrich_session_projects(
@@ -5738,9 +5740,9 @@ fn run_search_request(
             if sessions.is_empty() {
                 anyhow::bail!("no analytics sessions");
             }
+            enrich_session_titles(index, &mut sessions);
             Ok(sessions)
         })?;
-        enrich_session_titles(index, &mut sessions);
         sessions.retain(|session| {
             session_matches_kind(request.kind, session.conversation_kind.as_deref())
         });


### PR DESCRIPTION
Use saved conversation names consistently across the session catalog and native browser, with readable agent fallbacks and prompt cleanup that preserves the actual request.

Prevent copied parent metadata from changing a subagent's identity or classification, and rebuild stale analytics catalogs so moved transcripts do not leave duplicate rows that open empty pages.

Remove leading icons from collapsible transcript sections and improve nested content rendering and pagination performance.

Focused Rust tests, formatting, and clippy pass. The rebuilt app was verified against repaired local and remote indexes. The native suite passes 202/205 tests; three tests in unchanged project-catalog paths remain failing.
