### PR TITLE
Upgrade lz4_flex to 0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "macro_rules_attribute"


### PR DESCRIPTION
Upgrade the transitive lz4_flex dependency from 0.11.5 to 0.11.6 to address CVE-2026-32829. Cargo regenerated the lockfile; Tantivy and the manifest are unchanged.

Formatting and dependency resolution checks passed. Full local test and Clippy validation were deferred to avoid further machine load.
