### PR TITLE
Bound context record hydration

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -31,6 +31,8 @@ use tantivy::{
     TantivyDocument, Term,
 };
 
+pub(crate) mod context;
+
 #[derive(Clone)]
 pub struct IndexFields {
     /// Optional for reading generations built before transcript presentation metadata.
@@ -905,6 +907,7 @@ impl SearchIndex {
         self.records_matching_query(query)
     }
 
+    #[cfg(test)]
     pub(crate) fn records_by_session_path(
         &self,
         source: crate::types::SourceKind,

--- a/src/index/context.rs
+++ b/src/index/context.rs
@@ -1,0 +1,358 @@
+//! Context selection metadata, kept separate from stored text and tool payloads.
+//!
+//! Exact indexed strings and numeric fast fields avoid session-wide stored-document reads on
+//! current indexes. A unique anchor adds one stored read. Selection still traverses segment term
+//! dictionaries and matching session metadata;
+//! it is a hydration bound, not a constant-time context lookup. Older projections without
+//! canonical IDs or numeric fast fields retain the stored-record compatibility fallback.
+
+use super::*;
+use crate::retrieval::{ContextSelector, canonical_record_id};
+use std::collections::HashMap;
+use tantivy::collector::DocSetCollector;
+use tantivy::{DocAddress, DocSet, Searcher, TERMINATED};
+
+#[cfg(test)]
+thread_local! {
+    pub(crate) static STORED_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+pub(crate) struct ContextEntry {
+    pub id: String,
+    pub record: Record,
+    address: DocAddress,
+}
+
+pub(crate) struct ContextReader<'a> {
+    fields: &'a IndexFields,
+    searcher: Searcher,
+}
+
+impl<'a> ContextReader<'a> {
+    pub fn new(index: &'a SearchIndex) -> Result<Self> {
+        Ok(Self {
+            fields: &index.fields,
+            searcher: index.reader()?.searcher(),
+        })
+    }
+
+    pub fn candidates(&self, selector: &ContextSelector) -> Result<Vec<ContextEntry>> {
+        let (term, session, source) = match selector {
+            ContextSelector::RecordId {
+                id,
+                session_id,
+                source,
+            } => (
+                self.fields
+                    .canonical_record_id
+                    .map(|field| Term::from_field_text(field, id)),
+                session_id,
+                source,
+            ),
+            ContextSelector::DocId {
+                id,
+                session_id,
+                source,
+            } => (
+                Some(Term::from_field_u64(self.fields.doc_id, *id)),
+                session_id,
+                source,
+            ),
+            ContextSelector::EventId {
+                id,
+                session_id,
+                source,
+            } => (
+                Some(Term::from_field_text(self.fields.event_id, id)),
+                session_id,
+                source,
+            ),
+        };
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+        if let Some(term) = term {
+            clauses.push((
+                Occur::Must,
+                Box::new(TermQuery::new(term, IndexRecordOption::Basic)),
+            ));
+        }
+        if let Some(session) = session {
+            clauses.push((
+                Occur::Must,
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.session_id, session),
+                    IndexRecordOption::Basic,
+                )),
+            ));
+        }
+        if let Some(source) = source
+            && let Some(query) = exact_source_query(self.fields, *source)
+        {
+            clauses.push((Occur::Must, query));
+        }
+        let query: Box<dyn Query> = if clauses.is_empty() {
+            Box::new(AllQuery)
+        } else {
+            Box::new(BooleanQuery::new(clauses))
+        };
+        Ok(self
+            .entries(query.as_ref(), None, true)?
+            .into_iter()
+            .filter(|entry| {
+                session
+                    .as_deref()
+                    .is_none_or(|session| entry.record.session_id == session)
+                    && source.is_none_or(|source| entry.record.source == source)
+                    && match selector {
+                        ContextSelector::RecordId { id, .. } => entry.id == *id,
+                        ContextSelector::DocId { id, .. } => entry.record.doc_id == *id,
+                        ContextSelector::EventId { id, .. } => {
+                            entry.record.links.event_id.as_deref() == Some(id.as_str())
+                        }
+                    }
+            })
+            .collect())
+    }
+
+    pub fn session(
+        &self,
+        anchor: &ContextEntry,
+        expand_interactions: bool,
+    ) -> Result<Vec<ContextEntry>> {
+        let record = &anchor.record;
+        let query = session_query(
+            self.fields,
+            &record.session_id,
+            Some(&record.source_path),
+            Some(record.source),
+            None,
+        );
+        Ok(self
+            .entries(&query, Some(record), expand_interactions)?
+            .into_iter()
+            // Legacy stored projections may infer source from the path. Preserve the
+            // in-memory isolation check even when the indexed source filter is unavailable.
+            .filter(|entry| entry.record.source == record.source)
+            .collect())
+    }
+
+    pub fn hydrate(&self, entry: ContextEntry) -> Result<Record> {
+        self.read_record(entry.address)
+    }
+
+    fn entries(
+        &self,
+        query: &dyn Query,
+        scope: Option<&Record>,
+        interactions: bool,
+    ) -> Result<Vec<ContextEntry>> {
+        let mut addresses = self
+            .searcher
+            .search(query, &DocSetCollector)?
+            .into_iter()
+            .collect::<Vec<_>>();
+        addresses.sort();
+        // Resolving one exact candidate has a fixed one-record hydration cost and avoids
+        // walking a segment dictionary just to recover its source/session/path.
+        if scope.is_none() && addresses.len() == 1 {
+            return Ok(vec![self.stored_entry(addresses[0])?]);
+        }
+        let mut entries = Vec::with_capacity(addresses.len());
+        for (ordinal, segment) in self.searcher.segment_readers().iter().enumerate() {
+            let matching = addresses
+                .iter()
+                .filter(|address| address.segment_ord == ordinal as u32)
+                .copied()
+                .collect::<Vec<_>>();
+            if matching.is_empty() {
+                continue;
+            }
+            let numeric = (
+                segment.fast_fields().u64("doc_id"),
+                segment.fast_fields().u64("ts"),
+                segment.fast_fields().u64("turn_id"),
+            );
+            let (Some(canonical), (Ok(doc_ids), Ok(timestamps), Ok(turns))) =
+                (self.fields.canonical_record_id, numeric)
+            else {
+                for address in matching {
+                    entries.push(self.stored_entry(address)?);
+                }
+                continue;
+            };
+            let positions = matching
+                .iter()
+                .enumerate()
+                .map(|(position, address)| (address.doc_id, position))
+                .collect::<HashMap<_, _>>();
+            let mut docs = vec![TantivyDocument::default(); matching.len()];
+            // Only exact metadata fields: never traverse the text/tool payload indexes.
+            let mut fields = vec![Some(canonical)];
+            if scope.is_none() {
+                fields.extend([
+                    Some(self.fields.session_id),
+                    Some(self.fields.source_path),
+                    self.fields.source,
+                ]);
+            }
+            if interactions {
+                fields.extend([
+                    Some(self.fields.role),
+                    Some(self.fields.event_id),
+                    Some(self.fields.parent_tool_use_id),
+                ]);
+            }
+            for field in fields.into_iter().flatten() {
+                let inverted = segment.inverted_index(field)?;
+                let mut terms = inverted.terms().stream()?;
+                while terms.advance() {
+                    let mut postings = inverted
+                        .read_postings_from_terminfo(terms.value(), IndexRecordOption::Basic)?;
+                    if postings.doc() < matching[0].doc_id {
+                        postings.seek(matching[0].doc_id);
+                    }
+                    while postings.doc() != TERMINATED
+                        && postings.doc() <= matching[matching.len() - 1].doc_id
+                    {
+                        if let Some(position) = positions.get(&postings.doc()) {
+                            docs[*position].add_text(field, std::str::from_utf8(terms.key())?);
+                        }
+                        postings.advance();
+                    }
+                }
+            }
+            for (address, mut doc) in matching.into_iter().zip(docs) {
+                let Some(id) = doc
+                    .get_first(canonical)
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned)
+                else {
+                    entries.push(self.stored_entry(address)?);
+                    continue;
+                };
+                doc.add_u64(
+                    self.fields.doc_id,
+                    doc_ids.first(address.doc_id).unwrap_or(0),
+                );
+                doc.add_u64(
+                    self.fields.ts,
+                    timestamps.first(address.doc_id).unwrap_or(0),
+                );
+                doc.add_u64(
+                    self.fields.turn_id,
+                    turns.first(address.doc_id).unwrap_or(0),
+                );
+                let mut record = record_from_doc(self.fields, &doc);
+                if let Some(scope) = scope {
+                    // The query fixes the exact path, so source inference is identical even
+                    // on schemas without an indexed source field.
+                    record.session_id.clone_from(&scope.session_id);
+                    record.source_path.clone_from(&scope.source_path);
+                    record.source = scope.source;
+                }
+                entries.push(ContextEntry {
+                    id,
+                    record,
+                    address,
+                });
+            }
+        }
+        Ok(entries)
+    }
+
+    fn stored_entry(&self, address: DocAddress) -> Result<ContextEntry> {
+        let mut record = self.read_record(address)?;
+        let id = canonical_record_id(&record);
+        // Legacy compatibility may require reading payloads, but do not retain them for the
+        // whole session. Selected records are read again from this same snapshot.
+        record.text.clear();
+        record.text.shrink_to_fit();
+        record.tool_input = None;
+        record.tool_output = None;
+        record.links.source_content = None;
+        Ok(ContextEntry {
+            id,
+            record,
+            address,
+        })
+    }
+
+    fn read_record(&self, address: DocAddress) -> Result<Record> {
+        #[cfg(test)]
+        STORED_READS.with(|reads| reads.set(reads.get() + 1));
+        let doc = self.searcher.doc::<TantivyDocument>(address)?;
+        Ok(record_from_doc(self.fields, &doc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::retrieval::{ContextOptions, context_records};
+
+    #[test]
+    fn legacy_context_preserves_windows_without_rebuilding() {
+        for canonical in [false, true] {
+            let tmp = tempfile::tempdir().unwrap();
+            let mut schema =
+                serde_json::to_value(build_schema_with_canonical_record_id(canonical).unwrap())
+                    .unwrap();
+            // Exercise both missing canonical identity and pre-fast-doc-ID projections.
+            if canonical {
+                for field in schema.as_array_mut().unwrap() {
+                    if field["name"] == "doc_id" {
+                        field["options"]["fast"] = false.into();
+                    }
+                }
+            }
+            let schema: Schema = serde_json::from_value(schema).unwrap();
+            drop(Index::create_in_dir(tmp.path(), schema).unwrap());
+            let index = SearchIndex::open_or_create(tmp.path()).unwrap();
+            let mut writer = index.writer().unwrap();
+            let mut records = Vec::new();
+            for turn in 1..=4 {
+                let record = Record {
+                    source: crate::types::SourceKind::Codex,
+                    doc_id: turn as u64,
+                    ts: turn as u64,
+                    turn_id: turn,
+                    project: "project".into(),
+                    session_id: "session".into(),
+                    role: "assistant".into(),
+                    text: format!("record {turn}"),
+                    source_path: "session.jsonl".into(),
+                    tool_name: None,
+                    tool_input: Some("input".into()),
+                    tool_output: Some("output".into()),
+                    links: RecordLinks::default(),
+                };
+                index.add_record(&mut writer, &record).unwrap();
+                records.push(record);
+            }
+            writer.commit().unwrap();
+            let selector = ContextSelector::record_id(canonical_record_id(&records[1])).with_scope(
+                Some("session".into()),
+                Some(crate::types::SourceKind::Codex),
+            );
+            let result = context_records(
+                &index,
+                &selector,
+                ContextOptions {
+                    before: 0,
+                    after: 1,
+                    expand_interactions: false,
+                },
+            )
+            .unwrap();
+            assert_eq!(result.records.len(), 2);
+            for (actual, expected) in result.records.iter().zip(&records[1..3]) {
+                assert_eq!(
+                    serde_json::to_value(&actual.record).unwrap(),
+                    serde_json::to_value(expected).unwrap()
+                );
+            }
+            assert_eq!(result.records[0].distance, 0);
+            assert_eq!(result.records[1].distance, 1);
+            assert_eq!(index.fields.canonical_record_id.is_some(), canonical);
+        }
+    }
+}

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -230,87 +230,104 @@ pub fn context_records(
     options: ContextOptions,
 ) -> Result<ContextResult> {
     options.validate()?;
-    let anchor = resolve_record(index, selector)?;
-    let anchor_id = canonical_record_id(&anchor);
-    let session_records = deduplicate_records(
-        index
-            .records_by_session_path(anchor.source, &anchor.session_id, &anchor.source_path)?
-            .into_iter()
-            // Keep this check even though current indexes include `source` in the query. It
-            // preserves the old in-memory isolation contract for legacy projections where the
-            // source field is absent and `record_from_doc` infers it from the path.
-            .filter(|record| record.source == anchor.source)
-            .collect(),
-    );
+    let reader = crate::index::context::ContextReader::new(index)?;
+    let candidates = deduplicate_entries(reader.candidates(selector)?);
+    let anchor = match candidates.as_slice() {
+        [] => bail!("context anchor not found"),
+        [anchor] => anchor,
+        _ => bail!(
+            "context selector is ambiguous; matching record IDs: {}",
+            candidates
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+    let anchor_id = anchor.id.clone();
+    let session_records = deduplicate_entries(reader.session(anchor, options.expand_interactions)?);
     let anchor_position = session_records
         .iter()
-        .position(|record| canonical_record_id(record) == anchor_id)
+        .position(|entry| entry.id == anchor_id)
         .ok_or_else(|| anyhow!("resolved context anchor is not in its session"))?;
-
     let first = anchor_position.saturating_sub(options.before);
     let last = (anchor_position + options.after + 1).min(session_records.len());
-    let mut selected = HashMap::<String, (Record, ContextRelation, i64)>::new();
-    for (position, record) in session_records[first..last].iter().enumerate() {
-        let absolute = first + position;
-        let key = canonical_record_id(record);
-        let (relation, distance) = if absolute == anchor_position {
-            (ContextRelation::Anchor, 0)
-        } else if absolute < anchor_position {
-            (
-                ContextRelation::Before,
-                -((anchor_position - absolute) as i64),
-            )
-        } else {
-            (ContextRelation::After, (absolute - anchor_position) as i64)
-        };
-        selected.insert(key, (record.clone(), relation, distance));
-    }
-
-    if options.expand_interactions {
-        let interaction_ids = selected
-            .values()
-            .filter_map(|(record, _, _)| tool_interaction_id(record))
-            .map(str::to_string)
-            .collect::<HashSet<_>>();
-        let expanded = session_records
+    let interaction_ids = if options.expand_interactions {
+        session_records[first..last]
             .iter()
-            .filter(|record| {
-                !selected.contains_key(&canonical_record_id(record))
-                    && tool_interaction_id(record)
-                        .is_some_and(|identifier| interaction_ids.contains(identifier))
-            })
-            .collect::<Vec<_>>();
-        if expanded.len() > MAX_INTERACTION_EXPANSION {
-            bail!(
-                "interaction expansion matched {} records, exceeding maximum {}; use a narrower \
-                 context window or disable --expand-interactions",
-                expanded.len(),
-                MAX_INTERACTION_EXPANSION
-            );
-        }
-        for record in expanded {
-            selected.insert(
-                canonical_record_id(record),
-                (record.clone(), ContextRelation::Interaction, 0),
-            );
-        }
+            .filter_map(|entry| tool_interaction_id(&entry.record))
+            .map(str::to_owned)
+            .collect::<HashSet<_>>()
+    } else {
+        HashSet::new()
+    };
+    let expanded_count = session_records
+        .iter()
+        .enumerate()
+        .filter(|(position, entry)| {
+            !(first..last).contains(position)
+                && tool_interaction_id(&entry.record).is_some_and(|id| interaction_ids.contains(id))
+        })
+        .count();
+    if expanded_count > MAX_INTERACTION_EXPANSION {
+        bail!(
+            "interaction expansion matched {} records, exceeding maximum {}; use a narrower \
+             context window or disable --expand-interactions",
+            expanded_count,
+            MAX_INTERACTION_EXPANSION
+        );
     }
-
-    let mut selected: Vec<(Record, ContextRelation, i64)> = selected.into_values().collect();
-    selected.sort_by(|left, right| record_order(&left.0, &right.0));
-    let records = selected
-        .into_iter()
-        .map(|(record, relation, distance)| ContextRecord {
-            record_id: canonical_record_id(&record),
+    let mut records = Vec::with_capacity(last - first + expanded_count);
+    for (position, entry) in session_records.into_iter().enumerate() {
+        let (relation, distance) = if (first..last).contains(&position) {
+            let distance = position as i64 - anchor_position as i64;
+            let relation = match distance.cmp(&0) {
+                std::cmp::Ordering::Less => ContextRelation::Before,
+                std::cmp::Ordering::Equal => ContextRelation::Anchor,
+                std::cmp::Ordering::Greater => ContextRelation::After,
+            };
+            (relation, distance)
+        } else if tool_interaction_id(&entry.record).is_some_and(|id| interaction_ids.contains(id))
+        {
+            (ContextRelation::Interaction, 0)
+        } else {
+            continue;
+        };
+        records.push(ContextRecord {
+            record_id: entry.id.clone(),
             relation,
             distance,
-            record,
-        })
-        .collect();
+            record: reader.hydrate(entry)?,
+        });
+    }
     Ok(ContextResult {
         anchor_record_id: anchor_id,
         records,
     })
+}
+
+fn deduplicate_entries(
+    entries: Vec<crate::index::context::ContextEntry>,
+) -> Vec<crate::index::context::ContextEntry> {
+    let mut unique = HashMap::<String, crate::index::context::ContextEntry>::new();
+    for entry in entries {
+        match unique.get(&entry.id) {
+            Some(previous) if projection_order(&previous.record, &entry.record).is_ge() => {}
+            _ => {
+                unique.insert(entry.id.clone(), entry);
+            }
+        }
+    }
+    let mut entries = unique.into_values().collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        left.record
+            .turn_id
+            .cmp(&right.record.turn_id)
+            .then_with(|| left.record.ts.cmp(&right.record.ts))
+            .then_with(|| left.record.doc_id.cmp(&right.record.doc_id))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    entries
 }
 
 /// Resolve exactly one context selector without loading its surrounding conversation.
@@ -524,6 +541,178 @@ mod tests {
     }
 
     #[test]
+    fn large_context_hydrates_only_the_selected_latest_projections() {
+        let mut records = (0..1200)
+            .map(|turn| {
+                let mut row = record(turn as u64, turn, &"payload ".repeat(1024));
+                row.links.event_id = Some(format!("event-{turn}"));
+                row.tool_input = Some("input ".repeat(1024));
+                row.tool_output = Some("output ".repeat(1024));
+                row
+            })
+            .collect::<Vec<_>>();
+        // The latest projection moves to another turn. Deduplicate before counting neighbors.
+        let mut latest = records[600].clone();
+        latest.doc_id = 5000;
+        latest.turn_id = 605;
+        latest.ts = 99_999;
+        latest.text = "latest projection".into();
+        records.push(latest);
+        for projection in 0..64 {
+            let mut duplicate = records[600].clone();
+            duplicate.doc_id = 7000 + projection;
+            duplicate.ts += projection;
+            records.push(duplicate);
+        }
+        // Same source-native identity on another path must not enter the scoped neighborhood.
+        let mut other_path = records[599].clone();
+        other_path.doc_id = 6000;
+        other_path.source_path = "/tmp/other.jsonl".into();
+        records.push(other_path);
+        let mut other_source = records[601].clone();
+        other_source.doc_id = 6001;
+        other_source.source = SourceKind::Claude;
+        records.push(other_source);
+        let index = indexed(&records);
+        let expected_session = deduplicate_records(
+            records
+                .into_iter()
+                .filter(|row| {
+                    row.source == SourceKind::Codex && row.source_path == "/tmp/session.jsonl"
+                })
+                .collect(),
+        );
+        for (anchor_doc, before, after) in [
+            (0, 3, 0),
+            (0, 3, 2),
+            (1199, 1, 4),
+            (600, 2, 0),
+            (600, 0, 3),
+            (599, 1, 2),
+        ] {
+            let anchor_id = if anchor_doc == 600 {
+                canonical_record_id(
+                    expected_session
+                        .iter()
+                        .find(|row| row.doc_id == 5000)
+                        .unwrap(),
+                )
+            } else {
+                canonical_record_id(
+                    expected_session
+                        .iter()
+                        .find(|row| row.doc_id == anchor_doc)
+                        .unwrap(),
+                )
+            };
+            let position = expected_session
+                .iter()
+                .position(|row| canonical_record_id(row) == anchor_id)
+                .unwrap();
+            let first = position.saturating_sub(before);
+            let last = (position + after + 1).min(expected_session.len());
+            crate::index::context::STORED_READS.with(|reads| reads.set(0));
+            let result = context_records(
+                &index,
+                &ContextSelector::doc_id(anchor_doc),
+                ContextOptions {
+                    before,
+                    after,
+                    expand_interactions: false,
+                },
+            )
+            .unwrap();
+            let reads = crate::index::context::STORED_READS.with(|reads| reads.get());
+            assert_eq!(
+                reads,
+                1 + last - first,
+                "one anchor read plus the selected neighborhood"
+            );
+            assert_eq!(result.anchor_record_id, anchor_id);
+            for (offset, (actual, expected)) in result
+                .records
+                .iter()
+                .zip(&expected_session[first..last])
+                .enumerate()
+            {
+                assert_eq!(
+                    serde_json::to_value(&actual.record).unwrap(),
+                    serde_json::to_value(expected).unwrap()
+                );
+                assert_eq!(actual.distance, (first + offset) as i64 - position as i64);
+            }
+            assert_eq!(result.records.len(), last - first);
+        }
+        crate::index::context::STORED_READS.with(|reads| reads.set(0));
+        let result = context_records(
+            &index,
+            &ContextSelector::event_id("event-600"),
+            ContextOptions {
+                before: 0,
+                after: 0,
+                expand_interactions: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(result.records[0].record.text, "latest projection");
+        assert_eq!(
+            crate::index::context::STORED_READS.with(|reads| reads.get()),
+            1,
+            "duplicate anchor projections are resolved from metadata"
+        );
+    }
+
+    #[test]
+    fn context_order_breaks_numeric_ties_by_canonical_identity() {
+        let mut rows = vec![record(7, 3, "a"), record(7, 3, "b"), record(7, 3, "c")];
+        for row in &mut rows {
+            row.links.event_id = Some(row.text.clone());
+        }
+        let index = indexed(&rows);
+        let expected = deduplicate_records(rows);
+        let result = context_records(
+            &index,
+            &ContextSelector::record_id(canonical_record_id(&expected[1])),
+            ContextOptions {
+                before: 1,
+                after: 1,
+                expand_interactions: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            result
+                .records
+                .iter()
+                .map(|row| row.record.text.as_str())
+                .collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|row| row.text.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            result
+                .records
+                .iter()
+                .map(|row| row.distance)
+                .collect::<Vec<_>>(),
+            [-1, 0, 1]
+        );
+        assert!(
+            context_records(
+                &index,
+                &ContextSelector::doc_id(7),
+                ContextOptions::default()
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("ambiguous")
+        );
+    }
+
+    #[test]
     fn context_selects_bounded_ordered_window_and_includes_anchor() {
         let records: Vec<Record> = (1..=5)
             .map(|turn| record(turn as u64, turn, &format!("r{turn}")))
@@ -673,6 +862,7 @@ mod tests {
             vec!["assistant"]
         );
 
+        crate::index::context::STORED_READS.with(|reads| reads.set(0));
         let from_call = context_records(
             &index,
             &ContextSelector::event_id("call"),
@@ -683,6 +873,10 @@ mod tests {
             },
         )
         .expect("expanded tool pair");
+        assert_eq!(
+            crate::index::context::STORED_READS.with(|reads| reads.get()),
+            3
+        );
         assert!(
             from_call
                 .records
@@ -857,6 +1051,7 @@ mod tests {
             records.push(result);
         }
         let index = indexed(&records);
+        crate::index::context::STORED_READS.with(|reads| reads.set(0));
         let error = context_records(
             &index,
             &ContextSelector::event_id("call-a"),
@@ -867,6 +1062,10 @@ mod tests {
             },
         )
         .expect_err("expansion cap");
+        assert_eq!(
+            crate::index::context::STORED_READS.with(|reads| reads.get()),
+            1
+        );
         let message = error.to_string();
         assert!(message.contains("exceeding maximum 100"));
         assert!(message.contains("disable --expand-interactions"));


### PR DESCRIPTION
Small context requests currently deserialize the entire scoped conversation before selecting neighbors. Select canonical projections and tool relationships from indexed metadata first, then hydrate only returned records from the same snapshot. Preserve asymmetric windows, ordering and signed distances, latest-projection deduplication, selector ambiguity, source/session/path isolation, and direct interaction expansion limits.

A unique anchor adds one stored read. Tests exercise a large session with duplicate projections and assert the exact hydration count, plus boundary windows, ordering ties, tool expansion and legacy indexes. Metadata traversal still scans term dictionaries in matching segments; this is a hydration bound, not a measured latency improvement. Older projections missing canonical IDs or numeric fast fields retain the stored-record fallback without requiring a rebuild.

Independent of the ingestion/index stack in #175: no schema, storage, or reader-cache changes.
