### PR TITLE
Activate daemon upgrades while preserving service ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Check local release scripts
         run: bash apps/macos/Tests/release-scripts.sh
+      - name: Check Nix daemon activation
+        run: bash nix/tests/activation.sh
 
   frontend:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Configure memex declaratively (generates `~/.memex/config.toml`):
       {
         programs.memex = {
           enable = true;
+          daemon.enable = true;
           settings = {
+            index_service_mode = "continuous";
             embeddings = true;
             include_reasoning = false;
             model = "minilm";
@@ -123,6 +125,42 @@ available. Press Enter to update Memex and refresh its installed skill copies, o
 choose no to continue into the TUI. Homebrew installs run `brew update` followed by
 `brew upgrade nicosuave/tap/memex`; skills are refreshed by the newly installed binary.
 After updating, run `memex` again to start that version.
+
+Enabled daemons follow binary upgrades automatically between indexing passes.
+Homebrew registrations use `opt/memex/bin/memex`, so direct `brew upgrade
+nicosuave/tap/memex` works without a second service manager. Cargo/manual installs
+follow replacement at their registered executable path; replace binaries atomically.
+Nix profile registrations follow the profile link. A running indexing pass finishes
+before handoff; Web UI and MCP connections reconnect when the process reloads.
+
+**One-time migration:** daemons installed before this behavior need
+`memex daemon restart` from the newly installed binary. Use `--root <path>` for
+each custom data root. This also replaces old version-specific Homebrew service
+paths. After migration, interval services use the new binary on their next run;
+continuous daemons detect a replacement within a few seconds when idle.
+
+`memex update` also runs `memex daemon reconcile` using the installed binary.
+Reconciliation updates an existing enabled, loaded Memex registration and checks
+continuous-daemon readiness; absent, stopped, disabled, and Nix-owned registrations
+stay unchanged. It preserves the registered arguments, environment and schedule.
+Use `memex daemon reconcile --root <path>` for a custom root. `memex daemon status`
+shows the running version, PID, executable, readiness and whether its file identity
+matches the installed executable, including same-version rebuilds. Older daemons
+without runtime reporting show their running build as unavailable.
+
+For Nix-managed services, update the flake input and activate with
+`home-manager switch` or `nixos-rebuild switch`. Home Manager's
+`programs.memex.daemon.enable` owns the native Linux/macOS service; Linux automatic
+activation requires `systemd.user.startServices = "sd-switch"` (or `true`).
+An explicit `false`/`"suggest"` setting leaves service activation manual.
+The NixOS module restarts active owned services on switch, preserves stopped
+services, and handles interval/continuous transitions. Disable
+`services.memex.enable` and switch before removing the module import.
+Disable a CLI-owned registration before enabling a declarative service; choose
+one owner. `memex update` refuses to overwrite immutable Nix store binaries.
+For a standalone Nix profile, upgrade the selected profile package; an already
+migrated daemon follows its stable profile link, or run `memex daemon reconcile`
+through that profile to activate an existing registration explicitly.
 
 Agents and scripts still receive update notices but never a startup prompt. Memex
 recognizes CI, Codex, and Claude Code environment markers; use `--non-interactive`

--- a/nix/activate-user-service.sh
+++ b/nix/activate-user-service.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+systemctl=$1
+mode=$2
+runtime_dir=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+ownership_file="$runtime_dir/memex-nixos-service"
+timer_ownership_file="$runtime_dir/memex-nixos-timer"
+service=memex-index.service
+timer=memex-index.timer
+
+# A removed unit is expected when the module is disabled on this switch.
+fragment=$("$systemctl" --user show "$service" --property=FragmentPath --value 2>/dev/null || true)
+case "$fragment" in
+  /etc/systemd/user/memex-index.service)
+    # Remember ownership across a switch that removes the unit. A running
+    # obsolete unit may no longer expose its FragmentPath after daemon-reload.
+    touch "$ownership_file"
+    ;;
+  "")
+    if [[ ! -f "$ownership_file" ]]; then
+      exit 0
+    fi
+    ;;
+  *)
+    # A Home Manager or CLI unit shadows the NixOS unit. Leave it alone.
+    rm -f "$ownership_file" "$timer_ownership_file"
+    exit 0
+    ;;
+esac
+
+service_active=false
+timer_active=false
+if "$systemctl" --user is-active --quiet "$service"; then
+  service_active=true
+fi
+timer_fragment=$("$systemctl" --user show "$timer" --property=FragmentPath --value 2>/dev/null || true)
+timer_owned=false
+case "$timer_fragment" in
+  /etc/systemd/user/memex-index.timer)
+    touch "$timer_ownership_file"
+    timer_owned=true
+    ;;
+  "")
+    if [[ -f "$timer_ownership_file" ]]; then timer_owned=true; fi
+    ;;
+  *) rm -f "$timer_ownership_file" ;;
+esac
+if $timer_owned; then
+  if "$systemctl" --user is-active --quiet "$timer"; then
+    timer_active=true
+  fi
+fi
+
+# An interval transition requires this module's current timer. Do not stop the
+# working daemon and then start a shadowing or unidentifiable timer.
+if [[ "$mode" == interval && "$timer_fragment" != /etc/systemd/user/memex-index.timer ]]; then
+  exit 0
+fi
+
+"$systemctl" --user daemon-reload
+case "$mode" in
+  disabled)
+    if $timer_active; then "$systemctl" --user stop "$timer"; fi
+    if $service_active; then "$systemctl" --user stop "$service"; fi
+    rm -f "$ownership_file" "$timer_ownership_file"
+    ;;
+  continuous)
+    if $timer_active; then "$systemctl" --user stop "$timer"; fi
+    if $service_active; then
+      "$systemctl" --user restart "$service"
+    elif $timer_active; then
+      "$systemctl" --user start "$service"
+    fi
+    ;;
+  interval)
+    if $service_active; then "$systemctl" --user stop "$service"; fi
+    if $timer_active; then
+      "$systemctl" --user restart "$timer"
+    elif $service_active; then
+      "$systemctl" --user start "$timer"
+    fi
+    ;;
+  *)
+    printf 'Unknown memex service mode: %s\n' "$mode" >&2
+    exit 1
+    ;;
+esac

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -6,6 +6,30 @@
 }: let
   cfg = config.programs.memex;
   tomlFormat = pkgs.formats.toml {};
