### PR TITLE
Reuse memory lexical indexes and readers across requests

### DIFF
--- a/src/memory_search.rs
+++ b/src/memory_search.rs
@@ -17,13 +17,14 @@ use anyhow::{Context, Result, anyhow, bail};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Arc, LazyLock, Mutex};
 use tantivy::collector::TopDocs;
 use tantivy::query::{AllQuery, Query, QueryParser};
 use tantivy::schema::{INDEXED, STORED, Schema, TEXT, Value};
-use tantivy::{Index, ReloadPolicy, TantivyDocument};
+use tantivy::{Index, IndexReader, ReloadPolicy, TantivyDocument};
 
 const DEFAULT_SEARCH_LIMIT: usize = 20;
 const DEFAULT_MAX_PER_DOCUMENT: usize = 2;
@@ -226,10 +227,87 @@ struct LexicalFields {
 
 struct LexicalMemoryIndex {
     index: Index,
+    reader: IndexReader,
     fields: LexicalFields,
 }
 
+// Process ownership is intentional: MemoryStore and federated worker threads are recreated
+// for each request, including requests in long-lived MCP servers.
+static MEMORY_LEXICAL_CACHE: LazyLock<MemoryLexicalCache> =
+    LazyLock::new(MemoryLexicalCache::default);
+const MEMORY_LEXICAL_CACHE_CAPACITY: usize = 8;
+
+#[derive(Default)]
+struct MemoryLexicalCache {
+    entries: Mutex<VecDeque<(LexicalCacheKey, Arc<LexicalMemoryIndex>)>>,
+}
+
+#[derive(PartialEq, Eq)]
+struct LexicalCacheKey {
+    snapshot_path: PathBuf,
+    rows_sha256: [u8; 32],
+}
+
+impl MemoryLexicalCache {
+    fn get(
+        &self,
+        paths: &Paths,
+        snapshot: &MemorySnapshot,
+        candidates: &[SectionCandidate],
+    ) -> Result<Arc<LexicalMemoryIndex>> {
+        // Hash the exact ordered rows passed to build, including field boundaries and IDs.
+        // Versions alone miss title/heading changes. Hashing all sections would lose scope
+        // identity and reuse BM25 statistics from the wrong eligible corpus.
+        let mut digest = Sha256::new();
+        for candidate in candidates {
+            let document = &snapshot.documents[candidate.document];
+            let section = &document.sections[candidate.section];
+            digest.update(candidate.vector_id.to_le_bytes());
+            for value in [
+                Some(section.content.as_str()),
+                section.heading.as_deref(),
+                document.title.as_deref(),
+            ] {
+                digest.update([u8::from(value.is_some())]);
+                let bytes = value.unwrap_or_default().as_bytes();
+                digest.update((bytes.len() as u64).to_le_bytes());
+                digest.update(bytes);
+            }
+        }
+        let key = LexicalCacheKey {
+            snapshot_path: std::path::absolute(memory_snapshot_path(paths))?,
+            rows_sha256: digest.finalize().into(),
+        };
+        let mut entries = self
+            .entries
+            .lock()
+            .map_err(|_| anyhow!("memory lexical cache lock poisoned"))?;
+        if let Some(position) = entries.iter().position(|(cached, _)| cached == &key) {
+            let entry = entries.remove(position).expect("cache entry exists");
+            let index = Arc::clone(&entry.1);
+            entries.push_back(entry);
+            return Ok(index);
+        }
+        // Serialize misses to avoid duplicate builds and bound simultaneous writer memory.
+        // Searches run outside this lock; eviction only drops the cache's Arc.
+        let index = Arc::new(LexicalMemoryIndex::build(snapshot, candidates)?);
+        if entries.len() == MEMORY_LEXICAL_CACHE_CAPACITY {
+            entries.pop_front();
+        }
+        entries.push_back((key, Arc::clone(&index)));
+        Ok(index)
+    }
+}
+
 pub fn search_memory(paths: &Paths, options: &MemorySearchOptions) -> Result<Vec<MemorySearchHit>> {
+    search_memory_with_cache(paths, options, &MEMORY_LEXICAL_CACHE)
+}
+
+fn search_memory_with_cache(
+    paths: &Paths,
+    options: &MemorySearchOptions,
+    cache: &MemoryLexicalCache,
+) -> Result<Vec<MemorySearchHit>> {
     options.validate()?;
     let queries = normalized_query_views(options)?;
     let store = MemoryStore::new(memory_snapshot_path(paths));
@@ -243,7 +321,7 @@ pub fn search_memory(paths: &Paths, options: &MemorySearchOptions) -> Result<Vec
         options.mode,
         MemorySearchMode::Lexical | MemorySearchMode::Hybrid
     ) {
-        Some(LexicalMemoryIndex::build(&snapshot, &candidates)?)
+        Some(cache.get(paths, &snapshot, &candidates)?)
     } else {
         None
     };
@@ -830,8 +908,13 @@ impl LexicalMemoryIndex {
             writer.add_document(row)?;
         }
         writer.commit()?;
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
         Ok(Self {
             index,
+            reader,
             fields: LexicalFields {
                 key,
                 text,
@@ -842,12 +925,7 @@ impl LexicalMemoryIndex {
     }
 
     fn search(&self, query: &str, limit: usize) -> Result<Vec<(u64, f32)>> {
-        let reader = self
-            .index
-            .reader_builder()
-            .reload_policy(ReloadPolicy::Manual)
-            .try_into()?;
-        let searcher = reader.searcher();
+        let searcher = self.reader.searcher();
         let parsed: Box<dyn Query> = if query == "*" {
             Box::new(AllQuery)
         } else {
@@ -1286,6 +1364,316 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn lexical_cache_reuses_searches_and_reads_updated_snapshot_metadata() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let cache = MemoryLexicalCache::default();
+        let mut doc = document(
+            temp.path().join("one.md"),
+            "one",
+            "alpha",
+            100,
+            &[("a", "rust cache"), ("b", "rust verification")],
+        );
+        write_snapshot(&paths, vec![doc.clone()]);
+        let options = MemorySearchOptions {
+            query: "rust".into(),
+            recency_weight: 0.0,
+            ..Default::default()
+        };
+        let first = search_memory_with_cache(&paths, &options, &cache).unwrap();
+        let index = Arc::clone(&cache.entries.lock().unwrap()[0].1);
+        for _ in 0..10 {
+            let hits = search_memory_with_cache(&paths, &options, &cache).unwrap();
+            assert_eq!(hits[0].score, first[0].score);
+            assert!(Arc::ptr_eq(&index, &cache.entries.lock().unwrap()[0].1));
+        }
+        // Presentation and query changes must not rebuild the corpus or its reader.
+        doc.mtime_ms = 200;
+        write_snapshot(&paths, vec![doc]);
+        let hits = search_memory_with_cache(
+            &paths,
+            &MemorySearchOptions {
+                query: "cache".into(),
+                additional_queries: vec!["verification".into()],
+                include_text: true,
+                ..options
+            },
+            &cache,
+        )
+        .unwrap();
+        assert!(
+            hits.iter()
+                .all(|hit| hit.mtime_ms == 200 && hit.text.is_some())
+        );
+        assert!(Arc::ptr_eq(&index, &cache.entries.lock().unwrap()[0].1));
+        assert_eq!(cache.entries.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn lexical_cache_invalidates_every_indexed_field_and_section_inventory() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let cache = MemoryLexicalCache::default();
+        let doc = document(
+            temp.path().join("one.md"),
+            "one",
+            "alpha",
+            100,
+            &[("a", "rust cache"), ("b", "rust verification")],
+        );
+        let original = MemorySnapshot {
+            documents: vec![doc],
+            ..Default::default()
+        };
+        let candidates = all_searchable_sections(&original).unwrap();
+        let index = cache.get(&paths, &original, &candidates).unwrap();
+        for change in [
+            "text",
+            "heading",
+            "title",
+            "version",
+            "section ID",
+            "deletion",
+            "addition",
+            "order",
+        ] {
+            let mut snapshot = original.clone();
+            let doc = &mut snapshot.documents[0];
+            match change {
+                "text" => doc.sections[0].content = "replacement".into(),
+                "heading" => doc.sections[0].heading = Some("replacement".into()),
+                "title" => doc.title = Some("replacement".into()),
+                "version" => doc.version_sha256 = "replacement".into(),
+                "section ID" => doc.sections[0].id = "replacement".into(),
+                "deletion" => {
+                    doc.sections.remove(0);
+                }
+                "addition" => {
+                    let mut added = doc.sections[0].clone();
+                    added.id = "added".into();
+                    doc.sections.push(added);
+                }
+                "order" => doc.sections.reverse(),
+                _ => unreachable!(),
+            }
+            write_snapshot(&paths, snapshot.documents.clone());
+            let options = MemorySearchOptions {
+                query: "rust".into(),
+                recency_weight: 0.0,
+                ..Default::default()
+            };
+            let hits = search_memory_with_cache(&paths, &options, &cache).unwrap();
+            let candidates = eligible_sections(&snapshot, &options).unwrap();
+            let cached = cache.get(&paths, &snapshot, &candidates).unwrap();
+            assert!(!Arc::ptr_eq(&index, &cached), "change {change}");
+            let fresh = LexicalMemoryIndex::build(&snapshot, &candidates).unwrap();
+            assert_eq!(
+                cached.search("rust", 10).unwrap(),
+                fresh.search("rust", 10).unwrap()
+            );
+            assert!(hits.iter().all(|hit| {
+                snapshot.documents[0]
+                    .sections
+                    .iter()
+                    .any(|section| section.id == hit.section_id)
+            }));
+            if matches!(change, "text" | "heading" | "title") {
+                assert!(!cached.search("replacement", 10).unwrap().is_empty());
+                assert!(index.search("replacement", 10).unwrap().is_empty());
+            }
+        }
+        write_snapshot(&paths, Vec::new());
+        assert!(
+            search_memory_with_cache(
+                &paths,
+                &MemorySearchOptions {
+                    query: "rust".into(),
+                    ..Default::default()
+                },
+                &cache
+            )
+            .unwrap()
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn lexical_cache_preserves_scoped_bm25_and_isolates_roots() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let other_paths = Paths::new(Some(temp.path().join("other"))).unwrap();
+        let cache = MemoryLexicalCache::default();
+        let mut beta = document(
+            temp.path().join("two.md"),
+            "two",
+            "beta",
+            200,
+            &[("a", "rust rust rust other words")],
+        );
+        beta.provider = SourceKind::Claude;
+        let snapshot = MemorySnapshot {
+            documents: vec![
+                document(
+                    temp.path().join("one.md"),
+                    "one",
+                    "alpha",
+                    100,
+                    &[("a", "rust cache"), ("b", "unrelated words")],
+                ),
+                beta,
+            ],
+            ..Default::default()
+        };
+        let options = MemorySearchOptions {
+            query: "rust".into(),
+            recency_weight: 0.0,
+            ..Default::default()
+        };
+        let all = eligible_sections(&snapshot, &options).unwrap();
+        let full = cache.get(&paths, &snapshot, &all).unwrap();
+        let mut scoped_index = None;
+        for scope in [
+            MemorySearchOptions {
+                project: Some("alpha".into()),
+                ..options.clone()
+            },
+            MemorySearchOptions {
+                cwd: Some("/work/alpha".into()),
+                ..options.clone()
+            },
+            MemorySearchOptions {
+                source: Some(SourceKind::Codex),
+                ..options.clone()
+            },
+            MemorySearchOptions {
+                until: Some(100),
+                ..options.clone()
+            },
+            MemorySearchOptions {
+                since: Some(100),
+                until: Some(199),
+                ..options.clone()
+            },
+        ] {
+            let candidates = eligible_sections(&snapshot, &scope).unwrap();
+            let cached = cache.get(&paths, &snapshot, &candidates).unwrap();
+            let fresh = LexicalMemoryIndex::build(&snapshot, &candidates).unwrap();
+            let ranking = cached.search("rust", 10).unwrap();
+            assert_eq!(ranking, fresh.search("rust", 10).unwrap());
+            assert_eq!(ranking.len(), 1);
+            assert_ne!(
+                ranking[0].1,
+                full.search("rust", 10)
+                    .unwrap()
+                    .iter()
+                    .find(|(id, _)| *id == ranking[0].0)
+                    .unwrap()
+                    .1
+            );
+            if let Some(previous) = &scoped_index {
+                assert!(Arc::ptr_eq(previous, &cached));
+            }
+            scoped_index = Some(cached);
+        }
+        let other = cache.get(&other_paths, &snapshot, &all).unwrap();
+        assert!(!Arc::ptr_eq(&full, &other));
+        // A filter can select a different corpus after a metadata-only snapshot update.
+        let mut moved = snapshot.clone();
+        moved.documents[0].scope.project = Some("beta".into());
+        moved.documents[1].scope.project = Some("alpha".into());
+        write_snapshot(&paths, moved.documents.clone());
+        let hits = search_memory_with_cache(
+            &paths,
+            &MemorySearchOptions {
+                project: Some("alpha".into()),
+                ..options
+            },
+            &cache,
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].memory_id, "two");
+    }
+
+    #[test]
+    fn lexical_cache_coalesces_concurrent_builds_and_eviction_retains_active_searches() {
+        let temp = TempDir::new().unwrap();
+        let paths = Paths::new(Some(temp.path().join("store"))).unwrap();
+        let cache = MemoryLexicalCache::default();
+        let snapshot = MemorySnapshot {
+            documents: vec![document(
+                temp.path().join("one.md"),
+                "one",
+                "alpha",
+                100,
+                &[("a", "rust cache")],
+            )],
+            ..Default::default()
+        };
+        let candidates = all_searchable_sections(&snapshot).unwrap();
+        let barrier = std::sync::Barrier::new(4);
+        let indexes = std::thread::scope(|scope| {
+            let workers = (0..4)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        let index = cache.get(&paths, &snapshot, &candidates).unwrap();
+                        assert_eq!(index.search("rust", 10).unwrap().len(), 1);
+                        index
+                    })
+                })
+                .collect::<Vec<_>>();
+            workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+        assert!(indexes.iter().all(|index| Arc::ptr_eq(index, &indexes[0])));
+        let first = &indexes[0];
+        let mut second = None;
+        for i in 0..MEMORY_LEXICAL_CACHE_CAPACITY - 1 {
+            let mut changed = snapshot.clone();
+            changed.documents[0].title = Some(format!("title {i}"));
+            let index = cache.get(&paths, &changed, &candidates).unwrap();
+            if i == 0 {
+                second = Some(Arc::downgrade(&index));
+            }
+        }
+        // Touch the oldest entry; the second entry should now be evicted.
+        assert!(Arc::ptr_eq(
+            first,
+            &cache.get(&paths, &snapshot, &candidates).unwrap()
+        ));
+        let mut changed = snapshot.clone();
+        changed.documents[0].title = Some("last".into());
+        cache.get(&paths, &changed, &candidates).unwrap();
+        assert!(second.unwrap().upgrade().is_none());
+        assert_eq!(
+            cache.entries.lock().unwrap().len(),
+            MEMORY_LEXICAL_CACHE_CAPACITY
+        );
+        // Force the original out while a worker holds and searches its immutable reader.
+        std::thread::scope(|scope| {
+            let worker = scope.spawn(|| {
+                for _ in 0..100 {
+                    assert_eq!(first.search("rust", 10).unwrap().len(), 1);
+                }
+            });
+            for i in 0..MEMORY_LEXICAL_CACHE_CAPACITY {
+                changed.documents[0].title = Some(format!("evict {i}"));
+                cache.get(&paths, &changed, &candidates).unwrap();
+            }
+            worker.join().unwrap();
+        });
+        assert_eq!(first.search("rust", 10).unwrap().len(), 1);
+        assert!(!Arc::ptr_eq(
+            first,
+            &cache.get(&paths, &snapshot, &candidates).unwrap()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Repeated memory lexical and hybrid searches rebuild the eligible Tantivy corpus on every request. Keep an eight-entry process-wide LRU cache of immutable indexes and readers, keyed by the absolute snapshot path and exact ordered eligible rows. Repeated requests reuse the same state while changed content, section IDs, or eligible corpora get a new index; returned metadata still comes from the current snapshot.

The cache preserves scoped BM25 statistics and retains active readers through eviction with Arc. Misses are serialized to avoid duplicate builds. Tokenization and conversation search are unchanged.

Regression coverage checks repeated reuse, indexed-field and inventory changes, metadata-driven eligibility changes, all scope filters, fresh-index score equivalence, root isolation, concurrent builds, and LRU eviction. The cache is process-local and bounded by entry count; snapshot loading and hashing remain per request, and lookups wait behind an in-progress miss.

Validation: four cache regressions, three project-scope tests, memory RPC, and MCP stdio memory search pass. The full memory-search unit module has 17 passing tests and one embedding-distance assertion failure (`memory_embeddings_reuse_text_across_snapshot_changes`), reproduced unchanged on trunk at 27ac648.

`cargo fmt --check` and `mbx clippy -- -D warnings` pass.
