### PR TITLE
Add native Home with activity charts and conversation filters

### DIFF
--- a/apps/macos/Sources/Memex/Client.swift
+++ b/apps/macos/Sources/Memex/Client.swift
@@ -6,7 +6,16 @@ struct ClientError: LocalizedError {
     var errorDescription: String? { message }
 }
 
-/// Run each request off the UI thread, with cancellation and a bounded lifetime.
+struct ActivityScanProgress: Decodable, Sendable, Equatable {
+    let source: String
+    let done: Int
+    let total: Int
+    var isValid: Bool { !source.isEmpty && source.count <= 100 && done >= 0 && total > 0 && done <= total }
+}
+
+typealias ActivityProgressHandler = @Sendable (ActivityScanProgress) -> Void
+
+/// Run each request off the UI thread, with cancellation and a watchdog.
 /// Files drain both streams without pipe-buffer deadlocks on large transcripts.
 final class CommandRun: @unchecked Sendable {
     private let lock = NSLock()
@@ -18,7 +27,7 @@ final class CommandRun: @unchecked Sendable {
         lock.unlock()
     }
 
-    func execute(executable: URL, arguments: [String], timeout: TimeInterval) throws -> Data {
+    func execute(executable: URL, arguments: [String], timeout: TimeInterval, progress: ActivityProgressHandler? = nil) throws -> Data {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -29,6 +38,8 @@ final class CommandRun: @unchecked Sendable {
         let output = try FileHandle(forWritingTo: outputURL)
         let errors = try FileHandle(forWritingTo: errorURL)
         defer { try? output.close(); try? errors.close() }
+        let progressReader = progress == nil ? nil : try FileHandle(forReadingFrom: errorURL)
+        defer { try? progressReader?.close() }
         let child = Process()
         child.executableURL = executable
         child.arguments = arguments
@@ -50,14 +61,36 @@ final class CommandRun: @unchecked Sendable {
                 kill(childID, signal)
             }
         }
-        let deadline = Date().addingTimeInterval(timeout)
+        var deadline = ContinuousClock.now.advanced(by: .seconds(timeout))
+        var progressBuffer = Data()
+        var completedBySource: [String: Int] = [:]
+        func consumeProgress() {
+            guard let progressReader, let bytes = try? progressReader.read(upToCount: 65_536), !bytes.isEmpty else { return }
+            progressBuffer.append(bytes)
+            while let newline = progressBuffer.firstIndex(of: 10) {
+                let line = Data(progressBuffer[..<newline])
+                progressBuffer.removeSubrange(...newline)
+                let prefix = Data("MEMEX_PROGRESS ".utf8)
+                guard line.starts(with: prefix),
+                      let update = try? JSONDecoder().decode(ActivityScanProgress.self, from: line.dropFirst(prefix.count)),
+                      update.isValid else { continue }
+                if let previous = completedBySource[update.source], update.done <= previous { continue }
+                completedBySource[update.source] = update.done
+                // A cold usage backfill can outlive a normal read. Keep the same
+                // watchdog duration, measured since the last advancing counter.
+                if update.done > 0 { deadline = ContinuousClock.now.advanced(by: .seconds(timeout)) }
+                progress?(update)
+            }
+            if progressBuffer.count > 65_536 { progressBuffer.removeAll(keepingCapacity: true) }
+        }
         var stoppingSince: Date?
         var timedOut = false
         while child.isRunning {
+            consumeProgress()
             lock.lock()
             let shouldCancel = cancelled
             lock.unlock()
-            if stoppingSince == nil && (shouldCancel || Date() >= deadline) {
+            if stoppingSince == nil && (shouldCancel || ContinuousClock.now >= deadline) {
                 timedOut = !shouldCancel
                 stoppingSince = Date()
                 stop(SIGTERM)
@@ -69,6 +102,7 @@ final class CommandRun: @unchecked Sendable {
             Thread.sleep(forTimeInterval: 0.025)
         }
         child.waitUntilExit()
+        consumeProgress()
         lock.lock()
         let wasCancelled = cancelled
         lock.unlock()
@@ -79,7 +113,9 @@ final class CommandRun: @unchecked Sendable {
         if timedOut { throw ClientError(message: "Memex took too long to respond. Try again.") }
         guard child.terminationStatus == 0 else {
             let message = (try? String(contentsOf: errorURL, encoding: .utf8)) ?? "Memex could not complete the request."
-            throw ClientError(message: String(message.prefix(4000)))
+            let failure = message.split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.hasPrefix("MEMEX_PROGRESS ") }.joined(separator: "\n")
+            throw ClientError(message: String(failure.prefix(4000)))
         }
         return try Data(contentsOf: outputURL)
     }
@@ -108,7 +144,8 @@ struct MemexClient: Sendable {
         } else { daemon = nil }
     }
 
-    func run(_ arguments: [String], timeout: TimeInterval = 60, daemonRequest: DaemonRequest? = nil) async throws -> Data {
+    func run(_ arguments: [String], timeout: TimeInterval = 60, daemonRequest: DaemonRequest? = nil,
+             progress: ActivityProgressHandler? = nil) async throws -> Data {
         if let daemon, let daemonRequest,
            let response = try await daemon.request(daemonRequest, timeout: timeout) { return response }
         try Task.checkCancellation()
@@ -123,7 +160,7 @@ struct MemexClient: Sendable {
         let arguments = args
         return try await withTaskCancellationHandler {
             try await Task.detached(priority: .userInitiated) {
-                try command.execute(executable: executable, arguments: arguments, timeout: timeout)
+                try command.execute(executable: executable, arguments: arguments, timeout: timeout, progress: progress)
             }.value
         } onCancel: { command.cancel() }
     }
@@ -203,7 +240,7 @@ struct MemexClient: Sendable {
                 since: String? = nil, origin: ConversationOrigin = .all) async throws -> [SearchHit] {
         var args = ["search", "--format", "json", "--machine", machine, "--mode", "lexical",
                     "--unique-session", "--limit", String(limit),
-                    "--fields", "source,session_id,source_path,project,snippet,ts,machine,record_id"]
+                    "--fields", "source,session_id,source_path,project,snippet,ts,machine,record_id,conversation_kind"]
         if let project { args += ["--project", project] }
         if let source { args += ["--source", source] }
         if let since { args += ["--since", since] }

--- a/apps/macos/Sources/Memex/ConversationFilterButton.swift
+++ b/apps/macos/Sources/Memex/ConversationFilterButton.swift
@@ -2,12 +2,24 @@ import SwiftUI
 
 struct ConversationFilterControls: View {
     @Bindable var store: Store
+    var includesProject = false
     let done: () -> Void
+
+    private var filtersAreActive: Bool { store.filters.isActive || (includesProject && store.homeProject != nil) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Filters").font(.headline)
             Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 12) {
+                if includesProject {
+                    GridRow {
+                        Text("Project").foregroundStyle(.secondary)
+                        Picker("Project", selection: $store.homeProject) {
+                            Text("All projects").tag(String?.none)
+                            ForEach(store.projects) { Text($0.project).tag(Optional($0.project)) }
+                        }.labelsHidden()
+                    }
+                }
                 GridRow {
                     Text("Timeframe").foregroundStyle(.secondary)
                     Picker("Timeframe", selection: $store.filters.timeframe) {
@@ -36,8 +48,11 @@ struct ConversationFilterControls: View {
                 .help("Include approval logs when showing chats and subagents")
             Divider()
             HStack {
-                Button("Reset Filters") { store.filters = .defaults }
-                    .disabled(!store.filters.isActive)
+                Button("Reset Filters") {
+                    store.filters = .defaults
+                    if includesProject { store.homeProject = nil }
+                }
+                    .disabled(!filtersAreActive)
                 Spacer()
                 Button("Done", action: done)
                     .keyboardShortcut(.defaultAction)

--- a/apps/macos/Sources/Memex/ConversationFilters.swift
+++ b/apps/macos/Sources/Memex/ConversationFilters.swift
@@ -3,7 +3,7 @@ import Foundation
 struct ConversationFilters: Codable, Equatable, Sendable {
     var timeframe = ConversationTimeframe.all
     var provider = ConversationProvider.all
-    var origin = ConversationOrigin.all
+    var origin = ConversationOrigin.interactive
 
     static let defaults = ConversationFilters()
     var conversationType: ConversationOrigin {
@@ -21,7 +21,7 @@ struct ConversationFilters: Codable, Equatable, Sendable {
     var summary: String {
         [timeframe == .all ? nil : timeframe.title,
          provider == .all ? nil : provider.title,
-         origin == .all ? nil : origin.title].compactMap { $0 }.joined(separator: " · ")
+         origin == Self.defaults.origin ? nil : origin.title].compactMap { $0 }.joined(separator: " · ")
     }
 }
 

--- a/apps/macos/Sources/Memex/ConversationList.swift
+++ b/apps/macos/Sources/Memex/ConversationList.swift
@@ -21,7 +21,7 @@ struct NativeConversationList: NSViewControllerRepresentable {
         let title: String
         let preview: String
         let date: String
-        let machine: String?
+        let metadata: String?
         init(_ session: Session) {
             self.session = session
             id = session.id
@@ -29,7 +29,9 @@ struct NativeConversationList: NSViewControllerRepresentable {
             title = session.title
             preview = session.snippet?.nilIfBlank ?? session.source
             date = session.date?.formatted(.dateTime.month(.abbreviated).day()) ?? ""
-            machine = session.machineID == "local" ? nil : session.machineID
+            metadata = [session.machineID == "local" ? nil : "▣ \(session.machineID)",
+                        session.isSubagent ? "Subagent" : nil]
+                .compactMap { $0 }.joined(separator: " · ").nilIfBlank
         }
     }
 
@@ -109,7 +111,7 @@ struct NativeConversationList: NSViewControllerRepresentable {
     }
 
     func numberOfRows(in tableView: NSTableView) -> Int { rows.count }
-    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat { rows[row].machine == nil ? 68 : 84 }
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat { rows[row].metadata == nil ? 68 : 84 }
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         let identifier = NSUserInterfaceItemIdentifier("conversation-cell")
         let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? ConversationCell ?? ConversationCell()
@@ -135,11 +137,11 @@ struct NativeConversationList: NSViewControllerRepresentable {
     private let date = NSTextField(labelWithString: "")
     private let title = NSTextField(wrappingLabelWithString: "")
     private let preview = NSTextField(wrappingLabelWithString: "")
-    private let machine = NSTextField(labelWithString: "")
+    private let metadata = NSTextField(labelWithString: "")
 
     override init(frame: NSRect) {
         super.init(frame: frame)
-        for field in [project, date, title, preview, machine] {
+        for field in [project, date, title, preview, metadata] {
             field.font = .systemFont(ofSize: 11)
             field.textColor = .secondaryLabelColor
             field.lineBreakMode = .byTruncatingTail
@@ -167,9 +169,9 @@ struct NativeConversationList: NSViewControllerRepresentable {
         date.stringValue = row.date
         title.stringValue = row.title
         preview.stringValue = row.preview
-        machine.stringValue = row.machine.map { "▣ \($0)" } ?? ""
-        machine.isHidden = row.machine == nil
-        setAccessibilityLabel([row.project, row.date, row.title, row.preview, row.machine].compactMap { $0 }.joined(separator: ", "))
+        metadata.stringValue = row.metadata ?? ""
+        metadata.isHidden = row.metadata == nil
+        setAccessibilityLabel([row.project, row.date, row.title, row.preview, row.metadata].compactMap { $0 }.joined(separator: ", "))
         needsLayout = true
     }
     override func layout() {
@@ -180,6 +182,6 @@ struct NativeConversationList: NSViewControllerRepresentable {
         date.frame = NSRect(x: 8 + width - dateWidth, y: 8, width: dateWidth, height: 15)
         title.frame = NSRect(x: 8, y: 25, width: width, height: 17)
         preview.frame = NSRect(x: 8, y: 43, width: width, height: 16)
-        machine.frame = NSRect(x: 8, y: 88, width: width, height: 15)
+        metadata.frame = NSRect(x: 8, y: 61, width: width, height: 15)
     }
 }

--- a/apps/macos/Sources/Memex/DaemonClient.swift
+++ b/apps/macos/Sources/Memex/DaemonClient.swift
@@ -15,10 +15,13 @@ struct DaemonRequest: Encodable, Sendable {
     var sourcePath: String?
     var offset: Int?
     var maxChars: Int?
+    var metric: String?
+    var range: String?
+    var nowMS: UInt64?
 
     enum CodingKeys: String, CodingKey {
-        case op, machine, filters, query, project, source, since, origin, limit, offset
-        case sessionID = "session_id", sourcePath = "source_path", maxChars = "max_chars"
+        case op, machine, filters, query, project, source, since, origin, limit, offset, metric, range
+        case sessionID = "session_id", sourcePath = "source_path", maxChars = "max_chars", nowMS = "now_ms"
     }
 }
 

--- a/apps/macos/Sources/Memex/HomeActivity.swift
+++ b/apps/macos/Sources/Memex/HomeActivity.swift
@@ -1,0 +1,378 @@
+import Charts
+import Foundation
+import SwiftUI
+
+struct HomeActivityPayload: Decodable, Sendable {
+    let metric: String
+    let bucketKeys: [String]
+    let tokenUsageEnabled: Bool
+    let partial: Bool
+    let points: [HomeActivityPoint]
+    var warnings: [String]? = nil
+
+    var total: Double { points.reduce(0) { $0 + $1.value } }
+    enum CodingKeys: String, CodingKey {
+        case metric, partial, points, warnings
+        case bucketKeys = "bucket_keys", tokenUsageEnabled = "token_usage_enabled"
+    }
+}
+
+struct HomeActivityPoint: Decodable, Sendable, Identifiable {
+    let date: String
+    let source: String
+    let value: Double
+    var id: String { "\(date)|\(source)" }
+}
+
+enum HomeActivityMetric: String, CaseIterable {
+    case sessions, tokens
+    var title: String { self == .sessions ? "Conversations" : "Tokens" }
+}
+
+extension ConversationTimeframe {
+    var activityRange: String {
+        switch self {
+        case .all: "all"
+        case .day: "24h"
+        case .week: "7d"
+        case .month: "30d"
+        }
+    }
+}
+
+struct RawHomeActivityPayload: Decodable, Sendable {
+    let tokenUsageEnabled: Bool
+    let partial: Bool
+    let points: [RawHomeActivityPoint]
+    var warnings: [String]? = nil
+    enum CodingKeys: String, CodingKey {
+        case partial, points, warnings
+        case tokenUsageEnabled = "token_usage_enabled"
+    }
+}
+
+struct RawHomeActivityPoint: Decodable, Sendable {
+    let timestampMS: UInt64
+    let source: String
+    let value: Double
+    enum CodingKeys: String, CodingKey {
+        case source, value
+        case timestampMS = "timestamp_ms"
+    }
+}
+
+struct HomeActivitySelection: Sendable {
+    let metric: String
+    let timeframe: ConversationTimeframe
+    let query: String?
+    let project: String?
+    let source: String?
+    let origin: ConversationOrigin
+    let nowMS: UInt64
+}
+
+struct HomeActivityBatch: Sendable {
+    let machine: String
+    let payload: RawHomeActivityPayload?
+    let error: String?
+}
+
+extension MemexClient {
+    func activity(_ selection: HomeActivitySelection, machine: String, progress: ActivityProgressHandler? = nil) async throws -> RawHomeActivityPayload {
+        var args = ["activity", "--format", "json", "--metric", selection.metric, "--range", selection.timeframe.activityRange,
+                    "--machine", machine, "--origin", selection.origin.argument, "--progress", "--raw", "--now-ms", String(selection.nowMS)]
+        if let query = selection.query?.nilIfBlank { args += ["--query=\(query)"] }
+        if let project = selection.project { args += ["--project", project] }
+        if let source = selection.source { args += ["--source", source] }
+        var request = DaemonRequest(op: "activity")
+        request.machine = machine
+        request.metric = selection.metric
+        request.range = selection.timeframe.activityRange
+        request.query = selection.query
+        request.project = selection.project
+        request.source = selection.source
+        request.origin = selection.origin.argument
+        request.nowMS = selection.nowMS
+        return try JSONDecoder().decode(RawHomeActivityPayload.self, from: await run(args, daemonRequest: selection.metric == "tokens" ? nil : request, progress: progress))
+    }
+
+    @MainActor
+    func activityBatches(_ selection: HomeActivitySelection, machines: [String],
+                         progress: @escaping @MainActor @Sendable (String, ActivityScanProgress) -> Void = { _, _ in },
+                         receive: (HomeActivityBatch) -> Void) async throws {
+        try await withThrowingTaskGroup(of: HomeActivityBatch.self) { group in
+            for machine in machines {
+                group.addTask {
+                    do {
+                        let result = try await activity(selection, machine: machine) { update in
+                            Task { @MainActor in progress(machine, update) }
+                        }
+                        return HomeActivityBatch(machine: machine, payload: result, error: nil)
+                    } catch is CancellationError { throw CancellationError() } catch {
+                        return HomeActivityBatch(machine: machine, payload: nil, error: error.localizedDescription)
+                    }
+                }
+            }
+            for try await batch in group {
+                try Task.checkCancellation()
+                receive(batch)
+            }
+        }
+    }
+}
+
+extension HomeActivityPayload {
+    /// Merge raw buckets, then compress once: per-machine all-time charts can have different grids.
+    static func merge(_ batches: [RawHomeActivityPayload], selection: HomeActivitySelection, failed: Bool) -> Self {
+        let unit: UInt64 = selection.timeframe == .day ? 3_600_000 : 86_400_000
+        let end = selection.nowMS / unit * unit
+        let days: UInt64?
+        switch selection.timeframe {
+        case .all: days = nil
+        case .day: days = 1
+        case .week: days = 7
+        case .month: days = 30
+        }
+        let raw = batches.flatMap(\.points)
+        let since = days.map { selection.nowMS > $0 * 86_400_000 ? selection.nowMS - $0 * 86_400_000 : 0 }
+        let start = min(end, since.map { $0 / unit * unit } ?? raw.map(\.timestampMS).min() ?? end)
+        let units = (end - start) / unit + 1
+        let step = ((units + 59) / 60) * unit
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = unit < 86_400_000 ? "yyyy-MM-dd'T'HH:mm'Z'" : "yyyy-MM-dd"
+        func label(_ timestamp: UInt64) -> String {
+            formatter.string(from: Date(timeIntervalSince1970: Double(timestamp) / 1000))
+        }
+        let keys = stride(from: start, through: end, by: Int(step)).map(label)
+        struct Bucket: Hashable { let timestamp: UInt64; let source: String }
+        var totals: [Bucket: Double] = [:]
+        for point in raw where point.timestampMS >= start && point.timestampMS <= end {
+            let timestamp = start + (point.timestampMS - start) / step * step
+            totals[Bucket(timestamp: timestamp, source: point.source), default: 0] += point.value
+        }
+        let points = totals.sorted {
+            $0.key.timestamp == $1.key.timestamp ? $0.key.source < $1.key.source : $0.key.timestamp < $1.key.timestamp
+        }.map { HomeActivityPoint(date: label($0.key.timestamp), source: $0.key.source, value: $0.value) }
+        return HomeActivityPayload(metric: selection.metric, bucketKeys: keys,
+            tokenUsageEnabled: batches.contains { $0.tokenUsageEnabled },
+            partial: failed || batches.contains { $0.partial || (selection.metric == "tokens" && !$0.tokenUsageEnabled) }, points: points,
+            warnings: batches.flatMap { $0.warnings ?? [] })
+    }
+}
+
+struct HomeActivityCache {
+    let criteria: String
+    let request: String
+    let payload: HomeActivityPayload
+    let machines: [String: RawHomeActivityPayload]
+    let failures: [String: String]
+    let complete: Bool
+    let updatedAt: Date
+
+    func isFresh(for request: String, now: Date = Date()) -> Bool {
+        complete && self.request == request && now.timeIntervalSince(updatedAt) < 60
+    }
+}
+
+struct HomeActivityView: View {
+    @Bindable var store: Store
+    @State private var error: String?
+    @State private var errorRequest: String?
+    @State private var retry = 0
+    @State private var remainingMachines = 0
+    @State private var failedMachines: [String: String] = [:]
+    @State private var pendingMachines = Set<String>()
+    @State private var scanProgress: [String: ActivityScanProgress] = [:]
+
+    private var metric: HomeActivityMetric { store.homeActivityMetric }
+    private var requestID: String { "\(store.homeActivityRequestID)|\(metric)|\(retry)" }
+    private var criteriaID: String { "\(store.homeActivityCriteriaID)|\(metric)" }
+    private var currentPayload: HomeActivityPayload? {
+        store.homeActivityCache?.criteria == criteriaID ? store.homeActivityCache?.payload : nil
+    }
+    private var currentError: String? { errorRequest == requestID ? error : nil }
+    private var loadingDetail: String {
+        let details = scanProgress.keys.sorted().compactMap { machine -> String? in
+            guard let update = scanProgress[machine] else { return nil }
+            let provider = ConversationProvider(rawValue: update.source)?.title ?? update.source
+            return "\(machine): preparing \(provider) usage, \(update.done.formatted()) of \(update.total.formatted()) logs"
+        }
+        return details.isEmpty ? "Loading activity" : details.joined(separator: "\n")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Activity").font(.title2.weight(.semibold))
+                if currentError == nil && (currentPayload == nil || remainingMachines > 0) {
+                    ProgressView().controlSize(.small)
+                        .accessibilityLabel("Loading activity")
+                        .accessibilityValue(loadingDetail)
+                        .help(loadingDetail)
+                }
+                Spacer()
+                Picker("Activity metric", selection: $store.homeActivityMetric) {
+                    ForEach(HomeActivityMetric.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .labelsHidden()
+                .frame(width: 150)
+                Picker("Activity timeframe", selection: $store.filters.timeframe) {
+                    ForEach(ConversationTimeframe.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .labelsHidden()
+                .frame(width: 160)
+            }
+            VStack(alignment: .leading, spacing: 16) {
+                if let payload = currentPayload {
+                    activityChart(payload)
+                } else if let error = currentError {
+                    VStack(spacing: 10) {
+                        Text("Activity unavailable").font(.headline)
+                        Text(error).font(.callout).foregroundStyle(.secondary).multilineTextAlignment(.center)
+                        Button("Try Again") { retry += 1 }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 200)
+                } else {
+                    Color.clear.frame(height: 200)
+                }
+                // Keep the footer's space while a new search is loading.
+                HStack(alignment: .firstTextBaseline) {
+                    Text(currentPayload.map { "\($0.total.formatted(.number.notation(.compactName))) \(metric.title.lowercased())" } ?? " ")
+                        .font(.headline)
+                    if remainingMachines == 0 && currentPayload?.partial == true {
+                        Text("Partial results").foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Text("UTC").font(.caption).foregroundStyle(.secondary)
+                }
+                if let payload = currentPayload {
+                    if metric == .tokens && !payload.tokenUsageEnabled {
+                        Text("Token usage is disabled on the available machines.")
+                            .font(.callout).foregroundStyle(.secondary)
+                    }
+                    if !failedMachines.isEmpty {
+                        Text("Unavailable: \(failedMachines.keys.sorted().joined(separator: ", "))")
+                            .font(.callout).foregroundStyle(.secondary)
+                            .help(failedMachines.keys.sorted().compactMap { id in failedMachines[id].map { "\(id): \($0)" } }.joined(separator: "\n"))
+                    }
+                    if let warning = payload.warnings?.first {
+                        Text(warning)
+                            .font(.callout).foregroundStyle(.secondary)
+                            .help((payload.warnings ?? []).joined(separator: "\n"))
+                    } else if payload.partial && failedMachines.isEmpty && payload.tokenUsageEnabled {
+                        Text("Some usage sources could not contribute activity.")
+                            .font(.callout).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(20)
+            .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 14))
+        }
+        .task(id: requestID) { await load() }
+    }
+
+    @ViewBuilder
+    private func activityChart(_ payload: HomeActivityPayload) -> some View {
+        if payload.points.isEmpty {
+            Text(metric == .tokens ? "No token activity in this timeframe" : "No conversations in this timeframe")
+                .foregroundStyle(.secondary).frame(maxWidth: .infinity).frame(height: 200)
+        } else {
+            Chart(payload.points) { point in
+                BarMark(x: .value("Date", point.date), y: .value(metric.title, point.value))
+                    .foregroundStyle(by: .value("Provider", ConversationProvider(rawValue: point.source)?.title ?? point.source))
+                    .accessibilityLabel("\(point.source), \(point.date)")
+                    .accessibilityValue("\(point.value.formatted()) \(metric.title.lowercased())")
+            }
+            .chartXScale(domain: payload.bucketKeys)
+            .chartXAxis {
+                AxisMarks(values: axisKeys(payload.bucketKeys)) { value in
+                    AxisValueLabel(anchor: value.index == 0 ? .topLeading : value.index == value.count - 1 ? .topTrailing : .top) {
+                        if let key = value.as(String.self) {
+                            Text(axisLabel(key)).fixedSize()
+                        }
+                    }
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) {
+                    AxisGridLine()
+                    AxisValueLabel(format: FloatingPointFormatStyle<Double>.number.notation(.compactName))
+                }
+            }
+            .chartLegend(position: .bottom, alignment: .leading)
+            .frame(height: 200)
+        }
+    }
+
+    private func axisKeys(_ keys: [String]) -> [String] {
+        guard keys.count > 5 else { return keys }
+        return (0..<5).map { keys[$0 * (keys.count - 1) / 4] }
+    }
+
+    private func axisLabel(_ key: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = key.contains("T") ? "yyyy-MM-dd'T'HH:mm'Z'" : "yyyy-MM-dd"
+        guard let date = formatter.date(from: key) else { return key }
+        formatter.locale = .current
+        formatter.dateFormat = key.contains("T") ? "HH:mm" : "MMM d"
+        return formatter.string(from: date)
+    }
+
+    private func load() async {
+        let request = requestID
+        let criteria = criteriaID
+        if let cache = store.homeActivityCache, cache.isFresh(for: request) {
+            failedMachines = cache.failures
+            return
+        }
+        let generation = UUID()
+        store.homeActivityGeneration = generation
+        store.loadingHomeActivity = true
+        defer { if store.homeActivityGeneration == generation { store.loadingHomeActivity = false } }
+        // Refresh the same selection in place, retaining each peer until its replacement arrives.
+        if store.homeActivityCache?.criteria != criteria { store.homeActivityCache = nil }
+        error = nil
+        errorRequest = nil
+        failedMachines = [:]
+        let machines = store.selectedMachineIDs
+        remainingMachines = machines.count
+        pendingMachines = Set(machines)
+        scanProgress = [:]
+        let selection = HomeActivitySelection(metric: metric.rawValue, timeframe: store.filters.timeframe,
+            query: store.query, project: store.selectedProject, source: store.filters.provider.argument,
+            origin: store.filters.origin, nowMS: UInt64(max(0, Date().timeIntervalSince1970 * 1000)))
+        var batches = store.homeActivityCache?.machines ?? [:]
+        do {
+            try await Task.sleep(for: .milliseconds(180))
+            try await store.client.activityBatches(selection, machines: machines, progress: { machine, update in
+                guard store.homeActivityGeneration == generation, requestID == request, pendingMachines.contains(machine) else { return }
+                scanProgress[machine] = update
+            }) { batch in
+                guard store.homeActivityGeneration == generation, requestID == request else { return }
+                pendingMachines.remove(batch.machine)
+                scanProgress.removeValue(forKey: batch.machine)
+                remainingMachines -= 1
+                if let result = batch.payload { batches[batch.machine] = result }
+                if let failure = batch.error { failedMachines[batch.machine] = failure }
+                if !batches.isEmpty {
+                    store.homeActivityCache = HomeActivityCache(criteria: criteria, request: request,
+                        payload: .merge(machines.compactMap { batches[$0] }, selection: selection, failed: !failedMachines.isEmpty),
+                        machines: batches, failures: failedMachines,
+                        complete: remainingMachines == 0, updatedAt: Date())
+                } else if remainingMachines == 0 {
+                    error = failedMachines.keys.sorted().compactMap { id in failedMachines[id].map { "\(id): \($0)" } }.joined(separator: "\n")
+                    errorRequest = request
+                }
+            }
+        } catch is CancellationError {} catch {
+            guard !Task.isCancelled, store.homeActivityGeneration == generation, requestID == request else { return }
+            self.error = error.localizedDescription
+            errorRequest = request
+        }
+    }
+}

--- a/apps/macos/Sources/Memex/HomeView.swift
+++ b/apps/macos/Sources/Memex/HomeView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+struct HomeView: View {
+    @Bindable var store: Store
+    @FocusState private var searchFocused: Bool
+    @State private var showingFilters = false
+
+    private var filtersHighlighted: Bool { showingFilters || store.filters.isActive || store.homeProject != nil }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                HomeActivityView(store: store)
+                HStack(spacing: 10) {
+                    Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                    TextField("Search conversations", text: $store.query)
+                        .textFieldStyle(.plain).font(.title3)
+                        .focused($searchFocused)
+                        .onSubmit {
+                            if let first = store.sessions.first { store.openConversation(first) }
+                        }
+                    if !store.query.isEmpty {
+                        Button { store.query = "" } label: { Image(systemName: "xmark.circle.fill") }
+                            .buttonStyle(.plain).foregroundStyle(.secondary)
+                            .accessibilityLabel("Clear search")
+                    }
+                }
+                .padding(14)
+                .background(.background, in: RoundedRectangle(cornerRadius: 10))
+                .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(.quaternary))
+
+                HStack {
+                    Text(store.query.isEmpty ? "Recent conversations" : "Matching conversations").font(.title2.weight(.semibold))
+                    if store.loadingSessions { ProgressView().controlSize(.small) }
+                    Spacer()
+                    Button { showingFilters.toggle() } label: {
+                        Image(systemName: "line.3.horizontal.decrease")
+                            .frame(width: 20, height: 20)
+                    }
+                    .modifier(HomeFilterButtonStyle())
+                    .foregroundStyle(filtersHighlighted ? Color.accentColor : Color.primary)
+                    .accessibilityLabel("Filter conversations")
+                    .help("Filter conversations")
+                    .popover(isPresented: $showingFilters, arrowEdge: .bottom) {
+                        ConversationFilterControls(store: store, includesProject: true) { showingFilters = false }
+                    }
+                }
+                if let error = store.listError {
+                    ErrorBanner(message: error) { Task { await store.loadSessions() } }
+                }
+                if store.sessions.isEmpty && !store.loadingSessions {
+                    ContentUnavailableView("No conversations", systemImage: "bubble.left.and.bubble.right",
+                        description: Text("Try another search or change your filters."))
+                }
+                LazyVStack(spacing: 0) {
+                    ForEach(store.sessions) { session in
+                        Button { store.openConversation(session) } label: {
+                            VStack(alignment: .leading, spacing: 7) {
+                                HStack(alignment: .firstTextBaseline) {
+                                    Text(session.title).font(.headline).lineLimit(1)
+                                    Spacer()
+                                    if let date = session.date {
+                                        Text(date, style: .relative).font(.caption).foregroundStyle(.secondary)
+                                    }
+                                }
+                                HStack(spacing: 6) {
+                                    Text([session.projectName, session.source, session.machineID].joined(separator: " · "))
+                                    if session.isSubagent {
+                                        Text("·")
+                                        Text("Subagent")
+                                    }
+                                }
+                                .font(.caption).foregroundStyle(.secondary)
+                                if let snippet = session.snippet?.nilIfBlank {
+                                    Text(snippet).font(.callout).foregroundStyle(.secondary).lineLimit(2)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 14).padding(.horizontal, 12)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        Divider()
+                    }
+                    if store.hasMoreSessions {
+                        Button("Load more conversations") {
+                            if let last = store.sessions.last { store.loadMoreSessionsIfNeeded(visibleID: last.id) }
+                        }.padding().disabled(store.loadingSessions)
+                    }
+                }
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(32)
+            .frame(maxWidth: .infinity)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear { searchFocused = true }
+        .task {
+            while !Task.isCancelled {
+                await refreshIfVisible()
+                do { try await Task.sleep(for: .seconds(30)) }
+                catch { return }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { await refreshIfVisible() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeMainNotification)) { _ in
+            Task { await refreshIfVisible() }
+        }
+    }
+
+    private func refreshIfVisible() async {
+        let window = NSApplication.shared.mainWindow
+        await store.refreshHomeIfStale(isVisible: NSApplication.shared.isActive
+            && window?.isVisible == true && window?.isMiniaturized == false)
+    }
+}
+
+private struct HomeFilterButtonStyle: ViewModifier {
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        styledButton(content)
+            .overlay {
+                Circle()
+                    .fill(.primary.opacity(hovering ? 0.08 : 0))
+                    .allowsHitTesting(false)
+            }
+            .contentShape(Circle())
+            .onHover { hovering = $0 }
+    }
+
+    @ViewBuilder
+    private func styledButton(_ content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+                .controlSize(.large)
+        } else {
+            content
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+        }
+    }
+}

--- a/apps/macos/Sources/Memex/MemexApp.swift
+++ b/apps/macos/Sources/Memex/MemexApp.swift
@@ -68,7 +68,10 @@ private struct BrowserReader: View {
     @Bindable var store: Store
 
     var body: some View {
-        ReaderView(store: store)
+        Group {
+            if store.scope == .home { HomeView(store: store) }
+            else { ReaderView(store: store) }
+        }
         .task(id: store.requestID) { await store.loadSessions() }
         .task(id: store.sessionCountRequestID) { await store.loadSessionCount() }
         .task(id: store.readerRequestID) { await store.loadRecords() }
@@ -117,6 +120,8 @@ private struct BrowserSidebar: View {
     private var sidebarList: some View {
         List(selection: $store.scope) {
             Section {
+                Label("Home", systemImage: "house")
+                    .tag(Store.Scope.home)
                 Label("All conversations", systemImage: "bubble.left.and.bubble.right")
                     .tag(Store.Scope.all)
             }

--- a/apps/macos/Sources/Memex/Models.swift
+++ b/apps/macos/Sources/Memex/Models.swift
@@ -14,6 +14,12 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
     var machine: String?
     var searchRecordID: String?
     var messageCount: Int?
+    var conversationKind: String?
+
+    // Match the backend's subagent filter, including provider-specific kinds.
+    var isSubagent: Bool {
+        conversationKind != nil && conversationKind != "main" && conversationKind != "guardian_review"
+    }
 
     // A session ID alone is not unique across machines, providers or transcript files.
     var machineID: String { machine ?? "local" }
@@ -47,6 +53,7 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
         if value.label == nil { value.label = label }
         if value.lastAt == nil { value.lastAt = lastAt }
         if value.messageCount == nil { value.messageCount = messageCount }
+        if value.conversationKind == nil { value.conversationKind = conversationKind }
         return value
     }
 
@@ -57,6 +64,7 @@ struct Session: Decodable, Identifiable, Hashable, Sendable {
         case repoProject = "repo_project"
         case searchRecordID = "search_record_id"
         case messageCount = "message_count"
+        case conversationKind = "conversation_kind"
     }
 }
 
@@ -69,17 +77,20 @@ struct SearchHit: Decodable, Sendable {
     let ts: String?
     var machine: String?
     var recordID: String?
+    var conversationKind: String?
 
     enum CodingKeys: String, CodingKey {
         case source, project, snippet, ts, machine
         case sessionID = "session_id", sourcePath = "source_path"
         case recordID = "record_id"
+        case conversationKind = "conversation_kind"
     }
 
     func session(known: [String: Session]) -> Session {
         var value = Session(source: source, sessionID: sessionID, sourcePath: sourcePath,
                             project: project, label: nil, lastAt: nil, machine: machine)
         if let existing = known[value.id] { value = existing }
+        if value.conversationKind == nil { value.conversationKind = conversationKind }
         value.snippet = snippet
         value.searchRecordID = recordID
         if value.lastAt == nil, let ts {
@@ -156,6 +167,9 @@ struct Message: Decodable, Equatable, Sendable {
     }
 
     var isActivity: Bool { ["tool_use", "tool_result", "tool", "reasoning"].contains(role) }
+    var isRoutineTurnBoundary: Bool {
+        role == "lifecycle" && (lifecycleEvent == "task_started" || lifecycleEvent == "task_complete")
+    }
     var isEnvironmentContext: Bool {
         guard role == "user" else { return false }
         let value = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/macos/Sources/Memex/NativeBrowserToolbar.swift
+++ b/apps/macos/Sources/Memex/NativeBrowserToolbar.swift
@@ -36,11 +36,13 @@ import SwiftUI
         conversations.minimumThickness = 260
         conversations.maximumThickness = 450
         conversations.holdingPriority = .defaultHigh
+        conversations.canCollapse = true
         let reader = NSSplitViewItem(viewController: readerHost)
         reader.minimumThickness = 400
         addSplitViewItem(sidebar)
         addSplitViewItem(conversations)
         addSplitViewItem(reader)
+        conversations.isCollapsed = store.scope == .home
     }
     override func viewDidAppear() {
         super.viewDidAppear()
@@ -63,7 +65,9 @@ import SwiftUI
 }
 
 @MainActor final class BrowserToolbarController: NSObject, NSToolbarDelegate, NSSearchFieldDelegate, NSPopoverDelegate {
-    let toolbar = NSToolbar(identifier: "MemexBrowserColumns")
+    // AppKit synchronizes item changes between toolbars with the same identifier.
+    // Each window must switch between Home and the reader independently.
+    let toolbar = NSToolbar(identifier: "MemexBrowserColumns-\(UUID().uuidString)")
     let store: Store
     let splitView: NSSplitView
     private var actionItems: [NSToolbarItem.Identifier: NSToolbarItem] = [:]
@@ -98,6 +102,7 @@ import SwiftUI
             _ = store.loadingSessions
             _ = store.query
             _ = store.filters
+            _ = store.scope
         } onChange: { [weak self] in
             // Observation fires before the mutation; read the completed state
             // on the next main-loop turn, then subscribe to subsequent changes.
@@ -109,7 +114,10 @@ import SwiftUI
     }
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        [.toggleSidebar, Self.sidebarBoundary, Self.title, .flexibleSpace, Self.filters,
+        if store.scope == .home {
+            return [.toggleSidebar, Self.sidebarBoundary, .flexibleSpace]
+        }
+        return [.toggleSidebar, Self.sidebarBoundary, Self.title, .flexibleSpace, Self.filters,
          Self.readerBoundary, Self.refresh, Self.find, Self.copyID, Self.reveal,
          .flexibleSpace, Self.resume, .flexibleSpace, Self.search]
     }
@@ -174,6 +182,20 @@ import SwiftUI
         return item
     }
     func update() {
+        if let columns = splitView.delegate as? NSSplitViewController, columns.splitViewItems.count == 3 {
+            let collapsed = store.scope == .home
+            if columns.splitViewItems[1].isCollapsed != collapsed {
+                columns.splitViewItems[1].isCollapsed = collapsed
+            }
+        }
+        let identifiers = toolbarDefaultItemIdentifiers(toolbar)
+        if toolbar.items.map(\.itemIdentifier) != identifiers {
+            filterPopover?.performClose(nil)
+            while !toolbar.items.isEmpty { toolbar.removeItem(at: toolbar.items.count - 1) }
+            for (index, identifier) in identifiers.enumerated() {
+                toolbar.insertItem(withItemIdentifier: identifier, at: index)
+            }
+        }
         if #available(macOS 26.0, *) {
             actionItems[Self.filters]?.style = filterPopover?.isShown == true || store.filters.isActive ? .prominent : .plain
         }
@@ -229,10 +251,12 @@ private struct ConversationToolbarTitle: View {
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(store.scope.title).font(.headline).lineLimit(1)
-            Text(store.sessionCountLabel)
-                .font(.subheadline).foregroundStyle(.secondary).monospacedDigit().lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .help(store.sessionCountHelp)
+            if store.scope != .home {
+                Text(store.sessionCountLabel)
+                    .font(.subheadline).foregroundStyle(.secondary).monospacedDigit().lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .help(store.sessionCountHelp)
+            }
         }
         .frame(minWidth: 70, idealWidth: 190, maxWidth: 240, alignment: .leading)
     }

--- a/apps/macos/Sources/Memex/Store.swift
+++ b/apps/macos/Sources/Memex/Store.swift
@@ -14,6 +14,8 @@ final class Store {
     private var projectGeneration = UUID()
     private var projectLoadScope = ""
     private var sessionMachineScope = ""
+    private var sessionBatchesCriteria: String?
+    private var sessionBatches: [String: [Session]] = [:]
     private var sortTask: Task<Void, Never>?
     private var projectSortWasSelected = false
     let projectCatalog: ProjectCatalog
@@ -25,7 +27,13 @@ final class Store {
     var selectedID: String?
     var records: [TranscriptRecord] = []
     var query = ""
-    var scope: Scope = .all
+    var homeProject: String?
+    var scope: Scope = .home {
+        didSet {
+            if scope == .home { selectedID = nil }
+            else if oldValue == .home && selectedID == nil { selectedID = sessions.first?.id }
+        }
+    }
     var filters = ConversationFilters.defaults {
         didSet {
             guard filters != oldValue else { return }
@@ -43,6 +51,13 @@ final class Store {
     private var filterReferenceDate = Date()
     private var activeSessionCriteria = ""
     var loadingSessions = false
+    var loadingHomeActivity = false
+    var homeActivityMetric = HomeActivityMetric.sessions
+    var homeActivityCache: HomeActivityCache?
+    var homeActivityGeneration = UUID()
+    private var refreshingHome = false
+    private var lastHomeRefresh = Date()
+    private var lastSessionsLoadedAt = Date()
     var loadingRecords = false
     var listError: String?
     var readerError: String?
@@ -69,6 +84,7 @@ final class Store {
     private var countResultKey: String?
     private var countValue: Int?
     private var countRefresh = 0
+    private var activityRefresh = 0
     private var listGeneration = UUID()
     private var readerGeneration = UUID()
     let client: MemexClient
@@ -82,9 +98,9 @@ final class Store {
     }
 
     enum Scope: Hashable {
-        case all, project(String)
+        case home, all, project(String)
         var title: String {
-            switch self { case .all: "All conversations"; case .project(let value): value }
+            switch self { case .home: "Home"; case .all: "All conversations"; case .project(let value): value }
         }
         var project: String? { if case .project(let value) = self { value } else { nil } }
     }
@@ -97,9 +113,12 @@ final class Store {
         }
     }
     var machineRequestID: String { "\(machineSelection)|\(selectedMachineIDs.joined(separator: "|"))" }
-    private var sessionCriteriaID: String { "\(machineRequestID)|\(scope)|\(filters)|\(query)" }
+    var selectedProject: String? { scope == .home ? homeProject : scope.project }
+    private var sessionCriteriaID: String { "\(machineRequestID)|\(selectedProject ?? "")|\(filters)|\(query)" }
     var requestID: String { "\(sessionCriteriaID)|\(sessionLimit)" }
     var sessionCountRequestID: String { "\(sessionCriteriaID)|\(countRefresh)" }
+    var homeActivityCriteriaID: String { sessionCriteriaID }
+    var homeActivityRequestID: String { "\(sessionCriteriaID)|\(activityRefresh)" }
     var sessionTotal: Int? {
         guard countResultKey == sessionCountRequestID, let countValue,
               countValue >= sessions.count else { return nil }
@@ -122,6 +141,11 @@ final class Store {
         [selectedID ?? "", query.nilIfBlank ?? "", readerAnchorID ?? ""].map { "\($0.utf8.count):\($0)" }.joined()
     }
     var readerRequestID: String { readerPositionKey }
+
+    func openConversation(_ session: Session) {
+        if scope == .home { scope = homeProject.map(Scope.project) ?? .all }
+        selectedID = session.id
+    }
 
     func loadMachines() async {
         guard !loadingMachines else { return }
@@ -188,15 +212,27 @@ final class Store {
         projectsError = snapshot.cacheWarning
     }
 
-    func refresh() async {
+    func refresh(refreshActivity: Bool = true) async {
         filterReferenceDate = Date()
         countRefresh += 1
+        if refreshActivity { activityRefresh += 1 }
         async let sessions: Void = loadSessions()
         async let projects: Void = loadProjects()
         async let machines: Void = loadMachines()
         async let count: Void = loadSessionCount()
         _ = await (sessions, projects, machines, count)
         await loadSelectedSessionMetadata()
+    }
+
+    func refreshHomeIfStale(isVisible: Bool, now: Date = Date()) async {
+        guard isVisible, scope == .home, !refreshingHome,
+              !loadingSessions, !loadingProjects, !loadingMachines,
+              now.timeIntervalSince(lastHomeRefresh) >= 60,
+              now.timeIntervalSince(lastSessionsLoadedAt) >= 60 else { return }
+        refreshingHome = true
+        lastHomeRefresh = now
+        defer { refreshingHome = false }
+        await refresh(refreshActivity: !loadingHomeActivity)
     }
 
     func loadMoreSessionsIfNeeded(visibleID: String) {
@@ -230,7 +266,7 @@ final class Store {
         }
         let ids = selectedMachineIDs
         let query = query.nilIfBlank
-        let project = scope.project
+        let project = selectedProject
         let source = filters.provider.argument
         let since = filters.timeframe.since(relativeTo: filterReferenceDate)
         let origin = filters.origin
@@ -262,6 +298,11 @@ final class Store {
     func loadSessions() async {
         prepareSessionCriteria()
         let criteria = sessionCriteriaID
+        if sessionBatchesCriteria != criteria {
+            sessionBatchesCriteria = criteria
+            sessionBatches = [:]
+        }
+        let previousBatches = sessionBatches
         let generation = UUID()
         listGeneration = generation
         loadingSessions = true
@@ -270,10 +311,15 @@ final class Store {
             sessionMachineScope = machineRequestID
             sessions = []; catalog = []; selectedID = nil
         }
-        defer { if listGeneration == generation { loadingSessions = false } }
+        defer {
+            if listGeneration == generation {
+                loadingSessions = false
+                if !Task.isCancelled { lastSessionsLoadedAt = Date() }
+            }
+        }
         let ids = selectedMachineIDs
         let query = query.nilIfBlank
-        let project = scope.project
+        let project = selectedProject
         let source = filters.provider.argument
         let origin = filters.origin
         let since = filters.timeframe.since(relativeTo: filterReferenceDate)
@@ -290,21 +336,31 @@ final class Store {
                         project: project, source: source, since: since, origin: origin, limit: limit, known: known)
                 }
             }
-            var batches: [String: [Session]] = [:]
+            // Keep each peer's previous page until its replacement arrives.
+            // Otherwise a fast peer temporarily removes the rows being scrolled
+            // on a slower peer, losing the native list's visible-row anchor.
+            var batches = previousBatches
             var errors: [String: String] = [:]
             for await batch in group {
                 guard listGeneration == generation, sessionCriteriaID == criteria, !Task.isCancelled else { group.cancelAll(); return }
                 if let error = batch.error { errors[batch.machine] = "\(batch.machine): \(error)" }
                 else { batches[batch.machine] = batch.rows }
+                sessionBatches = batches
                 let rows = await mergeMachineSessions(batches: ids.compactMap { batches[$0] }, limit: limit, ranked: query != nil)
                 guard listGeneration == generation, sessionCriteriaID == criteria, !Task.isCancelled else { group.cancelAll(); return }
                 if query != nil {
                     let metadata = Dictionary(catalog.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
                     sessions = rows.map { row in metadata[row.id].map { row.applyingMetadata($0) } ?? row }
                 } else { sessions = rows }
-                if scope == .all && query == nil && !filters.isActive { catalog = rows }
+                if query == nil {
+                    // Search results need metadata from every previously browsed
+                    // filter, including subagents explicitly shown by the user.
+                    let refreshedIDs = Set(rows.map(\.id))
+                    catalog.removeAll { refreshedIDs.contains($0.id) }
+                    catalog.append(contentsOf: rows)
+                }
                 hasMoreSessions = rows.count >= limit
-                if !rows.contains(where: { $0.id == selectedID }) { selectedID = rows.first?.id }
+                if scope != .home && !rows.contains(where: { $0.id == selectedID }) { selectedID = rows.first?.id }
                 listError = errors.keys.sorted().compactMap { errors[$0] }.joined(separator: "\n").nilIfBlank
             }
         }

--- a/apps/macos/Sources/Memex/TranscriptController.swift
+++ b/apps/macos/Sources/Memex/TranscriptController.swift
@@ -284,6 +284,10 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
         updatingRows = true
         defer { updatingRows = wasUpdating }
         var opened = Set<String>()
+        if records.first(where: { $0.id == hit.recordID })?.record.isRoutineTurnBoundary == true {
+            let id = "message:\(hit.recordID)"
+            if expanded.insert(id).inserted { opened.insert(id) }
+        }
         if let item = TranscriptItem.group(records).first(where: { $0.records.contains { $0.id == hit.recordID } }) {
             var disclosureIDs: [String] = []
             if item.isActivity || item.isInstructions {
@@ -447,11 +451,11 @@ final class TranscriptController: NSViewController, NSTableViewDataSource, NSTab
                         ? .message($0.records[0]) : .activity($0, nested: true)
                 } : [group]
         }
-        // Searching injected text reveals the original mixed record once, so a
-        // source occurrence cannot be confused with a projected request segment.
+        // Explicit Find reveals hidden bookkeeping or the original mixed record,
+        // so every source occurrence has an exact, navigable display row.
         if !rawTranscript, let hit = findHit, !findQuery.isEmpty,
            let original = records.first(where: { $0.id == hit.recordID }),
-           TranscriptPresentation.project([original]) != [original] {
+           (original.record.isRoutineTurnBoundary || TranscriptPresentation.project([original]) != [original]) {
             let insertion = rows.firstIndex { $0.records.contains { $0.sourceID == hit.recordID } } ?? rows.count
             rows = rows.compactMap { row in
                 let remaining = row.records.filter { $0.sourceID != hit.recordID }

--- a/apps/macos/Sources/Memex/TranscriptPresentation.swift
+++ b/apps/macos/Sources/Memex/TranscriptPresentation.swift
@@ -217,6 +217,13 @@ enum TranscriptPresentation {
             work = []
         }
         for entry in records {
+            // Keep completion evidence and turn boundaries for grouping without
+            // presenting routine Codex bookkeeping as conversation messages.
+            if entry.record.isRoutineTurnBoundary {
+                flushWork()
+                flushOrdinary()
+                continue
+            }
             if isWork(entry) {
                 flushOrdinary()
                 if work.first?.record.sourceTurnID != entry.record.sourceTurnID { flushWork() }

--- a/apps/macos/Tests/MemexTests/BrowserToolbarTests.swift
+++ b/apps/macos/Tests/MemexTests/BrowserToolbarTests.swift
@@ -8,6 +8,7 @@ struct BrowserToolbarTests {
     @Test func nativeRootKeepsToolbarAndFullHeightSidebarAcrossHostedUpdates() async throws {
         _ = NSApplication.shared
         let store = Store()
+        store.scope = .all
         let controller = BrowserColumnsController(store: store, sidebar: Text("Sidebar"),
             conversations: Text("Conversations"), reader: Text("Reader"))
         let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 1380, height: 700),
@@ -216,7 +217,9 @@ struct BrowserToolbarTests {
         for _ in 0..<3 { split.addArrangedSubview(NSView()) }
         window.contentView = split
         split.adjustSubviews()
-        let controller = BrowserToolbarController(store: Store(), splitView: split)
+        let store = Store()
+        store.scope = .all
+        let controller = BrowserToolbarController(store: store, splitView: split)
         window.toolbar = controller.toolbar
         window.toolbarStyle = .unified
         window.titleVisibility = .hidden

--- a/apps/macos/Tests/MemexTests/ClientTests.swift
+++ b/apps/macos/Tests/MemexTests/ClientTests.swift
@@ -28,6 +28,71 @@ import Testing
     }
 }
 
+private final class ScanProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var received: [ActivityScanProgress] = []
+    func append(_ value: ActivityScanProgress) { lock.lock(); defer { lock.unlock() }; received.append(value) }
+    var values: [ActivityScanProgress] { lock.lock(); defer { lock.unlock() }; return received }
+}
+
+@Test func advancingScanProgressKeepsColdBackfillAliveBeyondNormalReadTimeout() throws {
+    let recorder = ScanProgressRecorder()
+    let script = #"""
+    for done in 0 1 2 3 4 5; do
+      printf 'MEMEX_PROGRESS {"source":"codex","done":%s,"total":5}\n' "$done" >&2
+      sleep 0.15
+    done
+    printf 'complete'
+    """#
+    let start = ContinuousClock.now
+    let result = try CommandRun().execute(executable: URL(fileURLWithPath: "/bin/sh"),
+        arguments: ["-c", script], timeout: 0.5, progress: recorder.append)
+    #expect(start.duration(to: .now) > .milliseconds(500))
+    #expect(String(decoding: result, as: UTF8.self) == "complete")
+    #expect(recorder.values.map(\.done) == [0, 1, 2, 3, 4, 5])
+}
+
+@Test(arguments: ["1 1", "2 1", "0 0", "-1 9"])
+func stalledRegressingAndInvalidScanCountersStillTimeOut(counters: String) {
+    let script = #"""
+    while :; do
+      for done in $1; do
+        printf 'MEMEX_PROGRESS {"source":"codex","done":%s,"total":5}\n' "$done" >&2
+        sleep 0.05
+      done
+    done
+    """#
+    let start = ContinuousClock.now
+    #expect(throws: ClientError.self) {
+        try CommandRun().execute(executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script, "fixture", counters], timeout: 0.25, progress: { _ in })
+    }
+    #expect(start.duration(to: .now) < .seconds(2))
+}
+
+@Test func coldScanRemainsCancellableWhileProgressAdvances() async throws {
+    let command = CommandRun()
+    let recorder = ScanProgressRecorder()
+    let script = #"""
+    done=1
+    while [ "$done" -lt 1000 ]; do
+      printf 'MEMEX_PROGRESS {"source":"codex","done":%s,"total":1000}\n' "$done" >&2
+      done=$((done+1))
+      sleep 0.05
+    done
+    """#
+    let task = Task.detached {
+        try command.execute(executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script], timeout: 0.5, progress: recorder.append)
+    }
+    let deadline = Date().addingTimeInterval(3)
+    while recorder.values.isEmpty && Date() < deadline { try await Task.sleep(for: .milliseconds(10)) }
+    #expect(!recorder.values.isEmpty)
+    command.cancel()
+    do { _ = try await task.value; Issue.record("Expected cancellation") }
+    catch is CancellationError {} catch { Issue.record("Unexpected error: \(error)") }
+}
+
 @Test func cancelledRunningRequestIsReaped() async throws {
     let command = CommandRun()
     let task = Task.detached {

--- a/apps/macos/Tests/MemexTests/ConversationListTests.swift
+++ b/apps/macos/Tests/MemexTests/ConversationListTests.swift
@@ -3,6 +3,33 @@ import Testing
 @testable import Memex
 
 @MainActor @Suite(.serialized) struct ConversationListTests {
+    @Test func nativeCellsShowSubagentsAndKeepMetadataInsideTheRow() throws {
+        let controller = ConversationListController()
+        let cell = ConversationCell()
+        for (machine, kind, expected) in [
+            ("local", "subagent", "Subagent"),
+            ("nicbook-atm", "subagent", "▣ nicbook-atm · Subagent"),
+            ("nicbook-atm", "main", "▣ nicbook-atm"),
+            ("local", "main", "")
+        ] {
+            let session = Session(source: "codex", sessionID: "s", sourcePath: "/s", project: "memex",
+                                  machine: machine, conversationKind: kind)
+            controller.update(sessions: [session], selectedID: nil, select: { _ in }, loadMore: { _ in })
+            let height = controller.tableView(controller.table, heightOfRow: 0)
+            cell.frame = NSRect(x: 0, y: 0, width: 300, height: height)
+            cell.configure(controller.rows[0])
+            cell.layoutSubtreeIfNeeded()
+            let visibleLabels = cell.subviews.compactMap { $0 as? NSTextField }.filter { !$0.isHidden }
+            #expect(visibleLabels.allSatisfy { $0.frame.maxY <= height })
+            if expected.isEmpty {
+                #expect(!visibleLabels.contains { $0.stringValue.contains("nicbook-atm") || $0.stringValue.contains("Subagent") })
+            } else {
+                #expect(visibleLabels.contains { $0.stringValue == expected })
+            }
+            #expect(cell.accessibilityLabel()?.contains("Subagent") == (kind == "subagent"))
+        }
+    }
+
     func sessions(_ count: Int) -> [Session] {
         (0..<count).map { Session(source: "codex", sessionID: "s\($0)", sourcePath: "/s\($0)", project: "memex", label: "Conversation \($0) with enough text to wrap onto another line", lastAt: "2026-09-07T12:00:00Z", snippet: "A two-line preview of this conversation.") }
     }

--- a/apps/macos/Tests/MemexTests/FilterTests.swift
+++ b/apps/macos/Tests/MemexTests/FilterTests.swift
@@ -92,10 +92,50 @@ private struct FilterFixture {
     #expect(Set(store.sessions.map(\.sessionID)) == ["r5"])
     store.filters = .defaults
     await store.loadSessions()
-    #expect(Set(store.sessions.map(\.sessionID)) == ["r1", "r2", "r4", "r5"])
+    #expect(Set(store.sessions.map(\.sessionID)) == ["r2", "r5"])
     store.scope = .all
     await store.loadSessions()
-    #expect(store.sessions.count == 10)
+    #expect(store.sessions.count == 4)
+}
+
+@MainActor @Test func homeLoadsFilteredResultsWithoutOpeningATranscript() async throws {
+    let fixture = try FilterFixture()
+    defer { fixture.cleanUp() }
+    let store = Store(client: fixture.client)
+    store.homeProject = "memex"
+    store.filters.provider = .codex
+    await store.loadSessions()
+    #expect(store.scope == .home)
+    #expect(store.sessions.count == 1)
+    #expect(store.sessions.allSatisfy { $0.project == "memex" && $0.source == "codex" })
+    #expect(store.selectedID == nil)
+    let session = try #require(store.sessions.last)
+    store.openConversation(session)
+    #expect(store.scope == .project("memex"))
+    #expect(store.selectedID == session.id)
+    store.scope = .home
+    await store.loadSessions()
+    #expect(store.selectedID == nil)
+}
+
+@MainActor @Test func browsingSubagentsPreservesTheirTitlesWhenSearching() async throws {
+    let fixture = try FilterFixture()
+    defer { fixture.cleanUp() }
+    let store = Store(client: fixture.client)
+    store.homeProject = "memex"
+    store.filters.origin = .subagent
+    await store.loadSessions()
+    let titles = Dictionary(uniqueKeysWithValues: store.sessions.map { ($0.id, $0.title) })
+    #expect(titles.count == 2)
+    // A subsequent browse with the default filter must not erase known agents.
+    store.filters = .defaults
+    await store.loadSessions()
+    store.filters.origin = .subagent
+    store.query = "needle"
+    await store.loadSessions()
+    #expect(store.sessions.count == titles.count)
+    #expect(store.sessions.allSatisfy { $0.title == titles[$0.id] })
+    #expect(store.sessions.allSatisfy { $0.searchRecordID != nil && $0.snippet == "needle" })
 }
 
 @MainActor @Test func filterChangesResetPaginationAndIgnoreOldResults() async throws {
@@ -116,7 +156,7 @@ private struct FilterFixture {
     await store.loadSessions()
     try FileManager.default.removeItem(at: hold)
     await pending.value
-    #expect(store.sessions.count == 4)
+    #expect(store.sessions.count == 1)
     #expect(store.sessions.allSatisfy { $0.source == "codex" })
     #expect(!store.loadingSessions)
 }
@@ -134,7 +174,7 @@ private struct FilterFixture {
     #expect(Store(filterPreferences: preferences).filters == .defaults)
 }
 
-@MainActor @Test func permissionReviewsAreHiddenByDefaultForBrowsingAndSearch() async throws {
+@MainActor @Test func subagentsAndPermissionReviewsAreHiddenByDefaultForBrowsingAndSearch() async throws {
     let fixture = try FilterFixture()
     defer { fixture.cleanUp() }
     let store = Store(client: fixture.client)
@@ -142,6 +182,10 @@ private struct FilterFixture {
     for query in ["", "needle"] {
         store.query = query
         store.filters = .defaults
+        await store.loadSessions()
+        #expect(store.sessions.count == 4)
+        #expect(Set(store.sessions.map(\.sessionID)) == ["r2", "r5"])
+        store.filters.origin = .all
         await store.loadSessions()
         #expect(store.sessions.count == 10)
         #expect(!store.sessions.contains { $0.sessionID == "r6" })
@@ -156,8 +200,11 @@ private struct FilterFixture {
 
 @Test func conversationTypeAndPermissionReviewToggleKeepDistinctMeanings() throws {
     var filters = ConversationFilters.defaults
-    #expect(filters.conversationType == .all)
+    #expect(filters.conversationType == .interactive)
     #expect(!filters.showsPermissionReviews)
+    #expect(filters.summary.isEmpty)
+    filters.conversationType = .all
+    #expect(filters.summary == "Chats and subagents")
     filters.showsPermissionReviews = true
     #expect(filters.origin.argument == "all")
     #expect(filters.conversationType == .all)
@@ -171,7 +218,7 @@ private struct FilterFixture {
         filters.showsPermissionReviews = true
         #expect(filters.origin == type)
     }
-    filters.conversationType = .all
+    filters.conversationType = .interactive
     #expect(filters == .defaults)
     let saved = try JSONDecoder().decode(ConversationFilters.self,
         from: Data(#"{"timeframe":"all","provider":"all","origin":"includingReviews"}"#.utf8))

--- a/apps/macos/Tests/MemexTests/HomeActivityTests.swift
+++ b/apps/macos/Tests/MemexTests/HomeActivityTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import Memex
+
+@Test func homeActivityCacheReusesOnlyCompletedCurrentRequests() {
+    let now = Date()
+    let payload = HomeActivityPayload(metric: "tokens", bucketKeys: [], tokenUsageEnabled: true, partial: false, points: [])
+    let cache = HomeActivityCache(criteria: "tokens", request: "tokens|1", payload: payload,
+        machines: [:], failures: [:], complete: true, updatedAt: now)
+    #expect(cache.isFresh(for: "tokens|1", now: now.addingTimeInterval(59)))
+    #expect(!cache.isFresh(for: "tokens|1", now: now.addingTimeInterval(60)))
+    #expect(!cache.isFresh(for: "tokens|2", now: now))
+    let incomplete = HomeActivityCache(criteria: "tokens", request: "tokens|1", payload: payload,
+        machines: [:], failures: [:], complete: false, updatedAt: now)
+    #expect(!incomplete.isFresh(for: "tokens|1", now: now))
+}
+
+@Test func homeActivityUsesAggregateCLIAndAllFilters() async throws {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let executable = directory.appendingPathComponent("fixture-cli")
+    let script = #"""
+    #!/bin/sh
+    [ "$1" = "--no-update-check" ] && [ "$2" = "--non-interactive" ] && [ "$3" = "activity" ] || exit 2
+    shift 3
+    [ "$1" = "--format" ] && [ "$2" = "json" ] || exit 3
+    shift 2
+    [ "$1" = "--metric" ] && [ "$2" = "tokens" ] || exit 4
+    shift 2
+    [ "$1" = "--range" ] && [ "$2" = "24h" ] || exit 5
+    shift 2
+    [ "$1" = "--machine" ] && [ "$2" = "nicbook-atm" ] || exit 6
+    shift 2
+    [ "$1" = "--origin" ] && [ "$2" = "regular" ] || exit 7
+    shift 2
+    [ "$1" = "--progress" ] && [ "$2" = "--raw" ] && [ "$3" = "--now-ms" ] && [ "$4" = "172800000" ] || exit 8
+    shift 4
+    [ "$1" = "--query=  --needle  " ] && [ "$2" = "--project" ] && [ "$3" = "memex" ] || exit 9
+    shift 3
+    [ "$1" = "--source" ] && [ "$2" = "codex" ] || exit 10
+    printf '%s' '{"token_usage_enabled":true,"partial":true,"warnings":["usage cache disabled: database is read-only"],"points":[{"timestamp_ms":3600000,"source":"codex","value":1200},{"timestamp_ms":7200000,"source":"codex","value":300}]}'
+    """#
+    try script.write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+    let selection = HomeActivitySelection(metric: "tokens", timeframe: .day, query: "  --needle  ",
+        project: "memex", source: "codex", origin: .all, nowMS: 172_800_000)
+    let payload = try await MemexClient(executable: executable).activity(selection, machine: "nicbook-atm")
+    #expect(payload.points.reduce(0) { $0 + $1.value } == 1500)
+    #expect(payload.partial)
+    #expect(payload.tokenUsageEnabled)
+    #expect(payload.warnings?.first == "usage cache disabled: database is read-only")
+}
+
+@Test func homeActivityMergesMachinesBeforeCompressingAllTimeBuckets() {
+    let day: UInt64 = 86_400_000
+    let selection = HomeActivitySelection(metric: "sessions", timeframe: .all, query: nil,
+        project: nil, source: nil, origin: .all, nowMS: 200 * day)
+    let local = RawHomeActivityPayload(tokenUsageEnabled: true, partial: false,
+        points: [RawHomeActivityPoint(timestampMS: day, source: "codex", value: 2)])
+    let remote = RawHomeActivityPayload(tokenUsageEnabled: true, partial: false,
+        points: [RawHomeActivityPoint(timestampMS: day, source: "codex", value: 3),
+                 RawHomeActivityPoint(timestampMS: 150 * day, source: "claude", value: 7)])
+    let merged = HomeActivityPayload.merge([local, remote], selection: selection, failed: true)
+    #expect(merged.total == 12)
+    #expect(merged.bucketKeys.count <= 60)
+    #expect(merged.points.allSatisfy { merged.bucketKeys.contains($0.date) })
+    #expect(merged.points.first { $0.source == "codex" }?.value == 5)
+    #expect(merged.partial)
+}
+
+@Test @MainActor func homeActivityPublishesFastMachineBeforeSlowMachineCompletes() async throws {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let executable = directory.appendingPathComponent("fixture-cli")
+    let script = #"""
+    #!/bin/sh
+    fixture_dir=${0%/*}
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--machine" ]; then
+        shift
+        machine=$1
+        break
+      fi
+      shift
+    done
+    if [ "$machine" = "slow-peer" ]; then
+      attempts=0
+      while [ ! -f "$fixture_dir/release" ] && [ "$attempts" -lt 200 ]; do
+        sleep 0.01
+        attempts=$((attempts + 1))
+      done
+      [ -f "$fixture_dir/release" ] || exit 11
+    fi
+    printf '%s' '{"token_usage_enabled":true,"partial":false,"points":[{"timestamp_ms":86400000,"source":"codex","value":5}]}'
+    """#
+    try script.write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+    let selection = HomeActivitySelection(metric: "sessions", timeframe: .all, query: nil,
+        project: nil, source: nil, origin: .all, nowMS: 172_800_000)
+    var batches: [HomeActivityBatch] = []
+    try await MemexClient(executable: executable).activityBatches(selection, machines: ["local", "slow-peer"]) { batch in
+        batches.append(batch)
+        if batch.machine == "local" { FileManager.default.createFile(atPath: directory.appendingPathComponent("release").path, contents: nil) }
+    }
+    #expect(batches.map(\.machine) == ["local", "slow-peer"])
+    #expect(batches.allSatisfy { $0.error == nil && $0.payload != nil })
+}

--- a/apps/macos/Tests/MemexTests/HomeTests.swift
+++ b/apps/macos/Tests/MemexTests/HomeTests.swift
@@ -1,0 +1,180 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Memex
+
+@Suite(.serialized) @MainActor
+struct HomeTests {
+    @Test func automaticRefreshWaitsForStalenessAndVisibilityAndRetainsResults() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let executable = directory.appendingPathComponent("cli")
+        let script = #"""
+        #!/bin/sh
+        fixture_dir=${0%/*}
+        case "$3" in
+          machines) printf '%s' '[{"id":"local","label":"This Mac"}]';;
+          projects) printf '%s' '[]';;
+          sessions)
+            case "$*" in
+              *--count*) printf '%s' '{"total":1}';;
+              *)
+                label=Before
+                if [ -f "$fixture_dir/refresh" ]; then
+                  touch "$fixture_dir/started"
+                  attempts=0
+                  while [ ! -f "$fixture_dir/release" ] && [ "$attempts" -lt 200 ]; do
+                    sleep 0.01
+                    attempts=$((attempts + 1))
+                  done
+                  [ -f "$fixture_dir/release" ] || exit 11
+                  label=After
+                fi
+                printf '[{"source":"codex","session_id":"one","source_path":"/fixture","project":"memex","label":"%s","message_count":0}]' "$label";;
+            esac;;
+        esac
+        """#
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        let client = MemexClient(executable: executable, root: directory.path)
+        let store = Store(client: client, projectCatalog: ProjectCatalog(client: client, cacheDirectory: directory))
+        await store.loadSessions()
+        #expect(store.sessions.first?.title == "Before")
+        let original = store.sessionCountRequestID
+        await store.refreshHomeIfStale(isVisible: true)
+        #expect(store.sessionCountRequestID == original)
+        let stale = Date().addingTimeInterval(120)
+        await store.refreshHomeIfStale(isVisible: false, now: stale)
+        store.scope = .all
+        await store.refreshHomeIfStale(isVisible: true, now: stale)
+        store.scope = .home
+        store.loadingSessions = true
+        await store.refreshHomeIfStale(isVisible: true, now: stale)
+        store.loadingSessions = false
+        #expect(store.sessionCountRequestID == original)
+
+        try Data().write(to: directory.appendingPathComponent("refresh"))
+        store.loadingHomeActivity = true
+        let activity = store.homeActivityRequestID
+        let refresh = Task { await store.refreshHomeIfStale(isVisible: true, now: stale) }
+        let deadline = Date().addingTimeInterval(3)
+        while !FileManager.default.fileExists(atPath: directory.appendingPathComponent("started").path), Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(store.loadingSessions)
+        #expect(store.sessions.first?.title == "Before")
+        let active = store.sessionCountRequestID
+        #expect(active != original)
+        await store.refreshHomeIfStale(isVisible: true, now: stale.addingTimeInterval(120))
+        #expect(store.sessionCountRequestID == active)
+        try Data().write(to: directory.appendingPathComponent("release"))
+        await refresh.value
+        #expect(store.sessions.first?.title == "After")
+        #expect(store.homeActivityRequestID == activity) // Returning Home must not restart an active token scan.
+        store.loadingHomeActivity = false
+        await store.refreshHomeIfStale(isVisible: true, now: stale.addingTimeInterval(1))
+        #expect(store.sessionCountRequestID == active)
+        await store.refreshHomeIfStale(isVisible: true, now: stale.addingTimeInterval(61))
+        #expect(store.sessionCountRequestID != active)
+        #expect(store.homeActivityRequestID != activity)
+    }
+
+    @Test func switchingHomeAndBrowserDoesNotRestartCatalogRequests() async throws {
+        _ = NSApplication.shared
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let executable = directory.appendingPathComponent("cli")
+        let script = #"""
+        #!/bin/sh
+        printf '%s\n' "$3" >> "$(dirname "$0")/requests"
+        case "$3" in
+          machines) printf '%s' '[{"id":"local","label":"This Mac"}]';;
+          projects) printf '%s' '[]';;
+          sessions)
+            case "$*" in
+              *--count*) printf '%s' '{"total":1}';;
+              *) printf '%s' '[{"source":"codex","session_id":"one","source_path":"/fixture","project":"memex","label":"A named conversation","message_count":0}]';;
+            esac;;
+          session) printf '%s' '[{"type":"page","total":0}]';;
+          activity) printf '%s' '{"points":[],"token_usage_enabled":true,"partial":false}';;
+        esac
+        """#
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        let client = MemexClient(executable: executable, root: directory.path)
+        let store = Store(client: client, projectCatalog: ProjectCatalog(client: client, cacheDirectory: directory))
+        let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 1000, height: 700),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+        window.contentViewController = NSHostingController(rootView: BrowserContent(store: store).reader)
+        window.orderBack(nil)
+        defer { window.close() }
+        let deadline = Date().addingTimeInterval(5)
+        while (store.sessions.isEmpty || store.loadingMachines || store.loadingProjects || store.homeActivityCache?.complete != true), Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(store.sessions.count == 1)
+        for scope in [Store.Scope.all, .home, .all] {
+            store.scope = scope
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        let requests = try String(contentsOf: directory.appendingPathComponent("requests"), encoding: .utf8)
+            .split(separator: "\n")
+        #expect(requests.filter { $0 == "machines" }.count == 1)
+        #expect(requests.filter { $0 == "projects" }.count == 1)
+        #expect(requests.filter { $0 == "sessions" }.count == 2) // list and count
+        #expect(requests.filter { $0 == "activity" }.count == 1) // Returning to fresh Home reuses its chart.
+    }
+
+    @Test func launchStartsAtHomeAndOpeningResultPreservesCriteria() {
+        let store = Store()
+        #expect(store.scope == .home)
+        #expect(store.selectedID == nil)
+        store.homeProject = "memex"
+        store.query = "navigation"
+        let session = Session(source: "codex", sessionID: "home", sourcePath: "/fixture", project: "memex")
+        store.sessions = [session]
+        let criteria = store.requestID
+        store.openConversation(session)
+        #expect(store.scope == .project("memex"))
+        #expect(store.selected == session)
+        #expect(store.requestID == criteria)
+        store.scope = .home
+        #expect(store.selectedID == nil)
+        #expect(store.query == "navigation")
+        store.homeProject = nil
+        store.openConversation(session)
+        #expect(store.scope == .all)
+    }
+
+    @Test func homeCollapsesListAndRestoresBrowserColumnsAndToolbar() async throws {
+        _ = NSApplication.shared
+        let store = Store()
+        let controller = BrowserColumnsController(store: store, sidebar: Text("Sidebar"),
+            conversations: Text("Conversations"), reader: Text("Content"))
+        let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 1380, height: 700),
+            styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+        window.contentViewController = controller
+        controller.splitView.autosaveName = nil
+        window.orderBack(nil)
+        defer { window.close() }
+        for scope in [Store.Scope.home, .all, .project("memex"), .home, .all] {
+            store.scope = scope
+            try await Task.sleep(for: .milliseconds(100))
+            window.contentView?.layoutSubtreeIfNeeded()
+            #expect(controller.splitViewItems[1].isCollapsed == (scope == .home))
+            let toolbar = try #require(window.toolbar)
+            let separators = toolbar.items.compactMap { $0 as? NSTrackingSeparatorToolbarItem }
+            #expect(separators.count == (scope == .home ? 1 : 2))
+            #expect(toolbar.items.contains { $0.itemIdentifier == BrowserToolbarController.search } == (scope != .home))
+            #expect(toolbar.items.contains { $0.itemIdentifier == BrowserToolbarController.title } == (scope != .home))
+            #expect(toolbar.items.contains { $0.itemIdentifier == BrowserToolbarController.refresh } == (scope != .home))
+            #expect(controller.readerHost.view.frame.width > 0)
+        }
+    }
+}

--- a/apps/macos/Tests/MemexTests/ModelTests.swift
+++ b/apps/macos/Tests/MemexTests/ModelTests.swift
@@ -2,6 +2,23 @@ import Foundation
 import Testing
 @testable import Memex
 
+@Test func subagentClassificationSurvivesBrowsingSearchAndMetadata() throws {
+    for kind in [nil, "main", "subagent", "sidechain", "guardian_review"] as [String?] {
+        var object: [String: String] = ["source": "codex", "session_id": "s", "source_path": "/s", "project": "p"]
+        object["conversation_kind"] = kind
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let session = try JSONDecoder().decode(Session.self, from: data)
+        let expected = kind == "subagent" || kind == "sidechain"
+        #expect(session.isSubagent == expected)
+        let hit = try JSONDecoder().decode(SearchHit.self, from: data)
+        #expect(hit.session(known: [:]).isSubagent == expected)
+        var oldMetadata = session
+        oldMetadata.conversationKind = nil
+        #expect(session.applyingMetadata(oldMetadata).isSubagent == expected)
+        #expect(hit.session(known: [oldMetadata.id: oldMetadata]).isSubagent == expected)
+    }
+}
+
 @Test func decodesCLIContracts() throws {
     let sessionJSON = #"[{"source":"codex","session_id":"session-1","source_path":"/tmp/one.jsonl","project":"memex","last_at":"2026-09-07T17:03:01Z","label":"Native app","resume_cmd":"codex resume session-1"}]"#
     let sessions = try JSONDecoder().decode([Session].self, from: Data(sessionJSON.utf8))

--- a/apps/macos/Tests/MemexTests/ReaderEnhancementTests.swift
+++ b/apps/macos/Tests/MemexTests/ReaderEnhancementTests.swift
@@ -161,15 +161,23 @@ import Testing
         #expect(reader.selectedFindRange != nil)
     }
 
-    @Test func lifecycleLabelsRequireRecordedEvents() {
+    @Test func routineLifecycleRowsAreHiddenButInterruptionsAndRawEventsRemain() throws {
         var completed = record("complete", "lifecycle", "Turn completed").record
         completed.lifecycleEvent = "task_complete"
         var aborted = record("abort", "lifecycle", "Turn interrupted").record
         aborted.lifecycleEvent = "turn_aborted"
-        let reader = controller([TranscriptRecord(recordID: "complete", record: completed), TranscriptRecord(recordID: "abort", record: aborted)])
-        #expect(reader.measurement(at: 0).title == "Completed")
-        #expect(reader.measurement(at: 1).title == "Interrupted")
-        #expect(reader.measurement(at: 1).hasFailure)
+        let records = [TranscriptRecord(recordID: "complete", record: completed), TranscriptRecord(recordID: "abort", record: aborted)]
+        let reader = controller(records)
+        #expect(reader.rows.count == 1)
+        #expect(reader.measurement(at: 0).title == "Interrupted")
+        #expect(reader.measurement(at: 0).hasFailure)
+        let hit = try #require(ConversationMatcher.matches(records, query: "Turn completed").first)
+        reader.update(sessionID: "reader", records: records, provider: "codex", findQuery: "Turn completed", findHit: hit, findGeneration: 1)
+        #expect(reader.rows.count == 2)
+        #expect(reader.selectedFindRange != nil)
+        reader.update(sessionID: "reader", records: records, provider: "codex", rawTranscript: true)
+        #expect(reader.rows.count == 2)
+        #expect(reader.measurement(at: 0).body.contains("task_complete"))
     }
 
     @Test func returningToLongExpandedRawMessageRestoresDisplayStateAndOffset() {

--- a/apps/macos/Tests/MemexTests/StorePagingTests.swift
+++ b/apps/macos/Tests/MemexTests/StorePagingTests.swift
@@ -1,0 +1,138 @@
+import AppKit
+import Testing
+@testable import Memex
+
+private struct PagingFixture {
+    let directory: URL
+    let client: MemexClient
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("cli")
+        let script = #"""
+        #!/bin/sh
+        directory=$(dirname "$0")
+        machine=local; limit=200; project=memex
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --machine) shift; machine="$1";;
+            --limit) shift; limit="$1";;
+            --project) shift; project="$1";;
+          esac
+          shift
+        done
+        if [ "$machine" = peer ]; then
+          while [ -e "$directory/hold-peer" ]; do sleep 0.01; done
+          if [ -e "$directory/fail-peer" ]; then echo 'Peer unavailable' >&2; exit 2; fi
+        fi
+        cat "$directory/$machine-$limit-$project.json"
+        """#
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        client = MemexClient(executable: executable)
+        let formatter = ISO8601DateFormatter()
+        for machine in ["local", "peer"] {
+            for limit in [200, 400] {
+                for project in ["memex", "other"] {
+                    let rows: [[String: Any]] = (0..<limit).map { index in
+                        let timestamp = Date(timeIntervalSince1970: 1_789_000_000 - Double(index * 2 + (machine == "peer" ? 1 : 0)))
+                        return ["source": "codex", "session_id": "\(project)-\(index)", "source_path": "/\(project)/\(index)",
+                                "project": project, "machine": machine, "label": "Page \(limit)",
+                                "last_at": formatter.string(from: timestamp)]
+                    }
+                    try JSONSerialization.data(withJSONObject: rows).write(to: directory.appendingPathComponent("\(machine)-\(limit)-\(project).json"))
+                }
+            }
+        }
+    }
+    func mark(_ name: String) throws { try Data().write(to: directory.appendingPathComponent(name)) }
+    func remove(_ name: String) throws { try FileManager.default.removeItem(at: directory.appendingPathComponent(name)) }
+    func cleanUp() { try? FileManager.default.removeItem(at: directory) }
+}
+
+@MainActor private func waitForPage(_ store: Store, project: String = "memex") async throws {
+    let deadline = Date().addingTimeInterval(10)
+    while !store.sessions.contains(where: { $0.machineID == "local" && $0.label == "Page 400" && $0.project == project }), Date() < deadline {
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    try #require(store.sessions.contains { $0.machineID == "local" && $0.label == "Page 400" && $0.project == project })
+}
+
+@MainActor @Suite(.serialized) struct StorePagingTests {
+    @Test func delayedPeerPagePreservesVisibleRemoteRowAndNativeScrollAnchor() async throws {
+        let fixture = try PagingFixture()
+        defer { fixture.cleanUp() }
+        let store = Store(client: fixture.client)
+        store.machines = [.local, MachineChoice(id: "peer", label: "Peer")]
+        await store.loadSessions()
+        let controller = ConversationListController()
+        let window = NSWindow(contentRect: NSRect(x: -10000, y: -10000, width: 300, height: 600), styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+        window.contentViewController = controller
+        window.setContentSize(NSSize(width: 300, height: 600))
+        defer { window.close() }
+        controller.update(sessions: store.sessions, selectedID: store.sessions.first?.id, select: { _ in }, loadMore: { _ in })
+        window.orderBack(nil)
+        await Task.yield()
+        window.contentView?.layoutSubtreeIfNeeded()
+        let anchorIndex = try #require(store.sessions.indices.first { $0 > 150 && store.sessions[$0].machineID == "peer" })
+        let anchorID = store.sessions[anchorIndex].id
+        let anchorY = controller.table.rect(ofRow: anchorIndex).minY + 7
+        controller.scrollView.contentView.scroll(to: NSPoint(x: 0, y: anchorY))
+        controller.scrollView.reflectScrolledClipView(controller.scrollView.contentView)
+        try fixture.mark("hold-peer")
+        store.loadMoreSessionsIfNeeded(visibleID: try #require(store.sessions.last?.id))
+        let pending = Task { await store.loadSessions() }
+        defer { pending.cancel() }
+        try await waitForPage(store)
+        #expect(store.loadingSessions)
+        #expect(store.sessions.contains { $0.id == anchorID })
+        controller.update(sessions: store.sessions, selectedID: store.sessions.first?.id, select: { _ in }, loadMore: { _ in })
+        controller.table.layoutSubtreeIfNeeded()
+        #expect(abs(controller.scrollView.contentView.bounds.minY - anchorY) < 1)
+        try fixture.remove("hold-peer")
+        await pending.value
+        controller.update(sessions: store.sessions, selectedID: store.sessions.first?.id, select: { _ in }, loadMore: { _ in })
+        controller.table.layoutSubtreeIfNeeded()
+        #expect(store.sessions.count == 400)
+        #expect(store.sessions.contains { $0.id == anchorID })
+        #expect(abs(controller.scrollView.contentView.bounds.minY - anchorY) < 1)
+    }
+
+    @Test func failedPeerPageKeepsLoadedRowsAndReportsFailure() async throws {
+        let fixture = try PagingFixture()
+        defer { fixture.cleanUp() }
+        let store = Store(client: fixture.client)
+        store.machines = [.local, MachineChoice(id: "peer", label: "Peer")]
+        await store.loadSessions()
+        let previousPeerIDs = Set(store.sessions.filter { $0.machineID == "peer" }.map(\.id))
+        try fixture.mark("fail-peer")
+        store.loadMoreSessionsIfNeeded(visibleID: try #require(store.sessions.last?.id))
+        await store.loadSessions()
+        #expect(previousPeerIDs.isSubset(of: Set(store.sessions.map(\.id))))
+        #expect(store.listError?.contains("Peer unavailable") == true)
+    }
+
+    @Test func changedProjectAndMachineDoNotReuseOtherCriteriaRows() async throws {
+        let fixture = try PagingFixture()
+        defer { fixture.cleanUp() }
+        let store = Store(client: fixture.client)
+        store.machines = [.local, MachineChoice(id: "peer", label: "Peer")]
+        await store.loadSessions()
+        try fixture.mark("hold-peer")
+        store.scope = .project("other")
+        store.sessionLimit = 400
+        let pending = Task { await store.loadSessions() }
+        defer { pending.cancel() }
+        try await waitForPage(store, project: "other")
+        #expect(store.sessions.allSatisfy { $0.project == "other" && $0.machineID == "local" })
+        try fixture.remove("hold-peer")
+        await pending.value
+        #expect(store.sessions.contains { $0.machineID == "peer" })
+        store.machineSelection = .machine("local")
+        await store.loadSessions()
+        #expect(store.sessions.allSatisfy { $0.machineID == "local" && $0.project == "other" })
+    }
+}

--- a/apps/macos/Tests/MemexTests/TranscriptPresentationTests.swift
+++ b/apps/macos/Tests/MemexTests/TranscriptPresentationTests.swift
@@ -53,7 +53,7 @@ private func presentationRecord(_ id: String, _ role: String, _ text: String, tu
     #expect(items[0].records.map(\.id) == ["c", "tool"])
     #expect(!items[1].isCompletedWork)
     #expect(items[1].records[0].id == "f")
-    #expect(items.flatMap(\.records).map(\.id) == ["c", "tool", "f", "done"])
+    #expect(items.flatMap(\.records).map(\.id) == ["c", "tool", "f"])
     for incomplete in [[commentary, tool, final], [commentary, tool, completion],
                        [commentary, tool, final, presentationRecord("x", "lifecycle", "", turn: "other", lifecycle: "task_complete")],
                        [commentary, tool, final, completion, presentationRecord("a", "lifecycle", "", turn: "t", lifecycle: "turn_aborted")]] {
@@ -71,7 +71,19 @@ private func presentationRecord(_ id: String, _ role: String, _ text: String, tu
     #expect(items[0].isCompletedWork)
     #expect(!items[1].isCompletedWork)
     #expect(items[2].isCompletedWork)
-    #expect(items.flatMap(\.records).map(\.id) == records.map(\.id))
+    #expect(items.flatMap(\.records).map(\.id) == ["a", "u", "b", "f"])
+}
+
+@Test func routineTurnEventsAreHiddenWithoutHidingMessagesOrJoiningTurns() {
+    let records = [presentationRecord("a", "tool_use", "first turn"),
+                   presentationRecord("done", "lifecycle", "Turn completed", lifecycle: "task_complete"),
+                   presentationRecord("start", "lifecycle", "Turn started", lifecycle: "task_started"),
+                   presentationRecord("b", "tool_use", "second turn"),
+                   presentationRecord("user", "user", "Turn completed"),
+                   presentationRecord("abort", "lifecycle", "Turn interrupted", lifecycle: "turn_aborted")]
+    let items = TranscriptItem.group(records)
+    #expect(items.map { $0.records.map(\.id) } == [["a"], ["b"], ["user"], ["abort"]])
+    #expect(TranscriptPresentation.project(records) == records)
 }
 
 @Test func rawTranscriptRetainsUnknownFieldsAndOriginalMixedRecord() throws {

--- a/apps/macos/scripts/build.sh
+++ b/apps/macos/scripts/build.sh
@@ -31,8 +31,8 @@ if [[ ! -f "$CLI" || ! -x "$CLI" ]]; then
 fi
 CLI=$(cd "$(dirname "$CLI")" && pwd)/$(basename "$CLI")
 "$CLI" --version
-if ! "$CLI" projects --help >/dev/null 2>&1 || ! "$CLI" machines --help >/dev/null 2>&1; then
-  echo "This app requires a Memex CLI with projects and machines commands. Build this checkout's CLI and set MEMEX_CLI to it." >&2
+if ! "$CLI" projects --help >/dev/null 2>&1 || ! "$CLI" machines --help >/dev/null 2>&1 || ! "$CLI" activity --help >/dev/null 2>&1; then
+  echo "This app requires a Memex CLI with projects, machines, and activity commands. Build this checkout's CLI and set MEMEX_CLI to it." >&2
   exit 1
 fi
 swift build --package-path "$ROOT" -c "$CONFIGURATION" "${SWIFT_ARGS[@]}" --product Memex --force-resolved-versions

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1980,13 +1980,15 @@ impl SessionTitleLookup {
         explicit
             .as_deref()
             .and_then(nonempty_label)
-            .or_else(|| opening.and_then(nonempty_label))
-            .or_else(|| codex.and_then(|metadata| metadata.first_user_message.clone()))
+            // Forked agents inherit the parent's opening prompt. Their own task
+            // path is a better label when Codex has not assigned an explicit title.
             .or_else(|| {
                 codex
                     .and_then(|metadata| metadata.agent_path.as_deref())
                     .and_then(human_agent_title)
             })
+            .or_else(|| opening.and_then(nonempty_label))
+            .or_else(|| codex.and_then(|metadata| metadata.first_user_message.clone()))
             .or_else(|| {
                 (source == SourceKind::Codex)
                     .then(|| codex_assignment_title(source_path))
@@ -3106,7 +3108,7 @@ mod tests {
     }
 
     #[test]
-    fn title_precedence_preserves_requests_and_humanizes_only_agent_identifiers() {
+    fn title_precedence_prefers_agent_tasks_over_inherited_requests() {
         use crate::sources::codex::SessionTitleMetadata;
         let mut titles = SessionTitleLookup {
             codex: HashMap::from([(
@@ -3128,10 +3130,8 @@ mod tests {
         titles.codex.get_mut("s").unwrap().title = None;
         assert_eq!(
             resolve(&titles, Some("Opening prompt")).as_deref(),
-            Some("Opening prompt")
+            Some("Cache invalidation")
         );
-        assert_eq!(resolve(&titles, None).as_deref(), Some("Original request"));
-        titles.codex.get_mut("s").unwrap().first_user_message = None;
         assert_eq!(
             resolve(&titles, None).as_deref(),
             Some("Cache invalidation")
@@ -3140,6 +3140,14 @@ mod tests {
             titles.codex["s"].agent_path.as_deref(),
             Some("/root/cache_invalidation")
         );
+        titles.codex.get_mut("s").unwrap().agent_path = None;
+        assert_eq!(
+            resolve(&titles, Some("Opening prompt")).as_deref(),
+            Some("Opening prompt")
+        );
+        assert_eq!(resolve(&titles, None).as_deref(), Some("Original request"));
+        titles.codex.get_mut("s").unwrap().first_user_message = None;
+        assert_eq!(resolve(&titles, None), None);
         assert_eq!(
             human_agent_title("/root/research/cache_invalidation").as_deref(),
             Some("Research / cache invalidation")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ static TRACE_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[command(
     name = "memex",
     version,
-    help_template = "{about-with-newline}\nUsage: {usage}\n\nFind and read:\n  search       Search history and memories\n  sessions     List sessions\n  projects     List project counts and activity\n  machines     List configured machines\n  session      Read a session or batch of pages\n  show         Read a record or memory\n  context      Read surrounding records\n\nBrowse and reuse:\n  tui          Browse interactively (also the default)\n  web          Serve or open the browser\n  share        Share a session\n  transfer     Transfer a session to another agent\n\nIndex and operate:\n  index        Index history and memories; rebuild, gc, embed, stats\n  daemon       Run indexing, web, and MCP together\n  usage        Report token usage and cost\n\nIntegrate and maintain:\n  mcp          Run the MCP server\n  skill        Manage the bundled search skill\n  update       Update Memex and installed skills\n  debug        Retrieval evaluation\n  help         Show command help\n\nOptions:\n{options}\n{after-help}",
+    help_template = "{about-with-newline}\nUsage: {usage}\n\nFind and read:\n  search       Search history and memories\n  sessions     List sessions\n  projects     List project counts and activity\n  activity     Chart conversation and token activity\n  machines     List configured machines\n  session      Read a session or batch of pages\n  show         Read a record or memory\n  context      Read surrounding records\n\nBrowse and reuse:\n  tui          Browse interactively (also the default)\n  web          Serve or open the browser\n  share        Share a session\n  transfer     Transfer a session to another agent\n\nIndex and operate:\n  index        Index history and memories; rebuild, gc, embed, stats\n  daemon       Run indexing, web, and MCP together\n  usage        Report token usage and cost\n\nIntegrate and maintain:\n  mcp          Run the MCP server\n  skill        Manage the bundled search skill\n  update       Update Memex and installed skills\n  debug        Retrieval evaluation\n  help         Show command help\n\nOptions:\n{options}\n{after-help}",
     about = "Search, browse, and reuse local agent history and memory",
     after_help = "\
 QUICK START:
@@ -573,6 +573,36 @@ The input contains at most 32 requests; each page is limited to 500 records."
     /// List this machine and enabled configured peers (without connecting)
     Machines {
         /// Path to memex data directory [default: ~/.memex]
+        #[arg(long)]
+        root: Option<PathBuf>,
+        #[command(flatten)]
+        output: OutputArgs,
+    },
+    /// Aggregate conversation or token activity over time
+    Activity {
+        #[arg(long, default_value = "sessions", value_parser = ["sessions", "tokens"])]
+        metric: String,
+        #[arg(long, default_value = "30d", value_parser = ["24h", "7d", "30d", "all"])]
+        range: String,
+        #[arg(long, default_value = "local")]
+        machine: String,
+        /// Return uncompressed time buckets for one machine
+        #[arg(long)]
+        raw: bool,
+        /// Emit advancing usage-cache progress on stderr
+        #[arg(long, hide = true)]
+        progress: bool,
+        /// Common clock for native requests across several machines
+        #[arg(long, hide = true, requires = "raw")]
+        now_ms: Option<u64>,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long)]
+        source: Option<SourceFilter>,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long, value_enum, default_value_t = SessionOrigin::Regular)]
+        origin: SessionOrigin,
         #[arg(long)]
         root: Option<PathBuf>,
         #[command(flatten)]
@@ -1684,6 +1714,63 @@ pub fn run() -> Result<()> {
             output
                 .resolve(OutputFormat::Jsonl, None, false)?
                 .print_values(crate::machine::configured_machine_summaries(&config)?)?;
+        }
+        Commands::Activity {
+            metric,
+            range,
+            machine,
+            query,
+            raw,
+            progress,
+            now_ms,
+            source,
+            project,
+            origin,
+            root,
+            output,
+        } => {
+            let paths = Paths::new(root)?;
+            let request = crate::web::ActivityRequest {
+                metric: if metric == "tokens" {
+                    crate::web::ActivityMetric::Tokens
+                } else {
+                    crate::web::ActivityMetric::Sessions
+                },
+                range: Some(crate::web::TimeRange::parse(&range)?),
+                query: query.unwrap_or_default().trim().to_owned(),
+                source,
+                project,
+                origin: origin.into(),
+                days: 30,
+            };
+            let collect = || -> Result<Value> {
+                Ok(if raw {
+                    let now = now_ms
+                        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+                    serde_json::to_value(crate::web::single_machine_activity_payload(
+                        &paths, &request, &machine, now,
+                    )?)?
+                } else {
+                    serde_json::to_value(crate::web::machine_activity_payload(
+                        &paths, &request, &machine,
+                    )?)?
+                })
+            };
+            let payload = if progress {
+                crate::usage::with_usage_progress(collect, |progress| {
+                    writeln!(
+                        std::io::stderr(),
+                        "MEMEX_PROGRESS {}",
+                        serde_json::to_string(&progress)?
+                    )?;
+                    Ok(())
+                })??
+            } else {
+                collect()?
+            };
+            output
+                .resolve(OutputFormat::Json, None, false)?
+                .print_value(&payload)?;
         }
         Commands::Projects {
             source,
@@ -2962,6 +3049,34 @@ pub(crate) fn native_request(paths: &Paths, operation: crate::native::Operation)
         Operation::Machines {} => Ok(Value::Array(crate::machine::configured_machine_summaries(
             &config,
         )?)),
+        Operation::Activity {
+            machine,
+            metric,
+            range,
+            query,
+            project,
+            source,
+            origin,
+            now_ms,
+        } => {
+            let metric = match metric.as_str() {
+                "sessions" => crate::web::ActivityMetric::Sessions,
+                "tokens" => crate::web::ActivityMetric::Tokens,
+                _ => anyhow::bail!("unknown activity metric: {metric}"),
+            };
+            let request = crate::web::ActivityRequest {
+                metric,
+                range: Some(crate::web::TimeRange::parse(&range)?),
+                query: query.unwrap_or_default().trim().to_owned(),
+                project,
+                source: parse_source_filter(source)?,
+                origin: origin.into(),
+                days: 30,
+            };
+            Ok(serde_json::to_value(
+                crate::web::single_machine_activity_payload(paths, &request, &machine, now_ms)?,
+            )?)
+        }
         Operation::Projects { machine } => {
             check_analytics(&machine)?;
             let items = if machine == crate::machine::LOCAL_MACHINE_ID {
@@ -3047,7 +3162,7 @@ pub(crate) fn native_request(paths: &Paths, operation: crate::native::Operation)
                     unique_session: true,
                     fields: search_fields(
                         Some(
-                            "source,session_id,source_path,project,snippet,ts,machine,record_id"
+                            "source,session_id,source_path,project,snippet,ts,machine,record_id,conversation_kind"
                                 .into(),
                         ),
                         false,
@@ -7841,6 +7956,38 @@ mod tests {
     use crate::test_support::{EnvVarGuard, env_lock};
     use crate::vector::VectorIndex;
     use tempfile::TempDir;
+
+    #[test]
+    fn activity_cli_validates_ranges_metrics_and_filter_arguments() {
+        for range in ["24h", "7d", "30d", "all"] {
+            for metric in ["sessions", "tokens"] {
+                assert!(
+                    Cli::try_parse_from([
+                        "memex",
+                        "activity",
+                        "--range",
+                        range,
+                        "--metric",
+                        metric,
+                        "--machine",
+                        "all",
+                        "--query=--needle",
+                        "--project",
+                        "memex",
+                        "--source",
+                        "codex",
+                        "--origin",
+                        "regular",
+                        "--format",
+                        "json"
+                    ])
+                    .is_ok()
+                );
+            }
+        }
+        assert!(Cli::try_parse_from(["memex", "activity", "--range", "year"]).is_err());
+        assert!(Cli::try_parse_from(["memex", "activity", "--metric", "cost"]).is_err());
+    }
 
     #[test]
     fn session_count_query_requires_count_and_rejects_cwd() {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -366,12 +366,18 @@ enum RpcOperation {
     SessionActivity {
         spec: SessionActivitySpec,
     },
+    HomeActivity {
+        request: crate::web::ActivityRequest,
+        now: u64,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct RpcRequest {
     protocol: u32,
     request: RpcOperation,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    usage_progress: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -437,6 +443,9 @@ enum RpcPayload {
     },
     SessionActivity {
         points: Vec<SessionActivityPointWire>,
+    },
+    HomeActivity {
+        activity: crate::web::RawActivityPayload,
     },
     Error {
         message: String,
@@ -1857,6 +1866,95 @@ pub(crate) fn remote_session_count(
     }
 }
 
+pub(crate) fn remote_activity(
+    config: &UserConfig,
+    id: &str,
+    request: crate::web::ActivityRequest,
+    now: u64,
+) -> Result<crate::web::RawActivityPayload> {
+    remote_activity_with(&request, now, |operation| {
+        metadata_rpc(config, id, operation, "activity")
+    })
+}
+
+fn remote_activity_with(
+    request: &crate::web::ActivityRequest,
+    now: u64,
+    mut call: impl FnMut(RpcOperation) -> Result<RpcPayload>,
+) -> Result<crate::web::RawActivityPayload> {
+    match call(RpcOperation::HomeActivity {
+        request: request.clone(),
+        now,
+    }) {
+        Ok(RpcPayload::HomeActivity { activity }) => return Ok(activity),
+        Err(error)
+            if error
+                .to_string()
+                .contains("unknown variant `home_activity`") => {}
+        Err(error) => return Err(error),
+        _ => bail!("unexpected activity response"),
+    }
+    if !request.query.is_empty() {
+        bail!("This machine needs a newer Memex build for activity filtered by search.");
+    }
+    let since_ms = request
+        .range
+        .map(|range| range.since_ms(now))
+        .unwrap_or_else(|| Some(now.saturating_sub(request.days as u64 * 86_400_000)));
+    let operation = match request.metric {
+        crate::web::ActivityMetric::Sessions => RpcOperation::SessionActivity {
+            spec: SessionActivitySpec {
+                source: request.source,
+                project: request.project.clone(),
+                project_grouping: ProjectGrouping::Flat,
+                since_ms,
+                until_ms: None,
+                kind: Some(request.origin),
+            },
+        },
+        crate::web::ActivityMetric::Tokens => RpcOperation::UsageActivity {
+            spec: UsageSpec {
+                source: request.source,
+                project: request.project.clone(),
+                project_grouping: ProjectGrouping::Flat,
+                session_keys: None,
+                machine_session_keys: None,
+                since_ms,
+                until_ms: None,
+                cost_mode: CostMode::Source,
+                include_events: false,
+                memo_ttl_ms: 60_000,
+                kind: Some(request.origin),
+            },
+        },
+    };
+    match call(operation)? {
+        RpcPayload::SessionActivity { points }
+            if matches!(request.metric, crate::web::ActivityMetric::Sessions) =>
+        {
+            Ok(crate::web::RawActivityPayload::from_remote_points(
+                points
+                    .into_iter()
+                    .map(|point| (point.timestamp_ms, point.source, 1)),
+                request,
+                false,
+            ))
+        }
+        RpcPayload::UsageActivity { points, partial }
+            if matches!(request.metric, crate::web::ActivityMetric::Tokens) =>
+        {
+            Ok(crate::web::RawActivityPayload::from_remote_points(
+                points
+                    .into_iter()
+                    .map(|point| (point.timestamp_ms, point.source, point.total_tokens)),
+                request,
+                partial,
+            ))
+        }
+        _ => bail!("unexpected legacy activity response"),
+    }
+}
+
 fn metadata_rpc(
     config: &UserConfig,
     id: &str,
@@ -1916,7 +2014,24 @@ pub fn run_rpc_stdio(root: Option<std::path::PathBuf>) -> Result<()> {
             ),
         }
     } else {
-        match handle_rpc(&paths, &config, request.request) {
+        let report_progress = request.usage_progress
+            && matches!(&request.request,
+            RpcOperation::HomeActivity { request, .. } if request.metric == crate::web::ActivityMetric::Tokens);
+        let action = || handle_rpc(&paths, &config, request.request);
+        let result = if report_progress {
+            crate::usage::with_usage_progress(action, |progress| {
+                writeln!(
+                    std::io::stderr(),
+                    "MEMEX_PROGRESS {}",
+                    serde_json::to_string(&progress)?
+                )?;
+                Ok(())
+            })
+            .and_then(|result| result)
+        } else {
+            action()
+        };
+        match result {
             Ok(response) => response,
             Err(err) => RpcPayload::Error {
                 message: err.to_string(),
@@ -2090,6 +2205,9 @@ fn handle_rpc(paths: &Paths, config: &UserConfig, request: RpcOperation) -> Resu
         }
         RpcOperation::SessionActivity { spec } => Ok(RpcPayload::SessionActivity {
             points: session_activity_local(paths, &spec)?,
+        }),
+        RpcOperation::HomeActivity { request, now } => Ok(RpcPayload::HomeActivity {
+            activity: crate::web::raw_activity_payload(paths, &request, now)?,
         }),
     }
 }
@@ -2688,9 +2806,12 @@ fn rpc(machine: &MachineConfig, operation: RpcOperation, timeout: Duration) -> R
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("failed to start SSH for '{}'", machine.id))?;
+    let usage_progress = matches!(&operation,
+        RpcOperation::HomeActivity { request, .. } if request.metric == crate::web::ActivityMetric::Tokens);
     let request = serde_json::to_vec(&RpcRequest {
         protocol: RPC_PROTOCOL,
         request: operation,
+        usage_progress,
     })?;
     child
         .stdin
@@ -2698,45 +2819,13 @@ fn rpc(machine: &MachineConfig, operation: RpcOperation, timeout: Duration) -> R
         .ok_or_else(|| anyhow!("missing SSH stdin"))?
         .write_all(&request)?;
 
-    let mut stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| anyhow!("missing SSH stdout"))?;
-    let mut stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| anyhow!("missing SSH stderr"))?;
-    let stdout_thread = std::thread::spawn(move || {
-        let mut bytes = Vec::new();
-        stdout.read_to_end(&mut bytes).map(|_| bytes)
-    });
-    let stderr_thread = std::thread::spawn(move || {
-        let mut bytes = Vec::new();
-        stderr.read_to_end(&mut bytes).map(|_| bytes)
-    });
-
-    let started = Instant::now();
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-        if started.elapsed() >= timeout {
-            let _ = child.kill();
-            let _ = child.wait();
-            bail!(
-                "SSH request to '{}' timed out after {}s",
-                machine.id,
-                timeout.as_secs()
-            );
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    };
-    let stdout = stdout_thread
-        .join()
-        .map_err(|_| anyhow!("SSH stdout reader panicked"))??;
-    let stderr = stderr_thread
-        .join()
-        .map_err(|_| anyhow!("SSH stderr reader panicked"))??;
+    let (status, stdout, stderr) = wait_rpc_child(
+        &mut child,
+        &machine.id,
+        timeout,
+        usage_progress,
+        crate::usage::publish_remote_scan_progress,
+    )?;
     if !status.success() {
         let message = String::from_utf8_lossy(&stderr).trim().to_string();
         bail!(
@@ -2759,6 +2848,118 @@ fn rpc(machine: &MachineConfig, operation: RpcOperation, timeout: Duration) -> R
         );
     }
     Ok(response.response)
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcUsageProgress {
+    source: String,
+    done: usize,
+    total: usize,
+}
+
+fn wait_rpc_child(
+    child: &mut std::process::Child,
+    machine_id: &str,
+    timeout: Duration,
+    usage_progress: bool,
+    mut publish: impl FnMut(crate::usage::UsageScanProgress),
+) -> Result<(std::process::ExitStatus, Vec<u8>, Vec<u8>)> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("missing SSH stdout"))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("missing SSH stderr"))?;
+    let stdout_thread = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).map(|_| bytes)
+    });
+    let (progress_sender, progress_receiver) = std::sync::mpsc::sync_channel(64);
+    let stderr_thread = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        let mut line = Vec::new();
+        let mut discard_line = false;
+        let mut buffer = [0; 8192];
+        loop {
+            let count = stderr.read(&mut buffer)?;
+            if count == 0 {
+                return Ok(bytes);
+            }
+            if !usage_progress {
+                bytes.extend_from_slice(&buffer[..count]);
+                continue;
+            }
+            // Keep the final diagnostic even after a long stream of progress.
+            let excess = (bytes.len() + count).saturating_sub(65_536);
+            bytes.drain(..excess);
+            bytes.extend_from_slice(&buffer[..count]);
+            for &byte in &buffer[..count] {
+                if byte == b'\n' {
+                    if !discard_line
+                        && let Some(json) = line.strip_prefix(b"MEMEX_PROGRESS ")
+                        && let Ok(progress) = serde_json::from_slice::<RpcUsageProgress>(json)
+                    {
+                        let _ = progress_sender.try_send((Instant::now(), progress));
+                    }
+                    line.clear();
+                    discard_line = false;
+                } else if !discard_line {
+                    if line.len() == 65_536 {
+                        line.clear();
+                        discard_line = true;
+                    } else {
+                        line.push(byte);
+                    }
+                }
+            }
+        }
+    });
+
+    let mut deadline = Instant::now() + timeout;
+    let mut completed = HashMap::new();
+    let status = loop {
+        for (received_at, progress) in progress_receiver.try_iter() {
+            let Some(source) = crate::types::SourceKind::from_label(&progress.source) else {
+                continue;
+            };
+            if progress.total == 0 || progress.done == 0 || progress.done > progress.total {
+                continue;
+            }
+            let previous = completed.entry(source.label()).or_insert(0);
+            if progress.done <= *previous {
+                continue;
+            }
+            *previous = progress.done;
+            deadline = received_at + timeout;
+            publish(crate::usage::UsageScanProgress {
+                source: source.label(),
+                done: progress.done,
+                total: progress.total,
+            });
+        }
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!(
+                "SSH request to '{}' timed out after {}s",
+                machine_id,
+                timeout.as_secs()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| anyhow!("SSH stdout reader panicked"))??;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| anyhow!("SSH stderr reader panicked"))??;
+    Ok((status, stdout, stderr))
 }
 
 fn validate_machine(machine: &MachineConfig) -> Result<()> {
@@ -2842,6 +3043,278 @@ mod tests {
     use crate::types::{RecordLinks, SourceKind};
     use tempfile::TempDir;
 
+    fn activity_progress_child(script: &str) -> std::process::Child {
+        Command::new("sh")
+            .args(["-c", script])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    #[test]
+    fn activity_rpc_progress_extends_idle_deadline_and_preserves_output() {
+        let mut child = activity_progress_child(
+            r#"
+            for done in 1 2 3 4 5; do
+                printf 'MEMEX_PROGRESS {"source":"codex","done":%s,"total":5}\n' "$done" >&2
+                sleep 0.1
+            done
+            printf 'complete'
+            printf 'diagnostic\n' >&2
+        "#,
+        );
+        let started = Instant::now();
+        let mut updates = Vec::new();
+        let (status, output, stderr) = wait_rpc_child(
+            &mut child,
+            "fixture",
+            Duration::from_millis(250),
+            true,
+            |progress| updates.push(progress.done),
+        )
+        .unwrap();
+        assert!(status.success());
+        assert!(started.elapsed() > Duration::from_millis(250));
+        assert_eq!(output, b"complete");
+        assert!(String::from_utf8(stderr).unwrap().contains("diagnostic"));
+        assert_eq!(updates, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn activity_rpc_nonadvancing_or_unrequested_progress_times_out_and_reaps_child() {
+        for (progress, enabled) in [
+            (r#"{"source":"codex","done":0,"total":5}"#, true),
+            (r#"{"source":"codex","done":1,"total":5}"#, true),
+            (r#"{"source":"codex","done":4,"total":3}"#, true),
+            (r#"{"source":"codex","done":-1,"total":3}"#, true),
+            (r#"{"source":"codex","done":1,"total":0}"#, true),
+            (r#"{"source":"unknown","done":1,"total":3}"#, true),
+            ("invalid JSON", true),
+            (r#"{"source":"codex","done":2,"total":5}"#, false),
+        ] {
+            let script = format!(
+                "while :; do printf '%s\\n' 'MEMEX_PROGRESS {progress}' >&2; sleep 0.05; done"
+            );
+            let mut child = activity_progress_child(&script);
+            let started = Instant::now();
+            let result = wait_rpc_child(
+                &mut child,
+                "fixture",
+                Duration::from_millis(200),
+                enabled,
+                |_| {},
+            );
+            assert!(result.unwrap_err().to_string().contains("timed out"));
+            assert!(started.elapsed() < Duration::from_secs(2));
+            assert!(child.try_wait().unwrap().is_some());
+        }
+        let mut child = activity_progress_child(
+            r#"
+            printf 'MEMEX_PROGRESS {"source":"codex","done":3,"total":5}\n' >&2
+            sleep 0.1
+            while :; do printf 'MEMEX_PROGRESS {"source":"codex","done":2,"total":5}\n' >&2; sleep 0.05; done
+        "#,
+        );
+        assert!(
+            wait_rpc_child(
+                &mut child,
+                "fixture",
+                Duration::from_millis(200),
+                true,
+                |_| {}
+            )
+            .is_err()
+        );
+        assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[test]
+    fn activity_rpc_progress_discards_overlong_lines_and_bounds_diagnostics() {
+        let mut child = activity_progress_child(
+            r#"
+            awk 'BEGIN { for (i=0; i<70000; i++) printf "x"; print "" }' >&2
+            printf 'MEMEX_PROGRESS {"source":"codex","done":1,"total":1}\n' >&2
+            sleep 0.1
+            printf 'complete'
+            printf 'final SSH failure detail\n' >&2
+        "#,
+        );
+        let mut updates = Vec::new();
+        let (_, output, stderr) = wait_rpc_child(
+            &mut child,
+            "fixture",
+            Duration::from_secs(2),
+            true,
+            |progress| updates.push(progress.done),
+        )
+        .unwrap();
+        assert_eq!(output, b"complete");
+        assert_eq!(stderr.len(), 65_536);
+        assert!(
+            String::from_utf8(stderr)
+                .unwrap()
+                .ends_with("final SSH failure detail\n")
+        );
+        assert_eq!(updates, [1]);
+    }
+
+    #[test]
+    fn activity_rpc_progress_is_optional_for_existing_requests() {
+        let request: RpcRequest =
+            serde_json::from_value(serde_json::json!({"protocol": 1, "request": {"op": "ping"}}))
+                .unwrap();
+        assert!(!request.usage_progress);
+        assert!(
+            serde_json::to_value(request)
+                .unwrap()
+                .get("usage_progress")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn legacy_home_activity_preserves_every_nonquery_filter() {
+        use crate::web::{ActivityMetric, ActivityRequest, TimeRange};
+        let now = 200 * 86_400_000;
+        for metric in [ActivityMetric::Sessions, ActivityMetric::Tokens] {
+            for origin in [
+                SessionKindFilter::All,
+                SessionKindFilter::Regular,
+                SessionKindFilter::Primary,
+                SessionKindFilter::Subagent,
+            ] {
+                for range in [
+                    None,
+                    Some(TimeRange::Day),
+                    Some(TimeRange::Week),
+                    Some(TimeRange::Month),
+                    Some(TimeRange::All),
+                ] {
+                    for filtered in [false, true] {
+                        let request = ActivityRequest {
+                            metric,
+                            query: String::new(),
+                            source: filtered.then_some(SourceFilter::Codex),
+                            project: filtered.then(|| "memex".to_string()),
+                            days: 10,
+                            range,
+                            origin,
+                        };
+                        let mut calls = 0;
+                        let payload = remote_activity_with(&request, now, |operation| {
+                            calls += 1;
+                            match operation {
+                                RpcOperation::HomeActivity { .. } => {
+                                    Err(anyhow!("unknown variant `home_activity`"))
+                                }
+                                RpcOperation::SessionActivity { spec } => {
+                                    assert!(matches!(metric, ActivityMetric::Sessions));
+                                    assert_eq!(spec.source, request.source);
+                                    assert_eq!(spec.project, request.project);
+                                    assert_eq!(spec.kind, Some(origin));
+                                    assert_eq!(spec.project_grouping, ProjectGrouping::Flat);
+                                    assert_eq!(spec.until_ms, None);
+                                    assert_eq!(
+                                        spec.since_ms,
+                                        range
+                                            .map(|value| value.since_ms(now))
+                                            .unwrap_or(Some(now - 10 * 86_400_000))
+                                    );
+                                    Ok(RpcPayload::SessionActivity {
+                                        points: vec![SessionActivityPointWire {
+                                            machine: "peer".into(),
+                                            source: "codex".into(),
+                                            timestamp_ms: now,
+                                        }],
+                                    })
+                                }
+                                RpcOperation::UsageActivity { spec } => {
+                                    assert!(matches!(metric, ActivityMetric::Tokens));
+                                    assert_eq!(spec.source, request.source);
+                                    assert_eq!(spec.project, request.project);
+                                    assert_eq!(spec.kind, Some(origin));
+                                    assert_eq!(spec.project_grouping, ProjectGrouping::Flat);
+                                    assert_eq!(spec.until_ms, None);
+                                    assert_eq!(
+                                        spec.since_ms,
+                                        range
+                                            .map(|value| value.since_ms(now))
+                                            .unwrap_or(Some(now - 10 * 86_400_000))
+                                    );
+                                    assert!(spec.session_keys.is_none());
+                                    assert!(!spec.include_events);
+                                    Ok(RpcPayload::UsageActivity {
+                                        points: vec![UsageActivityPointWire {
+                                            machine: "peer".into(),
+                                            source: "codex".into(),
+                                            timestamp_ms: now,
+                                            total_tokens: 42,
+                                        }],
+                                        partial: true,
+                                    })
+                                }
+                                _ => panic!("unexpected legacy operation"),
+                            }
+                        })
+                        .unwrap();
+                        assert_eq!(calls, 2);
+                        let json = serde_json::to_value(payload).unwrap();
+                        assert_eq!(
+                            json["points"][0]["value"],
+                            if matches!(metric, ActivityMetric::Tokens) {
+                                42
+                            } else {
+                                1
+                            }
+                        );
+                        assert_eq!(json["partial"], matches!(metric, ActivityMetric::Tokens));
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_home_activity_never_ignores_query_or_other_errors() {
+        use crate::web::{ActivityMetric, ActivityRequest, TimeRange};
+        for metric in [ActivityMetric::Sessions, ActivityMetric::Tokens] {
+            let mut request = ActivityRequest {
+                metric,
+                query: "exact search".into(),
+                source: None,
+                project: None,
+                days: 30,
+                range: Some(TimeRange::All),
+                origin: SessionKindFilter::All,
+            };
+            let mut calls = 0;
+            let error = remote_activity_with(&request, 100, |_| {
+                calls += 1;
+                Err(anyhow!("unknown variant `home_activity`"))
+            })
+            .unwrap_err();
+            assert_eq!(calls, 1);
+            assert!(error.to_string().contains("activity filtered by search"));
+            request.query.clear();
+            for message in [
+                "connection timed out",
+                "invalid activity data",
+                "unknown variant `another_operation`",
+                "unsupported RPC protocol",
+            ] {
+                let mut calls = 0;
+                let error = remote_activity_with(&request, 100, |_| {
+                    calls += 1;
+                    Err(anyhow!(message.to_string()))
+                })
+                .unwrap_err();
+                assert_eq!(calls, 1);
+                assert_eq!(error.to_string(), message);
+            }
+        }
+    }
+
     fn machine(id: &str) -> MachineConfig {
         MachineConfig {
             id: id.to_string(),
@@ -2921,6 +3394,7 @@ mod tests {
         let request = serde_json::to_vec(&RpcRequest {
             protocol: RPC_PROTOCOL,
             request: operation,
+            usage_progress: false,
         })
         .unwrap();
         let request: RpcRequest = serde_json::from_slice(&request).unwrap();
@@ -3760,6 +4234,50 @@ mod tests {
         )
         .unwrap();
         assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn home_activity_rpc_round_trips_filtered_complete_history() {
+        let tmp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(tmp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut writer = AnalyticsWriter::open(analytics_path(&paths.state)).unwrap();
+        for id in 1..=240 {
+            let mut row = test_record(id, &format!("session-{id}"), &format!("/{id}.jsonl"), 1);
+            row.source = SourceKind::Codex;
+            row.project = if id % 2 == 0 { "memex" } else { "other" }.into();
+            writer.record(&row).unwrap();
+        }
+        writer.flush().unwrap();
+        drop(writer);
+        let response = rpc_handler_round_trip(
+            &paths,
+            &UserConfig::default(),
+            RpcOperation::HomeActivity {
+                request: crate::web::ActivityRequest {
+                    metric: crate::web::ActivityMetric::Sessions,
+                    query: String::new(),
+                    source: Some(SourceFilter::Codex),
+                    project: Some("memex".into()),
+                    days: 30,
+                    range: Some(crate::web::TimeRange::All),
+                    origin: SessionKindFilter::Regular,
+                },
+                now: 2_000_000_000_000,
+            },
+        );
+        let RpcPayload::HomeActivity { activity } = response else {
+            panic!("expected home activity");
+        };
+        let json = serde_json::to_value(activity).unwrap();
+        let total = json["points"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["value"].as_u64().unwrap())
+            .sum::<u64>();
+        assert_eq!(total, 120);
+        assert_eq!(json["partial"], false);
     }
 
     #[test]

--- a/src/native.rs
+++ b/src/native.rs
@@ -23,6 +23,7 @@ const MAX_CONNECTIONS: usize = 16;
 const IO_TIMEOUT: Duration = Duration::from_secs(120);
 const CAPABILITIES: &[&str] = &[
     "machines",
+    "activity",
     "projects",
     "sessions",
     "count",
@@ -36,6 +37,16 @@ const CAPABILITIES: &[&str] = &[
 pub(crate) enum Operation {
     Hello {},
     Machines {},
+    Activity {
+        machine: String,
+        metric: String,
+        range: String,
+        query: Option<String>,
+        project: Option<String>,
+        source: Option<String>,
+        origin: SessionOrigin,
+        now_ms: u64,
+    },
     Projects {
         machine: String,
     },
@@ -426,6 +437,52 @@ mod tests {
             json!({"id":"local","label":"This Mac"})
         );
         assert!(!root.path().join("index").exists());
+    }
+
+    #[test]
+    fn activity_returns_one_machine_raw_buckets_at_a_shared_clock() {
+        let root = root();
+        let paths = Paths::new(Some(root.path().to_path_buf())).unwrap();
+        paths.ensure_dirs().unwrap();
+        let day = 86_400_000;
+        let mut analytics = AnalyticsWriter::open(analytics_path(&paths.state)).unwrap();
+        for (id, timestamp) in [(1, day), (2, 2 * day + 1)] {
+            analytics
+                .record(&Record {
+                    source: SourceKind::Codex,
+                    doc_id: id,
+                    ts: timestamp,
+                    project: "memex".into(),
+                    session_id: format!("session-{id}"),
+                    turn_id: 1,
+                    role: "user".into(),
+                    text: "hello".into(),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_output: None,
+                    links: RecordLinks::default(),
+                    source_path: format!("/{id}.jsonl"),
+                })
+                .unwrap();
+        }
+        analytics.flush().unwrap();
+        drop(analytics);
+        let server = spawn(Some(root.path().to_path_buf())).unwrap();
+        let mut stream = connect(&server);
+        let operation = json!({"op":"activity", "machine":"local", "metric":"sessions", "range":"24h",
+            "source":"codex", "project":"memex", "origin":"regular", "now_ms":3 * day});
+        let response = request(&mut stream, operation.clone());
+        assert_eq!(
+            response["result"]["points"],
+            json!([{"timestamp_ms":2 * day,"source":"codex","value":1}])
+        );
+        assert_eq!(response["result"]["partial"], false);
+        let mut invalid = operation;
+        invalid["metric"] = json!("wrong");
+        assert_eq!(
+            request(&mut stream, invalid)["error"]["code"],
+            "request_failed"
+        );
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -204,6 +204,13 @@ pub struct UsageActivityPoint {
 /// points instead of deep-cloning full events out of the memoized assembly. The boolean is
 /// true when any scanner reported a warning, i.e. the totals may be partial.
 pub fn scan_usage_activity(query: &UsageQuery) -> Result<(Vec<UsageActivityPoint>, bool)> {
+    let (points, warnings) = scan_usage_activity_with_warnings(query)?;
+    Ok((points, !warnings.is_empty()))
+}
+
+pub(crate) fn scan_usage_activity_with_warnings(
+    query: &UsageQuery,
+) -> Result<(Vec<UsageActivityPoint>, Vec<String>)> {
     let _scan_guard = USAGE_SCAN_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -215,7 +222,7 @@ pub fn scan_usage_activity(query: &UsageQuery) -> Result<(Vec<UsageActivityPoint
             total_tokens: event.tokens.total(),
         })
         .collect();
-    Ok((points, !warnings.is_empty()))
+    Ok((points, warnings.as_ref().clone()))
 }
 
 /// Assembled events are already sorted; filtering preserves that order.
@@ -632,7 +639,7 @@ static USAGE_SCAN_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 /// Parse-phase progress of the usage scan currently holding `USAGE_SCAN_LOCK`. Cache hits
 /// are not counted: progress is only published while files are being (re)parsed, which is
 /// the phase that can take minutes on a cold cache.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub struct UsageScanProgress {
     pub source: &'static str,
     pub done: usize,
@@ -647,10 +654,45 @@ pub fn usage_scan_progress() -> Option<UsageScanProgress> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Forward advancing cold-cache counters without imposing a total scan lifetime.
+/// Callers retain their own cancellation and inactivity watchdogs.
+pub(crate) fn with_usage_progress<T: Send>(
+    action: impl FnOnce() -> T + Send,
+    mut publish: impl FnMut(UsageScanProgress) -> Result<()>,
+) -> Result<T> {
+    std::thread::scope(|scope| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        scope.spawn(move || {
+            let _ = sender.send(action());
+        });
+        let mut previous = None;
+        loop {
+            match receiver.recv_timeout(Duration::from_millis(200)) {
+                Ok(result) => return Ok(result),
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(anyhow::anyhow!("activity worker stopped without a result"));
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    if let Some(progress) = usage_scan_progress()
+                        && Some(progress) != previous
+                    {
+                        publish(progress)?;
+                        previous = Some(progress);
+                    }
+                }
+            }
+        }
+    })
+}
+
 fn publish_scan_progress(progress: Option<UsageScanProgress>) {
     *USAGE_SCAN_PROGRESS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = progress;
+}
+
+pub(crate) fn publish_remote_scan_progress(progress: UsageScanProgress) {
+    publish_scan_progress(Some(progress));
 }
 
 fn bump_scan_progress() {
@@ -1655,6 +1697,37 @@ fn claude_rates(input: u64, write_5m: u64, write_1h: u64, read: u64, output: u64
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn activity_reports_progress_before_the_scan_completes() {
+        let _scan_guard = super::USAGE_SCAN_LOCK.lock().unwrap();
+        let (acknowledge, received) = std::sync::mpsc::channel();
+        let mut updates = Vec::new();
+        let value = super::with_usage_progress(
+            move || {
+                for done in [0, 1] {
+                    super::publish_scan_progress(Some(super::UsageScanProgress {
+                        source: "codex",
+                        done,
+                        total: 2,
+                    }));
+                    received
+                        .recv_timeout(std::time::Duration::from_secs(2))
+                        .unwrap();
+                }
+                super::publish_scan_progress(None);
+                42
+            },
+            |progress| {
+                updates.push(progress.done);
+                acknowledge.send(()).unwrap();
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(value, 42);
+        assert_eq!(updates, vec![0, 1]);
+    }
+
     use super::*;
     use std::fs;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,12 +2,12 @@ use crate::analytics::{AnalyticsStore, ProjectGrouping, SessionKindFilter, analy
 use crate::config::{Paths, UserConfig};
 use crate::index::{QueryOptions, SearchIndex, SessionScopeKey, TimestampOrder};
 use crate::types::SourceFilter;
-use crate::usage::{CostMode, UsageQuery, scan_usage, scan_usage_activity};
+use crate::usage::{CostMode, UsageQuery, scan_usage, scan_usage_activity_with_warnings};
 use crate::web_auth::WebAuth;
 use anyhow::{Context, Result, anyhow};
 use base64::Engine as _;
 use chrono::Utc;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
@@ -361,14 +361,14 @@ struct SessionTokenPayload<'a> {
     token: &'a str,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ActivityMetric {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ActivityMetric {
     Sessions,
     Tokens,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TimeRange {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum TimeRange {
     Day,
     Week,
     Month,
@@ -376,7 +376,7 @@ enum TimeRange {
 }
 
 impl TimeRange {
-    fn parse(value: &str) -> Result<Self> {
+    pub(crate) fn parse(value: &str) -> Result<Self> {
         match value {
             "24h" => Ok(Self::Day),
             "7d" => Ok(Self::Week),
@@ -397,7 +397,7 @@ impl TimeRange {
         }
     }
 
-    fn since_ms(self, now: u64) -> Option<u64> {
+    pub(crate) fn since_ms(self, now: u64) -> Option<u64> {
         let days = match self {
             Self::Day => 1,
             Self::Week => 7,
@@ -408,15 +408,15 @@ impl TimeRange {
     }
 }
 
-#[derive(Debug)]
-struct ActivityRequest {
-    metric: ActivityMetric,
-    query: String,
-    source: Option<SourceFilter>,
-    project: Option<String>,
-    days: i64,
-    range: Option<TimeRange>,
-    origin: SessionKindFilter,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ActivityRequest {
+    pub(crate) metric: ActivityMetric,
+    pub(crate) query: String,
+    pub(crate) source: Option<SourceFilter>,
+    pub(crate) project: Option<String>,
+    pub(crate) days: i64,
+    pub(crate) range: Option<TimeRange>,
+    pub(crate) origin: SessionKindFilter,
 }
 
 impl ActivityRequest {
@@ -495,7 +495,7 @@ fn activity_matching_session_scopes(
 }
 
 #[derive(Serialize)]
-struct ActivityPayload {
+pub(crate) struct ActivityPayload {
     metric: &'static str,
     days: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -504,6 +504,8 @@ struct ActivityPayload {
     token_usage_enabled: bool,
     partial: bool,
     points: Vec<ActivityPoint>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -544,10 +546,64 @@ impl AllowedUsageScopes {
     }
 }
 
-fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityPayload> {
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct RawActivityPayload {
+    points: Vec<RawActivityPoint>,
+    token_usage_enabled: bool,
+    partial: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RawActivityPoint {
+    timestamp_ms: u64,
+    source: String,
+    value: u64,
+}
+
+impl RawActivityPayload {
+    pub(crate) fn from_remote_points(
+        points: impl IntoIterator<Item = (u64, String, u64)>,
+        request: &ActivityRequest,
+        partial: bool,
+    ) -> Self {
+        let bucket_ms = if request.range == Some(TimeRange::Day) {
+            3_600_000
+        } else {
+            86_400_000
+        };
+        let mut buckets = BTreeMap::new();
+        for (timestamp, source, value) in points {
+            add_activity_value(&mut buckets, timestamp, &source, value, bucket_ms);
+        }
+        Self {
+            points: buckets
+                .into_iter()
+                .map(|((timestamp_ms, source), value)| RawActivityPoint {
+                    timestamp_ms,
+                    source,
+                    value,
+                })
+                .collect(),
+            token_usage_enabled: true,
+            partial,
+            warnings: if partial {
+                vec!["The peer reported incomplete token usage data".to_string()]
+            } else {
+                Vec::new()
+            },
+        }
+    }
+}
+
+pub(crate) fn raw_activity_payload(
+    paths: &Paths,
+    params: &ActivityRequest,
+    now: u64,
+) -> Result<RawActivityPayload> {
     let config = UserConfig::load(paths)?;
     let token_usage_enabled = config.token_usage_enabled();
-    let now = Utc::now().timestamp_millis().max(0) as u64;
     let since_ms = params
         .range
         .map(|range| range.since_ms(now))
@@ -560,6 +616,7 @@ fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityP
     let mut buckets: BTreeMap<(u64, String), u64> = BTreeMap::new();
     let matching_scopes = activity_matching_session_scopes(paths, params, since_ms)?;
 
+    let mut warnings = Vec::new();
     let partial = match (params.metric, matching_scopes.as_ref()) {
         (ActivityMetric::Sessions, matching_scopes) => {
             let store = AnalyticsStore::open_read_only(analytics_path(&paths.state))?;
@@ -633,6 +690,7 @@ fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityP
                 };
                 let report = scan_usage(&query)?;
                 let partial = !report.warnings.is_empty();
+                warnings.extend(report.warnings.iter().cloned());
                 for event in report.details {
                     let Some(session_id) = event.session_id else {
                         continue;
@@ -698,7 +756,9 @@ fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityP
                 cache_path: Some(paths.state.join("usage-cache.sqlite3")),
                 memo_ttl_ms: 60_000,
             };
-            let (points, partial) = scan_usage_activity(&query)?;
+            let (points, scan_warnings) = scan_usage_activity_with_warnings(&query)?;
+            let partial = !scan_warnings.is_empty();
+            warnings.extend(scan_warnings);
             for point in points {
                 add_activity_value(
                     &mut buckets,
@@ -712,6 +772,50 @@ fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityP
         }
     };
 
+    Ok(RawActivityPayload {
+        points: buckets
+            .into_iter()
+            .map(|((timestamp_ms, source), value)| RawActivityPoint {
+                timestamp_ms,
+                source,
+                value,
+            })
+            .collect(),
+        token_usage_enabled,
+        partial,
+        warnings,
+    })
+}
+
+fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityPayload> {
+    let now = Utc::now().timestamp_millis().max(0) as u64;
+    finish_activity_payload(raw_activity_payload(paths, params, now)?, params, now)
+}
+
+fn finish_activity_payload(
+    raw: RawActivityPayload,
+    params: &ActivityRequest,
+    now: u64,
+) -> Result<ActivityPayload> {
+    let since_ms = params
+        .range
+        .map(|range| range.since_ms(now))
+        .unwrap_or_else(|| Some(now.saturating_sub(params.days as u64 * 86_400_000)));
+    let bucket_ms = if params.range == Some(TimeRange::Day) {
+        3_600_000
+    } else {
+        86_400_000
+    };
+    let buckets = raw
+        .points
+        .into_iter()
+        .fold(BTreeMap::new(), |mut buckets, point| {
+            let total = buckets
+                .entry((point.timestamp_ms, point.source))
+                .or_insert(0_u64);
+            *total = total.saturating_add(point.value);
+            buckets
+        });
     let (bucket_keys, points, days) = activity_buckets(buckets, since_ms, now, bucket_ms);
     Ok(ActivityPayload {
         metric: match params.metric {
@@ -727,10 +831,107 @@ fn activity_payload(paths: &Paths, params: &ActivityRequest) -> Result<ActivityP
         },
         range: params.range.map(TimeRange::label),
         bucket_keys,
-        token_usage_enabled,
-        partial,
+        token_usage_enabled: raw.token_usage_enabled,
+        partial: raw.partial,
         points,
+        warnings: raw.warnings,
     })
+}
+
+/// A native request reads one machine so a slow peer cannot hold completed data.
+pub(crate) fn single_machine_activity_payload(
+    paths: &Paths,
+    params: &ActivityRequest,
+    machine: &str,
+    now: u64,
+) -> Result<RawActivityPayload> {
+    let config = UserConfig::load(paths)?;
+    crate::machine::selected_machine_ids(&config, &[machine.to_owned()])?;
+    if machine == crate::machine::LOCAL_MACHINE_ID {
+        raw_activity_payload(paths, params, now)
+    } else {
+        crate::machine::remote_activity(&config, machine, params.clone(), now)
+    }
+}
+
+/// Collect raw time buckets concurrently, then choose one common bucket grid.
+/// Combining already compressed per-machine charts would misalign all-time data.
+pub(crate) fn machine_activity_payload(
+    paths: &Paths,
+    params: &ActivityRequest,
+    machine: &str,
+) -> Result<ActivityPayload> {
+    let config = UserConfig::load(paths)?;
+    let requested = if machine == "all" {
+        crate::machine::configured_machine_summaries(&config)?
+            .into_iter()
+            .filter_map(|row| row["id"].as_str().map(str::to_owned))
+            .collect()
+    } else {
+        vec![machine.to_owned()]
+    };
+    let ids = crate::machine::selected_machine_ids(&config, &requested)?;
+    let now = Utc::now().timestamp_millis().max(0) as u64;
+    let (sender, receiver) = mpsc::channel();
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let sender = sender.clone();
+            let config = &config;
+            scope.spawn(move || {
+                let result = if id == crate::machine::LOCAL_MACHINE_ID {
+                    raw_activity_payload(paths, params, now)
+                } else {
+                    crate::machine::remote_activity(config, id, params.clone(), now)
+                };
+                let _ = sender.send((id.clone(), result));
+            });
+        }
+        drop(sender);
+    });
+    finish_activity_payload(
+        merge_activity_results(receiver, params.metric)?,
+        params,
+        now,
+    )
+}
+
+fn merge_activity_results(
+    results: impl IntoIterator<Item = (String, Result<RawActivityPayload>)>,
+    metric: ActivityMetric,
+) -> Result<RawActivityPayload> {
+    let mut merged = RawActivityPayload {
+        points: Vec::new(),
+        token_usage_enabled: false,
+        partial: false,
+        warnings: Vec::new(),
+    };
+    let mut successes = 0;
+    let mut errors = Vec::new();
+    for (id, result) in results {
+        match result {
+            Ok(raw) => {
+                successes += 1;
+                merged.points.extend(raw.points);
+                merged.token_usage_enabled |= raw.token_usage_enabled;
+                merged.partial |= raw.partial;
+                merged.warnings.extend(
+                    raw.warnings
+                        .into_iter()
+                        .map(|warning| format!("{id}: {warning}")),
+                );
+                // A disabled peer contributes no token usage; keep that absence explicit.
+                if metric == ActivityMetric::Tokens && !raw.token_usage_enabled {
+                    merged.partial = true;
+                }
+            }
+            Err(error) => errors.push(format!("{id}: {error}")),
+        }
+    }
+    if successes == 0 {
+        return Err(anyhow!("Activity unavailable: {}", errors.join("; ")));
+    }
+    merged.partial |= !errors.is_empty();
+    Ok(merged)
 }
 
 fn add_activity_value(
@@ -740,6 +941,10 @@ fn add_activity_value(
     value: u64,
     bucket_ms: u64,
 ) {
+    // Missing source timestamps are encoded as zero, not activity in 1970.
+    if timestamp_ms == 0 || timestamp_ms > i64::MAX as u64 {
+        return;
+    }
     let Some(timestamp) = chrono::DateTime::<Utc>::from_timestamp_millis(timestamp_ms as i64)
     else {
         return;
@@ -2337,6 +2542,171 @@ mod tests {
         for selector in [format!("before={}", total + 1), format!("offset={}", total)] {
             let error = session_payload(&paths, &request(&selector)).unwrap_err();
             assert!(error.downcast_ref::<InvalidSessionOffset>().is_some());
+        }
+    }
+
+    #[test]
+    fn native_activity_uses_web_filters_and_complete_history() {
+        use crate::analytics::AnalyticsWriter;
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("memex"))).unwrap();
+        paths.ensure_dirs().unwrap();
+        let mut rows = Vec::new();
+        for index in 1..=240 {
+            let mut row = record(
+                index,
+                &format!("session-{index}"),
+                &format!("/{index}.jsonl"),
+                if index % 2 == 0 {
+                    "needle"
+                } else {
+                    "unrelated"
+                }
+                .into(),
+            );
+            if index % 3 == 0 {
+                row.project = "other".into();
+            }
+            rows.push(row);
+        }
+        let mut writer = AnalyticsWriter::open(analytics_path(&paths.state)).unwrap();
+        for row in &rows {
+            writer.record(row).unwrap();
+        }
+        writer.flush().unwrap();
+        drop(writer);
+        publish_records(&paths, rows);
+        for (filters, expected) in [
+            ("", 240),
+            ("&q=needle&project=memex&source=claude", 80),
+            ("&source=codex", 0),
+        ] {
+            let request = ActivityRequest::from_url(
+                &parse_url(&format!("/api/activity?range=all&origin=regular{filters}")).unwrap(),
+            )
+            .unwrap();
+            let web = activity_payload(&paths, &request).unwrap();
+            for machine in ["local", "all"] {
+                let native = machine_activity_payload(&paths, &request, machine).unwrap();
+                assert_eq!(native.points.iter().map(|p| p.value).sum::<u64>(), expected);
+                assert_eq!(
+                    serde_json::to_value(&native).unwrap(),
+                    serde_json::to_value(&web).unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn native_activity_preserves_successful_peers_and_reports_failures() {
+        let good = RawActivityPayload {
+            points: vec![RawActivityPoint {
+                timestamp_ms: 0,
+                source: "codex".into(),
+                value: 10,
+            }],
+            token_usage_enabled: true,
+            partial: false,
+            warnings: Vec::new(),
+        };
+        let merged = merge_activity_results(
+            [
+                ("local".into(), Ok(good)),
+                (
+                    "older-peer".into(),
+                    Err(anyhow!("unknown variant home_activity")),
+                ),
+            ],
+            ActivityMetric::Sessions,
+        )
+        .unwrap();
+        assert!(merged.partial);
+        assert_eq!(merged.points[0].value, 10);
+        let failed = merge_activity_results(
+            [(
+                "older-peer".into(),
+                Err(anyhow!("unknown variant home_activity")),
+            )],
+            ActivityMetric::Sessions,
+        )
+        .unwrap_err();
+        assert!(
+            failed
+                .to_string()
+                .contains("older-peer: unknown variant home_activity")
+        );
+    }
+
+    #[test]
+    fn native_activity_merges_raw_buckets_on_one_all_time_grid() {
+        let day = 86_400_000;
+        let request =
+            ActivityRequest::from_url(&parse_url("/api/activity?range=all").unwrap()).unwrap();
+        let raw = RawActivityPayload {
+            points: vec![
+                RawActivityPoint {
+                    timestamp_ms: day,
+                    source: "Claude".into(),
+                    value: 2,
+                },
+                RawActivityPoint {
+                    timestamp_ms: day,
+                    source: "Claude".into(),
+                    value: 3,
+                },
+                RawActivityPoint {
+                    timestamp_ms: 150 * day,
+                    source: "Codex".into(),
+                    value: 7,
+                },
+            ],
+            token_usage_enabled: true,
+            partial: true,
+            warnings: Vec::new(),
+        };
+        let payload = finish_activity_payload(raw, &request, 200 * day).unwrap();
+        assert!(payload.bucket_keys.len() <= 60);
+        assert!(
+            payload
+                .points
+                .iter()
+                .all(|p| payload.bucket_keys.contains(&p.date))
+        );
+        assert_eq!(payload.points.iter().map(|p| p.value).sum::<u64>(), 12);
+        assert_eq!(
+            payload
+                .points
+                .iter()
+                .find(|p| p.source == "Claude")
+                .unwrap()
+                .value,
+            5
+        );
+        assert!(payload.partial);
+    }
+
+    #[test]
+    fn activity_excludes_missing_and_invalid_timestamps_for_both_metrics() {
+        let now = 1_789_000_000_000;
+        for metric in ["sessions", "tokens"] {
+            let request = ActivityRequest::from_url(
+                &parse_url(&format!("/api/activity?range=all&metric={metric}")).unwrap(),
+            )
+            .unwrap();
+            let raw = RawActivityPayload::from_remote_points(
+                [
+                    (0, "cursor".into(), 19_955_038),
+                    (u64::MAX, "cursor".into(), 7),
+                    (now, "cursor".into(), 3),
+                ],
+                &request,
+                false,
+            );
+            let result = finish_activity_payload(raw, &request, now).unwrap();
+            assert_eq!(result.bucket_keys.len(), 1);
+            assert_eq!(result.points.len(), 1);
+            assert_eq!(result.points[0].value, 3);
+            assert!(!result.bucket_keys[0].starts_with("1970"));
         }
     }
 


### PR DESCRIPTION
Adds a native Home screen with conversation and token activity charts, search, recent conversations, and shared filters. Home refreshes automatically while visible and keeps existing charts and rows in place while local and remote results update. Cold token scans report progress so active work can finish without hitting a fixed request deadline.

Subagents are hidden by default and show a text label when enabled; task names and browsing metadata survive search transitions. The filter uses a circular Liquid Glass button with hover feedback. Routine Codex turn-boundary events are hidden in the reader while remaining available in raw mode and Find.