+  configSource = tomlFormat.generate "memex-config" cfg.settings;
+  continuous =
+    (cfg.settings.index_service_mode or (
+      if cfg.settings.index_service_continuous or false
+      then "continuous"
+      else "interval"
+    ))
+    == "continuous"
+    || (cfg.settings.index_service_web_ui or false)
+    || (cfg.settings.index_service_mcp or false);
+  interval = cfg.settings.index_service_interval or 3600;
+  label =
+    cfg.settings.index_service_label or (
+      if pkgs.stdenv.hostPlatform.isDarwin
+      then "com.memex.index"
+      else "memex-index"
+    );
+  command =
+    ["${cfg.package}/bin/memex"]
+    ++ (
+      if continuous
+      then ["daemon" "run"]
+      else ["index"]
+    );
 in {
   options.programs.memex = {
     enable = lib.mkEnableOption "memex";
@@ -15,6 +39,8 @@ in {
       default = pkgs.memex;
       description = "The memex package to install.";
     };
+
+    daemon.enable = lib.mkEnableOption "the Home Manager managed memex daemon";
 
     settings = lib.mkOption {
       type = tomlFormat.type;
@@ -59,11 +85,76 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home.packages = [cfg.package];
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      assertions = lib.optionals cfg.daemon.enable [
+        {
+          assertion = builtins.elem (cfg.settings.index_service_mode or "interval") ["interval" "continuous"];
+          message = "programs.memex.settings.index_service_mode must be interval or continuous.";
+        }
+        {
+          assertion = builtins.isInt interval && interval > 0;
+          message = "programs.memex.settings.index_service_interval must be a positive number of seconds.";
+        }
+      ];
+      home.packages = [cfg.package];
 
-    home.file.".memex/config.toml" = lib.mkIf (cfg.settings != {}) {
-      source = tomlFormat.generate "memex-config" cfg.settings;
-    };
-  };
+      home.file.".memex/config.toml" = lib.mkIf (cfg.settings != {}) {
+        source = configSource;
+      };
+    }
+    (lib.mkIf (cfg.daemon.enable && pkgs.stdenv.hostPlatform.isLinux) {
+      systemd.user.services.${label} = {
+        Unit = {
+          Description = "Memex Index Service";
+          X-Restart-Triggers = lib.optional (cfg.settings != {}) configSource;
+        };
+        Service = {
+          ExecStart = lib.escapeShellArgs command;
+          Environment = ["MEMEX_SERVICE_MANAGER=nix"];
+          Restart =
+            if continuous
+            then "on-failure"
+            else "no";
+          RestartSec = 10;
+        };
+        Install.WantedBy = lib.optional continuous "default.target";
+      };
+      systemd.user.timers.${label} = lib.mkIf (!continuous) {
+        Unit.Description = "Memex Index Timer";
+        Timer = {
+          OnBootSec = "5m";
+          OnUnitActiveSec = "${toString interval}s";
+        };
+        Install.WantedBy = ["timers.target"];
+      };
+    })
+    (lib.mkIf (cfg.daemon.enable && pkgs.stdenv.hostPlatform.isDarwin) {
+      launchd.agents.memex = {
+        enable = true;
+        config =
+          {
+            Label = label;
+            ProgramArguments = command;
+            EnvironmentVariables = {
+              MEMEX_SERVICE_MANAGER = "nix";
+              # Include the settings generation so Home Manager reloads the agent
+              # when settings change even if its command remains `daemon run`.
+              MEMEX_CONFIG_GENERATION = builtins.hashString "sha256" (builtins.toJSON cfg.settings);
+            };
+            RunAtLoad = true;
+            KeepAlive = continuous;
+          }
+          // lib.optionalAttrs (!continuous) {
+            StartInterval = interval;
+          }
+          // lib.optionalAttrs (cfg.settings ? index_service_stdout) {
+            StandardOutPath = cfg.settings.index_service_stdout;
+          }
+          // lib.optionalAttrs (cfg.settings ? index_service_stderr) {
+            StandardErrorPath = cfg.settings.index_service_stderr;
+          };
+      };
+    })
+  ]);
 }

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -46,32 +46,48 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.user.services.memex-index = {
-      description = "Memex Index Service";
-      wantedBy = ["default.target"];
-      path = [cfg.package];
-      serviceConfig = {
-        ExecStart =
-          if cfg.continuous || cfg.webUI
-          then "${cfg.package}/bin/memex index --watch --watch-interval ${toString cfg.watchInterval}${lib.optionalString cfg.webUI " --web-ui --web-listen ${lib.escapeShellArg cfg.webListen}"}"
-          else "${cfg.package}/bin/memex index";
+  config = lib.mkMerge [
+    {
+      # NixOS reloads user managers on switch but does not restart changed user
+      # services. Keep this activation hook when disabled to stop obsolete units.
+      system.userActivationScripts.memex = ''
+        ${pkgs.bash}/bin/bash ${./activate-user-service.sh} ${config.systemd.package}/bin/systemctl ${
+          if !cfg.enable
+          then "disabled"
+          else if cfg.continuous || cfg.webUI
+          then "continuous"
+          else "interval"
+        }
+      '';
+    }
+    (lib.mkIf cfg.enable {
+      systemd.user.services.memex-index = {
+        description = "Memex Index Service";
+        wantedBy = ["default.target"];
+        path = [cfg.package];
+        serviceConfig = {
+          Environment = "MEMEX_SERVICE_MANAGER=nix";
+          ExecStart =
+            if cfg.continuous || cfg.webUI
+            then "${cfg.package}/bin/memex index --watch --watch-interval ${toString cfg.watchInterval}${lib.optionalString cfg.webUI " --web-ui --web-listen ${lib.escapeShellArg cfg.webListen}"}"
+            else "${cfg.package}/bin/memex index";
 
-        Restart =
-          if cfg.continuous || cfg.webUI
-          then "always"
-          else "no";
-        RestartSec = 10;
+          Restart =
+            if cfg.continuous || cfg.webUI
+            then "always"
+            else "no";
+          RestartSec = 10;
+        };
       };
-    };
 
-    systemd.user.timers.memex-index = lib.mkIf (!cfg.continuous && !cfg.webUI) {
-      description = "Memex Index Timer";
-      wantedBy = ["timers.target"];
-      timerConfig = {
-        OnBootSec = "5m";
-        OnUnitActiveSec = cfg.interval;
+      systemd.user.timers.memex-index = lib.mkIf (!cfg.continuous && !cfg.webUI) {
+        description = "Memex Index Timer";
+        wantedBy = ["timers.target"];
+        timerConfig = {
+          OnBootSec = "5m";
+          OnUnitActiveSec = cfg.interval;
+        };
       };
-    };
-  };
+    })
+  ];
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,0 +1,61 @@
+# Evaluate with nix-instantiate --eval --strict nix/tests.nix --arg homeManager /path/to/home-manager
+{
+  nixpkgs ? <nixpkgs>,
+  homeManager,
+}: let
+  linux = import nixpkgs {system = "x86_64-linux";};
+  darwin = import nixpkgs {system = "aarch64-darwin";};
+  home = pkgs: settings: enabled:
+    (import (homeManager + "/modules") {
+      inherit pkgs;
+      configuration = {
+        imports = [./hm-module.nix];
+        home.username = "memex-test";
+        home.homeDirectory =
+          if pkgs.stdenv.hostPlatform.isDarwin
+          then "/Users/memex-test"
+          else "/home/memex-test";
+        home.stateVersion = "25.11";
+        programs.memex = {
+          enable = true;
+          package = pkgs.hello;
+          daemon.enable = enabled;
+          inherit settings;
+        };
+      };
+    }).config;
+  linuxInterval = home linux {} true;
+  linuxContinuous = home linux {index_service_mode = "continuous";} true;
+  linuxMcp = home linux {index_service_mcp = true;} true;
+  darwinInterval = home darwin {} true;
+  darwinContinuous = home darwin {index_service_web_ui = true;} true;
+  system = continuous:
+    (import (nixpkgs + "/nixos/lib/eval-config.nix") {
+      system = "x86_64-linux";
+      modules = [
+        ./nixos-module.nix
+        {
+          services.memex = {
+            enable = true;
+            package = linux.hello;
+            inherit continuous;
+          };
+          system.stateVersion = "25.11";
+        }
+      ];
+    }).config;
+in
+  assert !(builtins.hasAttr "memex-index" (home linux {} false).systemd.user.services);
+  assert !(builtins.hasAttr "memex" (home darwin {} false).launchd.agents);
+  assert linuxInterval.systemd.user.timers.memex-index.Timer.OnUnitActiveSec == "3600s";
+  assert linuxInterval.systemd.user.services.memex-index.Install.WantedBy == [];
+  assert linuxContinuous.systemd.user.services.memex-index.Service.ExecStart == ["${linux.hello}/bin/memex daemon run"];
+  assert linuxContinuous.systemd.user.services.memex-index.Unit.X-Restart-Triggers != [];
+  assert !(builtins.hasAttr "memex-index" linuxContinuous.systemd.user.timers);
+  assert !(builtins.hasAttr "memex-index" linuxMcp.systemd.user.timers);
+  assert darwinInterval.launchd.agents.memex.config.StartInterval == 3600;
+  assert darwinContinuous.launchd.agents.memex.config.KeepAlive;
+  assert darwinContinuous.launchd.agents.memex.config.ProgramArguments == ["${darwin.hello}/bin/memex" "daemon" "run"];
+  assert darwinInterval.launchd.agents.memex.config.EnvironmentVariables.MEMEX_CONFIG_GENERATION != darwinContinuous.launchd.agents.memex.config.EnvironmentVariables.MEMEX_CONFIG_GENERATION;
+  assert (system true).systemd.user.services.memex-index.serviceConfig.Environment == "MEMEX_SERVICE_MANAGER=nix";
+  assert (system false).systemd.user.timers.memex-index.timerConfig.OnUnitActiveSec == "3600"; "Nix module checks passed"

--- a/nix/tests/activation.sh
+++ b/nix/tests/activation.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+script_dir=$(cd "$(dirname "$0")/.." && pwd)
+export XDG_RUNTIME_DIR="$test_dir/runtime"
+mkdir -p "$XDG_RUNTIME_DIR"
+export trace="$test_dir/trace"
+
+cat > "$test_dir/systemctl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+shift # --user
+case "$1" in
+  show)
+    if [[ "$2" == memex-index.service ]]; then
+      printf '%s\n' "$MOCK_SERVICE_FRAGMENT"
+    else
+      printf '%s\n' "$MOCK_TIMER_FRAGMENT"
+    fi
+    ;;
+  is-active)
+    if [[ "$3" == memex-index.service ]]; then
+      "$MOCK_SERVICE_ACTIVE"
+    else
+      "$MOCK_TIMER_ACTIVE"
+    fi
+    ;;
+  *) printf '%s\n' "$*" >> "$trace" ;;
+esac
+MOCK
+chmod +x "$test_dir/systemctl"
+
+check() {
+  local mode=$1 expected=$2
+  : > "$trace"
+  bash "$script_dir/activate-user-service.sh" "$test_dir/systemctl" "$mode"
+  local actual
+  actual=$(cat "$trace")
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'mode=%s: expected <%s>, got <%s>\n' "$mode" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+export MOCK_SERVICE_FRAGMENT=/etc/systemd/user/memex-index.service
+export MOCK_TIMER_FRAGMENT=/etc/systemd/user/memex-index.timer
+export MOCK_SERVICE_ACTIVE=false MOCK_TIMER_ACTIVE=false
+check continuous 'daemon-reload'
+check interval 'daemon-reload'
+export MOCK_SERVICE_ACTIVE=true
+check continuous $'daemon-reload\nrestart memex-index.service'
+check interval $'daemon-reload\nstop memex-index.service\nstart memex-index.timer'
+export MOCK_SERVICE_ACTIVE=false MOCK_TIMER_ACTIVE=true
+check interval $'daemon-reload\nrestart memex-index.timer'
+check continuous $'daemon-reload\nstop memex-index.timer\nstart memex-index.service'
+export MOCK_SERVICE_ACTIVE=true
+check disabled $'daemon-reload\nstop memex-index.timer\nstop memex-index.service'
+
+# The unit can disappear on disable, while its previous process is still alive.
+touch "$XDG_RUNTIME_DIR/memex-nixos-service"
+export MOCK_SERVICE_FRAGMENT= MOCK_TIMER_FRAGMENT= MOCK_TIMER_ACTIVE=false
+check disabled $'daemon-reload\nstop memex-index.service'
+check disabled ''
+
+# A foreign timer must not be started, even when our own daemon is active.
+export MOCK_SERVICE_FRAGMENT=/etc/systemd/user/memex-index.service
+export MOCK_TIMER_FRAGMENT=/home/test/.config/systemd/user/memex-index.timer
+export MOCK_SERVICE_ACTIVE=true MOCK_TIMER_ACTIVE=false
+check interval ''
+export MOCK_TIMER_ACTIVE=true
+check interval ''
+
+# Service ownership alone does not establish ownership of an unknown timer.
+export MOCK_TIMER_FRAGMENT=
+check interval ''
+check disabled $'daemon-reload\nstop memex-index.service'
+
+# A previously observed owned timer can disappear while it is still active.
+touch "$XDG_RUNTIME_DIR/memex-nixos-service" "$XDG_RUNTIME_DIR/memex-nixos-timer"
+export MOCK_SERVICE_FRAGMENT= MOCK_SERVICE_ACTIVE=false
+check disabled $'daemon-reload\nstop memex-index.timer'
+
+# A user or Home Manager unit with the same label takes precedence.
+export MOCK_SERVICE_FRAGMENT=/home/test/.config/systemd/user/memex-index.service
+touch "$XDG_RUNTIME_DIR/memex-nixos-service"
+check continuous ''
+[[ ! -f "$XDG_RUNTIME_DIR/memex-nixos-service" ]]
+printf 'NixOS activation checks passed\n'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,7 @@ use std::time::Duration;
 use std::time::Instant;
 use toml_edit::{DocumentMut, Item as TomlItem, value};
 
+mod daemon_upgrade;
 mod surface;
 use surface::{
     CliSearchMode, DaemonMcpArgs, DebugCommand, IndexCommand, IndexSource, OutputArgs,
@@ -1102,6 +1103,11 @@ impl From<SessionOrigin> for crate::analytics::SessionKindFilter {
 
 #[derive(Subcommand)]
 enum IndexServiceCommand {
+    /// Activate an installed update for an already enabled Memex-owned daemon
+    Reconcile {
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
     /// Run the configured daemon in the foreground
     Run {
         #[command(flatten)]
@@ -1439,6 +1445,7 @@ pub fn run() -> Result<()> {
             crate::web::serve(root, &listen)?;
         }
         Commands::IndexService { action } => match action {
+            IndexServiceCommand::Reconcile { root } => daemon_upgrade::reconcile(root)?,
             IndexServiceCommand::Run {
                 index,
                 web_ui,
@@ -1920,6 +1927,9 @@ fn run_index_loop(
 ) -> Result<()> {
     // Keep the native listener alive for every daemon watch mode, including
     // the default event loop, and release it when that loop exits or fails.
+    let paths = Paths::new(index.root.clone())?;
+    let mut runtime = crate::daemon_runtime::DaemonRuntime::start(&paths)?;
+    let mut upgrade = daemon_upgrade::Replacement::new()?;
     #[cfg(unix)]
     let _native_server = match crate::native::spawn(index.root.clone()) {
         Ok(server) => Some(server),
@@ -1929,9 +1939,23 @@ fn run_index_loop(
         }
     };
     if mode == WatchMode::Poll {
-        run_poll_loop(index, interval_secs, web_listen, mcp)
+        run_poll_loop(
+            index,
+            interval_secs,
+            web_listen,
+            mcp,
+            &mut runtime,
+            &mut upgrade,
+        )
     } else {
-        run_event_loop(index, Duration::from_secs(interval_secs), web_listen, mcp)
+        run_event_loop(
+            index,
+            Duration::from_secs(interval_secs),
+            web_listen,
+            mcp,
+            &mut runtime,
+            &mut upgrade,
+        )
     }
 }
 
@@ -1940,6 +1964,8 @@ fn run_poll_loop(
     interval_secs: u64,
     web_listen: Option<String>,
     mcp: Option<crate::mcp::HttpOptions>,
+    runtime: &mut crate::daemon_runtime::DaemonRuntime,
+    upgrade: &mut daemon_upgrade::Replacement,
 ) -> Result<()> {
     let mcp_server = mcp
         .map(|options| crate::mcp::spawn_http(index.root.clone(), options))
@@ -1953,13 +1979,21 @@ fn run_poll_loop(
                 .transpose()
         },
     )?;
+    runtime.mark_ready()?;
     loop {
-        if let Some(server) = &mcp_server {
-            if !server.wait_timeout(Duration::from_secs(interval_secs))? {
-                return Ok(());
+        let deadline = Instant::now() + Duration::from_secs(interval_secs);
+        while Instant::now() < deadline {
+            upgrade.check();
+            let remaining = deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_secs(1));
+            if let Some(server) = &mcp_server {
+                if !server.wait_timeout(remaining)? {
+                    return Ok(());
+                }
+            } else {
+                std::thread::sleep(remaining);
             }
-        } else {
-            std::thread::sleep(Duration::from_secs(interval_secs));
         }
         run_index_args(index, false, true)?;
         std::io::stdout().flush().ok();
@@ -1984,6 +2018,8 @@ fn run_event_loop(
     resync: Duration,
     web_listen: Option<String>,
     mcp: Option<crate::mcp::HttpOptions>,
+    runtime: &mut crate::daemon_runtime::DaemonRuntime,
+    upgrade: &mut daemon_upgrade::Replacement,
 ) -> Result<()> {
     use crate::watch::{
         FireCause, HOT_SWEEP_INTERVAL, HOT_WINDOW, WatchConfig, WatchService, dirty_needs_ingest,
@@ -2021,9 +2057,11 @@ fn run_event_loop(
         },
     )?;
 
+    runtime.mark_ready()?;
     service.mark_complete(FireCause::Resync);
     let mut last_sweep = Instant::now();
     loop {
+        upgrade.check();
         match service.poll() {
             Some(FireCause::Resync) => {
                 if let Err(error) = refresh_watch_roots(&mut service, index) {
@@ -5697,6 +5735,7 @@ fn run_index_service_enable(
 
     let paths = Paths::new(index.root.clone())?;
     let config = UserConfig::load(&paths)?;
+    daemon_upgrade::ensure_mutable(&paths.root.join("config.toml"))?;
     let mcp = mcp_args.resolve(&config);
     let mcp_listen = mcp.as_ref().map(|options| options.listen);
     let cli_web_ui = web_ui || web_listen.is_some();
@@ -5733,7 +5772,7 @@ fn run_index_service_enable(
         crate::web::validate_listener(&web_listen)?;
     }
 
-    let exe = std::env::current_exe()?;
+    let exe = daemon_upgrade::service_executable()?;
     let program_args = build_index_command_args(
         index,
         continuous,
@@ -5779,6 +5818,9 @@ fn run_index_service_enable(
     result?;
     persist_index_service_config(&paths, &config_updates)?;
     disable_auto_index_on_search_by_default(&paths, &config)?;
+    if continuous {
+        daemon_upgrade::wait_ready(&paths, Duration::from_secs(30))?;
+    }
     if web_ui {
         wait_for_web_ui(&web_listen, Duration::from_secs(5))?;
         println!("web UI: running on {web_listen}");
@@ -6017,6 +6059,12 @@ fn run_index_service_enable_launchd(
         .or_else(|| config.index_service_plist.clone())
         .unwrap_or(default_plist);
     validate_service_label(&label)?;
+    daemon_upgrade::ensure_mutable(&plist_path)?;
+
+    let (domain_target, service_target) = launchctl_targets(&label)?;
+    if launchctl_service_exists(&service_target)? {
+        verify_launchd_job_loaded(&service_target, &plist_path)?;
+    }
 
     if let Some(parent) = plist_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -6044,8 +6092,6 @@ fn run_index_service_enable_launchd(
     std::fs::write(&plist_path, contents)?;
 
     println!("wrote launchd plist: {}", plist_path.display());
-    let (domain_target, service_target) = launchctl_targets(&label)?;
-
     // Replace any existing job with the same label to avoid stale launchd state.
     let _ = launchctl_bootout_service(&service_target)?;
 
@@ -6112,6 +6158,10 @@ fn run_index_service_enable_systemd(
 
     let service_path = systemd_dir.join(format!("{}.service", label));
     let timer_path = systemd_dir.join(format!("{}.timer", label));
+    daemon_upgrade::ensure_mutable(&service_path)?;
+    daemon_upgrade::ensure_mutable(&timer_path)?;
+    daemon_upgrade::ensure_systemd_owner(&label, &service_path)?;
+    daemon_upgrade::ensure_systemd_owner(&label, &timer_path)?;
     let existing_mode = registered_systemd_mode(&service_path, &timer_path)?;
     if let Some(counterpart) =
         systemd_counterpart_unit(&label, continuous, existing_mode, timer_path.exists())
@@ -6188,7 +6238,7 @@ fn run_index_service_status(
     let paths = Paths::new(root)?;
     let config = UserConfig::load(&paths)?;
 
-    if cfg!(target_os = "macos") {
+    let result = if cfg!(target_os = "macos") {
         run_index_service_status_launchd(&config, &paths, label, plist)
     } else if cfg!(target_os = "linux") {
         run_index_service_status_systemd(&config, label, systemd_dir)
@@ -6196,7 +6246,9 @@ fn run_index_service_status(
         Err(anyhow!(
             "background service scheduling is only supported on macOS and Linux"
         ))
-    }
+    };
+    result?;
+    daemon_upgrade::print_runtime(&paths)
 }
 
 fn run_index_service_open(
@@ -6606,7 +6658,11 @@ fn run_index_service_disable_launchd(
         .or_else(|| config.index_service_plist.clone())
         .unwrap_or(default_plist);
     validate_service_label(&label)?;
+    daemon_upgrade::ensure_mutable(&plist_path)?;
     let (_domain_target, service_target) = launchctl_targets(&label)?;
+    if launchctl_service_exists(&service_target)? {
+        verify_launchd_job_loaded(&service_target, &plist_path)?;
+    }
     let _ = launchctl_bootout_service(&service_target)?;
 
     if plist_path.exists() {
@@ -6695,7 +6751,7 @@ fn verify_launchd_job_loaded(service_target: &str, plist_path: &std::path::Path)
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let expected_path = plist_path.to_string_lossy();
-    if !stdout.contains(&format!("path = {expected_path}")) {
+    if service_output_value(&stdout, "path") != Some(expected_path.as_ref()) {
         return Err(anyhow!(
             "launchd job state mismatch; expected path {}, launchctl output did not match",
             plist_path.display()
@@ -6738,6 +6794,10 @@ fn run_index_service_disable_systemd(
 
     let service_path = systemd_dir.join(format!("{}.service", label));
     let timer_path = systemd_dir.join(format!("{}.timer", label));
+    daemon_upgrade::ensure_mutable(&service_path)?;
+    daemon_upgrade::ensure_mutable(&timer_path)?;
+    daemon_upgrade::ensure_systemd_owner(&label, &service_path)?;
+    daemon_upgrade::ensure_systemd_owner(&label, &timer_path)?;
 
     // Stop and disable timer if it exists
     if timer_path.exists() {
@@ -7545,6 +7605,19 @@ fn refresh_installed_skills(binary: &Path) -> Result<()> {
     Ok(())
 }
 
+fn activate_installed_daemon(binary: &Path) -> Result<()> {
+    let status = std::process::Command::new(binary)
+        .args(["--no-update-check", "daemon", "reconcile"])
+        .stdin(std::process::Stdio::null())
+        .status()
+        .with_context(|| format!("activate daemon using {}", binary.display()))?;
+    anyhow::ensure!(
+        status.success(),
+        "memex is installed, but daemon activation failed ({status}); run `memex daemon reconcile` to retry"
+    );
+    Ok(())
+}
+
 fn update_homebrew(brew: &Path, expected_version: Option<&str>) -> Result<PathBuf> {
     for args in [vec!["update"], vec!["upgrade", HOMEBREW_FORMULA]] {
         let status = std::process::Command::new(brew)
@@ -7596,6 +7669,7 @@ fn update_homebrew(brew: &Path, expected_version: Option<&str>) -> Result<PathBu
         .filter(|value| parse_version_parts(value).is_some())
         .ok_or_else(|| anyhow!("unexpected installed memex version: {version}"))?;
     println!("Installed {version}");
+    activate_installed_daemon(&binary)?;
     refresh_installed_skills(&binary)?;
     if expected_version.is_some_and(|latest| is_newer_version(installed_version, latest)) {
         return Err(anyhow!(
@@ -7630,6 +7704,7 @@ fn update_release(current_exe: &Path, latest: &str) -> Result<()> {
     let current = env!("CARGO_PKG_VERSION");
     if !is_newer_version(current, latest) {
         println!("memex is already up to date (v{current}); refreshing installed skills");
+        activate_installed_daemon(current_exe)?;
         return refresh_installed_skills(current_exe);
     }
     let (os, arch) = detect_platform()?;
@@ -7665,13 +7740,23 @@ fn update_release(current_exe: &Path, latest: &str) -> Result<()> {
     if !status.success() {
         return Err(anyhow!("Failed to extract release"));
     }
-    replace_binary(&tmp_dir.path().join("memex"), current_exe)?;
+    let downloaded = tmp_dir.path().join("memex");
+    anyhow::ensure!(
+        daemon_upgrade::verify_binary(&downloaded)? == latest,
+        "downloaded memex does not match requested release {latest}"
+    );
+    replace_binary(&downloaded, current_exe)?;
     println!("Updated memex to v{latest}");
+    activate_installed_daemon(current_exe)?;
     refresh_installed_skills(current_exe)
 }
 
 fn perform_update(known_latest: Option<&str>) -> Result<()> {
     let current_exe = std::env::current_exe()?.canonicalize()?;
+    anyhow::ensure!(
+        !daemon_upgrade::nix_store(&current_exe),
+        "Nix manages this installation. Update the flake/profile and activate your NixOS or Home Manager configuration; memex update cannot replace an immutable Nix store binary. For a profile-owned daemon, run `memex daemon reconcile` after upgrading the profile."
+    );
     if homebrew_executable(&current_exe) {
         let brew = find_in_path("brew").ok_or_else(|| {
             anyhow!("Homebrew manages this installation, but brew is not on PATH")

--- a/src/cli/daemon_upgrade.rs
+++ b/src/cli/daemon_upgrade.rs
@@ -1,0 +1,539 @@
+//! Installation paths and activation of an existing daemon, independent of installer.
+use super::*;
+use crate::daemon_runtime::{current_executable_identity, executable_identity};
+
+pub(super) fn nix_store(path: &Path) -> bool {
+    path.starts_with("/nix/store")
+}
+
+fn homebrew_opt(path: &Path) -> Option<PathBuf> {
+    let mut prefix = PathBuf::new();
+    let mut components = path.components();
+    while let Some(component) = components.next() {
+        if component.as_os_str() == "Cellar" {
+            return (components.next()?.as_os_str() == "memex")
+                .then(|| prefix.join("opt/memex/bin/memex"));
+        }
+        prefix.push(component);
+    }
+    None
+}
+
+pub(super) fn service_executable() -> Result<PathBuf> {
+    let current = std::env::current_exe()?.canonicalize()?;
+    if let Some(opt) = homebrew_opt(&current) {
+        anyhow::ensure!(
+            opt.canonicalize().ok().as_ref() == Some(&current),
+            "Homebrew's active memex differs from this executable; run the installed memex daemon restart"
+        );
+        return Ok(opt);
+    }
+    // Preserve invocation through a profile or manually maintained symlink.
+    let invoked = std::env::args_os().next().map(PathBuf::from);
+    let candidate = invoked
+        .filter(|path| path.is_absolute())
+        .or_else(|| find_in_path("memex"));
+    if let Some(path) = candidate
+        && !nix_store(&path)
+        && path.canonicalize().ok().as_ref() == Some(&current)
+    {
+        return Ok(path);
+    }
+    if nix_store(&current) {
+        return Err(anyhow!(
+            "Use a Nix profile's memex to register a daemon, or configure the NixOS/Home Manager daemon module"
+        ));
+    }
+    Ok(current)
+}
+
+/// Check the installed file identity without interrupting an indexing pass.
+pub(super) struct Replacement {
+    path: Option<PathBuf>,
+    identity: String,
+    checked: Instant,
+}
+
+fn observed_executable(current: &Path, invoked: Option<&Path>) -> Option<PathBuf> {
+    homebrew_opt(current)
+        .or_else(|| {
+            invoked
+                .filter(|path| path.is_absolute() && !nix_store(path))
+                .map(Path::to_path_buf)
+        })
+        .or_else(|| (!nix_store(current)).then(|| current.to_path_buf()))
+}
+
+impl Replacement {
+    pub(super) fn new() -> Result<Self> {
+        let path = if std::env::var("MEMEX_SERVICE_MANAGER").as_deref() == Ok("nix") {
+            None
+        } else {
+            // Unlike registration, observing an update must allow the stable
+            // link to have advanced while this process was starting.
+            let current = std::env::current_exe()?;
+            let invoked = std::env::args_os()
+                .next()
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .or_else(|| find_in_path("memex"));
+            observed_executable(&current, invoked.as_deref())
+        };
+        Ok(Self {
+            path,
+            identity: current_executable_identity()?,
+            checked: Instant::now(),
+        })
+    }
+
+    pub(super) fn check(&mut self) {
+        if self.checked.elapsed() < Duration::from_secs(2) {
+            return;
+        }
+        self.checked = Instant::now();
+        let Some(path) = &self.path else {
+            return;
+        };
+        let result = (|| -> Result<()> {
+            let identity = executable_identity(path)?;
+            if identity == self.identity {
+                return Ok(());
+            }
+            verify_binary(path)?;
+            // Retry failures later; a partially written replacement must not strand
+            // the old daemon or be mistaken for an activated build.
+            eprintln!("daemon: activating updated executable {}", path.display());
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::CommandExt;
+                let error = std::process::Command::new(path)
+                    .args(std::env::args_os().skip(1))
+                    .exec();
+                Err(error).context("activate updated daemon")
+            }
+            #[cfg(not(unix))]
+            {
+                Err(anyhow!("daemon activation requires Unix"))
+            }
+        })();
+        if let Err(error) = result {
+            eprintln!("daemon: update not activated (will retry): {error:#}");
+        }
+    }
+}
+
+pub(super) fn verify_binary(path: &Path) -> Result<String> {
+    let mut child = std::process::Command::new(path)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait()?.is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(anyhow!("replacement version check timed out"));
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let output = child.wait_with_output()?;
+    let version = std::str::from_utf8(&output.stdout)?.trim();
+    anyhow::ensure!(
+        output.status.success()
+            && version
+                .strip_prefix("memex ")
+                .is_some_and(|v| parse_version_parts(v).is_some()),
+        "replacement is not a working memex binary"
+    );
+    Ok(version
+        .strip_prefix("memex ")
+        .expect("validated version")
+        .to_string())
+}
+
+pub(super) fn ensure_mutable(path: &Path) -> Result<()> {
+    if path.canonicalize().is_ok_and(|target| nix_store(&target))
+        || std::fs::read_to_string(path).is_ok_and(|contents| {
+            contents.contains("MEMEX_SERVICE_MANAGER=nix")
+                || contents
+                    .split_once("<key>MEMEX_SERVICE_MANAGER</key>")
+                    .is_some_and(|(_, value)| {
+                        value.trim_start().starts_with("<string>nix</string>")
+                    })
+        })
+    {
+        return Err(anyhow!(
+            "{} is managed by Nix; update and activate your Nix configuration instead",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn ensure_systemd_owner(label: &str, definition: &Path) -> Result<()> {
+    let unit = definition
+        .file_name()
+        .context("systemd definition has no unit name")?
+        .to_string_lossy();
+    let output = std::process::Command::new("systemctl")
+        .args([
+            "--user",
+            "show",
+            "--property=FragmentPath",
+            "--value",
+            &unit,
+        ])
+        .output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "cannot determine systemd service ownership: {}",
+        format_command_output(&output)
+    );
+    let fragment = String::from_utf8_lossy(&output.stdout);
+    let fragment = Path::new(fragment.trim());
+    if fragment.as_os_str().is_empty() {
+        return Ok(());
+    }
+    anyhow::ensure!(
+        fragment == definition
+            || (fragment.canonicalize().ok().is_some()
+                && fragment.canonicalize().ok() == definition.canonicalize().ok()),
+        "service {label} is owned by {}; use its package manager to activate it",
+        fragment.display()
+    );
+    ensure_mutable(fragment)
+}
+
+pub(super) fn wait_ready(paths: &Paths, timeout: Duration) -> Result<()> {
+    let expected = current_executable_identity()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(info) = crate::daemon_runtime::read(paths)?
+            && info.ready
+            && info.executable_id == expected
+        {
+            println!("daemon: ready (memex {}, pid {})", info.version, info.pid);
+            return Ok(());
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "daemon activation did not become ready with the installed build within {} seconds; inspect `memex daemon status` and daemon logs",
+            timeout.as_secs()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(super) fn print_runtime(paths: &Paths) -> Result<()> {
+    println!("installed version: {}", env!("CARGO_PKG_VERSION"));
+    match crate::daemon_runtime::read(paths)? {
+        Some(info) => {
+            println!("running version: {}", info.version);
+            println!("pid: {}", info.pid);
+            println!("executable: {}", info.executable.display());
+            println!(
+                "readiness: {}",
+                if info.ready { "ready" } else { "starting" }
+            );
+            println!(
+                "build: {}",
+                if info.executable_id == current_executable_identity()? {
+                    "matches installed binary"
+                } else {
+                    "update pending; running build differs"
+                }
+            );
+        }
+        None => println!(
+            "running build: unavailable (stopped, interval mode, or daemon predates runtime reporting)"
+        ),
+    }
+    Ok(())
+}
+
+fn program_range(contents: &str, macos: bool) -> Result<(usize, usize)> {
+    Ok(if macos {
+        let args = contents
+            .find("<key>ProgramArguments</key>")
+            .context("missing ProgramArguments")?;
+        let start = args
+            + contents[args..]
+                .find("<string>")
+                .context("missing daemon program")?
+            + "<string>".len();
+        let end = start
+            + contents[start..]
+                .find("</string>")
+                .context("unterminated daemon program")?;
+        (start, end)
+    } else {
+        let start = contents.find("ExecStart=").context("missing ExecStart")? + "ExecStart=".len();
+        let end = start
+            + contents[start..]
+                .find(' ')
+                .context("missing daemon arguments")?;
+        (start, end)
+    })
+}
+
+fn different_nix_installation(contents: &str, macos: bool, current: &Path) -> Result<bool> {
+    let (start, end) = program_range(contents, macos)?;
+    Ok(contents[start..end].starts_with("/nix/store/") && !nix_store(current))
+}
+
+fn replace_program(contents: &str, exe: &Path, macos: bool) -> Result<String> {
+    let (start, end) = program_range(contents, macos)?;
+    let old = &contents[start..end];
+    anyhow::ensure!(
+        old.ends_with("/memex"),
+        "service executable is not a mutable Memex installation"
+    );
+    let new = if macos {
+        xml_escape(&exe.to_string_lossy())
+    } else {
+        anyhow::ensure!(
+            !exe.to_string_lossy().contains(char::is_whitespace),
+            "systemd executable path contains whitespace"
+        );
+        exe.to_string_lossy().into_owned()
+    };
+    Ok(format!("{}{}{}", &contents[..start], new, &contents[end..]))
+}
+
+pub(super) fn reconcile(root: Option<PathBuf>) -> Result<()> {
+    let paths = Paths::new(root)?;
+    let config = UserConfig::load(&paths)?;
+    let macos = cfg!(target_os = "macos");
+    let label = config.index_service_label.clone().unwrap_or_else(|| {
+        if macos {
+            default_index_service_label()
+        } else {
+            "memex-index".into()
+        }
+    });
+    validate_service_label(&label)?;
+    let definition = if macos {
+        config
+            .index_service_plist
+            .clone()
+            .unwrap_or_else(|| default_index_service_plist(&paths.root))
+    } else {
+        config
+            .index_service_systemd_dir
+            .clone()
+            .unwrap_or_else(default_systemd_user_dir)
+            .join(format!("{label}.service"))
+    };
+    if !definition.exists() {
+        println!("daemon: no Memex-owned registration; unchanged");
+        return Ok(());
+    }
+    if ensure_mutable(&definition).is_err() {
+        println!("daemon: Nix-managed registration; activate your Nix configuration");
+        return Ok(());
+    }
+    let contents = std::fs::read_to_string(&definition)?;
+    if different_nix_installation(&contents, macos, &std::env::current_exe()?)? {
+        println!("daemon: uses a Nix installation; reconcile through that profile");
+        return Ok(());
+    }
+    let continuous = if macos {
+        contents.contains("<key>KeepAlive</key>")
+    } else {
+        contents.contains("Type=simple")
+    };
+    let unit = format!("{label}.{}", if continuous { "service" } else { "timer" });
+    if macos {
+        let (domain, target) = launchctl_targets(&label)?;
+        if !launchctl_service_exists(&target)? {
+            println!("daemon: stopped; unchanged");
+            return Ok(());
+        }
+        let disabled = std::process::Command::new("launchctl")
+            .args(["print-disabled", &domain])
+            .output()?;
+        anyhow::ensure!(
+            disabled.status.success(),
+            "cannot determine launchd enabled state"
+        );
+        if String::from_utf8_lossy(&disabled.stdout).contains(&format!("\"{label}\" => true")) {
+            println!("daemon: disabled; unchanged");
+            return Ok(());
+        }
+        verify_launchd_job_loaded(&target, &definition)?;
+    } else {
+        let enabled = std::process::Command::new("systemctl")
+            .args(["--user", "is-enabled", &unit])
+            .output()?;
+        let state = String::from_utf8_lossy(&enabled.stdout);
+        if !matches!(state.trim(), "enabled" | "enabled-runtime") {
+            anyhow::ensure!(
+                matches!(
+                    state.trim(),
+                    "disabled" | "masked" | "masked-runtime" | "static" | "indirect" | "not-found"
+                ),
+                "cannot determine systemd enabled state: {}",
+                format_command_output(&enabled)
+            );
+            println!("daemon: disabled; unchanged");
+            return Ok(());
+        }
+        if systemd_unit_state(&unit)? != "active" {
+            println!("daemon: stopped; unchanged");
+            return Ok(());
+        }
+        ensure_systemd_owner(&label, &definition)?;
+        if !continuous {
+            ensure_systemd_owner(&label, &definition.with_extension("timer"))?;
+        }
+    }
+    let exe = service_executable()?;
+    let updated = replace_program(&contents, &exe, macos)?;
+    if updated == contents
+        && continuous
+        && let Some(info) = crate::daemon_runtime::read(&paths)?
+        && info.executable_id == current_executable_identity()?
+    {
+        if info.ready {
+            println!("daemon: already running installed build");
+        } else {
+            // A retry must not restart a healthy process still doing its first
+            // index pass. Wait for that same installed process to finish startup.
+            wait_ready(&paths, Duration::from_secs(30))?;
+        }
+        return Ok(());
+    }
+    // Only the executable changes: preserve every existing argument, root,
+    // environment variable, listener and scheduling setting exactly.
+    let mut staged = tempfile::NamedTempFile::new_in(
+        definition
+            .parent()
+            .context("service definition has no parent")?,
+    )?;
+    use std::io::Write;
+    staged.write_all(updated.as_bytes())?;
+    staged.persist(&definition).map_err(|error| error.error)?;
+    if macos {
+        let (domain, target) = launchctl_targets(&label)?;
+        launchctl_bootout_service(&target)?;
+        let output = std::process::Command::new("launchctl")
+            .args(["bootstrap", &domain])
+            .arg(&definition)
+            .output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "daemon bootstrap failed: {}",
+            format_command_output(&output)
+        );
+    } else {
+        run_systemctl(&["--user", "daemon-reload"], "daemon reload")?;
+        // An already running interval invocation must also stop using the old
+        // executable; try-restart leaves an idle oneshot idle.
+        if !continuous {
+            run_systemctl(
+                &["--user", "try-restart", &format!("{label}.service")],
+                "restart active indexer",
+            )?;
+        }
+        run_systemctl(&["--user", "restart", &unit], "daemon restart")?;
+    }
+    if continuous {
+        wait_ready(&paths, Duration::from_secs(30))?;
+    } else {
+        println!("daemon: interval registration updated; next invocation uses installed binary");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn observation_keeps_profile_and_manual_links_that_advanced_during_startup() {
+        let profile = Path::new("/home/me/.nix-profile/bin/memex");
+        assert_eq!(
+            observed_executable(Path::new("/nix/store/old/bin/memex"), Some(profile)),
+            Some(profile.to_path_buf())
+        );
+        let manual = Path::new("/home/me/bin/memex");
+        assert_eq!(
+            observed_executable(Path::new("/releases/old/memex"), Some(manual)),
+            Some(manual.to_path_buf())
+        );
+        assert_eq!(
+            observed_executable(
+                Path::new("/nix/store/old/bin/memex"),
+                Some(Path::new("/nix/store/old/bin/memex"))
+            ),
+            None
+        );
+    }
+    #[test]
+    fn cellar_paths_use_stable_formula_link() {
+        assert_eq!(
+            homebrew_opt(Path::new("/opt/homebrew/Cellar/memex/1.0/bin/memex")),
+            Some(PathBuf::from("/opt/homebrew/opt/memex/bin/memex"))
+        );
+        assert_eq!(
+            homebrew_opt(Path::new(
+                "/home/linuxbrew/.linuxbrew/Cellar/memex/1/bin/memex"
+            )),
+            Some(PathBuf::from(
+                "/home/linuxbrew/.linuxbrew/opt/memex/bin/memex"
+            ))
+        );
+        assert_eq!(homebrew_opt(Path::new("/tmp/memex")), None);
+        assert!(!nix_store(Path::new("/tmp/nix/store/memex")));
+        assert!(nix_store(Path::new("/nix/store/hash-memex/bin/memex")));
+    }
+    #[test]
+    fn activation_preserves_service_arguments_and_environment() {
+        let args = vec![
+            "/old/bin/memex".into(),
+            "index".into(),
+            "--root".into(),
+            "/data/custom root".into(),
+            "--no-codex".into(),
+        ];
+        let env = vec![("CUSTOM".into(), "value".into())];
+        let plist = build_launchd_plist("custom", &args, Some(600), false, None, None, &env);
+        let updated = replace_program(&plist, Path::new("/new/bin/memex"), true).unwrap();
+        assert_eq!(
+            updated,
+            plist.replacen("/old/bin/memex", "/new/bin/memex", 1)
+        );
+        let unit = build_systemd_service("/old/bin/memex", &args[1..], true, &env);
+        assert_eq!(
+            replace_program(&unit, Path::new("/new/bin/memex"), false).unwrap(),
+            unit.replacen("/old/bin/memex", "/new/bin/memex", 1)
+        );
+        let old_profile = "ExecStart=/nix/store/hash/bin/memex index\n";
+        assert!(different_nix_installation(old_profile, false, Path::new("/new/memex")).unwrap());
+        assert!(
+            !different_nix_installation(old_profile, false, Path::new("/nix/store/new/bin/memex"))
+                .unwrap()
+        );
+        assert_eq!(
+            replace_program(
+                old_profile,
+                Path::new("/home/me/.nix-profile/bin/memex"),
+                false
+            )
+            .unwrap(),
+            "ExecStart=/home/me/.nix-profile/bin/memex index\n"
+        );
+        assert!(
+            !different_nix_installation(
+                "Environment=PATH=/nix/store/helper/bin\nExecStart=/usr/bin/memex index\n",
+                false,
+                Path::new("/usr/bin/memex")
+            )
+            .unwrap()
+        );
+    }
+}

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1,0 +1,329 @@
+//! Root-scoped daemon lifetime and readiness information.
+//!
+//! The OS lock establishes liveness; the JSON file alone is never evidence of a
+//! running process. This information is for status and activation checks, not
+//! authority to send signals to a PID.
+
+use crate::config::Paths;
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RuntimeInfo {
+    pub pid: u32,
+    pub version: String,
+    pub executable: PathBuf,
+    pub executable_id: String,
+    pub started_at: u64,
+    pub ready: bool,
+    pub instance_id: String,
+}
+
+/// Hold this guard for the entire daemon lifetime, including initialization.
+#[derive(Debug)]
+pub struct DaemonRuntime {
+    lock: File,
+    state_path: PathBuf,
+    info: RuntimeInfo,
+}
+
+impl DaemonRuntime {
+    pub fn start(paths: &Paths) -> Result<Self> {
+        std::fs::create_dir_all(&paths.state)?;
+        let mut lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(lock_path(paths))
+            .context("failed to open daemon runtime lock")?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(anyhow!(
+                    "a daemon is already running for {}",
+                    paths.root.display()
+                ));
+            }
+            Err(TryLockError::Error(error)) => {
+                return Err(error).context("failed to acquire daemon runtime lock");
+            }
+        }
+
+        let mut nonce = [0_u8; 16];
+        getrandom::fill(&mut nonce).map_err(|error| anyhow!("runtime identity: {error}"))?;
+        let instance_id = hex(&nonce);
+        // Change the token before publishing the new state, so readers cannot
+        // mistake a previous daemon's JSON for this lock holder's information.
+        lock.set_len(0)?;
+        lock.seek(SeekFrom::Start(0))?;
+        lock.write_all(instance_id.as_bytes())?;
+        lock.flush()?;
+
+        let runtime = Self {
+            lock,
+            state_path: state_path(paths),
+            info: RuntimeInfo {
+                pid: std::process::id(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                executable: std::env::current_exe().context("resolve daemon executable")?,
+                executable_id: current_executable_identity()?,
+                started_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+                ready: false,
+                instance_id,
+            },
+        };
+        runtime.publish()?;
+        Ok(runtime)
+    }
+
+    /// Call only after the daemon has initialized its requested services.
+    pub fn mark_ready(&mut self) -> Result<()> {
+        self.info.ready = true;
+        self.publish()
+    }
+
+    fn publish(&self) -> Result<()> {
+        let parent = self.state_path.parent().context("runtime state parent")?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        serde_json::to_writer(&mut temporary, &self.info)?;
+        temporary.write_all(b"\n")?;
+        temporary.flush()?;
+        temporary.persist(&self.state_path)?;
+        Ok(())
+    }
+}
+
+impl Drop for DaemonRuntime {
+    fn drop(&mut self) {
+        // Remove metadata while still holding the lock. Never unlink the lock
+        // file: another opener must always contend on the same inode.
+        let _ = std::fs::remove_file(&self.state_path);
+        let _ = self.lock.unlock();
+    }
+}
+
+/// Read a snapshot only when a daemon holds the runtime lock. A stale PID in a
+/// file cannot establish liveness, including when the OS has reused that PID.
+pub fn read(paths: &Paths) -> Result<Option<RuntimeInfo>> {
+    let lock_path = lock_path(paths);
+    let lock = match OpenOptions::new().read(true).write(true).open(&lock_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("open daemon runtime lock"),
+    };
+    if !is_locked(&lock)? {
+        return Ok(None);
+    }
+    let token = std::fs::read_to_string(&lock_path)?;
+    let contents = match std::fs::read(state_path(paths)) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("read daemon runtime state"),
+    };
+    let info: RuntimeInfo =
+        serde_json::from_slice(&contents).context("parse daemon runtime state")?;
+    // A restart may happen between the reads. Reject metadata from a different
+    // lock generation and check that the lock is still held before returning.
+    if token.is_empty()
+        || info.instance_id != token
+        || std::fs::read_to_string(&lock_path)? != token
+        || !is_locked(&lock)?
+    {
+        return Ok(None);
+    }
+    Ok(Some(info))
+}
+
+fn is_locked(file: &File) -> Result<bool> {
+    match file.try_lock() {
+        Ok(()) => {
+            file.unlock()?;
+            Ok(false)
+        }
+        Err(TryLockError::WouldBlock) => Ok(true),
+        Err(TryLockError::Error(error)) => Err(error).context("check daemon runtime lock"),
+    }
+}
+
+/// Identify the installed file without reading the executable's contents.
+///
+/// Unix inode and change timestamps distinguish ordinary replacements and
+/// same-version rebuilds, including replacements preserving size and mtime.
+/// This is advisory file identity, not proof of content equality: copying the
+/// same bytes to a new inode can trigger a harmless extra daemon handoff.
+pub fn executable_identity(path: &Path) -> Result<String> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("read executable identity: {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(format!(
+            "unix:{}:{}:{}:{}:{}:{}:{}",
+            metadata.dev(),
+            metadata.ino(),
+            metadata.len(),
+            metadata.mtime(),
+            metadata.mtime_nsec(),
+            metadata.ctime(),
+            metadata.ctime_nsec(),
+        ))
+    }
+    #[cfg(not(unix))]
+    {
+        let modified = metadata.modified()?.duration_since(UNIX_EPOCH)?.as_nanos();
+        Ok(format!("file:{}:{modified}", metadata.len()))
+    }
+}
+
+/// Capture once at startup, before an updater can replace the executable path.
+pub fn current_executable_identity() -> Result<String> {
+    static IDENTITY: OnceLock<std::result::Result<String, String>> = OnceLock::new();
+    IDENTITY
+        .get_or_init(|| {
+            std::env::current_exe()
+                .map_err(anyhow::Error::from)
+                .and_then(|path| executable_identity(&path))
+                .map_err(|error| format!("{error:#}"))
+        })
+        .clone()
+        .map_err(anyhow::Error::msg)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn lock_path(paths: &Paths) -> PathBuf {
+    paths.state.join("daemon-runtime.lock")
+}
+
+fn state_path(paths: &Paths) -> PathBuf {
+    paths.state.join("daemon-runtime.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_tracks_readiness_and_releases_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().to_path_buf())).unwrap();
+        assert!(read(&paths).unwrap().is_none());
+        let mut runtime = DaemonRuntime::start(&paths).unwrap();
+        let initial = read(&paths).unwrap().unwrap();
+        assert_eq!(initial.pid, std::process::id());
+        assert!(!initial.ready);
+        assert!(DaemonRuntime::start(&paths).is_err());
+        runtime.mark_ready().unwrap();
+        assert!(read(&paths).unwrap().unwrap().ready);
+        drop(runtime);
+        assert!(read(&paths).unwrap().is_none());
+        let _next = DaemonRuntime::start(&paths).unwrap();
+        assert_ne!(
+            read(&paths).unwrap().unwrap().instance_id,
+            initial.instance_id
+        );
+    }
+
+    #[test]
+    fn stale_state_with_live_pid_is_not_a_running_daemon() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Paths::new(Some(temp.path().to_path_buf())).unwrap();
+        let runtime = DaemonRuntime::start(&paths).unwrap();
+        let stale = std::fs::read(state_path(&paths)).unwrap();
+        drop(runtime);
+        std::fs::write(state_path(&paths), &stale).unwrap();
+        assert!(read(&paths).unwrap().is_none());
+        let _next = DaemonRuntime::start(&paths).unwrap();
+        // Even an active lock cannot authenticate JSON from the old instance.
+        std::fs::write(state_path(&paths), stale).unwrap();
+        assert!(read(&paths).unwrap().is_none());
+    }
+
+    #[test]
+    fn independent_roots_can_each_run_a_daemon() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = Paths::new(Some(temp.path().join("first"))).unwrap();
+        let second = Paths::new(Some(temp.path().join("second"))).unwrap();
+        let _first = DaemonRuntime::start(&first).unwrap();
+        let _second = DaemonRuntime::start(&second).unwrap();
+        assert!(read(&first).unwrap().is_some());
+        assert!(read(&second).unwrap().is_some());
+    }
+
+    #[test]
+    fn executable_identity_distinguishes_same_version_rebuilds() {
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("memex");
+        std::fs::write(&executable, b"version 1.0 build A").unwrap();
+        let first = executable_identity(&executable).unwrap();
+        assert_eq!(first, executable_identity(&executable).unwrap());
+        // Ensure successive writes fall in different filesystem timestamp ticks.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        std::fs::write(&executable, b"version 1.0 build B").unwrap();
+        assert_ne!(first, executable_identity(&executable).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_identity_detects_replacement_preserving_size_and_mtime() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("memex");
+        std::fs::write(&executable, b"version 1.0 build A").unwrap();
+        let original = std::fs::metadata(&executable).unwrap();
+        let first = executable_identity(&executable).unwrap();
+
+        let mut replacement = tempfile::NamedTempFile::new_in(temp.path()).unwrap();
+        replacement.write_all(b"version 1.0 build B").unwrap();
+        replacement
+            .as_file()
+            .set_times(std::fs::FileTimes::new().set_modified(original.modified().unwrap()))
+            .unwrap();
+        replacement.persist(&executable).unwrap();
+
+        let replaced = std::fs::metadata(&executable).unwrap();
+        assert_eq!(original.len(), replaced.len());
+        assert_eq!(original.modified().unwrap(), replaced.modified().unwrap());
+        assert_ne!(original.ino(), replaced.ino());
+        assert_ne!(first, executable_identity(&executable).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_identity_detects_in_place_write_with_restored_mtime() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("memex");
+        std::fs::write(&executable, b"version 1.0 build A").unwrap();
+        let original = std::fs::metadata(&executable).unwrap();
+        let first = executable_identity(&executable).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        std::fs::write(&executable, b"version 1.0 build B").unwrap();
+        File::options()
+            .write(true)
+            .open(&executable)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(original.modified().unwrap()))
+            .unwrap();
+
+        let updated = std::fs::metadata(&executable).unwrap();
+        assert_eq!(original.ino(), updated.ino());
+        assert_eq!(original.len(), updated.len());
+        assert_eq!(original.modified().unwrap(), updated.modified().unwrap());
+        assert_ne!(
+            (original.ctime(), original.ctime_nsec()),
+            (updated.ctime(), updated.ctime_nsec())
+        );
+        assert_ne!(first, executable_identity(&executable).unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod analytics;
 pub mod cli;
 pub mod config;
+pub mod daemon_runtime;
 pub mod embed;
 pub mod herdr;
 pub mod index;

--- a/tests/daemon_cli.rs
+++ b/tests/daemon_cli.rs
@@ -257,6 +257,70 @@ fn configured_daemon_runs_index_web_and_mcp_in_one_process() {
     assert_listener_closes(web);
 }
 
+#[cfg(unix)]
+#[test]
+fn daemon_hands_off_stable_executable_preserving_arguments_and_environment() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    for mode in ["events", "poll"] {
+        let dirs = TestDirs::new();
+        dirs.write_config("auto_index_on_search = false\nindex_service_mcp = false\n");
+        let executable = dirs.home.path().join("memex");
+        symlink(env!("CARGO_BIN_EXE_memex"), &executable).unwrap();
+        let result = dirs.home.path().join("handoff");
+        let args = [
+            "--no-update-check",
+            "daemon",
+            "run",
+            "--root",
+            dirs.root.path().to_str().unwrap(),
+            "--only-source",
+            "claude",
+            "--claude-path",
+            dirs.claude.path().to_str().unwrap(),
+            "--no-embeddings",
+            "--watch-mode",
+            mode,
+            "--poll-interval",
+            "3600",
+        ];
+        let child = Command::new(&executable)
+            .args(args)
+            .env("HOME", dirs.home.path())
+            .env("MEMEX_HANDOFF_RESULT", &result)
+            .env("MEMEX_HANDOFF_VALUE", "preserved")
+            .env_remove("MEMEX_SERVICE_MANAGER")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut daemon = ChildGuard {
+            child,
+            logs: Arc::new(Mutex::new(Vec::new())),
+        };
+        let paths = memex::config::Paths::new(Some(dirs.root.path().to_path_buf())).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !memex::daemon_runtime::read(&paths)
+            .unwrap()
+            .is_some_and(|info| info.ready)
+        {
+            daemon.assert_running();
+            assert!(Instant::now() < deadline, "daemon readiness timed out");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let replacement = dirs.home.path().join("replacement");
+        std::fs::write(&replacement, "#!/bin/sh\nif [ \"$1\" = '--version' ]; then printf 'memex 99.0.0\\n'; exit 0; fi\nprintf '%s\\n' \"$MEMEX_HANDOFF_VALUE\" \"$@\" > \"$MEMEX_HANDOFF_RESULT\"\n").unwrap();
+        std::fs::set_permissions(&replacement, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let staged = dirs.home.path().join("next-link");
+        symlink(&replacement, &staged).unwrap();
+        std::fs::rename(&staged, &executable).unwrap();
+        assert!(daemon.wait_for_exit().success());
+        let expected = format!("preserved\n{}\n", args.join("\n"));
+        assert_eq!(std::fs::read_to_string(&result).unwrap(), expected);
+        assert!(memex::daemon_runtime::read(&paths).unwrap().is_none());
+    }
+}
+
 #[test]
 fn daemon_mcp_flags_override_the_configured_enablement() {
     let dirs = TestDirs::new();

--- a/tests/daemon_upgrade_cli.rs
+++ b/tests/daemon_upgrade_cli.rs
@@ -1,0 +1,411 @@
+#![cfg(any(target_os = "macos", target_os = "linux"))]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const LABEL: &str = "test.memex.upgrade";
+const OLD_EXE: &str = "/old/installation/bin/memex";
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    home: PathBuf,
+    root: PathBuf,
+    bin: PathBuf,
+    definition: PathBuf,
+    log: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let root = temp.path().join("custom root");
+        let bin = temp.path().join("bin");
+        let units = temp.path().join("units");
+        for directory in [&home, &root, &bin, &units] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        let definition = if cfg!(target_os = "macos") {
+            root.join("index-service.plist")
+        } else {
+            units.join(format!("{LABEL}.service"))
+        };
+        let log = temp.path().join("manager.log");
+        let config = format!(
+            "auto_index_on_search = false\nindex_service_label = '{LABEL}'\nindex_service_plist = '{}'\nindex_service_systemd_dir = '{}'\nindex_service_mode = 'interval'\nindex_service_interval = 731\n",
+            definition.display(),
+            units.display(),
+        );
+        std::fs::write(root.join("config.toml"), config).unwrap();
+        write_script(&bin.join("launchctl"), LAUNCHCTL);
+        write_script(&bin.join("systemctl"), SYSTEMCTL);
+        Self {
+            _temp: temp,
+            home,
+            root,
+            bin,
+            definition,
+            log,
+        }
+    }
+
+    fn interval_definition(&self, executable: &str) -> String {
+        if cfg!(target_os = "macos") {
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>Label</key><string>{LABEL}</string>
+<key>ProgramArguments</key><array>
+<string>{executable}</string><string>index</string>
+<string>--root</string><string>{}</string>
+<string>--no-embeddings</string><string>--no-codex</string>
+</array>
+<key>StartInterval</key><integer>731</integer>
+<key>RunAtLoad</key><true/>
+<key>EnvironmentVariables</key><dict><key>CUSTOM_SETTING</key><string>/nix/store/helper/bin &amp; preserve</string><key>USER_NOTE</key><string>nix</string></dict>
+<key>StandardOutPath</key><string>/tmp/custom-output.log</string>
+</dict></plist>
+"#,
+                self.root.display()
+            )
+        } else {
+            format!(
+                "[Unit]\nDescription=Memex Index Service\n\n[Service]\nEnvironment=\"CUSTOM_SETTING=keep & preserve\"\nType=oneshot\nExecStart={executable} index --root '{}' --no-embeddings --no-codex\n\n[Install]\n",
+                self.root.display()
+            )
+        }
+    }
+
+    fn register(&self, executable: &str) -> String {
+        let definition = self.interval_definition(executable);
+        std::fs::write(&self.definition, &definition).unwrap();
+        if cfg!(target_os = "linux") {
+            std::fs::write(self.definition.with_extension("timer"),
+                "[Unit]\nDescription=Memex Index Timer\n[Timer]\nOnUnitActiveSec=731\n[Install]\nWantedBy=timers.target\n").unwrap();
+        }
+        definition
+    }
+
+    fn reconcile(&self, state: &str) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_memex"))
+            .args(["--no-update-check", "daemon", "reconcile", "--root"])
+            .arg(&self.root)
+            .env("HOME", &self.home)
+            .env("PATH", &self.bin)
+            .env("UID", "12345")
+            .env("MEMEX_TEST_LOG", &self.log)
+            .env("MEMEX_TEST_STATE", state)
+            .env("MEMEX_TEST_DEFINITION", &self.definition)
+            .env_remove("MEMEX_SERVICE_MANAGER")
+            .output()
+            .unwrap()
+    }
+
+    fn calls(&self) -> String {
+        std::fs::read_to_string(&self.log).unwrap_or_default()
+    }
+}
+
+fn write_script(path: &Path, contents: &str) {
+    std::fs::write(path, contents).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+const LAUNCHCTL: &str = r#"#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "$MEMEX_TEST_LOG"
+case "$1" in
+  print)
+    if [ "$MEMEX_TEST_STATE" = stopped ]; then
+      printf 'Could not find service\n' >&2
+      exit 113
+    fi
+    if [ "$MEMEX_TEST_STATE" = foreign ]; then
+      printf 'path = /external/manager/memex.plist\n'
+      exit 0
+    fi
+    printf 'path = %s\n' "$MEMEX_TEST_DEFINITION"
+    ;;
+  print-disabled)
+    if [ "$MEMEX_TEST_STATE" = disabled ]; then
+      printf '"test.memex.upgrade" => true\n'
+    else
+      printf '"test.memex.upgrade" => false\n'
+    fi
+    ;;
+  bootout|bootstrap)
+    [ "$MEMEX_TEST_STATE" = active ] || exit 91
+    ;;
+  *) printf 'Unexpected launchctl command\n' >&2; exit 92 ;;
+esac
+"#;
+
+const SYSTEMCTL: &str = r#"#!/bin/sh
+printf 'systemctl %s\n' "$*" >> "$MEMEX_TEST_LOG"
+[ "$1" = --user ] || exit 90
+case "$2" in
+  is-enabled)
+    if [ "$MEMEX_TEST_STATE" = unavailable ]; then
+      printf 'Failed to connect to user bus\n' >&2
+      exit 1
+    fi
+    if [ "$MEMEX_TEST_STATE" = disabled ]; then printf 'disabled\n'; exit 1; fi
+    printf 'enabled\n'
+    ;;
+  is-active)
+    if [ "$MEMEX_TEST_STATE" = stopped ]; then printf 'inactive\n'; exit 3; fi
+    printf 'active\n'
+    ;;
+  show)
+    [ "$3" = --property=FragmentPath ] && [ "$4" = --value ] || exit 93
+    case "$5" in
+      test.memex.upgrade.service)
+        if [ "$MEMEX_TEST_STATE" = foreign ]; then
+          printf '/external/manager/memex.service\n'
+        else
+          printf '%s\n' "$MEMEX_TEST_DEFINITION"
+        fi
+        ;;
+      test.memex.upgrade.timer)
+        if [ "$MEMEX_TEST_STATE" = foreign-timer ]; then
+          printf '/external/manager/memex.timer\n'
+        else
+          printf '%s.timer\n' "${MEMEX_TEST_DEFINITION%.service}"
+        fi
+        ;;
+      *) exit 94 ;;
+    esac
+    ;;
+  daemon-reload|try-restart|restart)
+    [ "$MEMEX_TEST_STATE" = active ] || exit 91
+    ;;
+  *) printf 'Unexpected systemctl command\n' >&2; exit 92 ;;
+esac
+"#;
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_no_mutations(calls: &str) {
+    for mutation in [
+        "bootout",
+        "bootstrap",
+        "daemon-reload",
+        "try-restart",
+        "restart",
+        "enable",
+        "disable",
+    ] {
+        assert!(
+            !calls
+                .lines()
+                .any(|line| line.split_whitespace().any(|word| word == mutation)),
+            "unexpected mutation {mutation}: {calls}"
+        );
+    }
+}
+
+#[test]
+fn absent_registration_does_not_call_a_service_manager() {
+    let fixture = Fixture::new();
+    let output = fixture.reconcile("active");
+    assert_success(&output);
+    assert!(!fixture.definition.exists());
+    assert!(fixture.calls().is_empty());
+}
+
+#[test]
+fn disabled_and_stopped_registrations_are_preserved() {
+    for state in ["disabled", "stopped"] {
+        let fixture = Fixture::new();
+        let original = fixture.register(OLD_EXE);
+        let output = fixture.reconcile(state);
+        assert_success(&output);
+        assert_eq!(
+            std::fs::read_to_string(&fixture.definition).unwrap(),
+            original
+        );
+        assert_no_mutations(&fixture.calls());
+    }
+}
+
+#[test]
+fn interval_activation_changes_only_executable_and_preserves_configuration() {
+    let fixture = Fixture::new();
+    let original = fixture.register(OLD_EXE);
+    let config = std::fs::read(fixture.root.join("config.toml")).unwrap();
+    let timer = cfg!(target_os = "linux")
+        .then(|| std::fs::read(fixture.definition.with_extension("timer")).unwrap());
+    let output = fixture.reconcile("active");
+    assert_success(&output);
+    // Keep the invoked stable path even when the build cache resolves it to
+    // another directory, just as a package profile link must remain stable.
+    let executable = Path::new(env!("CARGO_BIN_EXE_memex"));
+    assert_eq!(
+        std::fs::read_to_string(&fixture.definition).unwrap(),
+        original.replacen(OLD_EXE, executable.to_str().unwrap(), 1)
+    );
+    assert_eq!(
+        std::fs::read(fixture.root.join("config.toml")).unwrap(),
+        config
+    );
+    if let Some(timer) = timer {
+        assert_eq!(
+            std::fs::read(fixture.definition.with_extension("timer")).unwrap(),
+            timer
+        );
+    }
+    let calls = fixture.calls();
+    if cfg!(target_os = "macos") {
+        assert!(
+            calls.contains("launchctl bootout gui/12345/test.memex.upgrade\n"),
+            "{calls}"
+        );
+        assert!(
+            calls.contains(&format!(
+                "launchctl bootstrap gui/12345 {}\n",
+                fixture.definition.display()
+            )),
+            "{calls}"
+        );
+    } else {
+        assert!(
+            calls.contains("systemctl --user daemon-reload\n"),
+            "{calls}"
+        );
+        assert!(
+            calls.contains("systemctl --user try-restart test.memex.upgrade.service\n"),
+            "{calls}"
+        );
+        assert!(
+            calls.contains("systemctl --user restart test.memex.upgrade.timer\n"),
+            "{calls}"
+        );
+    }
+}
+
+#[test]
+fn nix_store_and_foreign_executables_are_not_rewritten_or_restarted() {
+    for executable in [
+        "/nix/store/package-memex/bin/memex",
+        "/other/package/bin/not-memex",
+    ] {
+        let fixture = Fixture::new();
+        let original = fixture.register(executable);
+        let output = fixture.reconcile("active");
+        if executable.starts_with("/nix/store/") {
+            assert_success(&output);
+            assert!(fixture.calls().is_empty());
+        } else {
+            assert!(!output.status.success());
+        }
+        assert_eq!(
+            std::fs::read_to_string(&fixture.definition).unwrap(),
+            original
+        );
+        assert_no_mutations(&fixture.calls());
+    }
+}
+
+#[test]
+fn nix_manager_marker_preserves_a_mutable_service_definition() {
+    let fixture = Fixture::new();
+    let original = fixture.register(OLD_EXE);
+    let marked = if cfg!(target_os = "macos") {
+        original.replace(
+            "<key>CUSTOM_SETTING</key>",
+            "<key>MEMEX_SERVICE_MANAGER</key><string>nix</string><key>CUSTOM_SETTING</key>",
+        )
+    } else {
+        original.replace(
+            "[Service]\n",
+            "[Service]\nEnvironment=\"MEMEX_SERVICE_MANAGER=nix\"\n",
+        )
+    };
+    std::fs::write(&fixture.definition, &marked).unwrap();
+    let output = fixture.reconcile("active");
+    assert_success(&output);
+    assert_eq!(
+        std::fs::read_to_string(&fixture.definition).unwrap(),
+        marked
+    );
+    assert!(fixture.calls().is_empty());
+}
+
+#[test]
+fn different_loaded_definition_is_not_replaced() {
+    let fixture = Fixture::new();
+    let original = fixture.register(OLD_EXE);
+    let output = fixture.reconcile("foreign");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("state mismatch") || stderr.contains("owned by"),
+        "{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&fixture.definition).unwrap(),
+        original
+    );
+    assert_no_mutations(&fixture.calls());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn different_loaded_timer_is_not_replaced_or_restarted() {
+    let fixture = Fixture::new();
+    let original = fixture.register(OLD_EXE);
+    let timer_path = fixture.definition.with_extension("timer");
+    let timer = std::fs::read(&timer_path).unwrap();
+    let output = fixture.reconcile("foreign-timer");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("owned by /external/manager/memex.timer"),
+        "{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&fixture.definition).unwrap(),
+        original
+    );
+    assert_eq!(std::fs::read(timer_path).unwrap(), timer);
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("show --property=FragmentPath --value test.memex.upgrade.service\n"),
+        "{calls}"
+    );
+    assert!(
+        calls.contains("show --property=FragmentPath --value test.memex.upgrade.timer\n"),
+        "{calls}"
+    );
+    assert_no_mutations(&calls);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn unavailable_systemd_is_an_error_not_a_disabled_daemon() {
+    let fixture = Fixture::new();
+    let original = fixture.register(OLD_EXE);
+    let output = fixture.reconcile("unavailable");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot determine systemd enabled state"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Failed to connect to user bus"), "{stderr}");
+    assert_eq!(
+        std::fs::read_to_string(&fixture.definition).unwrap(),
+        original
+    );
+    assert_eq!(
+        fixture.calls(),
+        "systemctl --user is-enabled test.memex.upgrade.timer\n"
+    );
+}

--- a/tests/update_cli.rs
+++ b/tests/update_cli.rs
@@ -86,6 +86,10 @@ if [ "$1" = "--version" ]; then
   printf 'memex 99.0.0\n'
   exit 0
 fi
+if [ "$1" = "--no-update-check" ]; then
+  [ "$MEMEX_TEST_FAIL" = "daemon" ] && exit 20
+  exit 0
+fi
 if [ "$MEMEX_TEST_FAIL" = "skill" ]; then exit 19; fi
 mkdir -p "$HOME/.agents/skills/memex-search"
 printf 'updated by installed binary\n' > "$HOME/.agents/skills/memex-search/SKILL.md"
@@ -120,6 +124,91 @@ printf 'updated by installed binary\n' > "$HOME/.agents/skills/memex-search/SKIL
             command.env_remove(name);
         }
         command
+    }
+
+    fn standalone() -> Self {
+        let mut fixture = Self::new();
+        let standalone = fixture.bin.join("memex");
+        std::fs::hard_link(env!("CARGO_BIN_EXE_memex"), &standalone).unwrap();
+        fixture.cellar_memex = standalone;
+        // The already-current case runs the real reconciler. Keep both platform
+        // registration locations inside this fixture, regardless of host config.
+        std::fs::write(
+            fixture.home.join(".memex/config.toml"),
+            format!(
+                "auto_index_on_search = false\nindex_service_plist = {:?}\nindex_service_systemd_dir = {:?}\n",
+                fixture.home.join("daemon.plist"),
+                fixture.home.join("systemd"),
+            ),
+        )
+        .unwrap();
+
+        let release = fixture._temp.path().join("release");
+        std::fs::create_dir_all(&release).unwrap();
+        write_script(
+            &release.join("memex"),
+            r#"#!/bin/sh
+printf 'release-binary %s\n' "$*" >> "$MEMEX_TEST_LOG"
+case "$*" in
+  --version)
+    [ "$MEMEX_TEST_FAIL" = version ] && exit 18
+    if [ "$MEMEX_TEST_FAIL" = wrong-version ]; then
+      printf 'memex 98.0.0\n'
+    else
+      printf 'memex 99.0.0\n'
+    fi
+    ;;
+  '--no-update-check daemon reconcile') exit 0 ;;
+  'skill update --target all')
+    mkdir -p "$HOME/.agents/skills/memex-search"
+    printf 'updated by release binary\n' > "$HOME/.agents/skills/memex-search/SKILL.md"
+    ;;
+  *) exit 96 ;;
+esac
+"#,
+        );
+        let archive = fixture.bin.join("release.tar.gz");
+        let archived = Command::new("tar")
+            .arg("-czf")
+            .arg(&archive)
+            .arg("-C")
+            .arg(&release)
+            .arg("memex")
+            .output()
+            .unwrap();
+        assert!(
+            archived.status.success(),
+            "{}",
+            String::from_utf8_lossy(&archived.stderr)
+        );
+        write_script(
+            &fixture.bin.join("curl"),
+            r#"#!/bin/sh
+destination=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; destination=$1 ;;
+    https://*) url=$1 ;;
+  esac
+  shift
+done
+case "$url" in
+  https://api.github.com/repos/nicosuave/memex/releases/latest)
+    printf 'release latest\n' >> "$MEMEX_TEST_LOG"
+    printf '{"tag_name":"v%s"}\n' "${MEMEX_TEST_LATEST:-99.0.0}"
+    ;;
+  https://github.com/nicosuave/memex/releases/download/v99.0.0/memex-99.0.0-*.tar.gz)
+    printf 'release download\n' >> "$MEMEX_TEST_LOG"
+    [ "$MEMEX_TEST_FAIL" = download ] && exit 17
+    [ -n "$destination" ] || exit 95
+    cp "$(dirname "$0")/release.tar.gz" "$destination"
+    ;;
+  *) exit 97 ;;
+esac
+"#,
+        );
+        fixture
     }
 
     fn cache_update(&self) {
@@ -286,7 +375,7 @@ fn bare_human_startup_accepts_cached_update_before_tui() {
     assert!(!output.output.contains("\u{1b}[?1049h"));
     assert_eq!(
         fixture.log(),
-        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n"
+        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled --no-update-check daemon reconcile\ninstalled skill update --target all\n"
     );
     assert_eq!(
         std::fs::read_to_string(fixture.home.join(".agents/skills/memex-search/SKILL.md")).unwrap(),
@@ -382,7 +471,7 @@ fn update_requires_yes_without_a_tty_and_yes_runs_installed_binary_chain() {
     );
     assert_eq!(
         fixture.log(),
-        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n"
+        "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled --no-update-check daemon reconcile\ninstalled skill update --target all\n"
     );
 }
 
@@ -406,8 +495,13 @@ fn homebrew_failures_stop_the_update_at_the_failing_step() {
             "installed memex version check failed",
         ),
         (
+            "daemon",
+            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled --no-update-check daemon reconcile\n",
+            "daemon activation failed",
+        ),
+        (
             "skill",
-            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled skill update --target all\n",
+            "brew update\nbrew upgrade nicosuave/tap/memex\nbrew --prefix nicosuave/tap/memex\ninstalled --version\ninstalled --no-update-check daemon reconcile\ninstalled skill update --target all\n",
             "refreshing its skills failed",
         ),
     ];
@@ -431,6 +525,88 @@ fn homebrew_failures_stop_the_update_at_the_failing_step() {
             );
         }
     }
+}
+
+#[test]
+fn standalone_update_verifies_release_then_activates_and_refreshes_skills() {
+    let fixture = Fixture::standalone();
+    let output = run(fixture
+        .command()
+        .args(["--no-update-check", "update", "--yes"]));
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fixture.log(),
+        "release latest\nrelease download\nrelease-binary --version\nrelease-binary --no-update-check daemon reconcile\nrelease-binary skill update --target all\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(fixture.home.join(".agents/skills/memex-search/SKILL.md")).unwrap(),
+        "updated by release binary\n"
+    );
+    let installed = run(fixture.command().arg("--version"));
+    assert!(installed.status.success());
+    assert_eq!(installed.stdout, b"memex 99.0.0\n");
+}
+
+#[test]
+fn standalone_download_and_verification_failures_preserve_original_binary() {
+    use std::os::unix::fs::MetadataExt;
+
+    for failure in ["download", "version", "wrong-version"] {
+        let fixture = Fixture::standalone();
+        let original = std::fs::metadata(&fixture.cellar_memex).unwrap();
+        let output = run(fixture.command().env("MEMEX_TEST_FAIL", failure).args([
+            "--no-update-check",
+            "update",
+            "--yes",
+        ]));
+        assert!(!output.status.success(), "{failure} unexpectedly succeeded");
+        let expected = if failure == "download" {
+            "release latest\nrelease download\n"
+        } else {
+            "release latest\nrelease download\nrelease-binary --version\n"
+        };
+        assert_eq!(fixture.log(), expected, "failure at {failure}");
+        let unchanged = std::fs::metadata(&fixture.cellar_memex).unwrap();
+        assert_eq!(original.ino(), unchanged.ino(), "failure at {failure}");
+        assert_eq!(original.len(), unchanged.len(), "failure at {failure}");
+        let installed = run(fixture.command().arg("--version"));
+        assert!(installed.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&installed.stdout),
+            format!("memex {}\n", env!("CARGO_PKG_VERSION"))
+        );
+    }
+}
+
+#[test]
+fn standalone_already_current_still_reconciles_and_refreshes_skills() {
+    let fixture = Fixture::standalone();
+    let skill = fixture.home.join(".agents/skills/memex-search/SKILL.md");
+    std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    std::fs::write(&skill, "outdated skill\n").unwrap();
+    let output = run(fixture
+        .command()
+        .env("MEMEX_TEST_LATEST", env!("CARGO_PKG_VERSION"))
+        .args(["--no-update-check", "update", "--yes"]));
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.log(), "release latest\n");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("already up to date"), "{stdout}");
+    assert!(
+        stdout.contains("daemon: no Memex-owned registration; unchanged"),
+        "{stdout}"
+    );
+    let updated = std::fs::read_to_string(&skill).unwrap();
+    assert_ne!(updated, "outdated skill\n");
+    assert!(updated.contains("memex-search"));
 }
 
 #[test]


### PR DESCRIPTION
Upgrades could leave the daemon running an older binary. Running daemons now detect executable replacement and hand off between indexing passes, and `memex update` reconciles through the newly installed binary while preserving service arguments, environment, ownership, and stopped or disabled state.

Use stable Homebrew and Nix profile paths, add declarative Home Manager daemon activation, and preserve NixOS service ownership. Existing daemons need one initial restart after installing this change; subsequent upgrades activate automatically.
