### PR TITLE
Reuse unchanged memory section embeddings across snapshots

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1414,7 +1414,7 @@ fn validate_content_page(record: &Record, content: &ContentPage) -> Result<usize
     if content.returned_chars > content.total_chars {
         bail!("bounded response returned_chars exceeds total_chars");
     }
-    if content.truncated != !content.continuations.is_empty() {
+    if content.truncated == content.continuations.is_empty() {
         bail!("bounded response has inconsistent truncation metadata");
     }
     let mut fields = Vec::new();

--- a/src/memory_search.rs
+++ b/src/memory_search.rs
@@ -14,6 +14,7 @@ use crate::read_budget::{ContentContinuation, ContentPage, ReadField};
 use crate::types::SourceKind;
 use crate::vector::VectorIndex;
 use anyhow::{Context, Result, anyhow, bail};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -565,6 +566,23 @@ pub fn embed_memory(
     model: ModelChoice,
     runtime: &EmbedRuntimeConfig,
 ) -> Result<usize> {
+    let mut embedder = None;
+    embed_memory_with(paths, model, |texts| {
+        if embedder.is_none() {
+            embedder = Some(EmbedderHandle::with_model_and_runtime(model, runtime)?);
+        }
+        embedder
+            .as_mut()
+            .expect("embedder initialized")
+            .embed_texts(texts)
+    })
+}
+
+fn embed_memory_with(
+    paths: &Paths,
+    model: ModelChoice,
+    mut embed: impl FnMut(&[&str]) -> Result<Vec<Vec<f32>>>,
+) -> Result<usize> {
     let snapshot = MemoryStore::new(memory_snapshot_path(paths)).load()?;
     let candidates = all_searchable_sections(&snapshot)?;
     if candidates.is_empty() {
@@ -572,15 +590,27 @@ pub fn embed_memory(
     }
     let snapshot_key = snapshot_fingerprint(&snapshot);
     let vector_path = memory_vector_path(paths, &snapshot_key);
+    // Cache the actual model input, independently of document versions and section IDs.
+    // Commit each batch so an interrupted snapshot build can reuse its completed inference.
+    let mut cache = Connection::open(paths.root.join("memory/section-embeddings.sqlite3"))?;
+    cache.busy_timeout(std::time::Duration::from_secs(30))?;
+    cache.execute_batch(
+        "CREATE TABLE IF NOT EXISTS embeddings (
+            model TEXT NOT NULL,
+            content_sha256 TEXT NOT NULL,
+            embedding BLOB NOT NULL,
+            PRIMARY KEY (model, content_sha256)
+        ) WITHOUT ROWID",
+    )?;
+    seed_memory_embedding_cache(&mut cache, paths, model, &snapshot, &candidates)?;
     if let Ok(existing) = VectorIndex::open(&vector_path)
         && existing.model() == Some(model.as_str())
         && validate_vector_inventory(&existing, &candidates).is_ok()
     {
         return Ok(0);
     }
-    let mut embedder = EmbedderHandle::with_model_and_runtime(model, runtime)?;
-    let mut vector =
-        VectorIndex::empty_replacement(&vector_path, embedder.dims, Some(model.as_str()))?;
+    let mut vector = None;
+    let mut embedded = 0;
     for batch in candidates.chunks(64) {
         let texts = batch
             .iter()
@@ -590,20 +620,137 @@ pub fn embed_memory(
                     .as_str()
             })
             .collect::<Vec<_>>();
-        let embeddings = embedder.embed_texts(&texts)?;
-        if embeddings.len() != batch.len() {
+        let keys = texts
+            .iter()
+            .map(|text| format!("{:x}", Sha256::digest(text.as_bytes())))
+            .collect::<Vec<_>>();
+        let mut embeddings =
+            keys.iter()
+                .map(|key| -> Result<Option<Vec<f32>>> {
+                    let bytes: Option<Vec<u8>> = cache.query_row(
+                    "SELECT embedding FROM embeddings WHERE model = ?1 AND content_sha256 = ?2",
+                    params![model.as_str(), key],
+                    |row| row.get(0),
+                ).optional()?;
+                    Ok(bytes
+                        .map(|bytes| serde_json::from_slice(&bytes))
+                        .transpose()?)
+                })
+                .collect::<Result<Vec<_>>>()?;
+        let missing = embeddings
+            .iter()
+            .enumerate()
+            .filter_map(|(index, embedding)| embedding.is_none().then_some(index))
+            .collect::<Vec<_>>();
+        let new_embeddings = if missing.is_empty() {
+            Vec::new()
+        } else {
+            embed(
+                &missing
+                    .iter()
+                    .map(|&index| texts[index])
+                    .collect::<Vec<_>>(),
+            )?
+        };
+        if new_embeddings.len() != missing.len() {
             bail!(
                 "memory embedder returned {} vectors for {} sections",
-                embeddings.len(),
-                batch.len()
+                new_embeddings.len(),
+                missing.len()
             );
         }
-        for (candidate, embedding) in batch.iter().zip(embeddings) {
-            vector.add(candidate.vector_id, &embedding)?;
+        for (&index, embedding) in missing.iter().zip(new_embeddings) {
+            embeddings[index] = Some(embedding);
+        }
+        for (candidate, embedding) in batch.iter().zip(&embeddings) {
+            let embedding = embedding.as_ref().expect("cached or embedded");
+            if embedding.is_empty() || embedding.iter().any(|value| !value.is_finite()) {
+                bail!("memory embedder returned an empty or non-finite vector");
+            }
+            if vector.is_none() {
+                vector = Some(VectorIndex::empty_replacement(
+                    &vector_path,
+                    model.known_dimensions().unwrap_or(embedding.len()),
+                    Some(model.as_str()),
+                )?);
+            }
+            vector
+                .as_mut()
+                .expect("vector initialized")
+                .add(candidate.vector_id, embedding)?;
+        }
+        let transaction = cache.transaction()?;
+        for &index in &missing {
+            transaction.execute(
+                "INSERT OR IGNORE INTO embeddings (model, content_sha256, embedding) VALUES (?1, ?2, ?3)",
+                params![model.as_str(), keys[index], serde_json::to_vec(embeddings[index].as_ref().expect("embedded"))?],
+            )?;
+        }
+        transaction.commit()?;
+        embedded += missing.len();
+    }
+    vector.expect("non-empty candidates").save()?;
+    Ok(embedded)
+}
+
+/// Bootstrap older installations from saved vectors without running the model again.
+fn seed_memory_embedding_cache(
+    cache: &mut Connection,
+    paths: &Paths,
+    model: ModelChoice,
+    snapshot: &MemorySnapshot,
+    candidates: &[SectionCandidate],
+) -> Result<()> {
+    let populated: bool = cache.query_row(
+        "SELECT EXISTS(SELECT 1 FROM embeddings WHERE model = ?1)",
+        [model.as_str()],
+        |row| row.get(0),
+    )?;
+    if populated {
+        return Ok(());
+    }
+    let root = paths.root.join("memory").join(MEMORY_VECTOR_DIR);
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut remaining = candidates.to_vec();
+    let transaction = cache.transaction()?;
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        // Old or incomplete generations are optional reuse sources, never authoritative.
+        let Ok(vector) = VectorIndex::open(&entry.path()) else {
+            continue;
+        };
+        if vector.model() != Some(model.as_str()) {
+            continue;
+        }
+        let mut missing = Vec::new();
+        for candidate in remaining {
+            if let Some(embedding) = vector.embedding(candidate.vector_id)? {
+                let text =
+                    &snapshot.documents[candidate.document].sections[candidate.section].content;
+                transaction.execute(
+                    "INSERT OR IGNORE INTO embeddings (model, content_sha256, embedding) VALUES (?1, ?2, ?3)",
+                    params![model.as_str(), format!("{:x}", Sha256::digest(text.as_bytes())), serde_json::to_vec(&embedding)?],
+                )?;
+            } else {
+                missing.push(candidate);
+            }
+        }
+        remaining = missing;
+        if remaining.is_empty() {
+            break;
         }
     }
-    vector.save()?;
-    Ok(candidates.len())
+    transaction.commit()?;
+    let reused = candidates.len() - remaining.len();
+    if reused > 0 {
+        eprintln!("memory embedding cache: reused {reused} saved section vectors");
+    }
+    Ok(())
 }
 
 /// Remove generated vector snapshots other than the one matching the current document snapshot.
@@ -1472,6 +1619,155 @@ mod tests {
     }
 
     #[test]
+    fn memory_embeddings_reuse_text_across_snapshot_changes() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let mut doc = document(
+            temp.path().join("one.md"),
+            "one",
+            "alpha",
+            100,
+            &[("first", "unchanged text"), ("second", "old text")],
+        );
+        write_snapshot(&paths, vec![doc.clone()]);
+        let mut seen = Vec::new();
+        let mut encode = |texts: &[&str]| -> Result<Vec<Vec<f32>>> {
+            seen.extend(texts.iter().map(|text| text.to_string()));
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    let mut embedding = vec![0.0; 384];
+                    embedding[0] = text.len() as f32;
+                    embedding[1] = 1.0;
+                    embedding
+                })
+                .collect())
+        };
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::BGESmall, &mut encode).unwrap(),
+            2
+        );
+        let old_snapshot = MemoryStore::new(memory_snapshot_path(&paths))
+            .load()
+            .unwrap();
+        let old_path = memory_vector_path(&paths, &snapshot_fingerprint(&old_snapshot));
+
+        // Changing the document version also changes IDs for its unchanged sections.
+        doc.version_sha256 = "edited".into();
+        doc.sections[1].content = "new text".into();
+        write_snapshot(&paths, vec![doc.clone()]);
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::BGESmall, &mut encode).unwrap(),
+            1
+        );
+        assert_eq!(seen, ["unchanged text", "old text", "new text"]);
+        let snapshot = MemoryStore::new(memory_snapshot_path(&paths))
+            .load()
+            .unwrap();
+        let vector = VectorIndex::open(&memory_vector_path(
+            &paths,
+            &snapshot_fingerprint(&snapshot),
+        ))
+        .unwrap();
+        validate_vector_inventory(&vector, &all_searchable_sections(&snapshot).unwrap()).unwrap();
+        let old_vector = VectorIndex::open(&old_path).unwrap();
+        validate_vector_inventory(
+            &old_vector,
+            &all_searchable_sections(&old_snapshot).unwrap(),
+        )
+        .unwrap();
+
+        // Renaming, deleting, and duplicating sections require no model initialization.
+        doc.version_sha256 = "rearranged".into();
+        doc.sections.remove(1);
+        doc.sections[0].id = "renamed".into();
+        let mut duplicate = doc.sections[0].clone();
+        duplicate.id = "duplicate".into();
+        doc.sections.push(duplicate);
+        write_snapshot(&paths, vec![doc]);
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::BGESmall, |_| panic!("cached text")).unwrap(),
+            0
+        );
+        let snapshot = MemoryStore::new(memory_snapshot_path(&paths))
+            .load()
+            .unwrap();
+        let vector_path = memory_vector_path(&paths, &snapshot_fingerprint(&snapshot));
+        let vector = VectorIndex::open(&vector_path).unwrap();
+        let candidates = all_searchable_sections(&snapshot).unwrap();
+        validate_vector_inventory(&vector, &candidates).unwrap();
+        let mut query = vec![0.0; 384];
+        query[0] = "unchanged text".len() as f32;
+        query[1] = 1.0;
+        let hits = vector.search(&query, 2).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|(_, distance)| distance.abs() < 1e-5));
+
+        // Reconstructing the published index also uses the persisted cache.
+        fs::remove_dir_all(&vector_path).unwrap();
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::BGESmall, |_| panic!("persisted cache"))
+                .unwrap(),
+            0
+        );
+        let mut inputs = 0;
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::MiniLM, |texts| {
+                inputs += texts.len();
+                Ok(vec![query.clone(); texts.len()])
+            })
+            .unwrap(),
+            2
+        );
+        assert_eq!(inputs, 2, "different models must never share embeddings");
+    }
+
+    #[test]
+    fn interrupted_memory_embedding_reuses_completed_batches() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let text = (0..65)
+            .map(|i| (format!("section-{i}"), format!("text-{i}")))
+            .collect::<Vec<_>>();
+        let sections = text
+            .iter()
+            .map(|(id, text)| (id.as_str(), text.as_str()))
+            .collect::<Vec<_>>();
+        let doc = document(temp.path().join("one.md"), "one", "alpha", 100, &sections);
+        write_snapshot(&paths, vec![doc]);
+        let mut calls = 0;
+        let result = embed_memory_with(&paths, ModelChoice::BGESmall, |texts| {
+            calls += 1;
+            if calls == 2 {
+                bail!("interrupted");
+            }
+            Ok(vec![vec![1.0; 384]; texts.len()])
+        });
+        assert!(result.unwrap_err().to_string().contains("interrupted"));
+        let snapshot = MemoryStore::new(memory_snapshot_path(&paths))
+            .load()
+            .unwrap();
+        let vector_path = memory_vector_path(&paths, &snapshot_fingerprint(&snapshot));
+        assert!(
+            !VectorIndex::exists(&vector_path),
+            "partial snapshots must not be published"
+        );
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::BGESmall, |texts| {
+                assert_eq!(texts, ["text-64"]);
+                Ok(vec![vec![1.0; 384]])
+            })
+            .unwrap(),
+            1
+        );
+        validate_vector_inventory(
+            &VectorIndex::open(&vector_path).unwrap(),
+            &all_searchable_sections(&snapshot).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn existing_complete_vector_snapshot_skips_model_initialization() {
         let temp = TempDir::new().unwrap();
         let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
@@ -1482,7 +1778,7 @@ mod tests {
             100,
             &[("section", "vector content")],
         );
-        write_snapshot(&paths, vec![doc]);
+        write_snapshot(&paths, vec![doc.clone()]);
         let snapshot = MemoryStore::new(memory_snapshot_path(&paths))
             .load()
             .unwrap();
@@ -1494,6 +1790,16 @@ mod tests {
 
         assert_eq!(
             embed_memory(&paths, ModelChoice::Potion, &EmbedRuntimeConfig::default()).unwrap(),
+            0
+        );
+        let mut updated = doc;
+        updated.version_sha256 = "metadata-only change".into();
+        write_snapshot(&paths, vec![updated]);
+        assert_eq!(
+            embed_memory_with(&paths, ModelChoice::Potion, |_| panic!(
+                "reuse legacy vector"
+            ))
+            .unwrap(),
             0
         );
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -380,6 +380,17 @@ impl VectorIndex {
         self.doc_id_set.contains(&doc_id)
     }
 
+    pub(crate) fn embedding(&self, doc_id: u64) -> Result<Option<Vec<f32>>> {
+        if !self.contains(doc_id) {
+            return Ok(None);
+        }
+        let mut embedding = vec![0.0; self.dims];
+        if self.index.get(doc_id, &mut embedding)? != 1 {
+            return Err(anyhow!("missing or duplicate vector for doc_id {doc_id}"));
+        }
+        Ok(Some(embedding))
+    }
+
     pub fn len(&self) -> usize {
         self.index.size()
     }


### PR DESCRIPTION
Editing one memory document currently re-embeds every section in the memory snapshot. On a local index with roughly 1,000 sections, that repeatedly used several CPU cores and several GB of RAM even when only one section changed.

Cache section embeddings by model and the SHA-256 of the exact input text. New snapshots reuse unchanged text while retaining the existing versioned section IDs and atomic vector publication. Each completed batch is persisted so interrupted builds can resume. Existing installations seed the cache from saved compatible vectors instead of requiring a full embedding rebuild.

Validation: all 14 memory-search tests pass on macOS and Linux, including single-section edits, renamed/deleted sections, model isolation, interrupted batches, legacy-vector reuse, and search over reused vectors. An isolated real-BGE CLI check produced 2, 1, 0, and 0 new embeddings for initial creation, one edit, reordering, and a repeated snapshot; semantic search also passed. Formatting and Clippy pass on this upstream branch. A one-line pre-existing boolean comparison is simplified to satisfy current Clippy.
