### PR TITLE
Upgrade ort to 2.0.0-rc.13 and retarget the CUDA 13 runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,12 +572,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96a4956774c13c126a8b5af4daa79384f4d826534c95a02d76afb39e2ab64e3"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -961,7 +1002,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -1148,7 +1189,7 @@ dependencies = [
  "lebe",
  "miniz_oxide",
  "rayon-core",
- "smallvec 1.15.1",
+ "smallvec",
  "zune-inflate",
 ]
 
@@ -1178,15 +1219,17 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastembed"
-version = "5.5.0"
+version = "5.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de72c516a1484c70ba0d98597dafc6274484b542c9ee54e7a326160baa013849"
+checksum = "4539f4a2c4472269adc227587b935c0a973e6b5fc4a03e14bbe62608e06c2298"
 dependencies = [
  "anyhow",
- "hf-hub",
+ "hf-hub 0.5.0",
  "image",
- "ndarray 0.16.1",
+ "ndarray 0.17.2",
  "ort",
+ "safetensors 0.8.0",
+ "serde",
  "serde_json",
  "tokenizers 0.22.2",
 ]
@@ -1224,18 +1267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1574,6 +1605,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1616,7 +1649,26 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
  "http",
- "indicatif",
+ "indicatif 0.17.11",
+ "libc",
+ "log",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif 0.18.6",
  "libc",
  "log",
  "native-tls",
@@ -1625,8 +1677,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
+ "ureq 3.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1637,6 +1689,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "htmlescape"
@@ -1707,7 +1765,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "pin-utils",
- "smallvec 1.15.1",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1830,7 +1888,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.1",
+ "smallvec",
  "zerovec",
 ]
 
@@ -1888,7 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.1",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -1904,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1922,8 +1980,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core 0.5.0",
- "zune-jpeg 0.5.8",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1960,10 +2018,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console 0.16.6",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2247,7 +2318,6 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -2352,6 +2422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,7 +2502,7 @@ dependencies = [
  "getrandom 0.3.4",
  "globset",
  "hmac",
- "indicatif",
+ "indicatif 0.17.11",
  "libc",
  "libloading",
  "memchr",
@@ -2513,9 +2589,9 @@ dependencies = [
  "anyhow",
  "clap",
  "half",
- "hf-hub",
+ "hf-hub 0.4.3",
  "ndarray 0.15.6",
- "safetensors",
+ "safetensors 0.5.3",
  "serde_json",
  "tokenizers 0.21.4",
 ]
@@ -2544,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2590,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -2844,26 +2920,25 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
- "ndarray 0.16.1",
+ "ndarray 0.17.2",
  "ort-sys",
- "smallvec 2.0.0-alpha.10",
+ "smallvec",
  "tracing",
+ "ureq 3.1.4",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2",
- "tar",
+ "hmac-sha256",
+ "lzma-rust2",
  "ureq 3.1.4",
 ]
 
@@ -2918,8 +2993,8 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
- "smallvec 1.15.1",
+ "redox_syscall",
+ "smallvec",
  "windows-link",
 ]
 
@@ -3338,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -3393,15 +3468,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -3632,7 +3698,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.15.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -3741,6 +3807,19 @@ checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -4028,12 +4107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "smallvec"
-version = "2.0.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
-
-[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,7 +4296,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sketches-ddsketch",
- "smallvec 1.15.1",
+ "smallvec",
  "tantivy-bitpacker",
  "tantivy-columnar",
  "tantivy-common",
@@ -4329,17 +4402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,16 +4465,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4482,8 +4544,8 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "hf-hub",
- "indicatif",
+ "hf-hub 0.4.3",
+ "indicatif 0.17.11",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -4811,7 +4873,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec 1.15.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -4844,6 +4906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4858,7 +4926,6 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
@@ -4876,15 +4943,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "der",
+ "flate2",
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "socks",
  "ureq-proto",
  "utf-8",
  "webpki-root-certs",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -5513,16 +5586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.3",
-]
-
-[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5673,12 +5736,6 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
@@ -5694,18 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35aee689668bf9bd6f6f3a6c60bb29ba1244b3b43adfd50edd554a371da37d5"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ clap = { version = "4.5", features = ["derive"] }
 dialoguer = "0.11"
 chrono = { version = "0.4", features = ["serde"] }
 directories = "5.0"
-fastembed = "5"
+fastembed = "5.17.4"
 model2vec-rs = "0.1.4"
-ort = "2.0.0-rc.10"
+ort = "2.0.0-rc.13"
 crossbeam-channel = "0.5"
 once_cell = "1.19"
 memchr = "2.7"
@@ -60,6 +60,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "net",
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "form", "query", "json"] }
 tower-http = { version = "0.6", features = ["cors"] }
 url = "2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# ort >= rc.13 gates each execution provider behind its own feature.
+ort = { version = "2.0.0-rc.13", features = ["coreml"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -16,20 +16,20 @@ const MEMEX_CUDNN_LIBRARY_PATHS_ENV: &str = "MEMEX_CUDNN_LIBRARY_PATHS";
 
 #[cfg(all(feature = "cuda", windows))]
 const CUDA_DYLIBS: &[&str] = &[
-    "cublasLt64_12.dll",
-    "cublas64_12.dll",
-    "cufft64_11.dll",
-    "cudart64_12.dll",
+    "cublasLt64_13.dll",
+    "cublas64_13.dll",
+    "cufft64_12.dll",
+    "cudart64_13.dll",
 ];
 
 #[cfg(all(feature = "cuda", not(windows)))]
 const CUDA_DYLIBS: &[&str] = &[
-    "libcublasLt.so.12",
-    "libcublas.so.12",
-    "libnvrtc.so.12",
+    "libcublasLt.so.13",
+    "libcublas.so.13",
+    "libnvrtc.so.13",
     "libcurand.so.10",
-    "libcufft.so.11",
-    "libcudart.so.12",
+    "libcufft.so.12",
+    "libcudart.so.13",
 ];
 
 #[cfg(all(feature = "cuda", windows))]
@@ -374,27 +374,58 @@ fn candidate_cudnn_library_dirs(explicit_paths: &[PathBuf]) -> Vec<PathBuf> {
 
 #[cfg(feature = "cuda")]
 fn append_common_cuda_dirs(dirs: &mut Vec<PathBuf>) {
-    for var in ["CUDA_PATH", "CUDA_HOME", "CUDA_ROOT"] {
-        if let Some(root) = std::env::var_os(var).map(PathBuf::from) {
-            dirs.push(root.clone());
-            dirs.push(root.join("lib64"));
-            dirs.push(root.join("lib"));
-            dirs.push(root.join("targets/x86_64-linux/lib"));
-            dirs.push(root.join("bin"));
-        }
+    for root in cuda_roots() {
+        append_cuda_root_dirs(dirs, &root);
     }
 
     #[cfg(target_os = "linux")]
     dirs.extend([
-        PathBuf::from("/usr/local/cuda/lib64"),
-        PathBuf::from("/usr/local/cuda/lib"),
-        PathBuf::from("/usr/local/cuda/targets/x86_64-linux/lib"),
         PathBuf::from("/usr/lib/x86_64-linux-gnu"),
         PathBuf::from("/usr/lib64"),
         PathBuf::from("/usr/lib"),
         PathBuf::from("/lib/x86_64-linux-gnu"),
         PathBuf::from("/lib64"),
     ]);
+}
+
+/// Toolkit roots to probe: those named by the environment first, then the
+/// conventional install prefixes (`/usr/local/cuda` on NVIDIA's runfile and
+/// Debian packages, `/opt/cuda` on Arch and Gentoo).
+#[cfg(feature = "cuda")]
+fn cuda_roots() -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = ["CUDA_PATH", "CUDA_HOME", "CUDA_ROOT"]
+        .iter()
+        .filter_map(|var| std::env::var_os(var).map(PathBuf::from))
+        .collect();
+
+    #[cfg(target_os = "linux")]
+    roots.extend([PathBuf::from("/usr/local/cuda"), PathBuf::from("/opt/cuda")]);
+
+    roots
+}
+
+#[cfg(feature = "cuda")]
+fn append_cuda_root_dirs(dirs: &mut Vec<PathBuf>, root: &Path) {
+    dirs.push(root.to_path_buf());
+    dirs.push(root.join("lib64"));
+    dirs.push(root.join("lib"));
+    dirs.extend(cuda_target_lib_dirs(root));
+    dirs.push(root.join("bin"));
+}
+
+/// A toolkit keeps its per-architecture libraries under `targets/<triple>/lib`,
+/// where the triple names the target the libraries are built for (for example
+/// `x86_64-linux`, or `sbsa-linux` and `aarch64-linux` on Arm hosts). Enumerate
+/// the directory rather than naming a triple, so every host resolves.
+#[cfg(feature = "cuda")]
+fn cuda_target_lib_dirs(root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(root.join("targets")) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path().join("lib"))
+        .collect()
 }
 
 #[cfg(feature = "cuda")]
@@ -406,6 +437,12 @@ fn append_common_cudnn_dirs(dirs: &mut Vec<PathBuf>) {
             dirs.push(root.join("lib"));
             dirs.push(root.join("bin"));
         }
+    }
+
+    // Some distributions install cuDNN into the CUDA toolkit prefix rather than
+    // a standalone one.
+    for root in cuda_roots() {
+        append_cuda_root_dirs(dirs, &root);
     }
 
     #[cfg(target_os = "linux")]
@@ -493,19 +530,19 @@ fn init_options_with_coreml(
     opts: InitOptions,
     runtime: &EmbedRuntimeConfig,
 ) -> Result<InitOptions> {
-    use ort::execution_providers::coreml::{CoreMLComputeUnits, CoreMLExecutionProvider};
+    use ort::ep::coreml::{ComputeUnits, CoreML};
 
     let compute_units = runtime
         .compute_units
         .as_deref()
         .map(|v| match v.to_lowercase().as_str() {
-            "ane" | "neural" | "neuralengine" => CoreMLComputeUnits::CPUAndNeuralEngine,
-            "gpu" => CoreMLComputeUnits::CPUAndGPU,
-            "cpu" => CoreMLComputeUnits::CPUOnly,
-            _ => CoreMLComputeUnits::All,
+            "ane" | "neural" | "neuralengine" => ComputeUnits::CPUAndNeuralEngine,
+            "gpu" => ComputeUnits::CPUAndGPU,
+            "cpu" => ComputeUnits::CPUOnly,
+            _ => ComputeUnits::All,
         })
-        .unwrap_or(CoreMLComputeUnits::All);
-    let provider = CoreMLExecutionProvider::default()
+        .unwrap_or(ComputeUnits::All);
+    let provider = CoreML::default()
         .with_subgraphs(true)
         .with_compute_units(compute_units);
     let dispatch = if matches!(runtime.execution_provider, ExecutionProviderChoice::CoreML) {
@@ -528,10 +565,10 @@ fn init_options_with_coreml(
 
 #[cfg(feature = "cuda")]
 fn init_options_with_cuda(opts: InitOptions, runtime: &EmbedRuntimeConfig) -> Result<InitOptions> {
-    use ort::execution_providers::{CUDAExecutionProvider, ExecutionProvider};
+    use ort::ep::{CUDA, ExecutionProvider};
 
     preload_cuda_dependencies(runtime)?;
-    let mut provider = CUDAExecutionProvider::default();
+    let mut provider = CUDA::default();
     if let Some(device_id) = runtime.cuda_device_id {
         provider = provider.with_device_id(device_id);
     }


### PR DESCRIPTION
## Summary

Moves the direct `ort` dependency from `2.0.0-rc.10` to `2.0.0-rc.13`, migrates the execution-provider code to the new API, and retargets the CUDA runtime preload that rc.13 invalidates.

### Execution provider API

Two breaking changes in rc.13:

- **Providers moved** from `ort::execution_providers` to `ort::ep`, and the types dropped their `ExecutionProvider` suffix (`CoreMLExecutionProvider` → `CoreML`, `CUDAExecutionProvider` → `CUDA`, `CoreMLComputeUnits` → `coreml::ComputeUnits`). The old path still resolves but is `#[deprecated]`, which fails this repo's `cargo clippy -- -D warnings` gate.
- **Each provider now sits behind its own cargo feature** rather than being compiled unconditionally. `cuda` was already covered by the existing optional feature; CoreML was not, so `ort/coreml` is enabled through a `cfg(target_os = "macos")` target dependency, matching the `#[cfg(target_os = "macos")]` on `init_options_with_coreml`. Without it the macOS build cannot resolve `ort::ep::coreml`.

`fastembed` is pinned to `5.17.4` because it pins ort exactly (`=2.0.0-rc.13`); 5.17.4 is the first 5.x release on rc.13. Staying on 5.x avoids the unrelated fastembed 6.0 API break.

### CUDA 13

`ort-sys` rc.13 adds something rc.10 had no equivalent of: it picks an ONNX Runtime build by CUDA major, sniffing `ORT_CUDA_VERSION`, `CUDA_HOME`, `NV_CUDA_CUDART_VERSION`, then `nvcc`. It currently ships **only** CUDA 13 — the fallback comment reads *"we only ship 13 for now"* — so there is no CUDA 12 binary to opt back into.

That silently invalidates `CUDA_DYLIBS`, which named CUDA 12 sonames. `preload_cuda_dependencies` then aborts before ONNX Runtime is ever reached:

```
missing CUDA libraries: libcublasLt.so.12, libcublas.so.12, libnvrtc.so.12,
libcufft.so.11, libcudart.so.12
```

Confirmed against the artifact ort actually downloads:

```
$ objdump -p libonnxruntime_providers_cuda.so | grep NEEDED
  libcublasLt.so.13   libcublas.so.13   libcurand.so.10
  libcudart.so.13     libcuda.so.1
```

So the list moves to the CUDA 13 sonames. Two entries do not simply follow the toolkit major: cuFFT trails it (`.so.11` → `.so.12`), and curand is unchanged at `.so.10` — which is why curand was the one name absent from the error above. `CUDNN_DYLIBS` is deliberately untouched: cuDNN carries its own major, and the CUDA 13 build still references only `libcudnn.so.9`.

### Library search

Two fixes, both pre-existing but surfaced by the above:

- `targets/x86_64-linux/lib` was hardcoded in two places, so a non-x86_64 toolkit never resolved. The directory is now enumerated, picking up whichever triples a host has (`sbsa-linux` and `aarch64-linux` on Arm). This follows `python_nvidia_lib_dirs`, which already discovers by enumeration rather than by name.
- Only `/usr/local/cuda` was probed (NVIDIA runfile / Debian). `/opt/cuda` — the Arch and Gentoo prefix — is now probed too, and the toolkit roots are searched for cuDNN as well, since some distributions install it into the toolkit prefix rather than a standalone one. Both are free elsewhere: `normalize_existing_dirs` already filters to directories that exist.

## Relationship to #159

#159 targets the same ort upgrade, and its `src/embed.rs` provider migration is equivalent to this one. It does not cover the CUDA 13 retarget. The other difference is the manifest — #159 uses:

```toml
ort = { version = "=2.0.0-rc.13", default-features = false, features = ["coreml"] }
```

`default-features = false` drops three things `main` has today. Resolved feature sets, via `cargo tree -i ort -e features`:

| | main (rc.10) | #159 | this PR |
| --- | --- | --- | --- |
| `copy-dylibs` | yes | **no** | yes |
| `tracing` | yes | **no** | yes |
| api level | — | api-24 | api-27 |
| `coreml` | n/a | all platforms | macOS only |

- `copy-dylibs` copies the ONNX Runtime shared libraries next to the built executable (`ort-sys` `build/dynamic_link.rs`). Dropping it changes what ships alongside a release binary.
- `tracing` is how ort's own log output reaches the tracing subscriber; without it that goes silent.
- api-27 → api-24 caps the ONNX Runtime API level the crate compiles against. Nothing here uses those entry points today, but there is no reason to give them up.
- Enabling `coreml` on every platform is inert (`ort-sys`'s `coreml` feature is empty and has no build-script effect), just imprecise.

This PR keeps ort's default features and adds only what is needed.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy -- -D warnings` — pass, default and `--features cuda`
- `cargo check --all-targets` — pass, default and `--features cuda`
- `cargo test --lib` — pass, 773 tests
- `cargo build --release --features cuda` — pass
- **Runtime, on an RTX-class GPU with CUDA 13.4 and cuDNN 9:** `daemon run` indexes and embeds through the CUDA execution provider, and `index embed` with `MEMEX_EXECUTION_PROVIDER=cuda` initializes cleanly against a scratch root. This is what the preload change fixes; before it, both aborted with the error above.
- CoreML branch compiled on Linux by temporarily forcing its `cfg` and the `coreml` feature, since it is `cfg`-gated off on other platforms and would otherwise go unbuilt on non-macOS runners.

**Not verified:** the Windows CUDA DLL names (`cudart64_13.dll`, `cublasLt64_13.dll`, `cublas64_13.dll`, `cufft64_12.dll`) follow NVIDIA's `<lib>64_<major>.dll` convention and mirror the Linux major bumps one-for-one, but were not checked on a Windows host. Worth a reviewer's eye or a Windows CI run. The CoreML path is likewise compile-verified only, not run on macOS hardware.

Note on `cargo clippy --all-targets`: it fails on this branch, but identically on `main` — pre-existing lint findings in the integration tests, untouched here. The gate AGENTS.md specifies, `cargo clippy -- -D warnings`, passes.
